### PR TITLE
Allow setting the reporting interval via cmd flags

### DIFF
--- a/api/v1/fluxreport_types.go
+++ b/api/v1/fluxreport_types.go
@@ -4,7 +4,6 @@
 package v1
 
 import (
-	"os"
 	"strings"
 	"time"
 
@@ -13,8 +12,7 @@ import (
 )
 
 const (
-	FluxReportKind       = "FluxReport"
-	ReportIntervalEvnKey = "REPORTING_INTERVAL"
+	FluxReportKind = "FluxReport"
 )
 
 // FluxReportSpec defines the observed state of a Flux installation.
@@ -192,30 +190,17 @@ func (in *FluxReport) IsDisabled() bool {
 }
 
 // GetInterval returns the interval at which the object should be reconciled.
-// If the annotation is not set, the interval is read from the
-// REPORTING_INTERVAL environment variable. If the variable is not set,
-// the default interval is 5 minutes.
+// If the annotation is not set, it returns 0.
 func (in *FluxReport) GetInterval() time.Duration {
-	val, ok := in.GetAnnotations()[ReconcileAnnotation]
-	if ok && strings.ToLower(val) == DisabledValue {
+	val, ok := in.GetAnnotations()[ReconcileEveryAnnotation]
+	if !ok {
 		return 0
 	}
-	defaultInterval := 5 * time.Minute
-	if ri, _ := os.LookupEnv(ReportIntervalEvnKey); ri != "" {
-		if d, err := time.ParseDuration(ri); err == nil {
-			defaultInterval = d
-		}
-	}
-
-	val, ok = in.GetAnnotations()[ReconcileEveryAnnotation]
-	if !ok {
-		return defaultInterval
-	}
 	interval, err := time.ParseDuration(val)
-	if err != nil {
-		return defaultInterval
+	if err == nil {
+		return interval
 	}
-	return interval
+	return 0
 }
 
 func init() {

--- a/docs/api/v1/fluxreport.md
+++ b/docs/api/v1/fluxreport.md
@@ -265,7 +265,8 @@ The reconciliation behaviour can be configured using the following annotations:
 - `fluxcd.controlplane.io/reconcile`: Enable or disable the reconciliation loop. Default is `enabled`, set to `disabled` to pause the reconciliation.
 - `fluxcd.controlplane.io/reconcileEvery`: Set the reconciliation interval. Default is `5m`.
 
-The default reconciliation interval of the report can be changed by setting
+The default reconciliation interval of the report can be changed with
+the `--reporting-interval` flag or by setting
 the `REPORTING_INTERVAL` environment variable in the operator deployment.
 
 ## Flux Resource Metrics

--- a/internal/controller/fluxreport_controller_test.go
+++ b/internal/controller/fluxreport_controller_test.go
@@ -6,6 +6,7 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/conditions"
@@ -190,10 +191,11 @@ func TestFluxReportReconciler_CustomSyncName(t *testing.T) {
 	checkInstanceReadiness(g, instance)
 
 	// Compute instance report.
-	r, err = reportRec.Reconcile(ctx, reconcile.Request{
+	rp, err := reportRec.Reconcile(ctx, reconcile.Request{
 		NamespacedName: client.ObjectKeyFromObject(report),
 	})
 	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(rp.RequeueAfter).To(BeEquivalentTo(time.Minute))
 
 	// Read the report.
 	err = testClient.Get(ctx, client.ObjectKeyFromObject(report), report)
@@ -230,9 +232,10 @@ func TestFluxReportReconciler_CustomSyncName(t *testing.T) {
 
 func getFluxReportReconciler() *FluxReportReconciler {
 	return &FluxReportReconciler{
-		Client:        testClient,
-		EventRecorder: testEnv.GetEventRecorderFor(controllerName),
-		Scheme:        NewTestScheme(),
-		StatusManager: controllerName,
+		Client:            testClient,
+		EventRecorder:     testEnv.GetEventRecorderFor(controllerName),
+		Scheme:            NewTestScheme(),
+		StatusManager:     controllerName,
+		ReportingInterval: time.Minute,
 	}
 }


### PR DESCRIPTION
Add `--reporting-interval` flag to the controller and switch the reporting reconciler logs to debug.