### PR TITLE
Add the MCP Server to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ that can be templated, parameterized and deployed as a single unit on self-servi
 The ResourceSet API integrates with GitLab and GitHub pull requests to create ephemeral environments
 for testing and validation.
 
+**AI-Assisted GitOps** - The [Flux MCP Server](https://fluxcd.control-plane.io/mcp/) connects
+AI assistants to Kubernetes clusters running the operator, enabling seamless interaction
+through natural language. It serves as a bridge between AI tools and GitOps pipelines,
+allowing you to analyze deployment across environments, troubleshoot issues,
+and perform operations using conversational prompts.
+
 **Enterprise Support** - The operator is a key component of the ControlPlane
 [Enterprise offering](https://fluxcd.control-plane.io/pricing/), and is designed to automate the
 rollout of new Flux versions, CVE patches and hotfixes to production environments in a secure and reliable way.

--- a/cmd/mcp/README.md
+++ b/cmd/mcp/README.md
@@ -1,0 +1,64 @@
+# Flux MCP Server
+
+The Flux MCP Server connects AI assistants directly to your Kubernetes clusters running Flux Operator,
+enabling GitOps analysis and troubleshooting through natural language.
+
+Using AI assistants with the Flux MCP Server, you can:
+
+- Debug GitOps pipelines end-to-end from Flux resources to application logs
+- Get intelligent root cause analysis for failed deployments
+- Compare Flux configurations and Kubernetes resources between clusters
+- Visualize Flux dependencies with diagrams generated from the cluster state
+- Instruct Flux to perform operations using conversational prompts
+
+## Quickstart
+
+Download the `flux-operator-mcp` archive from GitHub
+[releases page](https://github.com/controlplaneio-fluxcd/flux-operator/releases),
+unpacking it, and place the binary in a directory included in your system's `PATH`.
+
+Add the following configuration to your AI assistant's MCP settings:
+
+```json
+{
+  "flux-operator-mcp":{
+    "command":"/path/to/flux-operator-mcp",
+    "args":[
+      "serve",
+      "--read-only=false"
+    ],
+    "env":{
+      "KUBECONFIG":"/path/to/.kube/config"
+    }
+  }
+}
+```
+
+Replace `/path/to/flux-operator-mcp` with the actual path to the binary
+and `/path/to/.kube/config` with the path to your kubeconfig file.
+
+Copy the AI rules from
+[instructions.md](https://raw.githubusercontent.com/controlplaneio-fluxcd/distribution/refs/heads/main/docs/mcp/instructions.md)
+and place them into the appropriate file for your assistant.
+
+Restart the AI assistant app and test the MCP Server with the following prompts:
+
+- "Which cluster contexts are available in my kubeconfig?"
+- "What version of Flux is running in my current cluster?"
+
+For more information on how to use the MCP Server with Claude, Cursor, GitHub Copilot,
+and other assistants, please refer to the [documentation website](https://fluxcd.control-plane.io/mcp/).
+
+## Documentation
+
+- [Flux MCP Server Overview](https://fluxcd.control-plane.io/mcp/)
+- [Installation Guide](https://fluxcd.control-plane.io/mcp/install/)
+- [Transport Modes and Security Configurations](https://fluxcd.control-plane.io/mcp/config/)
+- [Effective Prompting Guide](https://fluxcd.control-plane.io/mcp/prompt-engineering/)
+- [MCP Tools Reference](https://fluxcd.control-plane.io/mcp/tools/)
+- [MCP Prompts Reference](https://fluxcd.control-plane.io/mcp/prompts/)
+
+## License
+
+The MCP Server is open-source and part of the [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator)
+project licensed under the [AGPL-3.0 license](https://github.com/controlplaneio-fluxcd/flux-operator/blob/main/LICENSE).

--- a/docs/mcp/prompts.md
+++ b/docs/mcp/prompts.md
@@ -1,0 +1,28 @@
+# Flux MCP Server Prompts
+
+The Flux MCP Server comes with a set of predefined prompts that instruct the AI assistant
+to perform complex tasks by chaining together multiple MCP [tools](tools.md).
+
+## Debugging Prompts
+
+These prompts are designed to help you quickly identify and resolve issues with your GitOps pipeline.
+
+### debug_flux_kustomization
+
+Troubleshoot a Flux Kustomization and provide root cause analysis for any issues.
+
+**Parameters:**
+
+- `name` (required): The name of the Kustomization
+- `namespace` (required): The namespace of the Kustomization
+- `cluster` (optional): The cluster context to use
+
+### debug_flux_helmrelease
+
+Troubleshoot a Flux HelmRelease and provide root cause analysis for any issues.
+
+**Parameters:**
+
+- `name` (required): The name of the HelmRelease
+- `namespace` (required): The namespace of the HelmRelease
+- `cluster` (optional): The cluster context to use

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-github/v69 v69.2.0
 	github.com/gosimple/slug v1.15.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
-	github.com/mark3labs/mcp-go v0.26.0
+	github.com/mark3labs/mcp-go v0.27.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
-github.com/mark3labs/mcp-go v0.26.0 h1:xz/Kv1cHLYovF8txv6btBM39/88q3YOjnxqhi51jB0w=
-github.com/mark3labs/mcp-go v0.26.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
+github.com/mark3labs/mcp-go v0.27.0 h1:iok9kU4DUIU2/XVLgFS2Q9biIDqstC0jY4EQTK2Erzc=
+github.com/mark3labs/mcp-go v0.27.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
This PR links to the MCP Server docs from the main readme and adds a quickstart guide to the mcp dir readme.