### PR TITLE
Add standalone Service definition to OLM bundle

### DIFF
--- a/config/olm/bundle/manifests/flux-operator.clusterserviceversion.yaml
+++ b/config/olm/bundle/manifests/flux-operator.clusterserviceversion.yaml
@@ -304,16 +304,6 @@ spec:
                 - "*"
               verbs:
                 - "*"
-      services:
-        - name: flux-operator
-          spec:
-            ports:
-              - name: http-metrics
-                port: 8080
-                protocol: TCP
-                targetPort: 8080
-            selector:
-              app.kubernetes.io/name: flux-operator
       deployments:
         - name: flux-operator
           spec:

--- a/config/olm/bundle/manifests/flux-operator.service.yaml
+++ b/config/olm/bundle/manifests/flux-operator.service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flux-operator
+  labels:
+    app.kubernetes.io/name: flux-operator
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: flux-operator

--- a/hack/build-olm-manifests.sh
+++ b/hack/build-olm-manifests.sh
@@ -35,6 +35,9 @@ fi
 cat ${SOUCE_DIR}/bundle/manifests/flux-operator.clusterserviceversion.yaml | \
 envsubst > ${DEST_DIR}/bundle/manifests/flux-operator.clusterserviceversion.yaml
 
+cat ${SOUCE_DIR}/bundle/manifests/flux-operator.service.yaml > \
+${DEST_DIR}/bundle/manifests/flux-operator.service.yaml
+
 cat ${SOUCE_DIR}/test/olm.yaml | \
 envsubst > ${DEST_DIR}/test/olm.yaml
 


### PR DESCRIPTION
The Kubernetes Service was not created by OLM on OpenShift, so we are adding it as a standalone manifest instead of specifying it in the ClusterServiceVersion.