### PR TITLE
Add force reconcile option to ResourceSet

### DIFF
--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -24,6 +24,7 @@ var (
 	ReconcileArtifactEveryAnnotation = fmt.Sprintf("%s/reconcileArtifactEvery", GroupVersion.Group)
 	ReconcileTimeoutAnnotation       = fmt.Sprintf("%s/reconcileTimeout", GroupVersion.Group)
 	PruneAnnotation                  = fmt.Sprintf("%s/prune", GroupVersion.Group)
+	ForceAnnotation                  = fmt.Sprintf("%s/force", GroupVersion.Group)
 	RevisionAnnotation               = fmt.Sprintf("%s/revision", GroupVersion.Group)
 	CopyFromAnnotation               = fmt.Sprintf("%s/copyFrom", GroupVersion.Group)
 )

--- a/api/v1/resourceset_types.go
+++ b/api/v1/resourceset_types.go
@@ -148,6 +148,12 @@ func (in *ResourceSet) IsDisabled() bool {
 	return ok && strings.ToLower(val) == DisabledValue
 }
 
+// IsForceEnabled returns true if the object has the force annotation set to 'enabled'.
+func (in *ResourceSet) IsForceEnabled() bool {
+	val, ok := in.GetAnnotations()[ForceAnnotation]
+	return ok && strings.ToLower(val) == EnabledValue
+}
+
 // GetInterval returns the interval at which the object should be reconciled.
 // If no interval is set, the default is 60 minutes.
 func (in *ResourceSet) GetInterval() time.Duration {

--- a/docs/api/v1/resourceset.md
+++ b/docs/api/v1/resourceset.md
@@ -542,11 +542,12 @@ For testing the CEL expressions, you can use the [CEL playground](https://playce
 
 ### Reconciliation configuration
 
-The reconciliation of behaviour of a ResourceSet can be configured using the following annotations:
+The reconciliation behavior of a ResourceSet can be configured using the following annotations:
 
 - `fluxcd.controlplane.io/reconcile`: Enable or disable the reconciliation loop. Default is `enabled`, set to `disabled` to pause the reconciliation.
 - `fluxcd.controlplane.io/reconcileEvery`: Set the reconciliation interval used for drift detection and correction. Default is `1h`.
 - `fluxcd.controlplane.io/reconcileTimeout`: Set the reconciliation timeout including health checks. Default is `5m`.
+- `fluxcd.controlplane.io/force`: When set to `enabled`, the controller will replace the generated resources that contain immutable field changes.
 
 ### Health check configuration
 

--- a/internal/controller/resourceset_controller.go
+++ b/internal/controller/resourceset_controller.go
@@ -393,6 +393,7 @@ func (r *ResourceSetReconciler) apply(ctx context.Context,
 	applySetDigest := digest.FromString(data).String()
 
 	applyOpts := ssa.DefaultApplyOptions()
+	applyOpts.Force = obj.IsForceEnabled()
 	applyOpts.Cleanup = ssa.ApplyCleanupOptions{
 		// Remove the kubectl and helm annotations.
 		Annotations: []string{


### PR DESCRIPTION
This PR introduces the `fluxcd.controlplane.io/force` annotation for ResourceSets.

When a ResourceSet is annotated with `fluxcd.controlplane.io/force: enabled`, the controller will replace the generated resources if the reconciliation fails due to immutable field changes.
