### PR TITLE
Add support for in-cluster deployment of Flux MCP Server

### DIFF
--- a/.github/workflows/push-mcp.yml
+++ b/.github/workflows/push-mcp.yml
@@ -1,6 +1,9 @@
 name: push-mcp
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: [release]
+    types: [completed]
 
 permissions:
   contents: read

--- a/.github/workflows/push-mcp.yml
+++ b/.github/workflows/push-mcp.yml
@@ -1,0 +1,65 @@
+name: push-mcp
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  IMAGE: ${{ github.event.repository.name }}-mcp
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for pushing and signing container images.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Prepare
+        id: prep
+        run: |
+          RELEASE=$(gh release view --json tagName -q '.tagName')
+          echo "VERSION=${RELEASE}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate images meta
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: |
+            ghcr.io/controlplaneio-fluxcd/${{ env.IMAGE }}
+          tags: |
+            type=raw,value=${{ steps.prep.outputs.VERSION }}
+      - name: Publish images
+        id: build-push
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          sbom: true
+          provenance: true
+          push: true
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./cmd/mcp/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: "VERSION=${{ steps.prep.outputs.VERSION }}"
+      - uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+      - name: Sign images
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign sign --yes ghcr.io/controlplaneio-fluxcd/${{ env.IMAGE }}@${{ steps.build-push.outputs.digest }}

--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,16 @@ build-manifests: ## Generate release manifests.
 cli-build: tidy fmt vet ## Build CLI binary.
 	CGO_ENABLED=0 go build -ldflags="-s -w -X main.VERSION=$(FLUX_OPERATOR_DEV_VERSION)" -o ./bin/flux-operator-cli ./cmd/cli/
 
+##@ MCP
+
 .PHONY: mcp-build
 mcp-build: tidy fmt vet ## Build MCP server binary.
 	CGO_ENABLED=0 go build -ldflags="-s -w -X main.VERSION=$(FLUX_OPERATOR_DEV_VERSION)" -o ./bin/flux-operator-mcp ./cmd/mcp/
+
+MCP_IMG ?= ghcr.io/controlplaneio-fluxcd/flux-operator-mcp:latest
+
+mcp-docker-build: ## Build docker image with the MCP server.
+	$(CONTAINER_TOOL) build -t ${MCP_IMG} --build-arg VERSION=$(FLUX_OPERATOR_VERSION) -f cmd/mcp/Dockerfile .
 
 ##@ Deployment
 

