### PR TITLE
Implement persistant storage for source-controller shards

### DIFF
--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -176,6 +176,14 @@ type Sharding struct {
 	// +kubebuilder:validation:MinItems=1
 	// +required
 	Shards []string `json:"shards"`
+
+	// Storage defines if the source-controller shards
+	// should use an emptyDir or a persistent volume claim for storage.
+	// Accepted values are 'ephemeral' or 'persistent', defaults to 'ephemeral'.
+	// For 'persistent' to take effect, the '.spec.storage' field must be set.
+	// +kubebuilder:validation:Enum:=ephemeral;persistent
+	// +optional
+	Storage string `json:"storage,omitempty"`
 }
 
 // Storage is the specification for the persistent volume claim.
@@ -336,6 +344,14 @@ func (in *FluxInstance) GetCluster() Cluster {
 	}
 
 	return *cluster
+}
+
+// IsShardingStorageEnabled returns true if 'spec.sharding.storage' is set to 'persistent'.
+func (in *FluxInstance) IsShardingStorageEnabled() bool {
+	if in.Spec.Sharding == nil {
+		return false
+	}
+	return in.Spec.Sharding.Storage == "persistent"
 }
 
 // GetMigrateResources returns the migration configuration with defaults.

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -249,6 +249,16 @@ spec:
                       type: string
                     minItems: 1
                     type: array
+                  storage:
+                    description: |-
+                      Storage defines if the source-controller shards
+                      should use an emptyDir or a persistent volume claim for storage.
+                      Accepted values are 'ephemeral' or 'persistent', defaults to 'ephemeral'.
+                      For 'persistent' to take effect, the '.spec.storage' field must be set.
+                    enum:
+                    - ephemeral
+                    - persistent
+                    type: string
                 required:
                 - shards
                 type: object

--- a/config/samples/fluxcd_v1_fluxinstance.yaml
+++ b/config/samples/fluxcd_v1_fluxinstance.yaml
@@ -24,6 +24,7 @@ spec:
     size: "1Gi"
   sharding:
     shards: [ "shard1" ]
+    storage: persistent
   sync:
     kind: GitRepository
     url: "https://github.com/controlplaneio-fluxcd/distribution.git"

--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -374,6 +374,7 @@ spec:
     shards:
       - "shard1"
       - "shard2"
