### PR TITLE
Wait for deployments removal during uninstallation

### DIFF
--- a/internal/entitlement/client_test.go
+++ b/internal/entitlement/client_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package entitlement
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNewClient_DefaultVendor(t *testing.T) {
+	g := NewWithT(t)
+
+	// Unset the environment variable
+	t.Setenv(MarketplaceTypeEnvKey, "")
+
+	client, err := NewClient()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(client).ToNot(BeNil())
+	g.Expect(client.GetVendor()).To(Equal(DefaultVendor))
+}
+
+func TestNewClient_UnsupportedVendor(t *testing.T) {
+	g := NewWithT(t)
+
+	// Set the environment variable to an unsupported value
+	t.Setenv(MarketplaceTypeEnvKey, "unsupported")
+
+	client, err := NewClient()
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(client).To(BeNil())
+}

--- a/internal/entitlement/default_test.go
+++ b/internal/entitlement/default_test.go
@@ -1,0 +1,48 @@
+// Copyright 2024 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package entitlement
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/opencontainers/go-digest"
+)
+
+func TestRegisterUsage(t *testing.T) {
+	g := NewWithT(t)
+	client := DefaultClient{Vendor: "testVendor"}
+	ctx := context.Background()
+	id := "testID"
+
+	token, err := client.RegisterUsage(ctx, id)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	expectedDigest := digest.FromString("testVendor-testID").Encoded()
+	g.Expect(token).To(Equal(expectedDigest))
+}
+
+func TestVerify(t *testing.T) {
+	g := NewWithT(t)
+	client := DefaultClient{Vendor: "testVendor"}
+	id := "testID"
+	token := digest.FromString("testVendor-testID").Encoded()
+
+	valid, err := client.Verify(token, id)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(valid).To(BeTrue())
+
+	invalidToken := "invalidToken"
+	valid, err = client.Verify(invalidToken, id)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(valid).To(BeFalse())
+}
+
+func TestGetVendor(t *testing.T) {
+	g := NewWithT(t)
+	client := DefaultClient{Vendor: "testVendor"}
+	vendor := client.GetVendor()
+	g.Expect(vendor).To(Equal("testVendor"))
+}


### PR DESCRIPTION
Perform uninstallation in stages by waiting for the Flux controller deployments to be removed before continuing with CR/CRD removal. This protects against any race conditions, where the controllers could start pruning resources before they receive the shutdown signal.  xref: #84 