### PR TITLE
Allow setting the sync name of a `FluxInstance`

### DIFF
--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -200,8 +200,10 @@ type Kustomize struct {
 }
 
 type Sync struct {
-	// Name is the name of the source and kustomization resources.
-	// When not specified, the name is set to namespace of the FluxInstance.
+	// Name is the name of the Flux source and kustomization resources.
+	// When not specified, the name is set to the namespace name of the FluxInstance.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Sync name is immutable"
+	// +kubebuilder:validation:MaxLength=63
 	// +optional
 	Name string `json:"name,omitempty"`
 

--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -200,6 +200,11 @@ type Kustomize struct {
 }
 
 type Sync struct {
+	// Name is the name of the source and kustomization resources.
+	// When not specified, the name is set to namespace of the FluxInstance.
+	// +optional
+	Name string `json:"name,omitempty"`
+
 	// Interval is the time between syncs.
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -275,6 +275,11 @@ spec:
                     - GitRepository
                     - Bucket
                     type: string
+                  name:
+                    description: |-
+                      Name is the name of the source and kustomization resources.
+                      When not specified, the name is set to namespace of the FluxInstance.
+                    type: string
                   path:
                     description: |-
                       Path is the path to the source directory containing

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -277,9 +277,13 @@ spec:
                     type: string
                   name:
                     description: |-
-                      Name is the name of the source and kustomization resources.
-                      When not specified, the name is set to namespace of the FluxInstance.
+                      Name is the name of the Flux source and kustomization resources.
+                      When not specified, the name is set to the namespace name of the FluxInstance.
+                    maxLength: 63
                     type: string
+                    x-kubernetes-validations:
+                    - message: Sync name is immutable
+                      rule: self == oldSelf
                   path:
                     description: |-
                       Path is the path to the source directory containing

--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -455,7 +455,7 @@ Sync fields:
 - `interval`: The sync interval. This field is optional, when not set the default is `1m`.
 - `name`: The name of the generated Flux source and Kustomization objects.
    This field is optional, when not set the default is the FluxInstance namespace name.
-   Note that this field is considered immutable, changing it after the FluxInstance is created, will result in a complete wipe of the cluster state.
+   Note that this field is considered immutable, and cannot be changed after the FluxInstance is created.
 
 #### Sync from Git over HTTP/S
 

--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -453,6 +453,9 @@ Sync fields:
 - `path`: The path to the source directory containing the kustomize overlay or plain Kubernetes manifests to sync from.
 - `pullSecret`: The name of the Kubernetes secret that contains the credentials to pull the source repository. This field is optional.
 - `interval`: The sync interval. This field is optional, when not set the default is `1m`.
+- `name`: The name of the generated Flux source and Kustomization objects.
+   This field is optional, when not set the default is the FluxInstance namespace name.
+   Note that this field is considered immutable, changing it after the FluxInstance is created, will result in a complete wipe of the cluster state.
 
 #### Sync from Git over HTTP/S
 

--- a/internal/builder/build_test.go
+++ b/internal/builder/build_test.go
@@ -252,6 +252,7 @@ func TestBuild_Sync(t *testing.T) {
 	options.ComponentImages = ci
 
 	options.Sync = &Sync{
+		Name:     "flux-system",
 		Interval: "5m",
 		Kind:     "GitRepository",
 		URL:      "https://host/repo.git",

--- a/internal/builder/options.go
+++ b/internal/builder/options.go
@@ -66,6 +66,7 @@ type ArtifactStorage struct {
 }
 
 type Sync struct {
+	Name       string
 	Kind       string
 	URL        string
 	Ref        string

--- a/internal/builder/templates.go
+++ b/internal/builder/templates.go
@@ -305,6 +305,7 @@ spec:
 
 var syncTmpl = `---
 {{- $sync := .Sync }}
+{{- $name := .Sync.Name }}
 {{- $namespace := .Namespace }}
 {{- if eq $sync.Kind "GitRepository" }}
 apiVersion: source.toolkit.fluxcd.io/v1
@@ -317,7 +318,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: Bucket
 {{- end }}
 metadata:
-  name: {{$namespace}}
+  name: {{$name}}
   namespace: {{$namespace}}
 spec:
   interval: {{$sync.Interval}}
@@ -339,7 +340,7 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: {{$namespace}}
+  name: {{$name}}
   namespace: {{$namespace}}
 spec:
   interval: 10m0s
@@ -347,7 +348,7 @@ spec:
   prune: true
   sourceRef:
     kind: {{$sync.Kind}}
-    name: {{$namespace}}
+    name: {{$name}}
 `
 
 func execTemplate(obj interface{}, tmpl, filename string) (err error) {

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -319,7 +319,12 @@ func (r *FluxInstanceReconciler) build(ctx context.Context,
 	}
 
 	if obj.Spec.Sync != nil {
+		syncName := obj.GetNamespace()
+		if obj.Spec.Sync.Name != "" {
+			syncName = obj.Spec.Sync.Name
+		}
 		options.Sync = &builder.Sync{
+			Name:       syncName,
 			Kind:       obj.Spec.Sync.Kind,
 			Interval:   obj.Spec.Sync.Interval.Duration.String(),
 			Ref:        obj.Spec.Sync.Ref,

--- a/internal/controller/fluxreport_controller_test.go
+++ b/internal/controller/fluxreport_controller_test.go
@@ -208,6 +208,16 @@ func TestFluxReportReconciler_CustomSyncName(t *testing.T) {
 	// Check ready condition.
 	g.Expect(conditions.GetReason(report, meta.ReadyCondition)).To(BeIdenticalTo(meta.SucceededReason))
 
+	// Verify that sync name is immutable.
+	inst := &fluxcdv1.FluxInstance{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(instance), inst)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	inst.Spec.Sync.Name = "new-sync"
+	err = testClient.Update(ctx, inst)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("immutable"))
+
 	// Delete the instance.
 	err = testClient.Delete(ctx, instance)
 	g.Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This PR adds an optional field `.spec.sync.name` to the `FluxInstance`. This field allows customising the name of the Flux source and Kustomization objects when the `FluxInstance` is created. Once set, the field is considered immutable and can't be change without deleting & recreating the `FluxInstance`. 

Closes: #122 