### PR TITLE
Add Terraform install example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@
 go.work
 bin/
 disto/
+
+# Terraform
+**/.terraform
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl
+.terraformrc

--- a/config/terraform/README.md
+++ b/config/terraform/README.md
@@ -1,0 +1,60 @@
+# Install Flux with Terraform
+
+This example demonstrates how to deploy Flux on a Kubernetes cluster using Terraform
+and the `flux-operator` and `flux-instance` Helm charts.
+
+## Usage
+
+Create a Kubernetes cluster using KinD:
+
+```shell
+kind create cluster --name flux
+```
+
+Install the Flux Operator and deploy the Flux instance on the cluster 
+set as the default context in the `~/.kube/config` file:
+
+```shell
+terraform apply \
+  -var flux_version="2.x" \
+  -var flux_registry="ghcr.io/fluxcd" \
+  -var git_token="${GITHUB_TOKEN}" \
+  -var git_url="https://github.com/fluxcd/flux2-kustomize-helm-example.git" \
+  -var git_ref="refs/heads/main" \
+  -var git_path="clusters/production"
+```
+
+Note that the `GITHUB_TOKEN` env var must be set to a GitHub personal access token.
+The `git_token` variable is used to create a Kubernetes secret in the `flux-system` namespace for
+Flux to authenticate with the Git repository over HTTPS.
+If the repository is public, the token variable can be omitted.
+
+Verify the Flux components are running:
+
+```shell
+kubectl -n flux-system get pods
+```
+
+Verify the Flux instance is syncing the cluster state from the Git repository:
+
+```shell
+kubectl -n flux-system get fluxreport/flux -o yaml
+```
+
+The output should show the sync status:
+
+```yaml
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxReport
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  # Distribution status omitted for brevity
+  sync:
+    id: kustomization/flux-system
+    path: clusters/production
+    ready: true
+    source: https://github.com/fluxcd/flux2-kustomize-helm-example.git
+    status: 'Applied revision: refs/heads/main@sha1:21486401be9bcdc37e6ebda48a3b68f8350777c9'
+```

--- a/config/terraform/main.tf
+++ b/config/terraform/main.tf
@@ -1,0 +1,109 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.27"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.12"
+    }
+  }
+}
+
+// Create the  flux-system namespace.
+resource "kubernetes_namespace" "flux_system" {
+  metadata {
+    name = "flux-system"
+  }
+
+  lifecycle {
+    ignore_changes = [metadata]
+  }
+}
+
+// Create a Kubernetes secret with the Git credentials
+// if a Git token is provided.
+resource "kubernetes_secret" "git_auth" {
+  count = var.git_token != "" ? 1 : 0
+  depends_on = [kubernetes_namespace.flux_system]
+
+  metadata {
+    name      = "flux-system"
+    namespace = "flux-system"
+  }
+
+  data = {
+    username = "git"
+    password = var.git_token
+  }
+
+  type = "Opaque"
+}
+
+// Install the Flux Operator.
+resource "helm_release" "flux_operator" {
+  depends_on = [kubernetes_namespace.flux_system]
+
+  name       = "flux-operator"
+  namespace  = "flux-system"
+  repository = "oci://ghcr.io/controlplaneio-fluxcd/charts"
+  chart      = "flux-operator"
+  wait       = true
+}
+
+// Configure the Flux instance.
+resource "helm_release" "flux_instance" {
+  depends_on = [helm_release.flux_operator]
+
+  name       = "flux"
+  namespace  = "flux-system"
+  repository = "oci://ghcr.io/controlplaneio-fluxcd/charts"
+  chart      = "flux-instance"
+
+  // Configure the Flux components and automated upgrades.
+  set {
+    name  = "instance.distribution.version"
+    value = var.flux_version
+  }
+  set {
+    name  = "instance.distribution.registry"
+    value = var.flux_registry
+  }
+  set_list {
+    name = "instance.components"
+    value = [
+      "source-controller",
+      "kustomize-controller",
+      "helm-controller",
+      "notification-controller",
+      "image-reflector-controller",
+      "image-automation-controller"
+    ]
+  }
+
+  // Configure Flux Git sync.
+  set {
+    name  = "instance.sync.kind"
+    value = "GitRepository"
+  }
+  set {
+    name  = "instance.sync.url"
+    value = var.git_url
+  }
+  set {
+    name  = "instance.sync.path"
+    value = var.git_path
+  }
+  set {
+    name  = "instance.sync.ref"
+    value = var.git_ref
+  }
+  set {
+    name  = "instance.sync.pullSecret"
+    value = var.git_token != "" ? "flux-system" : ""
+  }
+}
+

