### PR TITLE
Add RBAC aggregations for ResourceSet APIs

### DIFF
--- a/config/default/rbac.yaml
+++ b/config/default/rbac.yaml
@@ -10,3 +10,42 @@ subjects:
   - kind: ServiceAccount
     name: flux-operator
     namespace: flux-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flux-operator-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - fluxcd.controlplane.io
+    resources:
+      - resourcesets
+      - resourcesetinputproviders
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flux-operator-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - fluxcd.controlplane.io
+    resources:
+      - resourcesets
+      - resourcesetinputproviders
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Extend the builtin Kubernetes roles `view`, `edit` and `admin` with access to the ResourceSet APIs.

xref: https://github.com/controlplaneio-fluxcd/charts/pull/48