### PR TITLE
cli: Add `Last Reconciled` column to get commands

### DIFF
--- a/cmd/cli/get_inputprovider.go
+++ b/cmd/cli/get_inputprovider.go
@@ -74,8 +74,10 @@ func getInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 			inputsCount = len(obj.Status.ExportedInputs)
 		}
 		ready := "Unknown"
+		lastReconciled := "Unknown"
 		if conditions.Has(&obj, "Ready") {
 			ready = string(conditions.Get(&obj, "Ready").Status)
+			lastReconciled = conditions.Get(&obj, "Ready").LastTransitionTime.String()
 		}
 		var nextSchedule string
 		if obj.Status.NextSchedule != nil {
@@ -86,6 +88,7 @@ func getInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 			strconv.Itoa(inputsCount),
 			ready,
 			conditions.GetMessage(&obj, "Ready"),
+			lastReconciled,
 			nextSchedule,
 		}
 		if getInputProviderArgs.allNamespaces {
@@ -94,7 +97,7 @@ func getInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 		rows = append(rows, row)
 	}
 
-	header := []string{"Name", "Inputs", "Ready", "Message", "Next Schedule"}
+	header := []string{"Name", "Inputs", "Ready", "Message", "Last Reconciled", "Next Schedule"}
 	if getInputProviderArgs.allNamespaces {
 		header = append([]string{"Namespace"}, header...)
 	}

--- a/cmd/cli/get_instance.go
+++ b/cmd/cli/get_instance.go
@@ -74,14 +74,17 @@ func geInstanceCmdRun(cmd *cobra.Command, args []string) error {
 			objCount = len(instance.Status.Inventory.Entries)
 		}
 		ready := "Unknown"
+		lastReconciled := "Unknown"
 		if conditions.Has(&instance, "Ready") {
 			ready = string(conditions.Get(&instance, "Ready").Status)
+			lastReconciled = conditions.Get(&instance, "Ready").LastTransitionTime.String()
 		}
 		row := []string{
 			instance.Name,
 			strconv.Itoa(objCount),
 			ready,
 			conditions.GetMessage(&instance, "Ready"),
+			lastReconciled,
 		}
 		if getInstanceArgs.allNamespaces {
 			row = append([]string{instance.Namespace}, row...)
@@ -89,7 +92,7 @@ func geInstanceCmdRun(cmd *cobra.Command, args []string) error {
 		rows = append(rows, row)
 	}
 
-	header := []string{"Name", "Resources", "Ready", "Message"}
+	header := []string{"Name", "Resources", "Ready", "Message", "Last Reconciled"}
 	if getInstanceArgs.allNamespaces {
 		header = append([]string{"Namespace"}, header...)
 	}

--- a/cmd/cli/get_resourceset.go
+++ b/cmd/cli/get_resourceset.go
@@ -74,14 +74,17 @@ func getResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 			objCount = len(rset.Status.Inventory.Entries)
 		}
 		ready := "Unknown"
+		lastReconciled := "Unknown"
 		if conditions.Has(&rset, "Ready") {
 			ready = string(conditions.Get(&rset, "Ready").Status)
+			lastReconciled = conditions.Get(&rset, "Ready").LastTransitionTime.String()
 		}
 		row := []string{
 			rset.Name,
 			strconv.Itoa(objCount),
 			ready,
 			conditions.GetMessage(&rset, "Ready"),
+			lastReconciled,
 		}
 		if getResourceSetArgs.allNamespaces {
 			row = append([]string{rset.Namespace}, row...)
@@ -89,7 +92,7 @@ func getResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 		rows = append(rows, row)
 	}
 
-	header := []string{"Name", "Resources", "Ready", "Message"}
+	header := []string{"Name", "Resources", "Ready", "Message", "Last Reconciled"}
 	if getResourceSetArgs.allNamespaces {
 		header = append([]string{"Namespace"}, header...)
 	}


### PR DESCRIPTION
This PR adds the `Last Reconciled` column to get commands to help with debugging.

Example output:

```console 
$ flux-operator get inputprovider -A
NAMESPACE       NAME                    INPUTS  READY   MESSAGE                                 LAST RECONCILED                 NEXT SCHEDULE
podinfo-test    podinfo-release         1       True    Reconciliation finished in 318ms        2025-06-17 19:57:00 +0300 EEST  2025-06-18 08:00:00 +0300 EEST
test            podinfo-releases        1       True    Reconciliation finished in 504ms        2025-06-18 16:17:56 +0300 EEST
test            test                    1       True    Reconciliation finished in 378ms        2025-06-16 15:53:21 +0300 EEST  2025-06-18 10:00:00 +0300 EEST
```