### PR TITLE
Add CLI commands for building and reconciling Flux Instances

### DIFF
--- a/cmd/cli/build_instance.go
+++ b/cmd/cli/build_instance.go
@@ -1,0 +1,298 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/builder"
+)
+
+var buildInstanceCmd = &cobra.Command{
+	Use:   "instance",
+	Short: "Build a FluxInstance definition to Kubernetes manifests",
+	Long: `The build instance command performs the following steps:
+1. Reads the FluxInstance YAML manifest from the specified file.
+2. Validates the instance definition and sets default values.
+3. Pulls the distribution OCI artifact from the registry using the Docker config file for authentication.
+   If not specified, the artifact is pulled from 'oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests'.
+4. Builds the Flux Kubernetes manifests according to the instance specifications and kustomize patches.
+5. Prints the multi-doc YAML containing the Flux Kubernetes manifests to stdout.
+`,
+	RunE: buildInstanceCmdRun,
+	Example: `  # Build the given FluxInstance and print the generated manifests
+  flux-operator build instance -f flux.yaml
+
+  # Pipe the FluxInstance definition to the build command
+  cat flux.yaml | flux-operator build instance -f -
+
+  # Build a FluxInstance and print a diff of the generated manifests
+  flux-operator build instance -f flux.yaml | \
+    kubectl diff --server-side --field-manager=flux-operator -f -
+`,
+}
+
+type buildInstanceFlags struct {
+	filename string
+}
+
+var buildInstanceArgs buildInstanceFlags
+
+func init() {
+	buildInstanceCmd.Flags().StringVarP(&buildInstanceArgs.filename, "filename", "f", "", "Path to the FluxInstance YAML manifest.")
+
+	buildCmd.AddCommand(buildInstanceCmd)
+}
+
+func buildInstanceCmdRun(cmd *cobra.Command, args []string) error {
+	if buildInstanceArgs.filename == "" {
+		return errors.New("--filename is required")
+	}
+
+	path := buildInstanceArgs.filename
+	var err error
+	if buildInstanceArgs.filename == "-" {
+		path, err = saveReaderToFile(os.Stdin)
+		if err != nil {
+			return err
+		}
+
+		defer os.Remove(path)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("invalid filename '%s', must point to an existing file", path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("error reading file: %w", err)
+	}
+
+	var instance fluxcdv1.FluxInstance
+	err = yaml.Unmarshal(data, &instance)
+	if err != nil {
+		return fmt.Errorf("error parsing FluxInstance: %w", err)
+	}
+
+	setInstanceDefaults(&instance)
+	if err := validateInstance(&instance); err != nil {
+		return err
+	}
+
+	tmpArtifactDir, err := builder.MkdirTempAbs("", "flux-artifact")
+	if err != nil {
+		return fmt.Errorf("failed to create tmp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpArtifactDir)
+
+	ctxPull, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, err := builder.PullArtifact(
+		ctxPull,
+		instance.Spec.Distribution.Artifact,
+		tmpArtifactDir,
+		authn.DefaultKeychain,
+	); err != nil {
+		return fmt.Errorf("failed to pull distribution artifact: %w", err)
+	}
+	fluxManifestsDir := filepath.Join(tmpArtifactDir, "flux")
+
+	ver, err := builder.MatchVersion(fluxManifestsDir, instance.Spec.Distribution.Version)
+	if err != nil {
+		return err
+	}
+
+	options := builder.MakeDefaultOptions()
+	options.Version = ver
+	options.Registry = instance.GetDistribution().Registry
+	options.ImagePullSecret = instance.GetDistribution().ImagePullSecret
+	options.Namespace = instance.GetNamespace()
+	options.Components = instance.GetComponents()
+	options.NetworkPolicy = instance.GetCluster().NetworkPolicy
+	options.ClusterDomain = instance.GetCluster().Domain
+
+	if instance.GetCluster().Type == "openshift" {
+		options.Patches += builder.ProfileOpenShift
+	}
+	if instance.GetCluster().Multitenant {
+		options.Patches += builder.GetMultitenantProfile(instance.GetCluster().TenantDefaultServiceAccount)
+	}
+
+	if options.HasNotificationController() {
+		options.Patches += builder.GetNotificationPatch(options.Namespace)
+	}
+
+	if instance.Spec.Sharding != nil {
+		options.ShardingKey = instance.Spec.Sharding.Key
+		options.Shards = instance.Spec.Sharding.Shards
+	}
+
+	if instance.Spec.Storage != nil {
+		options.ArtifactStorage = &builder.ArtifactStorage{
+			Class: instance.Spec.Storage.Class,
+			Size:  instance.Spec.Storage.Size,
+		}
+	}
+
+	if instance.Spec.Sync != nil {
+		syncName := instance.GetNamespace()
+		if instance.Spec.Sync.Name != "" {
+			syncName = instance.Spec.Sync.Name
+		}
+		options.Sync = &builder.Sync{
+			Name:       syncName,
+			Kind:       instance.Spec.Sync.Kind,
+			Interval:   instance.Spec.Sync.Interval.Duration.String(),
+			Ref:        instance.Spec.Sync.Ref,
+			PullSecret: instance.Spec.Sync.PullSecret,
+			URL:        instance.Spec.Sync.URL,
+			Path:       instance.Spec.Sync.Path,
+			Provider:   instance.Spec.Sync.Provider,
+		}
+	}
+
+	if instance.Spec.Kustomize != nil && len(instance.Spec.Kustomize.Patches) > 0 {
+		patchesData, err := yaml.Marshal(instance.Spec.Kustomize.Patches)
+		if err != nil {
+			return fmt.Errorf("failed to parse kustomize patches: %w", err)
+		}
+		options.Patches += string(patchesData)
+	}
+
+	srcDir := filepath.Join(fluxManifestsDir, ver)
+	images, err := builder.ExtractComponentImages(srcDir, options)
+	if err != nil {
+		return fmt.Errorf("failed to extract container images from manifests: %w", err)
+	}
+	options.ComponentImages = images
+
+	tmpWorkDir, err := builder.MkdirTempAbs("", "flux-instance")
+	if err != nil {
+		return fmt.Errorf("failed to create tmp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpWorkDir)
+
+	res, err := builder.Build(srcDir, tmpWorkDir, options)
+	if err != nil {
+		return err
+	}
+	objects := res.Objects
+
+	if len(objects) == 0 {
+		return fmt.Errorf("no objects were generated")
+	}
+
+	if instance.Spec.CommonMetadata != nil {
+		ssautil.SetCommonMetadata(objects, instance.Spec.CommonMetadata.Labels, instance.Spec.CommonMetadata.Annotations)
+	}
+
+	ownerGroup := fmt.Sprintf("%s", fluxcdv1.GroupVersion.Group)
+	ssautil.SetCommonMetadata(objects, map[string]string{
+		fmt.Sprintf("%s/name", ownerGroup):      instance.GetName(),
+		fmt.Sprintf("%s/namespace", ownerGroup): instance.GetNamespace(),
+	}, nil)
+
+	for _, obj := range objects {
+		var strBuilder strings.Builder
+		strBuilder.WriteString("---\n")
+		yml, ymlErr := yaml.Marshal(obj)
+		if ymlErr != nil {
+			return fmt.Errorf("error marshalling object: %w", ymlErr)
+		}
+		strBuilder.Write(yml)
+		rootCmd.Print(strBuilder.String())
+	}
+
+	return nil
+}
+
+// setInstanceDefaults emulates the Kubernetes admission by setting default values.
+func setInstanceDefaults(instance *fluxcdv1.FluxInstance) {
+	if instance.Namespace == "" {
+		instance.Namespace = "flux-system"
+	}
+
+	if instance.Spec.Distribution.Artifact == "" {
+		instance.Spec.Distribution.Artifact = "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
+	}
+
+	if instance.Spec.Cluster != nil {
+		if instance.Spec.Cluster.Type == "" {
+			instance.Spec.Cluster.Type = "kubernetes"
+		}
+		if instance.Spec.Cluster.Domain == "" {
+			instance.Spec.Cluster.Domain = "cluster.local"
+		}
+	}
+
+	if instance.Spec.Sharding != nil {
+		if instance.Spec.Sharding.Key == "" {
+			instance.Spec.Sharding.Key = "sharding.fluxcd.io/key"
+		}
+	}
+
+	if instance.Spec.Sync != nil {
+		if instance.Spec.Sync.Interval == nil {
+			instance.Spec.Sync.Interval = &metav1.Duration{Duration: time.Minute}
+		}
+	}
+}
+
+// validateInstance emulates the Kubernetes admission by verifying required fields.
+func validateInstance(instance *fluxcdv1.FluxInstance) error {
+	if instance.Spec.Distribution.Version == "" {
+		return fmt.Errorf(".spec.distribution.version is required")
+	}
+
+	if instance.Spec.Distribution.Registry == "" {
+		return fmt.Errorf(".spec.distribution.registry is required")
+	}
+
+	if instance.Spec.Sharding != nil {
+		if len(instance.Spec.Sharding.Shards) == 0 {
+			return fmt.Errorf(".spec.sharding.shards is required")
+		}
+	}
+
+	if instance.Spec.Storage != nil {
+		if instance.Spec.Storage.Class == "" {
+			return fmt.Errorf(".spec.storage.class is required")
+		}
+		if instance.Spec.Storage.Size == "" {
+			return fmt.Errorf(".spec.storage.size is required")
+		}
+	}
+
+	if instance.Spec.Sync != nil {
+		if instance.Spec.Sync.Kind == "" {
+			return fmt.Errorf(".spec.sync.kind is required")
+		}
+		if instance.Spec.Sync.URL == "" {
+			return fmt.Errorf(".spec.sync.url is required")
+		}
+		if instance.Spec.Sync.Ref == "" {
+			return fmt.Errorf(".spec.sync.ref is required")
+		}
+		if instance.Spec.Sync.Path == "" {
+			return fmt.Errorf(".spec.sync.path is required")
+		}
+	}
+
+	return nil
+}

--- a/cmd/cli/get_instance.go
+++ b/cmd/cli/get_instance.go
@@ -82,14 +82,14 @@ func geInstanceCmdRun(cmd *cobra.Command, args []string) error {
 			ready,
 			conditions.GetMessage(&instance, "Ready"),
 		}
-		if getResourceSetArgs.allNamespaces {
+		if getInstanceArgs.allNamespaces {
 			row = append([]string{instance.Namespace}, row...)
 		}
 		rows = append(rows, row)
 	}
 
 	header := []string{"Name", "Resources", "Ready", "Message"}
-	if getResourceSetArgs.allNamespaces {
+	if getInstanceArgs.allNamespaces {
 		header = append([]string{"Namespace"}, header...)
 	}
 

--- a/cmd/cli/get_instance.go
+++ b/cmd/cli/get_instance.go
@@ -1,0 +1,99 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/fluxcd/pkg/runtime/conditions"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+var getInstanceCmd = &cobra.Command{
+	Use:     "instance",
+	Aliases: []string{"instances"},
+	Short:   "List Flux instances",
+	RunE:    geInstanceCmdRun,
+}
+
+type getInstanceFlags struct {
+	allNamespaces bool
+}
+
+var getInstanceArgs getInstanceFlags
+
+func init() {
+	getInstanceCmd.Flags().BoolVarP(&getInstanceArgs.allNamespaces, "all-namespaces", "A", true,
+		"List instances in all namespaces.")
+	getCmd.AddCommand(getInstanceCmd)
+}
+
+func geInstanceCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) > 1 {
+		return fmt.Errorf("a single FluxInstance name can be specified")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	lsOpts := &client.ListOptions{}
+	if !getInstanceArgs.allNamespaces {
+		lsOpts.Namespace = *kubeconfigArgs.Namespace
+	}
+	if len(args) == 1 {
+		sel, err := fields.ParseSelector(fmt.Sprintf("metadata.name=%s", args[0]))
+		if err != nil {
+			return fmt.Errorf("unable to parse field selector: %w", err)
+		}
+		lsOpts.FieldSelector = sel
+	}
+
+	var list fluxcdv1.FluxInstanceList
+	err = kubeClient.List(ctx, &list, lsOpts)
+	if err != nil {
+		return err
+	}
+
+	var rows [][]string
+	for _, instance := range list.Items {
+		objCount := 0
+		if instance.Status.Inventory != nil {
+			objCount = len(instance.Status.Inventory.Entries)
+		}
+		ready := "Unknown"
+		if conditions.Has(&instance, "Ready") {
+			ready = string(conditions.Get(&instance, "Ready").Status)
+		}
+		row := []string{
+			instance.Name,
+			strconv.Itoa(objCount),
+			ready,
+			conditions.GetMessage(&instance, "Ready"),
+		}
+		if getResourceSetArgs.allNamespaces {
+			row = append([]string{instance.Namespace}, row...)
+		}
+		rows = append(rows, row)
+	}
+
+	header := []string{"Name", "Resources", "Ready", "Message"}
+	if getResourceSetArgs.allNamespaces {
+		header = append([]string{"Namespace"}, header...)
+	}
+
+	printTable(rootCmd.OutOrStdout(), header, rows)
+
+	return nil
+}

--- a/cmd/cli/reconcile_instance.go
+++ b/cmd/cli/reconcile_instance.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+var reconcileInstanceCmd = &cobra.Command{
+	Use:   "instance",
+	Short: "Trigger FluxInstance reconciliation",
+	Example: `  # Trigger the reconciliation of an instance
+  flux-operator -n flux-system reconcile instance flux
+`,
+	RunE: reconcileInstanceCmdRun,
+}
+
+func init() {
+	reconcileCmd.AddCommand(reconcileInstanceCmd)
+}
+
+func reconcileInstanceCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("name is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	return annotateResource(ctx,
+		fluxcdv1.FluxInstanceKind, args[0],
+		*kubeconfigArgs.Namespace,
+		meta.ReconcileRequestAnnotation,
+		metav1.Now().String())
+}

--- a/cmd/cli/resume_instance.go
+++ b/cmd/cli/resume_instance.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+var resumeInstanceCmd = &cobra.Command{
+	Use:   "instance",
+	Short: "Resume FluxInstance reconciliation",
+	RunE:  resumeInstanceCmdRun,
+}
+
+func init() {
+	resumeCmd.AddCommand(resumeInstanceCmd)
+}
+
+func resumeInstanceCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("name is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	return annotateResource(ctx,
+		fluxcdv1.FluxInstanceKind, args[0],
+		*kubeconfigArgs.Namespace,
+		fluxcdv1.ReconcileAnnotation,
+		fluxcdv1.EnabledValue)
+}

--- a/cmd/cli/suspend_instance.go
+++ b/cmd/cli/suspend_instance.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+var suspendInstanceCmd = &cobra.Command{
+	Use:   "instance",
+	Short: "Suspend FluxInstance reconciliation",
+	RunE:  suspendInstanceCmdRun,
+}
+
+func init() {
+	suspendCmd.AddCommand(suspendInstanceCmd)
+}
+
+func suspendInstanceCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("name is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	return annotateResource(ctx,
+		fluxcdv1.FluxInstanceKind, args[0],
+		*kubeconfigArgs.Namespace,
+		fluxcdv1.ReconcileAnnotation,
+		fluxcdv1.DisabledValue)
+}


### PR DESCRIPTION
Implement CLI commands for building a `FluxInstance` locally and for listing, reconciling, suspending and resuming FluxInstances in cluster.

The `flux-operator build instance` command performs the following steps:
1. Reads the FluxInstance YAML manifest from the specified file.
2. Validates the instance definition and sets default values.
3. Pulls the distribution OCI artifact from the registry using the Docker config file for authentication.
   If not specified, the artifact is pulled from `oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests`.
4. Builds the Flux Kubernetes manifests according to the instance specifications and kustomize patches.
5. Prints the multi-doc YAML containing the Flux Kubernetes manifests to stdout.

Examples:

```sh
  # Build the given FluxInstance and print the generated manifests
  flux-operator build instance -f flux.yaml

  # Pipe the FluxInstance definition to the build command
  cat flux.yaml | flux-operator build instance -f -

  # Build a FluxInstance and print a diff of the generated manifests
  flux-operator build instance -f flux.yaml | \
    kubectl diff --server-side --field-manager=flux-operator -f -

  # Print the status of an instance
  flux-operator -n flux-system get instance flux

  # Reconcile an instance 
  flux-operator -n flux-system reconcile instance flux

  # Suspend an instance 
  flux-operator -n flux-system suspend instance flux

  # Resume an instance 
  flux-operator -n flux-system resume instance flux
```