### PR TITLE
Build with Go 1.24 and FIPS 140-3 mode enabled

### DIFF
--- a/.github/workflows/e2e-olm.yml
+++ b/.github/workflows/e2e-olm.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
           cache-dependency-path: |
             **/go.sum
             **/go.mod

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,14 +19,14 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
           cache-dependency-path: |
             **/go.sum
             **/go.mod
       - name: Setup Kubernetes
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          version: v0.23.0
+          version: v0.24.0
           cluster_name: kind
       - name: Run controller tests
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,12 +16,13 @@ issues:
       linters:
         - dupl
         - lll
+  exclude-dirs:
+    - "cmd/cli"
 linters:
   disable-all: true
   enable:
     - dupl
     - errcheck
-    - exportloopref
     - ginkgolinter
     - goconst
     - gocyclo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary using the Docker's Debian image.
-FROM --platform=${BUILDPLATFORM} golang:1.23 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /workspace
@@ -17,7 +17,7 @@ COPY api/ api/
 COPY internal/ internal/
 
 # Build the operator binary.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o flux-operator cmd/operator/main.go
+RUN CGO_ENABLED=0 GOFIPS140=latest GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o flux-operator cmd/operator/main.go
 
 # Run the operator binary using Google's Distroless image.
 FROM gcr.io/distroless/static:nonroot

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test-e2e:
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter.
-	$(GOLANGCI_LINT) run --skip-dirs cmd/cli
+	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
@@ -193,7 +193,7 @@ OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk-$(OPERATOR_SDK_VERSION)
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.16.1
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.60.1
+GOLANGCI_LINT_VERSION ?= v1.64.4
 OPERATOR_SDK_VERSION ?= v1.34.2
 
 .PHONY: operator-sdk

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"crypto/fips140"
+	"errors"
 	"os"
 
 	"github.com/fluxcd/cli-utils/pkg/kstatus/polling"
@@ -76,6 +78,13 @@ func main() {
 	flag.Parse()
 
 	logger.SetLogger(logger.NewLogger(logOptions))
+
+	// Perform FIPS 140-3 check, will panic if integrity check fails.
+	if fips140.Enabled() {
+		setupLog.Info("Operating in FIPS 140-3 mode, integrity check passed")
+	} else {
+		setupLog.Error(errors.New("FIPS 140-3 mode disabled"), "Operating in non-FIPS mode")
+	}
 
 	runtimeNamespace := os.Getenv("RUNTIME_NAMESPACE")
 	if runtimeNamespace == "" {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/controlplaneio-fluxcd/flux-operator
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1


### PR DESCRIPTION
Update Go to 1.24 and build the operator binary with FIPS 140-3 mode enabled