### PR TITLE
Add `tenantDefaultServiceAccount` to FluxInstance API

### DIFF
--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -130,6 +130,12 @@ type Cluster struct {
 	// +optional
 	Multitenant bool `json:"multitenant,omitempty"`
 
+	// TenantDefaultServiceAccount is the name of the service account
+	// to use as default when the multitenant lockdown is enabled.
+	// Defaults to the 'default' service account from the tenant namespace.
+	// +optional
+	TenantDefaultServiceAccount string `json:"tenantDefaultServiceAccount,omitempty"`
+
 	// NetworkPolicy restricts network access to the current namespace.
 	// Defaults to true.
 	// +kubebuilder:default:=true

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -70,6 +70,12 @@ spec:
                       NetworkPolicy restricts network access to the current namespace.
                       Defaults to true.
                     type: boolean
+                  tenantDefaultServiceAccount:
+                    description: |-
+                      TenantDefaultServiceAccount is the name of the service account
+                      to use as default when the multitenant lockdown is enabled.
+                      Defaults to the 'default' service account from the tenant namespace.
+                    type: string
                   type:
                     default: kubernetes
                     description: |-

--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -276,6 +276,7 @@ spec:
   cluster:
     type: openshift
     multitenant: true
+    tenantDefaultServiceAccount: "flux"
     networkPolicy: true
     domain: "cluster.local"
 ```
@@ -291,6 +292,10 @@ The supported values are `kubernetes` (default), `openshift`, `aks`, `eks` and `
 
 The `.spec.cluster.multitenant` field is optional and specifies whether to enable Flux
 [multi-tenancy lockdown](https://fluxcd.io/flux/installation/configuration/multitenancy/).
+
+The `.spec.cluster.tenantDefaultServiceAccount` is optional and specifies the default
+service account used by Flux when reconciling `Kustomization` and `HelmRelease`
+resources found in the tenant namespaces.
 
 #### Cluster network policy
 

--- a/internal/builder/build_test.go
+++ b/internal/builder/build_test.go
@@ -129,7 +129,7 @@ func TestBuild_Profiles(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	options.ComponentImages = ci
 
-	options.Patches = ProfileOpenShift + ProfileMultitenant
+	options.Patches = ProfileOpenShift + GetMultitenantProfile("")
 
 	result, err := Build(srcDir, dstDir, options)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/internal/builder/profiles.go
+++ b/internal/builder/profiles.go
@@ -3,6 +3,8 @@
 
 package builder
 
+import "fmt"
+
 const ProfileOpenShift = `
 - target:
     kind: Deployment
@@ -22,7 +24,7 @@ const ProfileOpenShift = `
       path: /metadata/labels/pod-security.kubernetes.io~1warn-version
 `
 
-const ProfileMultitenant = `
+const profileMultitenant = `
 - target:
     kind: Deployment
     name: "(kustomize-controller|helm-controller|notification-controller|image-reflector-controller|image-automation-controller)"
@@ -43,7 +45,7 @@ const ProfileMultitenant = `
   patch: |-
     - op: add
       path: /spec/template/spec/containers/0/args/-
-      value: --default-service-account=default
+      value: --default-service-account=%s
 - target:
     kind: Kustomization
   patch: |-
@@ -51,3 +53,11 @@ const ProfileMultitenant = `
       path: /spec/serviceAccountName
       value: kustomize-controller
 `
+
+func GetMultitenantProfile(defaultSA string) string {
+	if defaultSA == "" {
+		defaultSA = "default"
+	}
+
+	return fmt.Sprintf(profileMultitenant, defaultSA)
+}

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -299,7 +299,7 @@ func (r *FluxInstanceReconciler) build(ctx context.Context,
 		options.Patches += builder.ProfileOpenShift
 	}
 	if obj.GetCluster().Multitenant {
-		options.Patches += builder.ProfileMultitenant
+		options.Patches += builder.GetMultitenantProfile(obj.GetCluster().TenantDefaultServiceAccount)
 	}
 
 	if obj.Spec.Storage != nil {


### PR DESCRIPTION
This PR adds an optional field `.spec.cluster.tenantDefaultServiceAccount` to the FluxInstance API that allows setting the
default service account used by Flux when reconciling `Kustomization` and `HelmRelease` resources found in the tenant namespaces.

Closes: #44