### PR TITLE
Update some inconsistencies in FluxInstance docs

### DIFF
--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -27,7 +27,7 @@ type FluxInstanceSpec struct {
 	Distribution Distribution `json:"distribution"`
 
 	// Components is the list of controllers to install.
-	// Defaults to all controllers.
+	// Defaults to a commonly used subset.
 	// +optional
 	Components []Component `json:"components,omitempty"`
 
@@ -133,10 +133,11 @@ type Cluster struct {
 	// Domain is the cluster domain used for generating the FQDN of services.
 	// Defaults to 'cluster.local'.
 	// +kubebuilder:default:=cluster.local
-	// +required
+	// +optional
 	Domain string `json:"domain"`
 
-	// Multitenant enables the multitenancy lockdown.
+	// Multitenant enables the multitenancy lockdown. Defaults to false.
+	// +kubebuilder:default:=false
 	// +optional
 	Multitenant bool `json:"multitenant,omitempty"`
 
@@ -155,7 +156,7 @@ type Cluster struct {
 	// NetworkPolicy restricts network access to the current namespace.
 	// Defaults to true.
 	// +kubebuilder:default:=true
-	// +required
+	// +optional
 	NetworkPolicy bool `json:"networkPolicy"`
 
 	// Type specifies the distro of the Kubernetes cluster.

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -62,7 +62,9 @@ spec:
                       Defaults to 'cluster.local'.
                     type: string
                   multitenant:
-                    description: Multitenant enables the multitenancy lockdown.
+                    default: false
+                    description: Multitenant enables the multitenancy lockdown. Defaults
+                      to false.
                     type: boolean
                   networkPolicy:
                     default: true
@@ -94,9 +96,6 @@ spec:
                     - azure
                     - gcp
                     type: string
-                required:
-                - domain
-                - networkPolicy
                 type: object
               commonMetadata:
                 description: |-
@@ -118,7 +117,7 @@ spec:
               components:
                 description: |-
                   Components is the list of controllers to install.
-                  Defaults to all controllers.
+                  Defaults to a commonly used subset.
                 items:
                   description: Component is the name of a controller to install.
                   enum:

--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -320,6 +320,7 @@ The supported values are `kubernetes` (default), `openshift`, `azure`, `aws` and
 
 The `.spec.cluster.multitenant` field is optional and specifies whether to enable Flux
 [multi-tenancy lockdown](https://fluxcd.io/flux/installation/configuration/multitenancy/).
+By default, it is `false` (disabled).
 
 The `.spec.cluster.tenantDefaultServiceAccount` is optional and specifies the default
 service account used by Flux when reconciling `Kustomization` and `HelmRelease`


### PR DESCRIPTION
Creating first FluxInstance and going through docs, I noticed these. I'm not sure I'm doing any of it right.
- The `components` list defaults to 4 out of 6, it is correct in docs, but the API says "all".
- Cluster `domain` and `networkPolicy` are marked as required, but they have default values. This causes at least VSCode yaml-spec extension to complain when editing the manifest if those properties are not specified. In documentation they are marked as optional.
- Cluster `multitenant` defaults to false, but that's not documented.