### PR TITLE
cli: Add `--wait` flag to reconcile commands

### DIFF
--- a/cmd/cli/client.go
+++ b/cmd/cli/client.go
@@ -5,19 +5,27 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
+	"time"
 
+	"github.com/fluxcd/cli-utils/pkg/kstatus/status"
+	"github.com/fluxcd/pkg/apis/meta"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
 
+// newKubeClient creates a new controller-runtime client using the local kubeconfig.
 func newKubeClient() (client.Client, error) {
 	cfg, err := kubeconfigArgs.ToRESTConfig()
 	if err != nil {
@@ -52,10 +60,12 @@ func newKubeClient() (client.Client, error) {
 	return client.WithFieldOwner(kubeClient, "flux-operator-ctl"), nil
 }
 
+// annotateResource annotates a resource with the specified key and value.
 func annotateResource(ctx context.Context, kind, name, namespace, key, val string) error {
 	return annotateResourceWithMap(ctx, kind, name, namespace, map[string]string{key: val})
 }
 
+// annotateResourceWithMap annotates a resource with the provided map of annotations.
 func annotateResourceWithMap(ctx context.Context, kind, name, namespace string, m map[string]string) error {
 	resource := &metav1.PartialObjectMetadata{}
 	resource.SetGroupVersionKind(schema.GroupVersionKind{
@@ -92,4 +102,70 @@ func annotateResourceWithMap(ctx context.Context, kind, name, namespace string, 
 	}
 
 	return nil
+}
+
+// waitForResourceReconciliation waits for a resource to become ready after a reconciliation request.
+func waitForResourceReconciliation(ctx context.Context, kind, name, namespace, requestTime string, timeout time.Duration) (string, error) {
+	resource := &unstructured.Unstructured{}
+	resource.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   fluxcdv1.GroupVersion.Group,
+		Version: fluxcdv1.GroupVersion.Version,
+		Kind:    kind,
+	})
+	resource.SetName(name)
+	resource.SetNamespace(namespace)
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return "", fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true,
+		isResourceReconciledFunc(kubeClient, resource, requestTime)); err != nil {
+		return "", err
+	}
+
+	if res, err := status.GetObjectWithConditions(resource.Object); err == nil {
+		for _, cond := range res.Status.Conditions {
+			if cond.Type == meta.ReadyCondition && cond.Status == corev1.ConditionTrue {
+				return cond.Message, nil
+			}
+		}
+	}
+
+	return "reconciliation completed successfully", nil
+}
+
+// isResourceReconciledFunc returns a function that checks if a resource has been reconciled and is ready.
+func isResourceReconciledFunc(kubeClient client.Client, obj *unstructured.Unstructured, requestTime string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		err := kubeClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		if err != nil {
+			return false, err
+		}
+
+		if ssautil.AnyInMetadata(obj, map[string]string{fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue}) {
+			return false, fmt.Errorf("Reconciliation is disabled for %s", obj.GetName())
+		}
+
+		lastHandledReconcileAt, _, _ := unstructured.NestedString(obj.Object, "status", "lastHandledReconcileAt")
+		if lastHandledReconcileAt != requestTime {
+			return false, nil
+		}
+
+		if res, err := status.GetObjectWithConditions(obj.Object); err == nil {
+			for _, cond := range res.Status.Conditions {
+				if cond.Type == meta.ReadyCondition {
+					switch cond.Status {
+					case corev1.ConditionTrue:
+						return true, nil
+					case corev1.ConditionFalse:
+						return false, errors.New(cond.Message)
+					}
+				}
+			}
+		}
+
+		return false, nil
+	}
 }

--- a/cmd/cli/get_inputprovider.go
+++ b/cmd/cli/get_inputprovider.go
@@ -23,9 +23,11 @@ var getInputProviderCmd = &cobra.Command{
 	RunE:    getInputProviderCmdRun,
 }
 
-var getInputProviderArgs struct {
+type getInputProviderFlags struct {
 	allNamespaces bool
 }
+
+var getInputProviderArgs getInputProviderFlags
 
 func init() {
 	getInputProviderCmd.Flags().BoolVarP(&getInputProviderArgs.allNamespaces, "all-namespaces", "A", false,

--- a/cmd/cli/resume_inputprovider.go
+++ b/cmd/cli/resume_inputprovider.go
@@ -31,9 +31,15 @@ func resumeInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	return annotateResource(ctx,
+	err := annotateResource(ctx,
 		fluxcdv1.ResourceSetInputProviderKind, args[0],
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.EnabledValue)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, "Reconciliation resumed")
+	return nil
 }

--- a/cmd/cli/resume_instance.go
+++ b/cmd/cli/resume_instance.go
@@ -30,9 +30,15 @@ func resumeInstanceCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	return annotateResource(ctx,
+	err := annotateResource(ctx,
 		fluxcdv1.FluxInstanceKind, args[0],
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.EnabledValue)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, "Reconciliation resumed")
+	return nil
 }

--- a/cmd/cli/resume_resourceset.go
+++ b/cmd/cli/resume_resourceset.go
@@ -31,9 +31,15 @@ func resumeResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	return annotateResource(ctx,
+	err := annotateResource(ctx,
 		fluxcdv1.ResourceSetKind, args[0],
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.EnabledValue)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, "Reconciliation resumed")
+	return nil
 }

--- a/cmd/cli/suspend_inputprovider.go
+++ b/cmd/cli/suspend_inputprovider.go
@@ -31,9 +31,15 @@ func suspendInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	return annotateResource(ctx,
+	err := annotateResource(ctx,
 		fluxcdv1.ResourceSetInputProviderKind, args[0],
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.DisabledValue)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, "Reconciliation suspended")
+	return nil
 }

--- a/cmd/cli/suspend_instance.go
+++ b/cmd/cli/suspend_instance.go
@@ -30,9 +30,15 @@ func suspendInstanceCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	return annotateResource(ctx,
+	err := annotateResource(ctx,
 		fluxcdv1.FluxInstanceKind, args[0],
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.DisabledValue)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, "Reconciliation suspended")
+	return nil
 }

--- a/cmd/cli/suspend_resourceset.go
+++ b/cmd/cli/suspend_resourceset.go
@@ -31,9 +31,15 @@ func suspendResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	return annotateResource(ctx,
+	err := annotateResource(ctx,
 		fluxcdv1.ResourceSetKind, args[0],
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.DisabledValue)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, "Reconciliation suspended")
+	return nil
 }


### PR DESCRIPTION
This PR adds a `--wait` flag (default `true`) to the `flux-operator reconcile` commands. The CLI commands will now output the ready message either when the reconciliation was successful or if it resulted in an error.

```console
$ flux-operator reconcile rset apps -n flux-system
► Reconciliation triggered
◎ Waiting for reconciliation...
✔ Reconciliation finished in 57ms

$ flux-operator reconcile instance flux -n flux-system
► Reconciliation triggered
◎ Waiting for reconciliation...
✗ Reconciliation is disabled for flux
``` 