--- a/cmd/mcp/Dockerfile
+++ b/cmd/mcp/Dockerfile
@@ -1,0 +1,36 @@
+# Build the Flux MCP server binary using Docker's Debian image.
+FROM --platform=${BUILDPLATFORM} golang:1.24 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION
+WORKDIR /workspace
+
+# Copy the Go Modules manifests.
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Cache the Go Modules
+RUN go mod download
+
+# Copy the Go sources.
+COPY cmd/mcp/ cmd/mcp/
+COPY api/ api/
+COPY internal/ internal/
+
+# Build the server binary.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -ldflags="-s -w -X main.VERSION=${VERSION}" -a -o flux-operator-mcp ./cmd/mcp/
+
+# Run the server binary using Google's Distroless image.
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+
+# Copy the license.
+COPY LICENSE /licenses/LICENSE
+
+# Copy the server binary.
+COPY --from=builder /workspace/flux-operator-mcp .
+
+# Run the server under a non-root user.
+USER 65532:65532
+ENTRYPOINT ["/flux-operator-mcp"]

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -71,7 +71,6 @@ func init() {
 }
 
 func main() {
-	log.SetFlags(0)
 	ctrllog.SetLogger(logr.New(ctrllog.NullLogSink{}))
 
 	if err := rootCmd.Execute(); err != nil {
@@ -157,7 +156,7 @@ var serveCmd = &cobra.Command{
 func serveCmdRun(cmd *cobra.Command, args []string) error {
 	inCluster := os.Getenv("KUBERNETES_SERVICE_HOST") != ""
 	if inCluster {
-		log.Printf("Starting in-cluster MCP server with read-only mode: %t", rootArgs.readOnly)
+		log.Printf("Starting the MCP server in-cluster with read-only mode set to %t", rootArgs.readOnly)
 	}
 
 	if os.Getenv("KUBECONFIG") == "" && !inCluster {

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -155,7 +155,12 @@ var serveCmd = &cobra.Command{
 }
 
 func serveCmdRun(cmd *cobra.Command, args []string) error {
-	if os.Getenv("KUBECONFIG") == "" {
+	inCluster := os.Getenv("KUBERNETES_SERVICE_HOST") != ""
+	if inCluster {
+		log.Printf("Starting in-cluster MCP server with read-only mode: %t", rootArgs.readOnly)
+	}
+
+	if os.Getenv("KUBECONFIG") == "" && !inCluster {
 		return errors.New("KUBECONFIG environment variable is not set")
 	}
 
@@ -168,7 +173,7 @@ func serveCmdRun(cmd *cobra.Command, args []string) error {
 	)
 
 	tm := toolbox.NewManager(kubeconfigArgs, rootArgs.timeout, rootArgs.maskSecrets)
-	tm.RegisterTools(mcpServer, rootArgs.readOnly)
+	tm.RegisterTools(mcpServer, rootArgs.readOnly, inCluster)
 
 	pm := prompter.NewManager()
 	pm.RegisterPrompts(mcpServer)

--- a/cmd/mcp/toolbox/apply_manifest.go
+++ b/cmd/mcp/toolbox/apply_manifest.go
@@ -26,6 +26,7 @@ func (m *Manager) NewApplyKubernetesManifestTool() SystemTool {
 		),
 		m.HandleApplyKubernetesManifest,
 		false,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/apply_manifest.go
+++ b/cmd/mcp/toolbox/apply_manifest.go
@@ -14,7 +14,7 @@ import (
 // NewApplyKubernetesManifestTool creates a new tool for applying Kubernetes manifests.
 func (m *Manager) NewApplyKubernetesManifestTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("apply_kubernetes_manifest",
+		Tool: mcp.NewTool("apply_kubernetes_manifest",
 			mcp.WithDescription("This tool applies a Kubernetes YAML manifest on the cluster."),
 			mcp.WithString("yaml_content",
 				mcp.Description("The multi-doc YAML content."),
@@ -24,9 +24,9 @@ func (m *Manager) NewApplyKubernetesManifestTool() SystemTool {
 				mcp.Description("Overwrite resources managed by Flux."),
 			),
 		),
-		m.HandleApplyKubernetesManifest,
-		false,
-		true,
+		Handler:   m.HandleApplyKubernetesManifest,
+		ReadOnly:  false,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/delete_resource.go
+++ b/cmd/mcp/toolbox/delete_resource.go
@@ -34,6 +34,7 @@ func (m *Manager) NewDeleteKubernetesResourceTool() SystemTool {
 		),
 		m.HandleDeleteKubernetesResource,
 		false,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/delete_resource.go
+++ b/cmd/mcp/toolbox/delete_resource.go
@@ -14,7 +14,7 @@ import (
 // NewDeleteKubernetesResourceTool creates a new tool for deleting Kubernetes resources.
 func (m *Manager) NewDeleteKubernetesResourceTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("delete_kubernetes_resource",
+		Tool: mcp.NewTool("delete_kubernetes_resource",
 			mcp.WithDescription("This tool deletes a Kubernetes resource based on its API version, kind, name, and namespace."),
 			mcp.WithString("apiVersion",
 				mcp.Description("The apiVersion of the resource to delete."),
@@ -32,9 +32,9 @@ func (m *Manager) NewDeleteKubernetesResourceTool() SystemTool {
 				mcp.Description("The namespace of the resource to delete."),
 			),
 		),
-		m.HandleDeleteKubernetesResource,
-		false,
-		true,
+		Handler:   m.HandleDeleteKubernetesResource,
+		ReadOnly:  false,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/get_apis.go
+++ b/cmd/mcp/toolbox/get_apis.go
@@ -19,6 +19,7 @@ func (m *Manager) NewGetAPIVersionsTool() SystemTool {
 		),
 		m.HandleGetAPIVersions,
 		true,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/get_apis.go
+++ b/cmd/mcp/toolbox/get_apis.go
@@ -14,12 +14,12 @@ import (
 // NewGetAPIVersionsTool creates a new tool for retrieving Kubernetes API versions.
 func (m *Manager) NewGetAPIVersionsTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("get_kubernetes_api_versions",
+		Tool: mcp.NewTool("get_kubernetes_api_versions",
 			mcp.WithDescription("This tool retrieves the Kubernetes CRDs registered on the cluster and returns the preferred apiVersion for each kind."),
 		),
-		m.HandleGetAPIVersions,
-		true,
-		true,
+		Handler:   m.HandleGetAPIVersions,
+		ReadOnly:  true,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/get_contexts.go
+++ b/cmd/mcp/toolbox/get_contexts.go
@@ -18,6 +18,7 @@ func (m *Manager) NewGetKubeconfigContextsTool() SystemTool {
 		),
 		m.HandleGetKubeconfigContexts,
 		true,
+		false,
 	}
 }
 

--- a/cmd/mcp/toolbox/get_contexts.go
+++ b/cmd/mcp/toolbox/get_contexts.go
@@ -13,12 +13,12 @@ import (
 // NewGetKubeconfigContextsTool creates a new tool for retrieving Kubernetes contexts from the kubeconfig.
 func (m *Manager) NewGetKubeconfigContextsTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("get_kubeconfig_contexts",
+		Tool: mcp.NewTool("get_kubeconfig_contexts",
 			mcp.WithDescription("This tool retrieves the Kubernetes clusters name and context found in the kubeconfig."),
 		),
-		m.HandleGetKubeconfigContexts,
-		true,
-		false,
+		Handler:   m.HandleGetKubeconfigContexts,
+		ReadOnly:  true,
+		InCluster: false,
 	}
 }
 

--- a/cmd/mcp/toolbox/get_instance.go
+++ b/cmd/mcp/toolbox/get_instance.go
@@ -16,12 +16,12 @@ import (
 // NewGetFluxInstanceTool creates a new tool for retrieving the Flux instance report.
 func (m *Manager) NewGetFluxInstanceTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("get_flux_instance",
+		Tool: mcp.NewTool("get_flux_instance",
 			mcp.WithDescription("This tool retrieves the Flux instance installation and a detailed report about Flux controllers, CRDs and their status."),
 		),
-		m.HandleGetFluxInstance,
-		true,
-		true, // InCluster is true because it operates on the cluster's Flux instance.
+		Handler:   m.HandleGetFluxInstance,
+		ReadOnly:  true,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/get_instance.go
+++ b/cmd/mcp/toolbox/get_instance.go
@@ -21,6 +21,7 @@ func (m *Manager) NewGetFluxInstanceTool() SystemTool {
 		),
 		m.HandleGetFluxInstance,
 		true,
+		true, // InCluster is true because it operates on the cluster's Flux instance.
 	}
 }
 

--- a/cmd/mcp/toolbox/get_logs.go
+++ b/cmd/mcp/toolbox/get_logs.go
@@ -15,7 +15,7 @@ import (
 // NewGetKubernetesLogsTool creates a new tool for retrieving the pod logs.
 func (m *Manager) NewGetKubernetesLogsTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("get_kubernetes_logs",
+		Tool: mcp.NewTool("get_kubernetes_logs",
 			mcp.WithDescription("This tool retrieves the the most recent logs of a Kubernetes pod."),
 			mcp.WithString("pod_name",
 				mcp.Description("The name of the pod."),
@@ -33,9 +33,9 @@ func (m *Manager) NewGetKubernetesLogsTool() SystemTool {
 				mcp.Description("The maximum number of log lines to return. Defaults to 100."),
 			),
 		),
-		m.HandleGetKubernetesLogs,
-		true,
-		true,
+		Handler:   m.HandleGetKubernetesLogs,
+		ReadOnly:  true,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/get_logs.go
+++ b/cmd/mcp/toolbox/get_logs.go
@@ -35,6 +35,7 @@ func (m *Manager) NewGetKubernetesLogsTool() SystemTool {
 		),
 		m.HandleGetKubernetesLogs,
 		true,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/get_resource.go
+++ b/cmd/mcp/toolbox/get_resource.go
@@ -40,6 +40,7 @@ func (m *Manager) NewGetKubernetesResourcesTool() SystemTool {
 		),
 		m.HandleGetKubernetesResources,
 		true,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/get_resource.go
+++ b/cmd/mcp/toolbox/get_resource.go
@@ -15,7 +15,7 @@ import (
 // NewGetKubernetesResourcesTool creates a new tool for retrieving Kubernetes resources.
 func (m *Manager) NewGetKubernetesResourcesTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("get_kubernetes_resources",
+		Tool: mcp.NewTool("get_kubernetes_resources",
 			mcp.WithDescription("This tool retrieves Kubernetes resources including Flux own resources, their status, and events"),
 			mcp.WithString("apiVersion",
 				mcp.Description("The apiVersion of the Kubernetes resource. Use the get_kubernetes_api_versions tool to get the available apiVersions."),
@@ -38,9 +38,9 @@ func (m *Manager) NewGetKubernetesResourcesTool() SystemTool {
 				mcp.Description("The maximum number of resources to return."),
 			),
 		),
-		m.HandleGetKubernetesResources,
-		true,
-		true,
+		Handler:   m.HandleGetKubernetesResources,
+		ReadOnly:  true,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/reconcile_helmrelease.go
+++ b/cmd/mcp/toolbox/reconcile_helmrelease.go
@@ -35,6 +35,7 @@ func (m *Manager) NewReconcileHelmReleaseTool() SystemTool {
 		),
 		m.HandleReconcileHelmRelease,
 		false,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/reconcile_helmrelease.go
+++ b/cmd/mcp/toolbox/reconcile_helmrelease.go
@@ -19,7 +19,7 @@ import (
 // NewReconcileHelmReleaseTool creates a new tool for reconciling a Flux HelmRelease.
 func (m *Manager) NewReconcileHelmReleaseTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("reconcile_flux_helmrelease",
+		Tool: mcp.NewTool("reconcile_flux_helmrelease",
 			mcp.WithDescription("This tool triggers the reconciliation of a Flux HelmRelease  and optionally its source reference."),
 			mcp.WithString("name",
 				mcp.Description("The name of the HelmRelease."),
@@ -33,9 +33,9 @@ func (m *Manager) NewReconcileHelmReleaseTool() SystemTool {
 				mcp.Description("If true, the source will be reconciled as well."),
 			),
 		),
-		m.HandleReconcileHelmRelease,
-		false,
-		true,
+		Handler:   m.HandleReconcileHelmRelease,
+		ReadOnly:  false,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/reconcile_kustomization.go
+++ b/cmd/mcp/toolbox/reconcile_kustomization.go
@@ -35,6 +35,7 @@ func (m *Manager) NewReconcileKustomizationTool() SystemTool {
 		),
 		m.HandleReconcileKustomization,
 		false,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/reconcile_kustomization.go
+++ b/cmd/mcp/toolbox/reconcile_kustomization.go
@@ -19,7 +19,7 @@ import (
 // NewReconcileKustomizationTool creates a new tool for reconciling a Flux Kustomization.
 func (m *Manager) NewReconcileKustomizationTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("reconcile_flux_kustomization",
+		Tool: mcp.NewTool("reconcile_flux_kustomization",
 			mcp.WithDescription("This tool triggers the reconciliation of a Flux Kustomization and optionally its source reference."),
 			mcp.WithString("name",
 				mcp.Description("The name of the Flux Kustomization."),
@@ -33,9 +33,9 @@ func (m *Manager) NewReconcileKustomizationTool() SystemTool {
 				mcp.Description("If true, the source will be reconciled as well."),
 			),
 		),
-		m.HandleReconcileKustomization,
-		false,
-		true,
+		Handler:   m.HandleReconcileKustomization,
+		ReadOnly:  false,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/reconcile_resourceset.go
+++ b/cmd/mcp/toolbox/reconcile_resourceset.go
@@ -32,6 +32,7 @@ func (m *Manager) NewReconcileResourceSetTool() SystemTool {
 		),
 		m.HandleReconcileResourceSet,
 		true,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/reconcile_resourceset.go
+++ b/cmd/mcp/toolbox/reconcile_resourceset.go
@@ -19,7 +19,7 @@ import (
 // NewReconcileResourceSetTool creates a new tool for reconciling a Flux ResourceSet.
 func (m *Manager) NewReconcileResourceSetTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("reconcile_flux_resourceset",
+		Tool: mcp.NewTool("reconcile_flux_resourceset",
 			mcp.WithDescription("This tool triggers the reconciliation of a Flux ResourceSet."),
 			mcp.WithString("name",
 				mcp.Description("The name of the ResourceSet."),
@@ -30,9 +30,9 @@ func (m *Manager) NewReconcileResourceSetTool() SystemTool {
 				mcp.Required(),
 			),
 		),
-		m.HandleReconcileResourceSet,
-		true,
-		true,
+		Handler:   m.HandleReconcileResourceSet,
+		ReadOnly:  false,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/reconcile_source.go
+++ b/cmd/mcp/toolbox/reconcile_source.go
@@ -18,7 +18,7 @@ import (
 // NewReconcileSourceTool creates a new tool for reconciling a Flux source.
 func (m *Manager) NewReconcileSourceTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("reconcile_flux_source",
+		Tool: mcp.NewTool("reconcile_flux_source",
 			mcp.WithDescription("This tool triggers the reconciliation of a Flux source."),
 			mcp.WithString("kind",
 				mcp.Description("The Flux source kind. Can only one of GitRepository, OCIRepository, Bucket, HelmChart, HelmRepository."),
@@ -33,9 +33,9 @@ func (m *Manager) NewReconcileSourceTool() SystemTool {
 				mcp.Required(),
 			),
 		),
-		m.HandleReconcileSource,
-		false,
-		true,
+		Handler:   m.HandleReconcileSource,
+		ReadOnly:  false,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/reconcile_source.go
+++ b/cmd/mcp/toolbox/reconcile_source.go
@@ -35,6 +35,7 @@ func (m *Manager) NewReconcileSourceTool() SystemTool {
 		),
 		m.HandleReconcileSource,
 		false,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/resume_reconciliation.go
+++ b/cmd/mcp/toolbox/resume_reconciliation.go
@@ -36,6 +36,7 @@ func (m *Manager) NewResumeReconciliationTool() SystemTool {
 		),
 		m.HandleResumeReconciliation,
 		false,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/resume_reconciliation.go
+++ b/cmd/mcp/toolbox/resume_reconciliation.go
@@ -15,7 +15,7 @@ import (
 // NewResumeReconciliationTool creates a new tool for resuming the reconciliation of a Flux resource.
 func (m *Manager) NewResumeReconciliationTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("resume_flux_reconciliation",
+		Tool: mcp.NewTool("resume_flux_reconciliation",
 			mcp.WithDescription("This tool resumes the reconciliation of a Flux resource."),
 			mcp.WithString("apiVersion",
 				mcp.Description("The apiVersion of the Flux resource."),
@@ -34,9 +34,9 @@ func (m *Manager) NewResumeReconciliationTool() SystemTool {
 				mcp.Required(),
 			),
 		),
-		m.HandleResumeReconciliation,
-		false,
-		true,
+		Handler:   m.HandleResumeReconciliation,
+		ReadOnly:  false,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/search_flux_docs.go
+++ b/cmd/mcp/toolbox/search_flux_docs.go
@@ -24,6 +24,7 @@ func (m *Manager) NewSearchFluxDocsTool() SystemTool {
 		),
 		m.HandleSearchFluxDocs,
 		true,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/search_flux_docs.go
+++ b/cmd/mcp/toolbox/search_flux_docs.go
@@ -12,7 +12,7 @@ import (
 // NewSearchFluxDocsTool creates a new tool for searching Flux documentation.
 func (m *Manager) NewSearchFluxDocsTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("search_flux_docs",
+		Tool: mcp.NewTool("search_flux_docs",
 			mcp.WithDescription("This tool searches the Flux documentation and returns relevant up-to-date API specifications in markdown format."),
 			mcp.WithString("query",
 				mcp.Description("The search query."),
@@ -22,9 +22,9 @@ func (m *Manager) NewSearchFluxDocsTool() SystemTool {
 				mcp.Description("The maximum number of matching documents to return. Default is 1."),
 			),
 		),
-		m.HandleSearchFluxDocs,
-		true,
-		true,
+		Handler:   m.HandleSearchFluxDocs,
+		ReadOnly:  true,
+		InCluster: true,
 	}
 }
 

--- a/cmd/mcp/toolbox/set_context.go
+++ b/cmd/mcp/toolbox/set_context.go
@@ -22,6 +22,7 @@ func (m *Manager) NewSetKubeconfigContextTool() SystemTool {
 		),
 		m.HandleSetKubeconfigContext,
 		true,
+		false,
 	}
 }
 

--- a/cmd/mcp/toolbox/set_context.go
+++ b/cmd/mcp/toolbox/set_context.go
@@ -13,16 +13,16 @@ import (
 // NewSetKubeconfigContextTool creates a new tool for setting the current kubeconfig context.
 func (m *Manager) NewSetKubeconfigContextTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("set_kubeconfig_context",
+		Tool: mcp.NewTool("set_kubeconfig_context",
 			mcp.WithDescription("This tool changes the kubeconfig context for this session."),
 			mcp.WithString("name",
 				mcp.Description("The name of the kubeconfig context."),
 				mcp.Required(),
 			),
 		),
-		m.HandleSetKubeconfigContext,
-		true,
-		false,
+		Handler:   m.HandleSetKubeconfigContext,
+		ReadOnly:  true,
+		InCluster: false,
 	}
 }
 

--- a/cmd/mcp/toolbox/suspend_reconciliation.go
+++ b/cmd/mcp/toolbox/suspend_reconciliation.go
@@ -36,6 +36,7 @@ func (m *Manager) NewSuspendReconciliationTool() SystemTool {
 		),
 		m.HandleSuspendReconciliation,
 		false,
+		true,
 	}
 }
 

--- a/cmd/mcp/toolbox/suspend_reconciliation.go
+++ b/cmd/mcp/toolbox/suspend_reconciliation.go
@@ -15,7 +15,7 @@ import (
 // NewSuspendReconciliationTool creates a new tool for suspending the reconciliation of a Flux resource.
 func (m *Manager) NewSuspendReconciliationTool() SystemTool {
 	return SystemTool{
-		mcp.NewTool("suspend_flux_reconciliation",
+		Tool: mcp.NewTool("suspend_flux_reconciliation",
 			mcp.WithDescription("This tool suspends the reconciliation of a Flux resource."),
 			mcp.WithString("apiVersion",
 				mcp.Description("The apiVersion of the Flux resource."),
@@ -34,9 +34,9 @@ func (m *Manager) NewSuspendReconciliationTool() SystemTool {
 				mcp.Required(),
 			),
 		),
-		m.HandleSuspendReconciliation,
-		false,
-		true,
+		Handler:   m.HandleSuspendReconciliation,
+		ReadOnly:  false,
+		InCluster: true,
 	}
 }
 

--- a/config/mcp/deployment.yaml
+++ b/config/mcp/deployment.yaml
@@ -9,7 +9,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: flux-operator-mcp
-  replicas: 1
   template:
     metadata:
       labels:
@@ -33,7 +32,7 @@ spec:
         args:
           - serve
           - --transport=sse
-          - --port=8080
+          - --port=9090
         securityContext:
           runAsNonRoot: true
           readOnlyRootFilesystem: true
@@ -44,15 +43,15 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         ports:
-        - containerPort: 8080
+        - containerPort: 9090
           name: http
           protocol: TCP
         livenessProbe:
           tcpSocket:
-            port: 8080
+            port: http
         readinessProbe:
           tcpSocket:
-            port: 8080
+            port: http
         resources:
           limits:
             cpu: 1000m

--- a/config/mcp/deployment.yaml
+++ b/config/mcp/deployment.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flux-operator-mcp
+  labels:
+    app.kubernetes.io/name: flux-operator-mcp
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: flux-operator-mcp
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: flux-operator-mcp
+    spec:
+      serviceAccountName: flux-operator
+      terminationGracePeriodSeconds: 10
+      affinity:
+       nodeAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+           nodeSelectorTerms:
+             - matchExpressions:
+               - key: kubernetes.io/os
+                 operator: In
+                 values:
+                   - linux
+      containers:
+      - name: server
+        image: flux-operator-mcp:latest
+        imagePullPolicy: IfNotPresent
+        args:
+          - serve
+          - --transport=sse
+          - --port=8080
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+          seccompProfile:
+            type: RuntimeDefault
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        volumeMounts:
+          - name: temp
+            mountPath: /tmp
+      volumes:
+        - name: temp
+          emptyDir: {}

--- a/config/mcp/kustomization.yaml
+++ b/config/mcp/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+resources:
+- deployment.yaml
+- service.yaml
+images:
+- name: flux-operator-mcp
+  newName: ghcr.io/controlplaneio-fluxcd/flux-operator-mcp
+  newTag: v0.20.0

--- a/config/mcp/service.yaml
+++ b/config/mcp/service.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 8080
+    port: 9090
     protocol: TCP
-    targetPort: 8080
+    targetPort: http
   selector:
     app.kubernetes.io/name: flux-operator-mcp

--- a/config/mcp/service.yaml
+++ b/config/mcp/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flux-operator-mcp
+  labels:
+    app.kubernetes.io/name: flux-operator-mcp
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: flux-operator-mcp

--- a/hack/build-dist-manifests.sh
+++ b/hack/build-dist-manifests.sh
@@ -22,6 +22,10 @@ mkdir -p ${DEST_DIR}/flux-operator
 kustomize build config/default > ${DEST_DIR}/flux-operator/install.yaml
 info "operator manifests generated to disto/flux-operator"
 
+mkdir -p ${DEST_DIR}/flux-operator-mcp
+kustomize build config/mcp > ${DEST_DIR}/flux-operator-mcp/install.yaml
+info "MCP server manifests generated to disto/flux-operator-mcp"
+
 mkdir -p ${DEST_DIR}/flux
 cp -r config/data/flux/* ${DEST_DIR}/flux/
 info "flux manifests copied to disto/flux"


### PR DESCRIPTION
This PR adds support for running the Flux MCP Server in SSE mode inside Kubernetes. The major difference from running the server locally is that the kubeconfig context switching tools are disabled, so comparing deployments across clusters is not possible. 

The server multi-arch container image will be available at `ghcr.io/controlplaneio-fluxcd/flux-operator-mcp`. The image embeds SBOMs and provenance attestations and is sign with Cosign and GitHub OIDC.

A Kubernetes deployment and service (port `9090`) are included in the Flux Operator distro, which allows deploying the MCP Server in the flux-system namespace:

```yaml
---
apiVersion: source.toolkit.fluxcd.io/v1beta2
kind: OCIRepository
metadata:
  name: flux-operator-manifests
  namespace: flux-system
spec:
  interval: 120m
  url: oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests
  ref:
    tag: latest
---
apiVersion: kustomize.toolkit.fluxcd.io/v1
kind: Kustomization
metadata:
  name: flux-operator-mcp
  namespace: flux-system
spec:
  interval: 60m
  wait: true
  timeout: 5m
  retryInterval: 5m
  prune: true
  sourceRef:
    kind: OCIRepository
    name: flux-operator-manifests
  path: ./flux-operator-mcp
  patches:
    - patch: |
        - op: add
          path: /spec/template/spec/containers/0/args/-
          value: --read-only=false
      target:
        kind: Deployment
```

Closes: #262