### PR TITLE
Takeover a bootstrapped cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
+.PHONY: load-image
+load-image: ## Load image into a Kind cluster.
+	kind load docker-image ${IMG}
+
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	mkdir -p config/dev && cp config/default/* config/dev

--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ kubectl create secret docker-registry flux-enterprise-auth \
   --docker-password=$ENTERPRISE_TOKEN
 ```
 
+### Migration of a bootstrap cluster
+
+To migrate a cluster that was bootstrapped, after the flux-operator is installed
+and the `FluxInstance` resource is created, the following steps are required:
+
+1. Checkout the branch of the Flux repository that was used to bootstrap the cluster.
+2. Replace the contents of the `flux-system/gok-components.yaml` with the `FluxInstance` YAML manifest.
+3. Remove all controllers patches from the `flux-system/kustomization.yaml`.
+4. Commit and push the changes to the Flux repository.
+
 ## Supply Chain Security
 
 The build, release and provenance portions of the ControlPlane distribution supply chain meet

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,7 +30,7 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-const controllerName = "fluxcd-controller"
+const controllerName = "flux-controller"
 
 var (
 	scheme   = runtime.NewScheme()

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -33,11 +33,14 @@ spec:
         image: flux-operator:latest
         imagePullPolicy: IfNotPresent
         securityContext:
+          runAsNonRoot: true
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - "ALL"
+          seccompProfile:
+            type: RuntimeDefault
         ports:
         - containerPort: 8080
           name: http-metrics

--- a/internal/builder/build.go
+++ b/internal/builder/build.go
@@ -66,6 +66,10 @@ func generate(base string, options Options) error {
 		return fmt.Errorf("generate namespace failed: %w", err)
 	}
 
+	if err := execTemplate(options, annotationsTmpl, path.Join(base, "annotations.yaml")); err != nil {
+		return fmt.Errorf("generate annotations failed: %w", err)
+	}
+
 	if err := execTemplate(options, labelsTmpl, path.Join(base, "labels.yaml")); err != nil {
 		return fmt.Errorf("generate labels failed: %w", err)
 	}

--- a/internal/builder/templates.go
+++ b/internal/builder/templates.go
@@ -23,6 +23,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: {{$namespace}}
 transformers:
+  - annotations.yaml
   - labels.yaml
 resources:
   - namespace.yaml
@@ -162,6 +163,18 @@ labels:
   app.kubernetes.io/part-of: flux
 fieldSpecs:
   - path: metadata/labels
+    create: true
+`
+
+var annotationsTmpl = `---
+apiVersion: builtin
+kind: AnnotationsTransformer
+metadata:
+  name: annotations
+annotations:
+  kustomize.toolkit.fluxcd.io/ssa: Ignore
+fieldSpecs:
+  - path: metadata/annotations
     create: true
 `
 

--- a/internal/builder/testdata/v2.3.0-golden/default.kustomization.yaml
+++ b/internal/builder/testdata/v2.3.0-golden/default.kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
 transformers:
+  - annotations.yaml
   - labels.yaml
 resources:
   - namespace.yaml

--- a/internal/builder/testdata/v2.3.0-golden/patches.kustomization.yaml
+++ b/internal/builder/testdata/v2.3.0-golden/patches.kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
 transformers:
+  - annotations.yaml
   - labels.yaml
 resources:
   - namespace.yaml

--- a/internal/builder/testdata/v2.3.0-golden/profiles.kustomization.yaml
+++ b/internal/builder/testdata/v2.3.0-golden/profiles.kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
 transformers:
+  - annotations.yaml
   - labels.yaml
 resources:
   - namespace.yaml

--- a/internal/builder/testdata/v2.3.0-golden/storage.kustomization.yaml
+++ b/internal/builder/testdata/v2.3.0-golden/storage.kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
 transformers:
+  - annotations.yaml
   - labels.yaml
 resources:
   - namespace.yaml


### PR DESCRIPTION
This PR enables the operator to takeover the ownership of Flux controllers when deployed on a bootstrapped cluster. Once the operator deploys Flux, it disables the reconciliation of Flux CRDs and controllers by setting the  `kustomize.toolkit.fluxcd.io/ssa: Ignore` annotation so that kustomize-controller will skip all manifests in `gotk-components.yaml`.

Fix: #11 