--- a/config/terraform/providers.tf
+++ b/config/terraform/providers.tf
@@ -1,0 +1,9 @@
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+}

--- a/config/terraform/values/components.yaml
+++ b/config/terraform/values/components.yaml
@@ -1,0 +1,20 @@
+instance:
+  components:
+    - source-controller
+    - kustomize-controller
+    - helm-controller
+    - notification-controller
+    - image-reflector-controller
+    - image-automation-controller
+  kustomize:
+    patches:
+      - target:
+          kind: Deployment
+          name: "(kustomize-controller|helm-controller)"
+        patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --concurrent=10
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --requeue-dependency=10s

--- a/config/terraform/variables.tf
+++ b/config/terraform/variables.tf
@@ -1,0 +1,36 @@
+variable "git_token" {
+  description = "Git PAT"
+  sensitive   = true
+  type        = string
+  default     = ""
+}
+
+variable "git_url" {
+  description = "Git repository URL"
+  type        = string
+  nullable    = false
+}
+
+variable "git_path" {
+  description = "Path to the cluster manifests in the Git repository"
+  type        = string
+  nullable    = false
+}
+
+variable "git_ref" {
+  description = "Git branch or tag in the format refs/heads/main or refs/tags/v1.0.0"
+  type        = string
+  default     = "refs/heads/main"
+}
+
+variable "flux_version" {
+  description = "Flux version semver range"
+  type        = string
+  default     = "2.x"
+}
+
+variable "flux_registry" {
+  description = "Flux distribution registry"
+  type        = string
+  default     = "ghcr.io/fluxcd"
+}


### PR DESCRIPTION
This PR adds an example under `config/terraform` to demonstrate how to deploy Flux on a Kubernetes cluster using Terraform and the `flux-operator` and `flux-instance` Helm charts.

> [!NOTE]
> The `flux-instance` Helm chart is needed because the Hashicorp Kubernetes provider can't do CRDs and CRs in the same module, xref: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1367

## Usage

Create a Kubernetes cluster using KinD:

```shell
kind create cluster --name flux
```

Install the Flux Operator and deploy the Flux instance on the cluster:

```shell
terraform apply \
  -var flux_version="2.x" \
  -var flux_registry="ghcr.io/fluxcd" \
  -var git_token="${GITHUB_TOKEN}" \
  -var git_url="https://github.com/fluxcd/flux2-kustomize-helm-example.git" \
  -var git_ref="refs/heads/main" \
  -var git_path="clusters/production"
```

Verify the Flux components are running:

```shell
kubectl -n flux-system get pods
```

Verify the Flux instance is syncing the cluster state from the Git repository:

```shell
kubectl -n flux-system get fluxreport/flux -o yaml
```

The output should show the sync status:

```yaml
apiVersion: fluxcd.controlplane.io/v1
kind: FluxReport
metadata:
  name: flux
  namespace: flux-system
spec:
  # Distribution status omitted for brevity
  sync:
    id: kustomization/flux-system
    path: clusters/production
    ready: true
    source: https://github.com/fluxcd/flux2-kustomize-helm-example.git
    status: 'Applied revision: refs/heads/main@sha1:21486401be9bcdc37e6ebda48a3b68f8350777c9'
```