### PR TITLE
Update `fluxcd/pkg/runtime` to v0.57.1

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -130,9 +130,7 @@ func main() {
 	}
 
 	// Disable the status poller cache to reduce memory usage.
-	pollingOpts := polling.Options{
-		ClusterReaderFactory: engine.ClusterReaderFactoryFunc(clusterreader.NewDirectClusterReader),
-	}
+	clusterReader := engine.ClusterReaderFactoryFunc(clusterreader.NewDirectClusterReader)
 
 	reporter.MustRegisterMetrics()
 
@@ -218,7 +216,7 @@ func main() {
 	if err = (&controller.FluxInstanceReconciler{
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),
-		PollingOpts:   pollingOpts,
+		ClusterReader: clusterReader,
 		StoragePath:   storagePath,
 		StatusManager: controllerName,
 		EventRecorder: mgr.GetEventRecorderFor(controllerName),
@@ -261,7 +259,7 @@ func main() {
 		Client:                mgr.GetClient(),
 		APIReader:             mgr.GetAPIReader(),
 		Scheme:                mgr.GetScheme(),
-		PollingOpts:           pollingOpts,
+		ClusterReader:         clusterReader,
 		StatusManager:         controllerName,
 		EventRecorder:         mgr.GetEventRecorderFor(controllerName),
 		DefaultServiceAccount: defaultServiceAccount,

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fluxcd/pkg/auth v0.8.0
 	github.com/fluxcd/pkg/cache v0.7.0
 	github.com/fluxcd/pkg/kustomize v1.16.0
-	github.com/fluxcd/pkg/runtime v0.56.0
+	github.com/fluxcd/pkg/runtime v0.57.1
 	github.com/fluxcd/pkg/ssa v0.45.1
 	github.com/fluxcd/pkg/tar v0.11.0
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/fluxcd/pkg/envsubst v1.3.0 h1:84Ain+8EBvyzu6y0FsKRwNsvaSiKuqhTqeh/4yo
 github.com/fluxcd/pkg/envsubst v1.3.0/go.mod h1:lz6HvqDnxbX0sIqjr1fxw0oTGYACLVFcOE/srKS0VQQ=
 github.com/fluxcd/pkg/kustomize v1.16.0 h1:UBOeIvkrC6y4owYs7vZwG5PUVFeqnRoDFN9eaNhuNPI=
 github.com/fluxcd/pkg/kustomize v1.16.0/go.mod h1:6yQkAZaG+w3nXY30LbyWRYHimjRcLRwlYkrwG0ygMSI=
-github.com/fluxcd/pkg/runtime v0.56.0 h1:EJiF7gvUnU0Yycvt/iYPk8UGcVkEidDQwl57poRJ/8Q=
-github.com/fluxcd/pkg/runtime v0.56.0/go.mod h1:ZRlEHAHhlP3gPl7/+kZ8i8nimZ+/mSnpURlexBJULnI=
+github.com/fluxcd/pkg/runtime v0.57.1 h1:OvzGfW4AZNpyV2e/QAE5pvUXm8CcNCoOU1MtrMEYV2I=
+github.com/fluxcd/pkg/runtime v0.57.1/go.mod h1:ZRlEHAHhlP3gPl7/+kZ8i8nimZ+/mSnpURlexBJULnI=
 github.com/fluxcd/pkg/sourceignore v0.11.0 h1:xzpYmc5/t/Ck+/DkJSX3r+VbahDRIAn5kbv04fynWUo=
 github.com/fluxcd/pkg/sourceignore v0.11.0/go.mod h1:ri2FvlzX8ep2iszOK5gF/riYq2TNgpVvsfJ2QY0dLWI=
 github.com/fluxcd/pkg/ssa v0.45.1 h1:ISl84TJwRP/GuZXrKiR9Tf8JOnG5XFgtjcYoR4XQYf4=


### PR DESCRIPTION
Includes https://github.com/fluxcd/pkg/pull/875

This update makes the impersonator use the impersonated client for kstatus readers and refactors the impersonator constructor with a progressive style for optional arguments.