### PR TITLE
Add `objectLevelWorkloadIdentity` option to FluxInstance

### DIFF
--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -146,6 +146,12 @@ type Cluster struct {
 	// +optional
 	TenantDefaultServiceAccount string `json:"tenantDefaultServiceAccount,omitempty"`
 
+	// ObjectLevelWorkloadIdentity enables the feature gate
+	// required for object-level workload identity.
+	// This feature is only available in Flux v2.6.0 and later.
+	// +optional
+	ObjectLevelWorkloadIdentity bool `json:"objectLevelWorkloadIdentity,omitempty"`
+
 	// NetworkPolicy restricts network access to the current namespace.
 	// Defaults to true.
 	// +kubebuilder:default:=true

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -70,6 +70,12 @@ spec:
                       NetworkPolicy restricts network access to the current namespace.
                       Defaults to true.
                     type: boolean
+                  objectLevelWorkloadIdentity:
+                    description: |-
+                      ObjectLevelWorkloadIdentity enables the feature gate
+                      required for object-level workload identity.
+                      This feature is only available in Flux v2.6.0 and later.
+                    type: boolean
                   tenantDefaultServiceAccount:
                     description: |-
                       TenantDefaultServiceAccount is the name of the service account

--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -304,6 +304,7 @@ spec:
     type: openshift
     multitenant: true
     tenantDefaultServiceAccount: "flux"
+    objectLevelWorkloadIdentity: false
     networkPolicy: true
     domain: "cluster.local"
 ```
@@ -323,6 +324,9 @@ The `.spec.cluster.multitenant` field is optional and specifies whether to enabl
 The `.spec.cluster.tenantDefaultServiceAccount` is optional and specifies the default
 service account used by Flux when reconciling `Kustomization` and `HelmRelease`
 resources found in the tenant namespaces.
+
+The `.spec.cluster.objectLevelWorkloadIdentity` field is optional and specifies whether to
+enable the object-level workload identity feature gate and RBAC for the Flux controllers.
 
 #### Cluster network policy
 

--- a/internal/builder/build.go
+++ b/internal/builder/build.go
@@ -60,6 +60,18 @@ func Build(srcDir, tmpDir string, options Options) (*Result, error) {
 }
 
 func generate(base string, options Options) error {
+	supportsObjectLevelWorkloadIdentity, err := SupportsObjectLevelWorkloadFeature(options.Version)
+	if err != nil {
+		return fmt.Errorf("check ObjectLevelWorkloadIdentity support failed: %w", err)
+	}
+	options.SupportsObjectLevelWorkloadIdentity = supportsObjectLevelWorkloadIdentity
+
+	enableObjectLevelWorkloadIdentity, err := EnableObjectLevelWorkloadFeature(options.Version, options.EnableObjectLevelWorkloadIdentity)
+	if err != nil {
+		return fmt.Errorf("check ObjectLevelWorkloadIdentity feature failed: %w", err)
+	}
+	options.EnableObjectLevelWorkloadIdentity = enableObjectLevelWorkloadIdentity
+
 	if options.HasNotificationController() {
 		options.EventsAddr = notifier.Address(options.Namespace, options.ClusterDomain)
 	}

--- a/internal/builder/options.go
+++ b/internal/builder/options.go
@@ -11,25 +11,27 @@ import (
 
 // Options defines the builder configuration.
 type Options struct {
-	Version            string
-	Namespace          string
-	Components         []string
-	ComponentImages    []ComponentImage
-	EventsAddr         string
-	Registry           string
-	ImagePullSecret    string
-	WatchAllNamespaces bool
-	NetworkPolicy      bool
-	LogLevel           string
-	ClusterDomain      string
-	TolerationKeys     []string
-	Patches            string
-	ArtifactStorage    *ArtifactStorage
-	Sync               *Sync
-	ShardingKey        string
-	Shards             []string
-	ShardName          string
-	SourceAPIVersion   string
+	Version                             string
+	Namespace                           string
+	Components                          []string
+	ComponentImages                     []ComponentImage
+	EventsAddr                          string
+	Registry                            string
+	ImagePullSecret                     string
+	WatchAllNamespaces                  bool
+	NetworkPolicy                       bool
+	LogLevel                            string
+	ClusterDomain                       string
+	TolerationKeys                      []string
+	Patches                             string
+	ArtifactStorage                     *ArtifactStorage
+	Sync                                *Sync
+	ShardingKey                         string
+	Shards                              []string
+	ShardName                           string
+	SourceAPIVersion                    string
+	EnableObjectLevelWorkloadIdentity   bool
+	SupportsObjectLevelWorkloadIdentity bool
 }
 
 // MakeDefaultOptions returns the default builder configuration.

--- a/internal/builder/semver.go
+++ b/internal/builder/semver.go
@@ -83,6 +83,38 @@ func MatchVersion(dataDir, semverRange string) (string, error) {
 	return matchingVersions[0].Original(), nil
 }
 
+// SupportsObjectLevelWorkloadFeature checks if the Flux version
+// supports the object level workload feature.
+func SupportsObjectLevelWorkloadFeature(fluxVersion string) (bool, error) {
+	c, err := semver.NewConstraint("< 2.6.0")
+	if err != nil {
+		return false, fmt.Errorf("semver constraint parse error: %w", err)
+	}
+
+	version, err := semver.NewVersion(fluxVersion)
+	if err != nil {
+		return false, fmt.Errorf("version '%s' parse error: %w", fluxVersion, err)
+	}
+
+	if c.Check(version) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// EnableObjectLevelWorkloadFeature checks if the object level workload feature
+// should be enabled based on the Flux version and the object level workload ID.
+func EnableObjectLevelWorkloadFeature(fluxVersion string, objectLevelWorkloadID bool) (bool, error) {
+	supported, err := SupportsObjectLevelWorkloadFeature(fluxVersion)
+	if err != nil {
+		return false, err
+	}
+
+	// If the Flux version is >= 2.6.0, we check if the object level workload ID is enabled.
+	return supported && objectLevelWorkloadID, nil
+}
+
 // getSourceAPIVersion determines the API version of the source based on the provided Flux version.
 func getSourceAPIVersion(fluxVersion string) (string, error) {
 	sourceAPIVersion := "source.toolkit.fluxcd.io/v1beta2"

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -316,6 +316,7 @@ func (r *FluxInstanceReconciler) build(ctx context.Context,
 	options.Namespace = obj.GetNamespace()
 	options.Components = obj.GetComponents()
 	options.NetworkPolicy = obj.GetCluster().NetworkPolicy
+	options.EnableObjectLevelWorkloadIdentity = obj.GetCluster().ObjectLevelWorkloadIdentity
 
 	if obj.GetCluster().Domain != "" {
 		options.ClusterDomain = obj.GetCluster().Domain


### PR DESCRIPTION
This adds `.spec.cluster.objectLevelWorkloadIdentity` boolean field that allows enabling the the feature gate and the RBAC permissions required for object-level workload identity.

By default, the object-level workload identity feature flag is disabled and the RBAC permissions for creating `serviceaccounts/token` is also disabled.