### PR TITLE
feature: Add support for Azure DevOps to `ResourceSetInputProvider`

### DIFF
--- a/api/v1/resourcesetinputprovider_types.go
+++ b/api/v1/resourcesetinputprovider_types.go
@@ -17,13 +17,16 @@ import (
 const (
 	ResourceSetInputProviderKind = "ResourceSetInputProvider"
 
-	InputProviderStatic             = "Static"
-	InputProviderGitHubBranch       = "GitHubBranch"
-	InputProviderGitHubTag          = "GitHubTag"
-	InputProviderGitHubPullRequest  = "GitHubPullRequest"
-	InputProviderGitLabBranch       = "GitLabBranch"
-	InputProviderGitLabTag          = "GitLabTag"
-	InputProviderGitLabMergeRequest = "GitLabMergeRequest"
+	InputProviderStatic                 = "Static"
+	InputProviderGitHubBranch           = "GitHubBranch"
+	InputProviderGitHubTag              = "GitHubTag"
+	InputProviderGitHubPullRequest      = "GitHubPullRequest"
+	InputProviderGitLabBranch           = "GitLabBranch"
+	InputProviderGitLabTag              = "GitLabTag"
+	InputProviderGitLabMergeRequest     = "GitLabMergeRequest"
+	InputProviderAzureDevOpsBranch      = "AzureDevOpsBranch"
+	InputProviderAzureDevOpsPullRequest = "AzureDevOpsPullRequest"
+	InputProviderAzureDevOpsTag         = "AzureDevOpsTag"
 
 	ReasonInvalidDefaultValues  = "InvalidDefaultValues"
 	ReasonInvalidExportedInputs = "InvalidExportedInputs"
@@ -34,7 +37,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="self.type == 'Static' || has(self.url)", message="spec.url must not be empty when spec.type is not 'Static'"
 type ResourceSetInputProviderSpec struct {
 	// Type specifies the type of the input provider.
-	// +kubebuilder:validation:Enum=Static;GitHubBranch;GitHubTag;GitHubPullRequest;GitLabBranch;GitLabTag;GitLabMergeRequest
+	// +kubebuilder:validation:Enum=Static;GitHubBranch;GitHubTag;GitHubPullRequest;GitLabBranch;GitLabTag;GitLabMergeRequest;AzureDevOpsBranch;AzureDevOpsTag;AzureDevOpsPullRequest
 	// +required
 	Type string `json:"type"`
 

--- a/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
@@ -168,6 +168,9 @@ spec:
                 - GitLabBranch
                 - GitLabTag
                 - GitLabMergeRequest
+                - AzureDevOpsBranch
+                - AzureDevOpsTag
+                - AzureDevOpsPullRequest
                 type: string
               url:
                 description: |-

--- a/docs/api/v1/resourcesetinputprovider.md
+++ b/docs/api/v1/resourcesetinputprovider.md
@@ -98,6 +98,9 @@ The following types are supported:
 - `GitLabMergeRequest`: fetches input values from opened GitLab Merge Requests.
 - `GitLabBranch`: fetches input values from GitLab project branches.
 - `GitLabTag`: fetches input values from GitLab project tags.
+- `AzureDevOpsPullRequest`: fetches input values from opened Azure DevOps Pull Requests.
+- `AzureDevOpsBranch`: fetches input values from Azure DevOps repository branches.
+- `AzureDevOpsTag`: fetches input values from AzureDevOps project tags.
 
 For the `Static` type, the flux-operator will export in `.status.exportedInputs` a
 single input map with the values from the field `.spec.defaultValues` and the

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/gosimple/slug v1.15.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/mark3labs/mcp-go v0.27.0
+	github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,7 @@ github.com/google/pprof v0.0.0-20250501235452-c0086092b71a h1:rDA3FfmxwXR+BVKKdz
 github.com/google/pprof v0.0.0-20250501235452-c0086092b71a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
@@ -252,6 +253,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0 h1:mmJCWLe63QvybxhW1iBmQWEaCKdc4SKgALfTNZ+OphU=
+github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0/go.mod h1:mDunUZ1IUJdJIRHvFb+LPBUtxe3AYB5MI6BMXNg8194=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=

--- a/internal/controller/resourcesetinputprovider_controller.go
+++ b/internal/controller/resourcesetinputprovider_controller.go
@@ -300,6 +300,16 @@ func (r *ResourceSetInputProviderReconciler) newGitProvider(ctx context.Context,
 			CertPool: certPool,
 			Token:    token,
 		})
+	case strings.HasPrefix(obj.Spec.Type, "AzureDevOps"):
+		token, err := r.getAzureDevOpsToken(obj, authData)
+		if err != nil {
+			return nil, err
+		}
+		return gitprovider.NewAzureDevOpsProvider(ctx, gitprovider.Options{
+			URL:      obj.Spec.URL,
+			CertPool: certPool,
+			Token:    token,
+		})
 	default:
 		return nil, fmt.Errorf("unsupported type: %s", obj.Spec.Type)
 	}
@@ -511,6 +521,19 @@ func (r *ResourceSetInputProviderReconciler) getGitHubToken(
 
 // getGitLabToken returns the appropriate GitLab token by reading the secrets in authData.
 func (r *ResourceSetInputProviderReconciler) getGitLabToken(
+	obj *fluxcdv1.ResourceSetInputProvider,
+	authData map[string][]byte) (string, error) {
+
+	if authData == nil {
+		return "", nil
+	}
+
+	_, password, err := r.getBasicAuth(obj, authData)
+	return password, err
+}
+
+// getAzureDevOpsToken returns the appropriate AzureDevOps token by reading the secrets in authData.
+func (r *ResourceSetInputProviderReconciler) getAzureDevOpsToken(
 	obj *fluxcdv1.ResourceSetInputProvider,
 	authData map[string][]byte) (string, error) {
 

--- a/internal/gitprovider/azuredevops.go
+++ b/internal/gitprovider/azuredevops.go
@@ -1,0 +1,215 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package gitprovider
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/inputs"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	git "github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
+)
+
+type AzureDevOpsProvider struct {
+	Client  git.Client
+	Owner   string
+	Project string
+	Repo    string
+}
+
+func NewAzureDevOpsProvider(ctx context.Context, opts Options) (*AzureDevOpsProvider, error) {
+	var client git.Client
+
+	host, owner, project, repo, err := parseAzureDevOpsURL(opts.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	if host == "https://dev.azure.com" {
+		// Create a Azure DevOps connection to your organization
+		connection := azuredevops.NewPatConnection(fmt.Sprintf("%s/%s/", host, owner), opts.Token)
+
+		// Create a Azure DevOps client to interact with the git area
+		client, err = git.NewClient(ctx, connection)
+		if err != nil {
+			return nil, fmt.Errorf("could not create Azure DevOps git client: %w", err)
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported Azure DevOps host: %s", host)
+	}
+
+	return &AzureDevOpsProvider{
+		Client:  client,
+		Owner:   owner,
+		Project: project,
+		Repo:    repo,
+	}, nil
+}
+
+func (p *AzureDevOpsProvider) ListTags(ctx context.Context, opts Options) ([]Result, error) {
+	filterString := "tags"
+	azRefArguments := git.GetRefsArgs{
+		RepositoryId: &p.Repo,
+		Project:      &p.Project,
+		Filter:       &filterString,
+	}
+
+	// No straightforward api call to list all tags (GetAnnotatedTag() does not return lightweight tags)
+	// will filter on "tags" with GetRefs
+	azRefs, err := p.Client.GetRefs(ctx, azRefArguments)
+	if err != nil {
+		return nil, fmt.Errorf("could not list tags: %v", err)
+	}
+
+	tagMap := make(map[string]string)
+	semverList := make([]string, 0, len(azRefs.Value))
+
+	for _, gitRef := range azRefs.Value {
+		if gitRef.Name == nil || gitRef.ObjectId == nil {
+			continue // skip invalid refs
+		}
+		tagName := strings.TrimPrefix(*gitRef.Name, "refs/tags/")
+		tagMap[tagName] = *gitRef.ObjectId
+		semverList = append(semverList, tagName)
+	}
+
+	// semver sorting
+	semverResults := sortSemver(opts, semverList)
+
+	results := make([]Result, 0)
+	for _, tagName := range semverResults {
+		objectID := tagMap[tagName]
+		sha := objectID // fallback for lightweight tag
+
+		azTagArguments := git.GetAnnotatedTagArgs{
+			Project:      &p.Project,
+			RepositoryId: &p.Repo,
+			ObjectId:     &objectID,
+		}
+
+		// if the tag is annotated, the commit sha is not stored in objectId but a separate api call must be made to access the commit sha
+		annotatedTag, err := p.Client.GetAnnotatedTag(ctx, azTagArguments)
+		if err == nil && annotatedTag != nil && annotatedTag.ObjectId != nil && annotatedTag.TaggedObject != nil && annotatedTag.TaggedObject.ObjectId != nil {
+			sha = *annotatedTag.TaggedObject.ObjectId
+		}
+
+		results = append(results, Result{
+			ID:  inputs.Checksum(tagName),
+			SHA: sha,
+			Tag: tagName,
+		})
+
+		if opts.Filters.Limit > 0 && len(results) >= opts.Filters.Limit {
+			break
+		}
+	}
+
+	return results, nil
+}
+
+func (p *AzureDevOpsProvider) ListBranches(ctx context.Context, opts Options) ([]Result, error) {
+	azBranchArguments := git.GetBranchesArgs{
+		RepositoryId: &p.Repo,
+		Project:      &p.Project,
+	}
+
+	azGitBranches, err := p.Client.GetBranches(ctx, azBranchArguments)
+	if err != nil {
+		return nil, fmt.Errorf("could not get branches: %v", err)
+	}
+
+	results := make([]Result, 0)
+	for _, branch := range *azGitBranches {
+		if branch.Commit == nil || branch.Commit.CommitId == nil || branch.Name == nil {
+			continue
+		}
+
+		if !matchBranch(opts, *branch.Name) {
+			continue
+		}
+
+		results = append(results, Result{
+			ID:     inputs.Checksum(*branch.Name),
+			SHA:    *branch.Commit.CommitId,
+			Branch: *branch.Name,
+		})
+
+		if opts.Filters.Limit > 0 && len(results) >= opts.Filters.Limit {
+			return results, nil
+		}
+	}
+
+	return results, nil
+}
+
+func (p *AzureDevOpsProvider) ListRequests(ctx context.Context, opts Options) ([]Result, error) {
+	azGitPullRequestsArguments := git.GetPullRequestsArgs{
+		RepositoryId:   &p.Repo,
+		SearchCriteria: &git.GitPullRequestSearchCriteria{},
+		Project:        &p.Project,
+	}
+
+	azGitPullRequests, err := p.Client.GetPullRequests(ctx, azGitPullRequestsArguments)
+	if err != nil {
+		return nil, fmt.Errorf("could not list pull requests: %v", err)
+	}
+
+	results := make([]Result, 0)
+	for _, pr := range *azGitPullRequests {
+		if pr.SourceRefName == nil || pr.PullRequestId == nil || pr.LastMergeSourceCommit == nil || pr.LastMergeSourceCommit.CommitId == nil || pr.Title == nil || pr.CreatedBy == nil || pr.CreatedBy.DisplayName == nil {
+			continue
+		}
+
+		sourceBranch := strings.TrimPrefix(*pr.SourceRefName, "refs/heads/")
+
+		if !matchBranch(opts, sourceBranch) {
+			continue
+		}
+
+		prLabels := []string{}
+		if pr.Labels != nil {
+			prLabels = make([]string, len(*pr.Labels))
+			for i, l := range *pr.Labels {
+				prLabels[i] = *l.Name
+			}
+		}
+
+		if !matchLabels(opts, prLabels) {
+			continue
+		}
+
+		results = append(results, Result{
+			ID:     fmt.Sprintf("%d", *pr.PullRequestId),
+			SHA:    *pr.LastMergeSourceCommit.CommitId,
+			Branch: sourceBranch,
+			Title:  *pr.Title,
+			Author: *pr.CreatedBy.DisplayName,
+			Labels: prLabels,
+		})
+
+		if opts.Filters.Limit > 0 && len(results) >= opts.Filters.Limit {
+			return results, nil
+		}
+	}
+	return results, nil
+}
+
+// parseAzureDevOpsURL parses a AzureDevOps URL and returns the host, owner, project and repo.
+// a AzureDevOps URL has the following structure: https://dev.azure.com/{organization}/{project}/_git/{repository}
+func parseAzureDevOpsURL(azURL string) (string, string, string, string, error) {
+	u, err := url.Parse(azURL)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("invalid URL %q: %w", azURL, err)
+	}
+
+	parts := strings.Split(strings.TrimLeft(u.Path, "/"), "/")
+	if len(parts) != 4 || parts[2] != "_git" {
+		return "", "", "", "", fmt.Errorf("invalid AzureDevOps URL %q: can't find owner and repository", azURL)
+	}
+
+	return fmt.Sprintf("%s://%s", u.Scheme, u.Host), parts[0], parts[1], parts[3], nil
+}

--- a/internal/gitprovider/azuredevops_test.go
+++ b/internal/gitprovider/azuredevops_test.go
@@ -1,0 +1,336 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package gitprovider
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	. "github.com/onsi/gomega"
+)
+
+func TestAzureDevOpsProvider_ListTags(t *testing.T) {
+	newConstraint := func(s string) *semver.Constraints {
+		c, err := semver.NewConstraint(s)
+		if err != nil {
+			panic(err)
+		}
+		return c
+	}
+	tests := []struct {
+		name       string
+		opts       Options
+		want       []Result
+		wantErrMsg string
+	}{
+		{
+			name: "filters tags by semver",
+			opts: Options{
+				Token: os.Getenv("AZURE_TOKEN"),
+				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
+				Filters: Filters{
+					SemverConstraints: newConstraint("> 6.0.1 < 6.1.0"),
+				},
+			},
+			want: []Result{
+				{
+					ID:  "48955639",
+					SHA: "11cf36d83818e64aaa60d523ab6438258ebb6009",
+					Tag: "6.0.4",
+				},
+				{
+					ID:  "48890102",
+					SHA: "ea292aa958c5e348266518af2261dc04d6270439",
+					Tag: "6.0.3",
+				},
+				{
+					ID:  "48824565",
+					SHA: "693ffa9d28208c677738a0e2061f41694dfaa183",
+					Tag: "6.0.2",
+				},
+			},
+		},
+		{
+			name: "filters tags by semver and limit",
+			opts: Options{
+				Token: os.Getenv("AZURE_TOKEN"),
+				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
+				Filters: Filters{
+					SemverConstraints: newConstraint("6.0.x"),
+					Limit:             1,
+				},
+			},
+			want: []Result{
+				{
+					ID:  "48955639",
+					SHA: "11cf36d83818e64aaa60d523ab6438258ebb6009",
+					Tag: "6.0.4",
+				},
+			},
+		},
+		{
+			name: "filters tags by limit",
+			opts: Options{
+				Token: os.Getenv("AZURE_TOKEN"),
+				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
+				Filters: Filters{
+					SemverConstraints: newConstraint("0.0.x"),
+				},
+			},
+			want: []Result{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			provider, err := NewAzureDevOpsProvider(context.Background(), tt.opts)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			got, err := provider.ListTags(context.Background(), tt.opts)
+			if len(tt.wantErrMsg) > 0 {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.wantErrMsg))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(got).To(BeEquivalentTo(tt.want))
+		})
+	}
+}
+
+func TestAzureDevOpsProvider_ListBranches(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       Options
+		want       []Result
+		wantErrMsg string
+	}{
+		{
+			name: "filters branches by regex",
+			opts: Options{
+				Token: os.Getenv("AZURE_TOKEN"),
+				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
+				Filters: Filters{
+					IncludeBranchRe: regexp.MustCompile(`test*`),
+					ExcludeBranchRe: regexp.MustCompile(`^feat/.*`),
+				},
+			},
+			want: []Result{
+				{
+					ID:     "105841138",
+					SHA:    "d233e53524b51c38f974f672d993bd8e6635f2cf",
+					Branch: "test1",
+				},
+				{
+					ID:     "105906675",
+					SHA:    "474beb4fe680877b42d22b66b921872c3aba6be3",
+					Branch: "test2",
+				},
+				{
+					ID:     "105972212",
+					SHA:    "abcad46a4437ca375e8533d42b9dc2609434aefe",
+					Branch: "test3",
+				},
+				{
+					ID:     "106037749",
+					SHA:    "d217582ec33a4697773631f0d59f45e1c7a915ec",
+					Branch: "test4",
+				},
+			},
+		},
+		{
+			name: "filters branches by limit",
+			opts: Options{
+				Token: os.Getenv("AZURE_TOKEN"),
+				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
+				Filters: Filters{
+					IncludeBranchRe: regexp.MustCompile(`ma*`),
+					Limit:           1,
+				},
+			},
+			want: []Result{
+				{
+					ID:     "148701837",
+					SHA:    "c23d57a4e998016075ad67f4ad0e6c607e012fc8",
+					Branch: "master",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			provider, err := NewAzureDevOpsProvider(context.Background(), tt.opts)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			got, err := provider.ListBranches(context.Background(), tt.opts)
+			if len(tt.wantErrMsg) > 0 {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.wantErrMsg))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(got).To(BeEquivalentTo(tt.want))
+		})
+	}
+}
+
+func TestAzureDevOpsProvider_ListRequests(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       Options
+		want       []Result
+		wantErrMsg string
+	}{
+		{
+			name: "all prs",
+			opts: Options{
+				Token: os.Getenv("AZURE_TOKEN"),
+				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
+			},
+			want: []Result{
+				{
+					ID:     "5",
+					SHA:    "2c63b750ee7520429fbf49f2867859211f3c94aa",
+					Branch: "feat/5",
+					Tag:    "",
+					Author: "Stefan Prodan",
+					Title:  "New feature test",
+					Labels: []string{"feat"},
+				},
+				{
+					ID:     "4",
+					SHA:    "d217582ec33a4697773631f0d59f45e1c7a915ec",
+					Branch: "test4",
+					Tag:    "",
+					Author: "Stefan Prodan",
+					Title:  "Test 4",
+					Labels: []string{"fix", "typo"},
+				},
+				{
+					ID:     "3",
+					SHA:    "abcad46a4437ca375e8533d42b9dc2609434aefe",
+					Branch: "test3",
+					Tag:    "",
+					Author: "Stefan Prodan",
+					Title:  "Test 3",
+					Labels: []string{"fix"},
+				},
+				{
+					ID:     "2",
+					SHA:    "474beb4fe680877b42d22b66b921872c3aba6be3",
+					Branch: "test2",
+					Tag:    "",
+					Author: "Stefan Prodan",
+					Title:  "Test 2",
+					Labels: []string{"fix"},
+				},
+				{
+					ID:     "1",
+					SHA:    "d233e53524b51c38f974f672d993bd8e6635f2cf",
+					Branch: "test1",
+					Tag:    "",
+					Author: "Stefan Prodan",
+					Title:  "Test 1",
+					Labels: []string{"fix", "typo"},
+				},
+			},
+		},
+		{
+			name: "filters prs by labels and limit",
+			opts: Options{
+				Token: os.Getenv("AZURE_TOKEN"),
+				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
+				Filters: Filters{
+					Limit:  2,
+					Labels: []string{"fix"},
+				},
+			},
+			want: []Result{
+				{
+					ID:     "4",
+					SHA:    "d217582ec33a4697773631f0d59f45e1c7a915ec",
+					Branch: "test4",
+					Tag:    "",
+					Author: "Stefan Prodan",
+					Title:  "Test 4",
+					Labels: []string{"fix", "typo"},
+				},
+				{
+					ID:     "3",
+					SHA:    "abcad46a4437ca375e8533d42b9dc2609434aefe",
+					Branch: "test3",
+					Tag:    "",
+					Author: "Stefan Prodan",
+					Title:  "Test 3",
+					Labels: []string{"fix"},
+				},
+			},
+		},
+		{
+			name: "filters prs by branches",
+			opts: Options{
+				Token: os.Getenv("AZURE_TOKEN"),
+				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
+				Filters: Filters{
+					IncludeBranchRe: regexp.MustCompile(`^feat/.*`),
+				},
+			},
+			want: []Result{
+				{
+					ID:     "5",
+					SHA:    "2c63b750ee7520429fbf49f2867859211f3c94aa",
+					Branch: "feat/5",
+					Tag:    "",
+					Author: "Stefan Prodan",
+					Title:  "New feature test",
+					Labels: []string{"feat"},
+				},
+			},
+		},
+		{
+			name: "repo not found",
+			opts: Options{
+				URL: "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/doesnotexist",
+			},
+			wantErrMsg: "could not list pull requests: TF401019: The Git repository with name or identifier doesnotexist does not exist or you do not have permissions for the operation you are attempting.",
+		},
+		{
+			name: "invalid token using random private azure dev ops repo",
+			opts: Options{
+				Token: "wrong-token",
+				URL:   "https://dev.azure.com/acme-corp/infrastructure-project/_git/terraform-modules",
+			},
+			wantErrMsg: "The user 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' is not authorized to access this resource.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			provider, err := NewAzureDevOpsProvider(context.Background(), tt.opts)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			got, err := provider.ListRequests(context.Background(), tt.opts)
+			if len(tt.wantErrMsg) > 0 {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.wantErrMsg))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(got).To(BeEquivalentTo(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
`ResourceSetInputProvider` currently has support for the GitHub and GitLab git providers. Since the interface for the git providers only has 2 functions(now 3), I would like to contribute by adding support for Azure Dev ops. I have made the commits for this contribution in the following forked repo: