### PR TITLE
Add GitHub App support to Terraform example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
 The Flux Operator is a Kubernetes CRD controller that manages
 the lifecycle of CNCF [Flux CD](https://fluxcd.io) and the
-[ControlPlane enterprise distribution](https://github.com/controlplaneio-fluxcd/distribution).
+[ControlPlane enterprise distribution](https://github.com/controlplaneio-fluxcd/distribution). The operator extends Flux with self-service
+capabilities and preview environments for GitLab and GitHub pull requests testing.
 
 ## Features
 
@@ -25,6 +26,12 @@ mechanism for the cluster desired state to OCI artifacts and S3-compatible stora
 **Deep Insights** - The operator provides deep insights into the delivery pipelines managed by Flux,
 including detailed reports and Prometheus metrics about the Flux controllers
 readiness status, reconcilers statistics, and cluster state synchronization.
+
+**Self-Service Environments** - The operator [ResourceSet API](https://fluxcd.control-plane.io/operator/resourcesets/introduction/)
+enables platform teams to define their own application standard as a group of Flux and Kubernetes resources
+that can be templated, parameterized and deployed as a single unit on self-service environments.
+The ResourceSet API integrates with GitLab and GitHub pull requests to create ephemeral environments
+for testing and validation.
 
 **Enterprise Support** - The operator is a key component of the ControlPlane
 [Enterprise offering](https://fluxcd.control-plane.io/pricing/), and is designed to automate the

--- a/config/terraform/README.md
+++ b/config/terraform/README.md
@@ -29,6 +29,22 @@ The `git_token` variable is used to create a Kubernetes secret in the `flux-syst
 Flux to authenticate with the Git repository over HTTPS.
 If the repository is public, the token variable can be omitted.
 
+Alternatively, you can use a GitHub App to authenticate with a GitHub repository:
+
+```shell
+export GITHUB_APP_PEM=`cat path/to/app.private-key.pem`
+
+terraform apply \
+  -var flux_version="2.x" \
+  -var flux_registry="ghcr.io/fluxcd" \
+  -var github_app_id="1" \
+  -var github_app_installation_id="2" \
+  -var github_app_pem="$GITHUB_APP_PEM" \
+  -var git_url="https://github.com/org/repo.git" \
+  -var git_ref="refs/heads/main" \
+  -var git_path="clusters/production"
+```
+
 Verify the Flux components are running:
 
 ```shell

--- a/config/terraform/variables.tf
+++ b/config/terraform/variables.tf
@@ -5,6 +5,25 @@ variable "git_token" {
   default     = ""
 }
 
+variable "github_app_id" {
+  description = "GitHub App ID"
+  type        = string
+  default     = ""
+}
+
+variable "github_app_installation_id" {
+  description = "GitHub App Installation ID"
+  type        = string
+  default     = ""
+}
+
+variable "github_app_pem" {
+  description = "The contents of the GitHub App private key PEM file"
+  sensitive   = true
+  type        = string
+  default     = ""
+}
+
 variable "git_url" {
   description = "Git repository URL"
   type        = string


### PR DESCRIPTION
Demonstrate how to setup GitHub App auth for a Flux Instance with Terraform.