### PR TITLE
Issue event for outdated versions

### DIFF
--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -20,6 +20,7 @@ const (
 	FluxInstanceKind    = "FluxInstance"
 	EnabledValue        = "enabled"
 	DisabledValue       = "disabled"
+	OutdatedReason      = "OutdatedVersion"
 )
 
 var (

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -275,6 +275,17 @@ func (r *FluxInstanceReconciler) build(ctx context.Context,
 		}
 	}
 
+	latestVer, err := builder.MatchVersion(fluxManifestsDir, "2.x")
+	if err != nil {
+		return nil, err
+	}
+
+	if ver != latestVer {
+		msg := fmt.Sprintf("Flux %s is outdated, the latest stable version is %s", ver, latestVer)
+		r.EventRecorder.Event(obj, corev1.EventTypeNormal, fluxcdv1.OutdatedReason, msg)
+		log.Info(msg)
+	}
+
 	options := builder.MakeDefaultOptions()
 	options.Version = ver
 	options.Registry = obj.GetDistribution().Registry


### PR DESCRIPTION
Emit a Kubernetes event with the `OutdatedVersion` reason and log when the installed version doesn't match latest.