### PR TITLE
Enable multitenancy lockdown for the ResourceSet APIs on OpenShift

### DIFF
--- a/config/olm/bundle/manifests/flux-operator.clusterserviceversion.yaml
+++ b/config/olm/bundle/manifests/flux-operator.clusterserviceversion.yaml
@@ -345,6 +345,9 @@ spec:
                   - name: manager
                     image: ghcr.io/controlplaneio-fluxcd/flux-operator:v${FLUX_OPERATOR_VERSION}${FLUX_OPERATOR_VARIANT}
                     imagePullPolicy: IfNotPresent
+                    args:
+                      - --default-service-account=flux-operator
+                      - --enable-leader-election=true
                     securityContext:
                       runAsNonRoot: true
                       readOnlyRootFilesystem: true


### PR DESCRIPTION
Enforce service account [impersonation](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for ResourceSets when installing the operator from RedHat Operator Hub.

xref: https://github.com/controlplaneio-fluxcd/charts/pull/47