### PR TITLE
Implement `apply_kubernetes_manifest` MCP tool

### DIFF
--- a/cmd/mcp/k8s/actions.go
+++ b/cmd/mcp/k8s/actions.go
@@ -6,6 +6,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/fluxcd/pkg/ssa"
@@ -19,7 +20,9 @@ import (
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
 
-func (k *Client) Apply(ctx context.Context, manifest string) (string, error) {
+// Apply parses the YAML manifest and creates or updates the Kubernetes objects using server-side apply.
+// If any of the Kubernetes objects are managed by Flux, it will return an error unless overwrite is set to true.
+func (k *Client) Apply(ctx context.Context, manifest string, overwrite bool) (string, error) {
 	objects, err := ssautil.ReadObjects(strings.NewReader(manifest))
 	if err != nil {
 		return "", fmt.Errorf("unable to parse YAML manifest: %w", err)
@@ -27,6 +30,15 @@ func (k *Client) Apply(ctx context.Context, manifest string) (string, error) {
 
 	if len(objects) == 0 {
 		return "", fmt.Errorf("no Kubernetes objects found in manifest")
+	}
+
+	if !overwrite {
+		for _, object := range objects {
+			if k.IsManagedByFlux(ctx, object.GroupVersionKind(), object.GetName(), object.GetNamespace()) {
+				return "", fmt.Errorf("%s/%s is managed by Flux",
+					object.GetKind(), object.GetName())
+			}
+		}
 	}
 
 	err = normalize.UnstructuredList(objects)
@@ -40,6 +52,36 @@ func (k *Client) Apply(ctx context.Context, manifest string) (string, error) {
 	}
 
 	return changeSet.String(), nil
+}
+
+// IsManagedByFlux checks if a Kubernetes resource is managed by Flux by inspecting specific Flux-related labels.
+func (k *Client) IsManagedByFlux(ctx context.Context, gvk schema.GroupVersionKind, name, namespace string) bool {
+	resource := &metav1.PartialObjectMetadata{}
+	resource.SetGroupVersionKind(gvk)
+
+	objectKey := ctrlclient.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	if err := k.Client.Get(ctx, objectKey, resource); err != nil {
+		return false
+	}
+
+	fluxLabels := []string{
+		"fluxcd.controlplane.io/namespace",
+		"resourceset.fluxcd.controlplane.io/namespace",
+		"kustomize.toolkit.fluxcd.io/namespace",
+		"helm.toolkit.fluxcd.io/namespace",
+	}
+
+	for key := range resource.GetLabels() {
+		if slices.Contains(fluxLabels, key) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Annotate sets annotations on a Kubernetes resource identified by GroupVersionKind, name, and namespace.

--- a/cmd/mcp/toolbox/apply_manifest.go
+++ b/cmd/mcp/toolbox/apply_manifest.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
+)
+
+// NewApplyKubernetesManifestTool creates a new tool for applying Kubernetes manifests.
+func (m *Manager) NewApplyKubernetesManifestTool() SystemTool {
+	return SystemTool{
+		mcp.NewTool("apply_kubernetes_manifest",
+			mcp.WithDescription("This tool applies a Kubernetes YAML manifest on the cluster."),
+			mcp.WithString("yaml",
+				mcp.Description("The multi-doc YAML content."),
+				mcp.Required(),
+			),
+		),
+		m.HandleApplyKubernetesManifest,
+		false,
+	}
+}
+
+// HandleApplyKubernetesManifest is the handler function for the apply_kubernetes_manifest tool.
+func (m *Manager) HandleApplyKubernetesManifest(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	manifest := mcp.ParseString(request, "yaml", "")
+	if manifest == "" {
+		return mcp.NewToolResultError("YAML manifest cannot be empty"), nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
+	kubeClient, err := k8s.NewClient(m.flags)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("Failed to create Kubernetes client", err), nil
+	}
+
+	changeSet, err := kubeClient.Apply(ctx, manifest)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("Failed to apply manifest", err), nil
+	}
+
+	return mcp.NewToolResultText(changeSet), nil
+}

--- a/cmd/mcp/toolbox/apply_manifest_test.go
+++ b/cmd/mcp/toolbox/apply_manifest_test.go
@@ -1,0 +1,67 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	. "github.com/onsi/gomega"
+	cli "k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
+)
+
+func TestManager_HandleApplyKubernetesManifest(t *testing.T) {
+	configFile := "testdata/kubeconfig.yaml"
+	t.Setenv("KUBECONFIG", configFile)
+
+	m := &Manager{
+		kubeconfig: k8s.NewKubeConfig(),
+		flags:      cli.NewConfigFlags(false),
+		timeout:    time.Second,
+	}
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "apply_kubernetes_manifest"
+
+	tests := []struct {
+		testName  string
+		arguments map[string]interface{}
+		matchErr  string
+	}{
+		{
+			testName: "fails without empty yaml",
+			arguments: map[string]interface{}{
+				"yaml": "",
+			},
+			matchErr: "YAML manifest cannot be empty",
+		},
+		{
+			testName: "fails with invalid kubeconfig",
+			arguments: map[string]interface{}{
+				"yaml": "test: test",
+			},
+			matchErr: "Failed to create Kubernetes client",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			request.Params.Arguments = test.arguments
+
+			result, err := m.HandleApplyKubernetesManifest(context.Background(), request)
+			g.Expect(err).ToNot(HaveOccurred())
+			textContent, ok := mcp.AsTextContent(result.Content[0])
+			g.Expect(ok).To(BeTrue())
+
+			g.Expect(result.IsError).To(BeTrue())
+			g.Expect(textContent.Text).To(ContainSubstring(test.matchErr))
+
+		})
+	}
+}

--- a/cmd/mcp/toolbox/apply_manifest_test.go
+++ b/cmd/mcp/toolbox/apply_manifest_test.go
@@ -36,14 +36,14 @@ func TestManager_HandleApplyKubernetesManifest(t *testing.T) {
 		{
 			testName: "fails without empty yaml",
 			arguments: map[string]interface{}{
-				"yaml": "",
+				"yaml_content": "",
 			},
 			matchErr: "YAML manifest cannot be empty",
 		},
 		{
 			testName: "fails with invalid kubeconfig",
 			arguments: map[string]interface{}{
-				"yaml": "test: test",
+				"yaml_content": "test: test",
 			},
 			matchErr: "Failed to create Kubernetes client",
 		},

--- a/cmd/mcp/toolbox/index.go
+++ b/cmd/mcp/toolbox/index.go
@@ -11,6 +11,7 @@ func (m *Manager) ToolSet() []SystemTool {
 		m.NewGetAPIVersionsTool(),
 		m.NewGetKubernetesLogsTool(),
 		m.NewGetKubernetesResourcesTool(),
+		m.NewApplyKubernetesManifestTool(),
 		m.NewDeleteKubernetesResourceTool(),
 		m.NewReconcileSourceTool(),
 		m.NewReconcileKustomizationTool(),

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -188,7 +188,8 @@ Confirmation message indicating the resource has been resumed.
 ## Apply Tool
 
 This tool allows creating or updating Kubernetes resources in the cluster.
-Note that if the resources are managed by Flux, the changes will be undone on the next reconciliation.
+If the resources already exist and are managed by Flux, the tool will error out unless
+explicitly told to overwrite them.
 
 ### apply_kubernetes_manifest
 
@@ -196,7 +197,8 @@ Applies a YAML manifest on the cluster using Kubernetes server-side apply.
 
 **Parameters:**
 
-- `yaml` (required): The multi-doc YAML content
+- `yaml_content` (required): The multi-doc YAML content
+- `overwrite` (optional): Whether to overwrite resources managed by Flux (default: false)
 
 **Output:**
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -185,6 +185,23 @@ Resumes the reconciliation of a previously suspended Flux resource.
 
 Confirmation message indicating the resource has been resumed.
 
+## Apply Tool
+
+This tool allows creating or updating Kubernetes resources in the cluster.
+Note that if the resources are managed by Flux, the changes will be undone on the next reconciliation.
+
+### apply_kubernetes_manifest
+
+Applies a YAML manifest on the cluster using Kubernetes server-side apply.
+
+**Parameters:**
+
+- `yaml` (required): The multi-doc YAML content
+
+**Output:**
+
+The list of applied resources in the format `kind/namespace/name [created|updated|unchanged]`.
+
 ## Deletion Tool
 
 This tool enables the removal of resources from your cluster.


### PR DESCRIPTION
This tool allows creating or updating Kubernetes resources in the cluster.
If the resources already exist and are managed by Flux, the tool will error out unless explicitly told to overwrite them.

### apply_kubernetes_manifest

Applies a YAML manifest on the cluster using Kubernetes server-side apply.

**Parameters:**

- `yaml_content` (required): The multi-doc YAML content
- `overwrite` (optional): Whether to overwrite resources managed by Flux (default: false)

**Output:**

The list of applied resources in the format `kind/namespace/name [created|updated|unchanged]`.