### PR TITLE
Introduce `DEFAULT_SERVICE_ACCOUNT` env var for OLM config

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -92,6 +92,13 @@ func main() {
 		setupLog.Info("RUNTIME_NAMESPACE env var not set, defaulting to " + fluxcdv1.DefaultNamespace)
 	}
 
+	// Allow the default service account name to be set by an environment variable.
+	// Needed for the OLM Subscription that only allows env var configuration.
+	defaultSA := os.Getenv("DEFAULT_SERVICE_ACCOUNT")
+	if defaultSA != "" {
+		defaultServiceAccount = defaultSA
+	}
+
 	reporter.MustRegisterMetrics()
 
 	ctx := ctrl.SetupSignalHandler()

--- a/docs/api/v1/resourceset.md
+++ b/docs/api/v1/resourceset.md
@@ -529,9 +529,24 @@ the resources defined in the ResourceSet.
 
 On multi-tenant clusters, it is recommended to use a dedicated ServiceAccount per tenant namespace
 with the minimum required permissions. To enforce a ServiceAccount for all ResourceSets,
-the `--default-service-account=flux-operator`flag can be set in the flux-operator container arguments.
+the `--default-service-account=flux-operator` flag can be set in the flux-operator container arguments.
 With this flag set, only the ResourceSets created in the same namespace as the flux-operator
 will run with cluster-admin permissions.
+
+When installing the Flux Operator with Helm, you can change the default service account name with:
+
+```shell
+helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator \
+  --namespace flux-system \
+  --create-namespace \
+  --set multitenancy.enabled=true \
+  --set multitenancy.defaultServiceAccount=flux-operator
+```
+
+When installing the Flux Operator on OpenShift from OperatorHub, the default service account name
+can be changed by setting the `DEFAULT_SERVICE_ACCOUNT` environment variable using the OLM
+[Subscription](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/subscription-config.md)
+`.spec.config.env` field.
 
 ### Garbage collection
 


### PR DESCRIPTION
Allow the default service account name used for ResourceSet impersonation to be set with the  `DEFAULT_SERVICE_ACCOUNT` environment variable.

This is needed for the OLM Subscription that only allows env var configuration. 

Closes: #184

