### PR TITLE
Release v0.15.0

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
 - name: flux-operator
   newName: ghcr.io/controlplaneio-fluxcd/flux-operator
-  newTag: v0.14.0
+  newTag: v0.15.0


### PR DESCRIPTION
This release comes with support for GitHub App authentication (ResourceSet APIs) and includes Flux v2.5.0 

Closes: https://github.com/controlplaneio-fluxcd/distribution/issues/150