### PR TITLE
Implement `get_kubernetes_metrics` MCP tool

### DIFF
--- a/cmd/mcp/k8s/helm.go
+++ b/cmd/mcp/k8s/helm.go
@@ -51,7 +51,7 @@ type HelmInventory struct {
 func (k *Client) GetHelmInventory(ctx context.Context, apiVersion string, objectKey ctrlclient.ObjectKey) ([]HelmInventory, error) {
 	inventory := make([]HelmInventory, 0)
 	hr := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": apiVersion,
 			"kind":       "HelmRelease",
 		},
@@ -74,9 +74,9 @@ func (k *Client) GetHelmInventory(ctx context.Context, apiVersion string, object
 
 	// get the latest release from the history
 	latest := &HelmHistory{}
-	latest.ChartName = history[0].(map[string]interface{})["chartName"].(string)
-	latest.Version = history[0].(map[string]interface{})["version"].(int64)
-	latest.Namespace = history[0].(map[string]interface{})["namespace"].(string)
+	latest.ChartName = history[0].(map[string]any)["chartName"].(string)
+	latest.Version = history[0].(map[string]any)["version"].(int64)
+	latest.Namespace = history[0].(map[string]any)["namespace"].(string)
 
 	storageKey := ctrlclient.ObjectKey{
 		Namespace: storageNamespace,
@@ -141,7 +141,7 @@ func (k *Client) GetHelmInventory(ctx context.Context, apiVersion string, object
 		// extract container images from Deployment, StatefulSet, DaemonSet and Job
 		if containers, found, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers"); found {
 			for _, container := range containers {
-				if image, found, _ := unstructured.NestedString(container.(map[string]interface{}), "image"); found {
+				if image, found, _ := unstructured.NestedString(container.(map[string]any), "image"); found {
 					containerImages = append(containerImages, image)
 				}
 			}
@@ -150,7 +150,7 @@ func (k *Client) GetHelmInventory(ctx context.Context, apiVersion string, object
 		// extract init container images from Deployment, StatefulSet, DaemonSet and Job
 		if containers, found, _ := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "initContainers"); found {
 			for _, container := range containers {
-				if image, found, _ := unstructured.NestedString(container.(map[string]interface{}), "image"); found {
+				if image, found, _ := unstructured.NestedString(container.(map[string]any), "image"); found {
 					if !slices.Contains(containerImages, image) {
 						containerImages = append(containerImages, image)
 					}
@@ -161,7 +161,7 @@ func (k *Client) GetHelmInventory(ctx context.Context, apiVersion string, object
 		// extract container images from CronJob
 		if containers, found, _ := unstructured.NestedSlice(obj.Object, "spec", "jobTemplate", "spec", "template", "spec", "containers"); found {
 			for _, container := range containers {
-				if image, found, _ := unstructured.NestedString(container.(map[string]interface{}), "image"); found {
+				if image, found, _ := unstructured.NestedString(container.(map[string]any), "image"); found {
 					if !slices.Contains(containerImages, image) {
 						containerImages = append(containerImages, image)
 					}

--- a/cmd/mcp/k8s/logs.go
+++ b/cmd/mcp/k8s/logs.go
@@ -48,10 +48,10 @@ func (k *Client) GetLogs(ctx context.Context, pod, container, namespace string, 
 	}
 
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Pod",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      pod,
 				"namespace": namespace,
 			},

--- a/cmd/mcp/k8s/metrics.go
+++ b/cmd/mcp/k8s/metrics.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
+)
+
+// GetMetrics retrieves the CPU and Memory metrics for a list of pods in the given namespace.
+func (k *Client) GetMetrics(ctx context.Context, pod, namespace, labelSelector string, limit int) (*unstructured.Unstructured, error) {
+	clientset, err := metricsclientset.NewForConfig(k.cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	ls := labels.Everything()
+	if len(labelSelector) > 0 {
+		ls, err = labels.Parse(labelSelector)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	versionedMetrics := &metricsv1beta1api.PodMetricsList{}
+	if pod != "" {
+		m, err := clientset.MetricsV1beta1().
+			PodMetricses(namespace).
+			Get(ctx, pod, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		versionedMetrics.Items = []metricsv1beta1api.PodMetrics{*m}
+	} else {
+		versionedMetrics, err = clientset.MetricsV1beta1().
+			PodMetricses(namespace).
+			List(ctx, metav1.ListOptions{LabelSelector: ls.String(), Limit: int64(limit)})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(versionedMetrics.Items) == 0 {
+		return nil, fmt.Errorf("no metrics found for pods in namespace %s", namespace)
+	}
+
+	metrics := make([]map[string]interface{}, 0, len(versionedMetrics.Items))
+	for _, item := range versionedMetrics.Items {
+		for _, container := range item.Containers {
+			metrics = append(metrics, map[string]interface{}{
+				"pod":       item.Name,
+				"namespace": item.Namespace,
+				"container": container.Name,
+				"cpuUsage":  container.Usage[corev1.ResourceCPU],
+				"memUsage":  container.Usage[corev1.ResourceMemory],
+			})
+		}
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "PodMetricsList",
+			"metadata": map[string]interface{}{
+				"name":      pod,
+				"namespace": namespace,
+			},
+			"items": metrics,
+		},
+	}, nil
+}

--- a/cmd/mcp/toolbox/get_metrics.go
+++ b/cmd/mcp/toolbox/get_metrics.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"sigs.k8s.io/yaml"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
+)
+
+// NewGetKubernetesMetricsTool creates a new tool for retrieving pod metrics.
+func (m *Manager) NewGetKubernetesMetricsTool() SystemTool {
+	return SystemTool{
+		Tool: mcp.NewTool("get_kubernetes_metrics",
+			mcp.WithDescription("This tool retrieves CPU and Memory usage of Kubernetes pods."),
+			mcp.WithString("pod_name",
+				mcp.Description("The name of the pod, when not specified all pods are selected."),
+			),
+			mcp.WithString("pod_namespace",
+				mcp.Description("The namespace of the pods."),
+				mcp.Required(),
+			),
+			mcp.WithString("pod_selector",
+				mcp.Description("The pod label selector in the format key1=value1,key2=value2."),
+			),
+			mcp.WithNumber("limit",
+				mcp.Description("The maximum number of resources to return. Defaults to 100."),
+			),
+		),
+		Handler:   m.HandleGetKubernetesMetrics,
+		ReadOnly:  true,
+		InCluster: true,
+	}
+}
+
+// HandleGetKubernetesMetrics is the handler function for the get_kubernetes_metrics tool.
+func (m *Manager) HandleGetKubernetesMetrics(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	podName := mcp.ParseString(request, "pod_name", "")
+	podNamespace := mcp.ParseString(request, "pod_namespace", "")
+	if podNamespace == "" {
+		return mcp.NewToolResultError("pod namespace is required"), nil
+	}
+	selector := mcp.ParseString(request, "pod_selector", "")
+	limit := mcp.ParseInt(request, "limit", 100)
+
+	ctx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
+	kubeClient, err := k8s.NewClient(m.flags)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("Failed to create Kubernetes client", err), nil
+	}
+
+	result, err := kubeClient.GetMetrics(ctx, podName, podNamespace, selector, limit)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("Failed marshalling data", err), nil
+	}
+
+	return mcp.NewToolResultText(string(data)), nil
+}

--- a/cmd/mcp/toolbox/get_metrics_test.go
+++ b/cmd/mcp/toolbox/get_metrics_test.go
@@ -1,0 +1,68 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	. "github.com/onsi/gomega"
+	cli "k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
+)
+
+func TestManager_HandleGetKubernetesMetrics(t *testing.T) {
+	configFile := "testdata/kubeconfig.yaml"
+	t.Setenv("KUBECONFIG", configFile)
+
+	m := &Manager{
+		kubeconfig: k8s.NewKubeConfig(),
+		flags:      cli.NewConfigFlags(false),
+		timeout:    time.Second,
+	}
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_kubernetes_metrics"
+
+	tests := []struct {
+		testName  string
+		arguments map[string]interface{}
+		matchErr  string
+	}{
+		{
+			testName: "fails without namespace",
+			arguments: map[string]interface{}{
+				"pod_name": "test",
+			},
+			matchErr: "pod namespace is required",
+		},
+		{
+			testName: "fails with invalid kubeconfig",
+			arguments: map[string]interface{}{
+				"pod_name":      "test",
+				"pod_namespace": "default",
+			},
+			matchErr: "Failed to create Kubernetes client",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			request.Params.Arguments = test.arguments
+
+			result, err := m.HandleGetKubernetesMetrics(context.Background(), request)
+			g.Expect(err).ToNot(HaveOccurred())
+			textContent, ok := mcp.AsTextContent(result.Content[0])
+			g.Expect(ok).To(BeTrue())
+
+			g.Expect(result.IsError).To(BeTrue())
+			g.Expect(textContent.Text).To(ContainSubstring(test.matchErr))
+
+		})
+	}
+}

--- a/cmd/mcp/toolbox/index.go
+++ b/cmd/mcp/toolbox/index.go
@@ -10,6 +10,7 @@ func (m *Manager) ToolSet() []SystemTool {
 		m.NewGetFluxInstanceTool(),
 		m.NewGetAPIVersionsTool(),
 		m.NewGetKubernetesLogsTool(),
+		m.NewGetKubernetesMetricsTool(),
 		m.NewGetKubernetesResourcesTool(),
 		m.NewApplyKubernetesManifestTool(),
 		m.NewDeleteKubernetesResourceTool(),

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -60,6 +60,22 @@ Retrieves logs from Kubernetes pods, allowing AI assistants to analyze applicati
 
 Returns the specified number of log lines from the requested container, with timestamps and log levels preserved.
 
+### get_kubernetes_metrics
+
+Retrieves CPU and Memory usage for Kubernetes pods, allowing AI assistants to monitor resource consumption and performance.
+This tool depends on the Kubernetes metrics-server being installed in the cluster.
+
+**Parameters:**
+
+- `pod_name` (optional): The name of the pod, when not specified all pods are selected.
+- `pod_namespace` (required): The namespace of the pods.
+- `pod_selector` (optional): Label selector in the format `key1=value1,key2=value2`
+- `limit` (optional): Maximum number of metrics to return (default: 100)
+
+**Output:**
+
+Returns the metrics for the specified pods, including CPU and Memory for each container, in YAML format.
+
 ### get_kubernetes_api_versions
 
 Retrieves the Kubernetes CRDs registered on the cluster and returns the preferred apiVersion for each kind.

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	k8s.io/apimachinery v0.33.0
 	k8s.io/cli-runtime v0.33.0
 	k8s.io/client-go v0.33.0
+	k8s.io/metrics v0.33.0
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/yaml v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -475,6 +475,8 @@ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUy
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
 k8s.io/kubectl v0.33.0 h1:HiRb1yqibBSCqic4pRZP+viiOBAnIdwYDpzUFejs07g=
 k8s.io/kubectl v0.33.0/go.mod h1:gAlGBuS1Jq1fYZ9AjGWbI/5Vk3M/VW2DK4g10Fpyn/0=
+k8s.io/metrics v0.33.0 h1:sKe5sC9qb1RakMhs8LWYNuN2ne6OTCWexj8Jos3rO2Y=
+k8s.io/metrics v0.33.0/go.mod h1:XewckTFXmE2AJiP7PT3EXaY7hi7bler3t2ZLyOdQYzU=
 k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e h1:KqK5c/ghOm8xkHYhlodbp6i6+r+ChV2vuAuVRdFbLro=
 k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=


### PR DESCRIPTION
This PR adds the `get_kubernetes_metrics` tool to the Flux MCP Sever which retrieves CPU and Memory usage for Kubernetes pods, allowing AI assistants to monitor resource consumption and performance.

Example prompt: "What is the resource consumption of the Flux controllers?"

<img width="925" alt="flux-mcp-metrics-tool" src="https://github.com/user-attachments/assets/e5c75e42-b901-481a-9839-0d55741fcdca" />

Closes: #258