### PR TITLE
Add `.spec.sync.provider` field to FluxInstance API

### DIFF
--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -235,6 +235,14 @@ type Sync struct {
 	// For Bucket sources, the secret must contain accesskey and secretkey fields.
 	// +optional
 	PullSecret string `json:"pullSecret,omitempty"`
+
+	// Provider specifies OIDC provider for source authentication.
+	// For OCIRepository and Bucket the provider can be set to 'aws', 'azure' or 'gcp'.
+	// for GitRepository the accepted value can be set to 'azure' or 'github'.
+	// To disable OIDC authentication the provider can be set to 'generic' or left empty.
+	// +kubebuilder:validation:Enum=generic;aws;azure;gcp;github
+	// +optional
+	Provider string `json:"provider,omitempty"`
 }
 
 // ResourceInventory contains a list of Kubernetes resource object references

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -294,6 +294,19 @@ spec:
                       Path is the path to the source directory containing
                       the kustomize overlay or plain Kubernetes manifests.
                     type: string
+                  provider:
+                    description: |-
+                      Provider specifies OIDC provider for source authentication.
+                      For OCIRepository and Bucket the provider can be set to 'aws', 'azure' or 'gcp'.
+                      for GitRepository the accepted value can be set to 'azure' or 'github'.
+                      To disable OIDC authentication the provider can be set to 'generic' or left empty.
+                    enum:
+                    - generic
+                    - aws
+                    - azure
+                    - gcp
+                    - github
+                    type: string
                   pullSecret:
                     description: |-
                       PullSecret specifies the Kubernetes Secret containing the

--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -472,6 +472,9 @@ Sync fields:
 - `ref`: The source reference, can be a Git ref name e.g. `refs/heads/main`, an OCI tag e.g. `latest` or a Bucket name.
 - `path`: The path to the source directory containing the kustomize overlay or plain Kubernetes manifests to sync from.
 - `pullSecret`: The name of the Kubernetes secret that contains the credentials to pull the source repository. This field is optional.
+- `provider`: The provider name used for OIDC-based authentication.
+   Supported values are `aws`, `azure` and `gcp` for `OCIRepository`/`Bucket`,
+   and `azure` or `github` for `GitRepository`. This field is optional.
 - `interval`: The sync interval. This field is optional, when not set the default is `1m`.
 - `name`: The name of the generated Flux source and Kustomization objects.
    This field is optional, when not set the default is the FluxInstance namespace name.

--- a/internal/builder/build_test.go
+++ b/internal/builder/build_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fluxcd/pkg/apis/kustomize"
 	. "github.com/onsi/gomega"
 	cp "github.com/otiai10/copy"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )
 
@@ -258,6 +259,7 @@ func TestBuild_Sync(t *testing.T) {
 		URL:      "https://host/repo.git",
 		Ref:      "refs/heads/main",
 		Path:     "clusters/prod",
+		Provider: "github",
 	}
 
 	result, err := Build(srcDir, dstDir, options)
@@ -287,6 +289,13 @@ func TestBuild_Sync(t *testing.T) {
 		g.Expect(obj.GetAnnotations()).To(HaveKeyWithValue("kustomize.toolkit.fluxcd.io/ssa", "Ignore"))
 	}
 	g.Expect(found).To(BeTrue())
+
+	for _, obj := range result.Objects {
+		if obj.GetKind() == "GitRepository" {
+			p, _, _ := unstructured.NestedString(obj.Object, "spec", "provider")
+			g.Expect(p).To(Equal("github"))
+		}
+	}
 }
 
 func TestBuild_InvalidPatches(t *testing.T) {

--- a/internal/builder/options.go
+++ b/internal/builder/options.go
@@ -73,4 +73,5 @@ type Sync struct {
 	Path       string
 	Interval   string
 	PullSecret string
+	Provider   string
 }

--- a/internal/builder/templates.go
+++ b/internal/builder/templates.go
@@ -335,6 +335,9 @@ spec:
   secretRef:
     name: {{$sync.PullSecret}}
 {{- end }}
+{{- if $sync.Provider }}
+  provider: {{$sync.Provider}}
+{{- end }}
   url: {{$sync.URL}}
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -355,6 +355,7 @@ func (r *FluxInstanceReconciler) build(ctx context.Context,
 			PullSecret: obj.Spec.Sync.PullSecret,
 			URL:        obj.Spec.Sync.URL,
 			Path:       obj.Spec.Sync.Path,
+			Provider:   obj.Spec.Sync.Provider,
 		}
 	}
 

--- a/internal/controller/fluxinstance_controller_test.go
+++ b/internal/controller/fluxinstance_controller_test.go
@@ -716,10 +716,11 @@ func getDefaultFluxSpec(t *testing.T) fluxcdv1.FluxInstanceSpec {
 			Registry: "ghcr.io/fluxcd",
 		},
 		Sync: &fluxcdv1.Sync{
-			Kind: "OCIRepository",
-			URL:  "oci://registry/repo",
-			Path: "./",
-			Ref:  "latest",
+			Kind:     "OCIRepository",
+			URL:      "oci://registry/repo",
+			Path:     "./",
+			Ref:      "latest",
+			Provider: "generic",
 		},
 		CommonMetadata: &fluxcdv1.CommonMetadata{
 			Labels: map[string]string{


### PR DESCRIPTION
Add an optional filed named `provider` to the `FluxInstance.spec.sync` for setting the provider name used for OIDC-based authentication. Supported values are `aws`, `azure` and `gcp` for `OCIRepository`/`Bucket`, and `azure` or `github` for `GitRepository`.

Closes: #180