### PR TITLE
Export Prometheus metrics for ResourceSet APIs

### DIFF
--- a/docs/api/v1/resourceset.md
+++ b/docs/api/v1/resourceset.md
@@ -660,3 +660,25 @@ Status:
       Id: default_podinfo_apps_Deployment
       V:  v1
 ```
+
+## ResourceSet Metrics
+
+The Flux Operator exports Prometheus metrics for the ResourceSet objects
+that can be used to monitor the reconciliation status.
+
+Metrics:
+
+```text
+flux_resourceset_info{uid, kind, name, exported_namespace, ready, suspended, revision}
+```
+
+Labels:
+
+- `uid`: The Kubernetes unique identifier of the resource.
+- `kind`: The kind of the resource (e.g. `ResourceSet`).
+- `name`: The name of the resource (e.g. `podinfo`).
+- `exported_namespace`: The namespace where the resource is deployed (e.g. `apps`).
+- `ready`: The readiness status of the resource (e.g. `True`, `False` or `Unkown`).
+- `reason`: The reason for the readiness status (e.g. `ReconciliationSucceeded`, `BuildFailed`, `HealthCheckFailed`, etc.).
+- `suspended`: The suspended status of the resource (e.g. `True` or `False`).
+- `revision`: The revision last applied on the cluster (e.g. `sha256:75aa209c6a...`).

--- a/docs/api/v1/resourcesetinputprovider.md
+++ b/docs/api/v1/resourcesetinputprovider.md
@@ -350,3 +350,25 @@ status:
     sha: 8166bdecd6b078b9e5dd14fa3b7b67a847f76893
     title: 'feat(ui): Default color scheme'
 ```
+
+## ResourceSetInputProvider Metrics
+
+The Flux Operator exports Prometheus metrics for the ResourceSetInputProvider objects
+that can be used to monitor the reconciliation status.
+
+Metrics:
+
+```text
+flux_resourcesetinputprovider_info{uid, kind, name, exported_namespace, ready, suspended, url}
+```
+
+Labels:
+
+- `uid`: The Kubernetes unique identifier of the resource.
+- `kind`: The kind of the resource (e.g. `ResourceSetInputProvider`).
+- `name`: The name of the resource (e.g. `podinfo-prs`).
+- `exported_namespace`: The namespace where the resource is deployed (e.g. `podinfo-review`).
+- `ready`: The readiness status of the resource (e.g. `True`, `False` or `Unkown`).
+- `reason`: The reason for the readiness status (e.g. `ReconciliationSucceeded` or `ReconciliationFailed`).
+- `suspended`: The suspended status of the resource (e.g. `True` or `False`).
+- `url`: The provider address (e.g. `https://github.com/stefanprodan/podinfo`).

--- a/internal/controller/resourceset_controller.go
+++ b/internal/controller/resourceset_controller.go
@@ -37,6 +37,7 @@ import (
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/builder"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/inventory"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/reporter"
 )
 
 // ResourceSetReconciler reconciles a ResourceSet object
@@ -74,6 +75,10 @@ func (r *ResourceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if err := r.finalizeStatus(ctx, obj, patcher); err != nil {
 			log.Error(err, "failed to update status")
 			retErr = kerrors.NewAggregate([]error{retErr, err})
+		}
+
+		if err := r.recordMetrics(obj); err != nil {
+			log.Error(err, "failed to record metrics")
 		}
 	}()
 
@@ -689,6 +694,19 @@ func (r *ResourceSetReconciler) patch(ctx context.Context,
 		}
 	}
 
+	return nil
+}
+
+func (r *ResourceSetReconciler) recordMetrics(obj *fluxcdv1.ResourceSet) error {
+	if !obj.ObjectMeta.DeletionTimestamp.IsZero() {
+		reporter.DeleteMetricsFor(fluxcdv1.ResourceSetKind, obj.GetName(), obj.GetNamespace())
+		return nil
+	}
+	rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return err
+	}
+	reporter.RecordMetrics(unstructured.Unstructured{Object: rawMap})
 	return nil
 }
 


### PR DESCRIPTION
This PR implements Prometheus instrumentation for the ResourceSet controllers.

### ResourceSet Metrics

Metrics:

```text
flux_resourceset_info{uid, kind, name, exported_namespace, ready, suspended, revision}
```

Labels:

- `uid`: The Kubernetes unique identifier of the resource.
- `kind`: The kind of the resource (e.g. `ResourceSet`).
- `name`: The name of the resource (e.g. `podinfo`).
- `exported_namespace`: The namespace where the resource is deployed (e.g. `apps`).
- `ready`: The readiness status of the resource (e.g. `True`, `False` or `Unkown`).
- `reason`: The reason for the readiness status (e.g. `ReconciliationSucceeded`, `BuildFailed`, `HealthCheckFailed`, etc.).
- `suspended`: The suspended status of the resource (e.g. `True` or `False`).
- `revision`: The revision last applied on the cluster (e.g. `sha256:75aa209c6a...`).

### ResourceSetInputProvider Metrics

Metrics:

```text
flux_resourcesetinputprovider_info{uid, kind, name, exported_namespace, ready, suspended, url}
```

Labels:

- `uid`: The Kubernetes unique identifier of the resource.
- `kind`: The kind of the resource (e.g. `ResourceSetInputProvider`).
- `name`: The name of the resource (e.g. `podinfo-prs`).
- `exported_namespace`: The namespace where the resource is deployed (e.g. `podinfo-review`).
- `ready`: The readiness status of the resource (e.g. `True`, `False` or `Unkown`).
- `reason`: The reason for the readiness status (e.g. `ReconciliationSucceeded` or `ReconciliationFailed`).
- `suspended`: The suspended status of the resource (e.g. `True` or `False`).
- `url`: The provider address (e.g. `https://github.com/stefanprodan/podinfo`).