### PR TITLE
Generate ConfigMaps/Secrets with data copied from existing objects

### DIFF
--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -25,6 +25,7 @@ var (
 	ReconcileTimeoutAnnotation       = fmt.Sprintf("%s/reconcileTimeout", GroupVersion.Group)
 	PruneAnnotation                  = fmt.Sprintf("%s/prune", GroupVersion.Group)
 	RevisionAnnotation               = fmt.Sprintf("%s/revision", GroupVersion.Group)
+	CopyFromAnnotation               = fmt.Sprintf("%s/copyFrom", GroupVersion.Group)
 )
 
 // InputProvider is the interface that the ResourceSet

--- a/docs/api/v1/resourceset.md
+++ b/docs/api/v1/resourceset.md
@@ -301,6 +301,50 @@ spec:
 In the above example, the `OCIRepository` resource is created only once
 and referred by all `HelmRelease` resources.
 
+#### Copying data from existing ConfigMaps and Secrets
+
+To generate resources with data copied from existing ConfigMaps and Secrets,
+the `fluxcd.toolkit.fluxcd.io/copyFrom: namespace/name` annotation must be
+set in the ConfigMap or Secret template.
+
+Example of copying data from an existing ConfigMap and Secret:
+
+```yaml
+spec:
+  inputs:
+    - tenant: "team1"
+    - tenant: "team2"
+  resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: << inputs.tenant >>
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: runtime-info
+        namespace: << inputs.tenant >>
+        annotations:
+          fluxcd.controlplane.io/copyFrom: "flux-system/runtime-info"
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: docker-auth
+        namespace: << inputs.tenant >>
+        annotations:
+          fluxcd.controlplane.io/copyFrom: "flux-system/docker-auth"
+```
+
+In the above example, a ConfigMap and a Secret are generated for each tenant
+with the data copied from the `runtime-info` and `docker-auth` ConfigMap and Secret
+from the `flux-system` namespace. If the source data changes, the operator will
+update the generated resources accordingly on the next
+[reconciliation interval](#reconciliation-configuration).
+
+Note that on [multi-tenant clusters](#role-based-access-control), the service account
+used by the ResourceSet must have the necessary permissions to read the ConfigMaps
+and Secrets from the source namespace.
+
 #### Conditionally resource exclusion
 
 To exclude a resource based on input values, the `fluxcd.controlplane.io/reconcile` annotation can be set


### PR DESCRIPTION
This PR closes: #185

To generate resources with data copied from existing ConfigMaps and Secrets, the `fluxcd.toolkit.fluxcd.io/copyFrom: namespace/name` annotation must be set in the ConfigMap or Secret template.

Example of copying data from an existing ConfigMap and Secret:

```yaml
apiVersion: fluxcd.controlplane.io/v1
kind: ResourceSet
metadata:
  name: tenants
  namespace: flux-system
  annotations:
    fluxcd.controlplane.io/reconcileEvery: "5m"
spec:
  serviceAccountName: flux-operator
  inputs:
    - tenant: "team1"
    - tenant: "team2"
  resources:
    - apiVersion: v1
      kind: Namespace
      metadata:
        name: << inputs.tenant >>
    - apiVersion: v1
      kind: ConfigMap
      metadata:
        name: runtime-info
        namespace: << inputs.tenant >>
        annotations:
          fluxcd.controlplane.io/copyFrom: "flux-system/runtime-info"
    - apiVersion: v1
      kind: Secret
      metadata:
        name: docker-auth
        namespace: << inputs.tenant >>
        annotations:
          fluxcd.controlplane.io/copyFrom: "flux-system/docker-auth"
```

In the above example, a ConfigMap and a Secret are generated for each tenant with the data copied from the `runtime-info` and `docker-auth` ConfigMap and Secret from the `flux-system` namespace. If the source data changes, the operator will
update the generated resources accordingly on the next reconciliation interval.

Note that on multi-tenant clusters, the service account used by the ResourceSet must have the necessary permissions to read the ConfigMaps and Secrets from the source namespace.