### PR TITLE
Add support for disabling the reconciliation

### DIFF
--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -243,6 +243,12 @@ func (in *FluxInstance) SetConditions(conditions []metav1.Condition) {
 	in.Status.Conditions = conditions
 }
 
+// IsDisabled returns true if the object has the reconcile annotation set to 'disabled'.
+func (in *FluxInstance) IsDisabled() bool {
+	val, ok := in.GetAnnotations()[ReconcileAnnotation]
+	return ok && strings.ToLower(val) == DisabledValue
+}
+
 // GetInterval returns the interval at which the object should be reconciled.
 // If no interval is set, the default is 60 minutes.
 func (in *FluxInstance) GetInterval() time.Duration {

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -87,6 +88,14 @@ func (r *FluxInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			meta.ProgressingReason,
 			msg)
 		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Pause reconciliation if the object has the reconcile annotation set to 'disabled'.
+	if obj.IsDisabled() {
+		msg := "Reconciliation in disabled"
+		log.Error(errors.New("can't reconcile instance"), msg)
+		r.Event(obj, corev1.EventTypeWarning, "ReconciliationDisabled", msg)
+		return ctrl.Result{}, nil
 	}
 
 	// Reconcile the object.

--- a/internal/controller/fluxinstance_uninstaller.go
+++ b/internal/controller/fluxinstance_uninstaller.go
@@ -30,7 +30,7 @@ func (r *FluxInstanceReconciler) uninstall(ctx context.Context,
 	reconcileStart := time.Now()
 	log := ctrl.LoggerFrom(ctx)
 
-	if obj.Status.Inventory == nil || len(obj.Status.Inventory.Entries) == 0 {
+	if obj.IsDisabled() || obj.Status.Inventory == nil || len(obj.Status.Inventory.Entries) == 0 {
 		controllerutil.RemoveFinalizer(obj, fluxcdv1.Finalizer)
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
Allow disabling the reconciliation by annotating  a `FluxInstance` with `fluxcd.controlplane.io/reconcile: disabled`. 