### PR TITLE
cli: Add completion for resource names and namespaces

### DIFF
--- a/cmd/cli/build_instance.go
+++ b/cmd/cli/build_instance.go
@@ -33,7 +33,6 @@ var buildInstanceCmd = &cobra.Command{
 4. Builds the Flux Kubernetes manifests according to the instance specifications and kustomize patches.
 5. Prints the multi-doc YAML containing the Flux Kubernetes manifests to stdout.
 `,
-	RunE: buildInstanceCmdRun,
 	Example: `  # Build the given FluxInstance and print the generated manifests
   flux-operator build instance -f flux.yaml
 
@@ -44,6 +43,8 @@ var buildInstanceCmd = &cobra.Command{
   flux-operator build instance -f flux.yaml | \
     kubectl diff --server-side --field-manager=flux-operator -f -
 `,
+	Args: cobra.NoArgs,
+	RunE: buildInstanceCmdRun,
 }
 
 type buildInstanceFlags struct {

--- a/cmd/cli/build_resourceset.go
+++ b/cmd/cli/build_resourceset.go
@@ -25,7 +25,6 @@ var buildResourceSetCmd = &cobra.Command{
 	Use:     "resourceset",
 	Aliases: []string{"rset"},
 	Short:   "Build ResourceSet templates to Kubernetes objects",
-	RunE:    buildResourceSetCmdRun,
 	Example: `  # Build the given ResourceSet and print the generated objects
   flux-operator build resourceset -f my-resourceset.yaml
 
@@ -40,18 +39,20 @@ var buildResourceSetCmd = &cobra.Command{
   flux-operator build resourceset -f my-resourceset.yaml | \
     kubectl diff --server-side --field-manager=flux-operator -f -
 `,
+	Args: cobra.NoArgs,
+	RunE: buildResourceSetCmdRun,
 }
 
 type buildResourceSetFlags struct {
 	filename   string
-	inputsProm string
+	inputsFrom string
 }
 
 var buildResourceSetArgs buildResourceSetFlags
 
 func init() {
 	buildResourceSetCmd.Flags().StringVarP(&buildResourceSetArgs.filename, "filename", "f", "", "Path to the ResourceSet YAML manifest.")
-	buildResourceSetCmd.Flags().StringVarP(&buildResourceSetArgs.inputsProm, "inputs-from", "i", "", "Path to the ResourceSet inputs YAML manifest.")
+	buildResourceSetCmd.Flags().StringVarP(&buildResourceSetArgs.inputsFrom, "inputs-from", "i", "", "Path to the ResourceSet inputs YAML manifest.")
 
 	buildCmd.AddCommand(buildResourceSetCmd)
 }
@@ -87,12 +88,12 @@ func buildResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error parsing ResourceSet: %w", err)
 	}
 
-	if len(rset.Spec.InputsFrom) > 0 && buildResourceSetArgs.inputsProm == "" {
+	if len(rset.Spec.InputsFrom) > 0 && buildResourceSetArgs.inputsFrom == "" {
 		return fmt.Errorf("ResourceSet has '.spec.inputsFrom', please provide the inputs with --inputs-from")
 	}
 
-	if buildResourceSetArgs.inputsProm != "" {
-		inputsData, err := os.ReadFile(buildResourceSetArgs.inputsProm)
+	if buildResourceSetArgs.inputsFrom != "" {
+		inputsData, err := os.ReadFile(buildResourceSetArgs.inputsFrom)
 		if err != nil {
 			return fmt.Errorf("error reading inputs file: %w", err)
 		}

--- a/cmd/cli/completion.go
+++ b/cmd/cli/completion.go
@@ -4,7 +4,14 @@
 package main
 
 import (
+	"context"
+	"strings"
+
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 )
 
 var completionCmd = &cobra.Command{
@@ -15,4 +22,62 @@ var completionCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(completionCmd)
+}
+
+// resourceNamesCompletionFunc returns a function that can be used as a completion function for resource names.
+func resourceNamesCompletionFunc(gvk schema.GroupVersionKind) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+		defer cancel()
+
+		cfg, err := kubeconfigArgs.ToRESTConfig()
+		if err != nil {
+			return completionError(err)
+		}
+
+		mapper, err := kubeconfigArgs.ToRESTMapper()
+		if err != nil {
+			return completionError(err)
+		}
+
+		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			return completionError(err)
+		}
+
+		kubeClient, err := dynamic.NewForConfig(cfg)
+		if err != nil {
+			return completionError(err)
+		}
+
+		var dr dynamic.ResourceInterface
+		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+			dr = kubeClient.Resource(mapping.Resource).Namespace(*kubeconfigArgs.Namespace)
+		} else {
+			dr = kubeClient.Resource(mapping.Resource)
+		}
+
+		list, err := dr.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return completionError(err)
+		}
+
+		var comps []string
+
+		for _, item := range list.Items {
+			name := item.GetName()
+
+			if strings.HasPrefix(name, toComplete) {
+				comps = append(comps, name)
+			}
+		}
+
+		return comps, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// completionError is a helper function to handle errors in completion functions.
+func completionError(err error) ([]string, cobra.ShellCompDirective) {
+	cobra.CompError(err.Error())
+	return nil, cobra.ShellCompDirectiveError
 }

--- a/cmd/cli/get_inputprovider.go
+++ b/cmd/cli/get_inputprovider.go
@@ -17,10 +17,11 @@ import (
 )
 
 var getInputProviderCmd = &cobra.Command{
-	Use:     "inputprovider",
-	Aliases: []string{"rsip", "resourcesetinputproviders"},
-	Short:   "List ResourceSetInputProviders",
-	RunE:    getInputProviderCmdRun,
+	Use:               "inputprovider",
+	Aliases:           []string{"rsip", "resourcesetinputproviders"},
+	Short:             "List ResourceSetInputProviders",
+	RunE:              getInputProviderCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)),
 }
 
 type getInputProviderFlags struct {

--- a/cmd/cli/get_instance.go
+++ b/cmd/cli/get_instance.go
@@ -17,10 +17,11 @@ import (
 )
 
 var getInstanceCmd = &cobra.Command{
-	Use:     "instance",
-	Aliases: []string{"instances"},
-	Short:   "List Flux instances",
-	RunE:    geInstanceCmdRun,
+	Use:               "instance",
+	Aliases:           []string{"instances"},
+	Short:             "List Flux instances",
+	RunE:              geInstanceCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)),
 }
 
 type getInstanceFlags struct {

--- a/cmd/cli/get_resourceset.go
+++ b/cmd/cli/get_resourceset.go
@@ -17,10 +17,11 @@ import (
 )
 
 var getResourceSetCmd = &cobra.Command{
-	Use:     "resourceset",
-	Aliases: []string{"resourcesets", "rset"},
-	Short:   "List ResourceSets",
-	RunE:    getResourceSetCmdRun,
+	Use:               "resourceset",
+	Aliases:           []string{"resourcesets", "rset"},
+	Short:             "List ResourceSets",
+	RunE:              getResourceSetCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)),
 }
 
 type getResourceSetFlags struct {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"
@@ -48,6 +49,11 @@ func init() {
 	rootCmd.PersistentFlags().DurationVar(&rootArgs.timeout, "timeout", rootArgs.timeout,
 		"The length of time to wait before giving up on the current operation.")
 	addKubeConfigFlags(rootCmd)
+
+	err := rootCmd.RegisterFlagCompletionFunc("namespace", resourceNamesCompletionFunc(corev1.SchemeGroupVersion.WithKind("Namespace")))
+	if err != nil {
+		rootCmd.PrintErrf("✗ failed to register namespace completion function: %v\n", err)
+	}
 
 	rootCmd.SetOut(os.Stdout)
 }

--- a/cmd/cli/reconcile_inputprovider.go
+++ b/cmd/cli/reconcile_inputprovider.go
@@ -27,7 +27,8 @@ var reconcileInputProviderCmd = &cobra.Command{
   # Trigger the reconciliation of a ResourceSetInputProvider without waiting for it to become ready
   flux-operator -n flux-system reconcile rsip my-inputprovider --wait=false
 `,
-	RunE: reconcileInputProviderCmdRun,
+	RunE:              reconcileInputProviderCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)),
 }
 
 type reconcileInputProviderFlags struct {

--- a/cmd/cli/reconcile_instance.go
+++ b/cmd/cli/reconcile_instance.go
@@ -23,7 +23,8 @@ var reconcileInstanceCmd = &cobra.Command{
   # Trigger the reconciliation of an instance without waiting for it to become ready
   flux-operator -n flux-system reconcile instance flux --wait=false
 `,
-	RunE: reconcileInstanceCmdRun,
+	RunE:              reconcileInstanceCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)),
 }
 
 type reconcileInstanceFlags struct {

--- a/cmd/cli/reconcile_resourceset.go
+++ b/cmd/cli/reconcile_resourceset.go
@@ -24,7 +24,8 @@ var reconcileResourceSetCmd = &cobra.Command{
   # Trigger the reconciliation of a ResourceSet without waiting for it to become ready
   flux-operator -n flux-system reconcile rset my-resourceset --wait=false
 `,
-	RunE: reconcileResourceSetCmdRun,
+	RunE:              reconcileResourceSetCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)),
 }
 
 type reconcileResourceSetFlags struct {

--- a/cmd/cli/resume_inputprovider.go
+++ b/cmd/cli/resume_inputprovider.go
@@ -13,10 +13,11 @@ import (
 )
 
 var resumeInputProviderCmd = &cobra.Command{
-	Use:     "inputprovider",
-	Aliases: []string{"rsip", "resourcesetinputprovider"},
-	Short:   "Resume ResourceSetInputProvider reconciliation",
-	RunE:    resumeInputProviderCmdRun,
+	Use:               "inputprovider",
+	Aliases:           []string{"rsip", "resourcesetinputprovider"},
+	Short:             "Resume ResourceSetInputProvider reconciliation",
+	RunE:              resumeInputProviderCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)),
 }
 
 func init() {

--- a/cmd/cli/resume_instance.go
+++ b/cmd/cli/resume_instance.go
@@ -13,9 +13,10 @@ import (
 )
 
 var resumeInstanceCmd = &cobra.Command{
-	Use:   "instance",
-	Short: "Resume FluxInstance reconciliation",
-	RunE:  resumeInstanceCmdRun,
+	Use:               "instance",
+	Short:             "Resume FluxInstance reconciliation",
+	RunE:              resumeInstanceCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)),
 }
 
 func init() {

--- a/cmd/cli/resume_resourceset.go
+++ b/cmd/cli/resume_resourceset.go
@@ -13,10 +13,11 @@ import (
 )
 
 var resumeResourceSetCmd = &cobra.Command{
-	Use:     "resourceset",
-	Aliases: []string{"rset"},
-	Short:   "Resume ResourceSet reconciliation",
-	RunE:    resumeResourceSetCmdRun,
+	Use:               "resourceset",
+	Aliases:           []string{"rset"},
+	Short:             "Resume ResourceSet reconciliation",
+	RunE:              resumeResourceSetCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)),
 }
 
 func init() {

--- a/cmd/cli/suspend_inputprovider.go
+++ b/cmd/cli/suspend_inputprovider.go
@@ -13,10 +13,11 @@ import (
 )
 
 var suspendInputProviderCmd = &cobra.Command{
-	Use:     "inputprovider",
-	Aliases: []string{"rsip", "resourcesetinputprovider"},
-	Short:   "Suspend ResourceSetInputProvider reconciliation",
-	RunE:    suspendInputProviderCmdRun,
+	Use:               "inputprovider",
+	Aliases:           []string{"rsip", "resourcesetinputprovider"},
+	Short:             "Suspend ResourceSetInputProvider reconciliation",
+	RunE:              suspendInputProviderCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)),
 }
 
 func init() {

--- a/cmd/cli/suspend_instance.go
+++ b/cmd/cli/suspend_instance.go
@@ -13,9 +13,10 @@ import (
 )
 
 var suspendInstanceCmd = &cobra.Command{
-	Use:   "instance",
-	Short: "Suspend FluxInstance reconciliation",
-	RunE:  suspendInstanceCmdRun,
+	Use:               "instance",
+	Short:             "Suspend FluxInstance reconciliation",
+	RunE:              suspendInstanceCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)),
 }
 
 func init() {

--- a/cmd/cli/suspend_resourceset.go
+++ b/cmd/cli/suspend_resourceset.go
@@ -13,10 +13,11 @@ import (
 )
 
 var suspendResourceSetCmd = &cobra.Command{
-	Use:     "resourceset",
-	Aliases: []string{"rset"},
-	Short:   "Suspend ResourceSet reconciliation",
-	RunE:    suspendResourceSetCmdRun,
+	Use:               "resourceset",
+	Aliases:           []string{"rset"},
+	Short:             "Suspend ResourceSet reconciliation",
+	RunE:              suspendResourceSetCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)),
 }
 
 func init() {


### PR DESCRIPTION
This PR adds dynamic completion for resource names and namespaces to the Flux Operator CLI.

Example pressing tab:

```console
$ flux-operator -n flux-system get resourceset
apps               flux-operator      flux-operator-mcp  infra              policies
``` 