### PR TITLE
Publish distro manifests at release time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,25 @@ jobs:
           COSIGN_EXPERIMENTAL: 1
         run: |
           cosign sign --yes ghcr.io/controlplaneio-fluxcd/${{ env.CONTROLLER }}@${{ steps.build-push.outputs.digest }}
+      - name: Push and sign manifests
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          set -euo pipefail
+          
+          make build-manifests
+          
+          img_digest=$(flux push artifact \
+          oci://ghcr.io/controlplaneio-fluxcd/${{ env.CONTROLLER }}-manifests:${{ steps.prep.outputs.VERSION }} \
+          --path=dist \
+          --source=${{ github.repositoryUrl }} \
+          --revision="${{ github.ref_name }}@sha1:${{ github.sha }}" \
+          --annotations='org.opencontainers.image.description=Flux Operator' \
+          --output=json | jq -r '.digest')
+          
+          cosign sign --yes ghcr.io/controlplaneio-fluxcd/${{ env.CONTROLLER }}-manifests@${img_digest}
+          
+          flux tag artifact oci://ghcr.io/controlplaneio-fluxcd/${{ env.CONTROLLER }}-manifests:${{ steps.prep.outputs.VERSION }} --tag=latest
       - name: Create release
         if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
@@ -91,9 +110,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p config/release
-          kustomize build ./config/default > ./config/release/install.yaml
-          gh release upload ${{ github.ref_name }} ./config/release/install.yaml
+          gh release upload ${{ github.ref_name }} ./dist/flux-operator/install.yaml
       - name: Generate SLSA metadata
         id: slsa
         run: |          

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,13 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 	mkdir -p dist
 	$(KUSTOMIZE) build config/default > dist/install.yaml
 
+.PHONY: build-manifests
+build-manifests: manifests generate kustomize ## Generate release manifests.
+	mkdir -p dist/flux-operator
+	kustomize build config/default > dist/flux-operator/install.yaml
+	mkdir -p dist/flux
+	cp -r config/data/flux/ dist/flux/
+
 ##@ Deployment
 
 ifndef ignore-not-found

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
 - name: flux-operator
   newName: ghcr.io/controlplaneio-fluxcd/flux-operator
-  newTag: v0.2.0
+  newTag: v0.3.0


### PR DESCRIPTION
Push to `ghcr.io/controlplaneio-fluxcd/flux-operator-manifests`