+    storage: persistent
 ```
 
 For each shard, the operator will create a separate set of controllers, e.g.:
@@ -406,6 +407,15 @@ By default, the key is set to `sharding.fluxcd.io/key`.
 #### Shards
 
 The `.spec.sharding.shards` field is required and specifies the list of sharding values to use for the Flux controllers.
+
+### Sharding storage
+
+The `.spec.sharding.storage` field is optional and specifies the storage type to use
+for the source-controller shards.
+
+The supported values are `ephemeral` (default) and `persistent`.
+When set to `persistent`, the operator will create a persistent volume claim for each shard using
+the storage class and size specified in the `.spec.storage` field.
 
 ### Common metadata
 

--- a/internal/builder/build.go
+++ b/internal/builder/build.go
@@ -141,6 +141,12 @@ func generate(base string, options Options) error {
 		if err := os.MkdirAll(path.Join(base, shard), os.ModePerm); err != nil {
 			return fmt.Errorf("generate shard dir failed: %w", err)
 		}
+		if options.ArtifactStorage != nil && options.ShardingStorage {
+			if err := execTemplate(options, pvcTmpl, path.Join(base, shard, "pvc.yaml")); err != nil {
+				return fmt.Errorf("generate shard pvc failed: %w", err)
+			}
+		}
+
 		if err := execTemplate(options, kustomizationShardTmpl, path.Join(base, shard, "kustomization.yaml")); err != nil {
 			return fmt.Errorf("generate shard kustomization failed: %w", err)
 		}

--- a/internal/builder/options.go
+++ b/internal/builder/options.go
@@ -27,6 +27,7 @@ type Options struct {
 	ArtifactStorage                     *ArtifactStorage
 	Sync                                *Sync
 	ShardingKey                         string
+	ShardingStorage                     bool
 	Shards                              []string
 	ShardName                           string
 	SourceAPIVersion                    string

--- a/internal/builder/testdata/v2.6.0-golden/shard1.kustomization.yaml
+++ b/internal/builder/testdata/v2.6.0-golden/shard1.kustomization.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+resources:
+  - ../source-controller.yaml
+  - ../kustomize-controller.yaml
+  - ../helm-controller.yaml
+  - pvc.yaml
+nameSuffix: "-shard1"
+commonAnnotations:
+  sharding.fluxcd.io/role: "shard"
+patches:
+  - target:
+      kind: (Namespace|CustomResourceDefinition|ClusterRole|ClusterRoleBinding|ServiceAccount|NetworkPolicy|ResourceQuota)
+    patch: |
+      apiVersion: v1
+      kind: all
+      metadata:
+        name: all
+      $patch: delete
+  - target:
+      kind: Service
+      name: (source-controller)
+    patch: |
+      - op: replace
+        path: /spec/selector/app
+        value: source-controller-shard1
+  - target:
+      kind: Deployment
+      name: (source-controller)
+    patch: |
+      - op: replace
+        path: /spec/selector/matchLabels/app
+        value: source-controller-shard1
+      - op: replace
+        path: /spec/template/metadata/labels/app
+        value: source-controller-shard1
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --storage-adv-addr=source-controller-shard1.$(RUNTIME_NAMESPACE).svc.cluster.local.
+      - op: replace
+        path: /spec/template/spec/volumes/0
+        value:
+          name: persistent-data-shard1
+          persistentVolumeClaim:
+            claimName: source-controller-shard1
+      - op: replace
+        path: /spec/template/spec/containers/0/volumeMounts/0
+        value:
+          name: persistent-data-shard1
+          mountPath: /data
+  - target:
+      kind: Deployment
+      name: (kustomize-controller)
+    patch: |
+      - op: replace
+        path: /spec/selector/matchLabels/app
+        value: kustomize-controller-shard1
+      - op: replace
+        path: /spec/template/metadata/labels/app
+        value: kustomize-controller-shard1
+  - target:
+      kind: Deployment
+      name: (helm-controller)
+    patch: |
+      - op: replace
+        path: /spec/selector/matchLabels/app
+        value: helm-controller-shard1
+      - op: replace
+        path: /spec/template/metadata/labels/app
+        value: helm-controller-shard1
+  - target:
+      kind: Deployment
+      name: (source-controller|kustomize-controller|helm-controller)
+    patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --watch-label-selector=sharding.fluxcd.io/key=shard1

--- a/internal/builder/testdata/v2.6.0-golden/shard2.kustomization.yaml
+++ b/internal/builder/testdata/v2.6.0-golden/shard2.kustomization.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+resources:
+  - ../source-controller.yaml
+  - ../kustomize-controller.yaml
+  - ../helm-controller.yaml
+  - pvc.yaml
+nameSuffix: "-shard2"
+commonAnnotations:
+  sharding.fluxcd.io/role: "shard"
+patches:
+  - target:
+      kind: (Namespace|CustomResourceDefinition|ClusterRole|ClusterRoleBinding|ServiceAccount|NetworkPolicy|ResourceQuota)
+    patch: |
+      apiVersion: v1
+      kind: all
+      metadata:
+        name: all
+      $patch: delete
+  - target:
+      kind: Service
+      name: (source-controller)
+    patch: |
+      - op: replace
+        path: /spec/selector/app
+        value: source-controller-shard2
+  - target:
+      kind: Deployment
+      name: (source-controller)
+    patch: |
+      - op: replace
+        path: /spec/selector/matchLabels/app
+        value: source-controller-shard2
+      - op: replace
+        path: /spec/template/metadata/labels/app
+        value: source-controller-shard2
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --storage-adv-addr=source-controller-shard2.$(RUNTIME_NAMESPACE).svc.cluster.local.
+      - op: replace
+        path: /spec/template/spec/volumes/0
+        value:
+          name: persistent-data-shard2
+          persistentVolumeClaim:
+            claimName: source-controller-shard2
+      - op: replace
+        path: /spec/template/spec/containers/0/volumeMounts/0
+        value:
+          name: persistent-data-shard2
+          mountPath: /data
+  - target:
+      kind: Deployment
+      name: (kustomize-controller)
+    patch: |
+      - op: replace
+        path: /spec/selector/matchLabels/app
+        value: kustomize-controller-shard2
+      - op: replace
+        path: /spec/template/metadata/labels/app
+        value: kustomize-controller-shard2
+  - target:
+      kind: Deployment
+      name: (helm-controller)
+    patch: |
+      - op: replace
+        path: /spec/selector/matchLabels/app
+        value: helm-controller-shard2
+      - op: replace
+        path: /spec/template/metadata/labels/app
+        value: helm-controller-shard2
+  - target:
+      kind: Deployment
+      name: (source-controller|kustomize-controller|helm-controller)
+    patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --watch-label-selector=sharding.fluxcd.io/key=shard2

--- a/internal/builder/testdata/v2.6.0-golden/sharding.kustomization.yaml
+++ b/internal/builder/testdata/v2.6.0-golden/sharding.kustomization.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+transformers:
+  - annotations.yaml
+  - labels.yaml
+resources:
+  - namespace.yaml
+  - policies.yaml
+  - roles
+  - source-controller.yaml
+  - kustomize-controller.yaml
+  - helm-controller.yaml
+  - notification-controller.yaml
+  - image-reflector-controller.yaml
+  - image-automation-controller.yaml
+  - shard1
+  - shard2
+  - pvc.yaml
+images:
+  - name: fluxcd/source-controller
+    newName: ghcr.io/fluxcd/source-controller
+    newTag: v1.6.0
+  - name: fluxcd/kustomize-controller
+    newName: ghcr.io/fluxcd/kustomize-controller
+    newTag: v1.6.0
+  - name: fluxcd/helm-controller
+    newName: ghcr.io/fluxcd/helm-controller
+    newTag: v1.3.0
+  - name: fluxcd/notification-controller
+    newName: ghcr.io/fluxcd/notification-controller
+    newTag: v1.6.0
+  - name: fluxcd/image-reflector-controller
+    newName: ghcr.io/fluxcd/image-reflector-controller
+    newTag: v0.35.0
+  - name: fluxcd/image-automation-controller
+    newName: ghcr.io/fluxcd/image-automation-controller
+    newTag: v0.41.0
+patches:
+- path: node-selector.yaml
+  target:
+    kind: Deployment
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: source-controller
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/args/0
+      value: --events-addr=http://notification-controller.flux-system.svc.cluster.local./
+    - op: replace
+      path: /spec/template/spec/containers/0/args/1
+      value: --watch-all-namespaces=true
+    - op: replace
+      path: /spec/template/spec/containers/0/args/2
+      value: --log-level=info
+    - op: replace
+      path: /spec/template/spec/containers/0/args/6
+      value: --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: source-controller
+    annotationSelector: "!sharding.fluxcd.io/role"
+  patch: |-
+    - op: add
+      path: '/spec/template/spec/volumes/-'
+      value:
+        name: persistent-data
+        persistentVolumeClaim:
+          claimName: source-controller
+    - op: replace
+      path: '/spec/template/spec/containers/0/volumeMounts/0'
+      value:
+        name: persistent-data
+        mountPath: /data
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: kustomize-controller
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/args/0
+      value: --events-addr=http://notification-controller.flux-system.svc.cluster.local./
+    - op: replace
+      path: /spec/template/spec/containers/0/args/1
+      value: --watch-all-namespaces=true
+    - op: replace
+      path: /spec/template/spec/containers/0/args/2
+      value: --log-level=info
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: helm-controller
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/args/0
+      value: --events-addr=http://notification-controller.flux-system.svc.cluster.local./
+    - op: replace
+      path: /spec/template/spec/containers/0/args/1
+      value: --watch-all-namespaces=true
+    - op: replace
+      path: /spec/template/spec/containers/0/args/2
+      value: --log-level=info
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: notification-controller
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/args/0
+      value: --watch-all-namespaces=true
+    - op: replace
+      path: /spec/template/spec/containers/0/args/1
+      value: --log-level=info
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: image-reflector-controller
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/args/0
+      value: --events-addr=http://notification-controller.flux-system.svc.cluster.local./
+    - op: replace
+      path: /spec/template/spec/containers/0/args/1
+      value: --watch-all-namespaces=true
+    - op: replace
+      path: /spec/template/spec/containers/0/args/2
+      value: --log-level=info
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: image-automation-controller
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/args/0
+      value: --events-addr=http://notification-controller.flux-system.svc.cluster.local./
+    - op: replace
+      path: /spec/template/spec/containers/0/args/1
+      value: --watch-all-namespaces=true
+    - op: replace
+      path: /spec/template/spec/containers/0/args/2
+      value: --log-level=info
+- target:
+    kind: Deployment
+    name: "(source-controller|kustomize-controller|helm-controller)"
+    annotationSelector: "!sharding.fluxcd.io/role"
+  patch: |
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --watch-label-selector=!sharding.fluxcd.io/key
+

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -336,6 +336,7 @@ func (r *FluxInstanceReconciler) build(ctx context.Context,
 	if obj.Spec.Sharding != nil {
 		options.ShardingKey = obj.Spec.Sharding.Key
 		options.Shards = obj.Spec.Sharding.Shards
+		options.ShardingStorage = obj.IsShardingStorageEnabled()
 	}
 
 	if obj.Spec.Storage != nil {


### PR DESCRIPTION
This PR adds an optional field `.spec.sharding.storage` to the FluxInstance API.  The supported values are `ephemeral` (default) and `persistent`. 

When set to `persistent`, the operator will create a persistent volume claim for each source-controller shard using the storage class and size specified in the `.spec.storage` field.

Example:

```yaml
apiVersion: fluxcd.controlplane.io/v1
kind: FluxInstance
metadata:
  name: flux
spec:
  distribution:
    version: "2.x"
    registry: "ghcr.io/fluxcd"
  storage:
    class: "standard"
    size: "10Gi"
  sharding:
    key: "sharding.fluxcd.io/key"
    shards:
      - "shard1"
      - "shard2"
    storage: "persistent"
```

Closes: #285