### PR TITLE
Introduce alphabetical and numerical ordering for tags

### DIFF
--- a/api/v1/resourcesetinputprovider_types.go
+++ b/api/v1/resourcesetinputprovider_types.go
@@ -82,6 +82,9 @@ type ResourceSetInputProviderSpec struct {
 }
 
 // ResourceSetInputFilter defines the filter to apply to the input provider response.
+// +kubebuilder:validation:XValidation:rule="!has(self.semver) || !has(self.alphabetical)",message="cannot specify more than one of semver, alphabetical or numerical"
+// +kubebuilder:validation:XValidation:rule="!has(self.alphabetical) || !has(self.numerical)",message="cannot specify more than one of semver, alphabetical or numerical"
+// +kubebuilder:validation:XValidation:rule="!has(self.numerical) || !has(self.semver)",message="cannot specify more than one of semver, alphabetical or numerical"
 type ResourceSetInputFilter struct {
 	// IncludeBranch specifies the regular expression to filter the branches
 	// that the input provider should include.
@@ -103,8 +106,21 @@ type ResourceSetInputFilter struct {
 	Limit int `json:"limit,omitempty"`
 
 	// Semver specifies the semantic version range to filter and order the tags.
+	// Cannot be specified alongside Alphabetical or Numerical.
 	// +optional
 	Semver string `json:"semver,omitempty"`
+
+	// Alphabetical specifies whether to sort the tags alphabetically.
+	// Cannot be specified alongside Semver or Numerical.
+	// +kubebuilder:validation:Enum=asc;desc
+	// +optional
+	Alphabetical string `json:"alphabetical,omitempty"`
+
+	// Numerical specifies whether to sort the tags numerically.
+	// Cannot be specified alongside Semver or Alphabetical.
+	// +kubebuilder:validation:Enum=asc;desc
+	// +optional
+	Numerical string `json:"numerical,omitempty"`
 }
 
 // ResourceSetInputSkip defines whether we need to skip input updates.

--- a/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
@@ -81,6 +81,14 @@ spec:
                 description: Filter defines the filter to apply to the input provider
                   response.
                 properties:
+                  alphabetical:
+                    description: |-
+                      Alphabetical specifies whether to sort the tags alphabetically.
+                      Cannot be specified alongside Semver or Numerical.
+                    enum:
+                    - asc
+                    - desc
+                    type: string
                   excludeBranch:
                     description: |-
                       ExcludeBranch specifies the regular expression to filter the branches
@@ -102,11 +110,30 @@ spec:
                       Limit specifies the maximum number of input sets to return.
                       When not set, the default limit is 100.
                     type: integer
+                  numerical:
+                    description: |-
+                      Numerical specifies whether to sort the tags numerically.
+                      Cannot be specified alongside Semver or Alphabetical.
+                    enum:
+                    - asc
+                    - desc
+                    type: string
                   semver:
-                    description: Semver specifies the semantic version range to filter
-                      and order the tags.
+                    description: |-
+                      Semver specifies the semantic version range to filter and order the tags.
+                      Cannot be specified alongside Alphabetical or Numerical.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: cannot specify more than one of semver, alphabetical or
+                    numerical
+                  rule: '!has(self.semver) || !has(self.alphabetical)'
+                - message: cannot specify more than one of semver, alphabetical or
+                    numerical
+                  rule: '!has(self.alphabetical) || !has(self.numerical)'
+                - message: cannot specify more than one of semver, alphabetical or
+                    numerical
+                  rule: '!has(self.numerical) || !has(self.semver)'
               schedule:
                 description: Schedule defines the schedules for the input provider
                   to run.

--- a/internal/controller/resourcesetinputprovider_controller.go
+++ b/internal/controller/resourcesetinputprovider_controller.go
@@ -336,12 +336,17 @@ func (r *ResourceSetInputProviderReconciler) makeGitOptions(obj *fluxcdv1.Resour
 			}
 			opts.Filters.ExcludeBranchRe = exRx
 		}
-		if obj.Spec.Filter.Semver != "" {
+		switch {
+		case obj.Spec.Filter.Semver != "":
 			constraints, err := semver.NewConstraint(obj.Spec.Filter.Semver)
 			if err != nil {
 				return gitprovider.Options{}, fmt.Errorf("invalid semver expression: %w", err)
 			}
 			opts.Filters.SemverConstraints = constraints
+		case obj.Spec.Filter.Alphabetical != "":
+			opts.Filters.Alphabetical = obj.Spec.Filter.Alphabetical
+		case obj.Spec.Filter.Numerical != "":
+			opts.Filters.Numerical = obj.Spec.Filter.Numerical
 		}
 	}
 

--- a/internal/gitprovider/github.go
+++ b/internal/gitprovider/github.go
@@ -84,15 +84,15 @@ func (p *GitHubProvider) ListTags(ctx context.Context, opts Options) ([]Result, 
 	}
 
 	tagMap := make(map[string]*github.RepositoryTag, len(tags))
-	semverList := make([]string, 0, len(tags))
+	sortedTags := make([]string, 0, len(tags))
 	for _, tag := range tags {
-		semverList = append(semverList, tag.GetName())
+		sortedTags = append(sortedTags, tag.GetName())
 		tagMap[tag.GetName()] = tag
 	}
 
 	results := make([]Result, 0)
-	semverResults := sortSemver(opts, semverList)
-	for _, version := range semverResults {
+	sortedTags = sortTags(opts, sortedTags)
+	for _, version := range sortedTags {
 		tag, ok := tagMap[version]
 		if !ok {
 			return nil, fmt.Errorf("could not find tag %s", version)

--- a/internal/gitprovider/github_test.go
+++ b/internal/gitprovider/github_test.go
@@ -73,6 +73,118 @@ func TestGitHubProvider_ListTags(t *testing.T) {
 			},
 		},
 		{
+			name: "sorts tags alphabetically in ascending order",
+			opts: Options{
+				Token: os.Getenv("GITHUB_TOKEN"),
+				URL:   "https://github.com/stefanprodan/podinfo",
+				Filters: Filters{
+					Alphabetical: "asc",
+					Limit:        3,
+				},
+			},
+			want: []Result{
+				{
+					ID:  "47251697",
+					SHA: "81ef8654bff2d5fba88dcf9cf874b3adc425d6b7",
+					Tag: "0.2.2",
+				},
+				{
+					ID:  "47382767",
+					SHA: "dc27269a47e66923dbd8bdecf465a23092097f9e",
+					Tag: "2.0.0",
+				},
+				{
+					ID:  "47448304",
+					SHA: "e0864b6e205dc7755cd7b2f47f89273b31f7189d",
+					Tag: "2.0.1",
+				},
+			},
+		},
+		{
+			name: "sorts tags alphabetically in descending order",
+			opts: Options{
+				Token: os.Getenv("GITHUB_TOKEN"),
+				URL:   "https://github.com/stefanprodan/podinfo",
+				Filters: Filters{
+					Alphabetical: "desc",
+					Limit:        3,
+				},
+			},
+			want: []Result{
+				{
+					ID:  "95093100",
+					SHA: "6c8a85a5ab953874c7c83d50317359a0e5a352a9",
+					Tag: "v1.8.0",
+				},
+				{
+					ID:  "94896491",
+					SHA: "18af1ea3a6c340c252e97b7875e929a97e7b0b8f",
+					Tag: "v1.7.0",
+				},
+				{
+					ID:  "94699882",
+					SHA: "44f588dd4c76ee5d78f7865ab016510c901096da",
+					Tag: "v1.6.0",
+				},
+			},
+		},
+		{
+			name: "sorts tags numerically in ascending order",
+			opts: Options{
+				Token: os.Getenv("GITHUB_TOKEN"),
+				URL:   "https://github.com/stefanprodan/podinfo",
+				Filters: Filters{
+					Numerical: "asc",
+					Limit:     3,
+				},
+			},
+			want: []Result{
+				{
+					ID:  "95093100",
+					SHA: "6c8a85a5ab953874c7c83d50317359a0e5a352a9",
+					Tag: "123456",
+				},
+				{
+					ID:  "94896491",
+					SHA: "18af1ea3a6c340c252e97b7875e929a97e7b0b8f",
+					Tag: "234567",
+				},
+				{
+					ID:  "94699882",
+					SHA: "44f588dd4c76ee5d78f7865ab016510c901096da",
+					Tag: "345678",
+				},
+			},
+		},
+		{
+			name: "sorts tags numerically in descending order",
+			opts: Options{
+				Token: os.Getenv("GITHUB_TOKEN"),
+				URL:   "https://github.com/stefanprodan/podinfo",
+				Filters: Filters{
+					Numerical: "desc",
+					Limit:     3,
+				},
+			},
+			want: []Result{
+				{
+					ID:  "94699882",
+					SHA: "44f588dd4c76ee5d78f7865ab016510c901096da",
+					Tag: "345678",
+				},
+				{
+					ID:  "94896491",
+					SHA: "18af1ea3a6c340c252e97b7875e929a97e7b0b8f",
+					Tag: "234567",
+				},
+				{
+					ID:  "95093100",
+					SHA: "6c8a85a5ab953874c7c83d50317359a0e5a352a9",
+					Tag: "123456",
+				},
+			},
+		},
+		{
 			name: "filters tags no results",
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),

--- a/internal/gitprovider/gitlab.go
+++ b/internal/gitprovider/gitlab.go
@@ -79,15 +79,15 @@ func (p *GitLabProvider) ListTags(ctx context.Context, opts Options) ([]Result, 
 	}
 
 	tagMap := make(map[string]*gitlab.Tag, len(tags))
-	semverList := make([]string, 0, len(tags))
+	sortedTags := make([]string, 0, len(tags))
 	for _, tag := range tags {
-		semverList = append(semverList, tag.Name)
+		sortedTags = append(sortedTags, tag.Name)
 		tagMap[tag.Name] = tag
 	}
 
 	results := make([]Result, 0)
-	semverResults := sortSemver(opts, semverList)
-	for _, version := range semverResults {
+	sortedTags = sortTags(opts, sortedTags)
+	for _, version := range sortedTags {
 		tag, ok := tagMap[version]
 		if !ok {
 			return nil, fmt.Errorf("could not find tag %s", version)

--- a/internal/gitprovider/gitlab_test.go
+++ b/internal/gitprovider/gitlab_test.go
@@ -94,6 +94,118 @@ func TestGitLabProvider_ListTags(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "sorts tags alphabetically in ascending order",
+			opts: Options{
+				Token: os.Getenv("GITHUB_TOKEN"),
+				URL:   "https://gitlab.com/stefanprodan/podinfo",
+				Filters: Filters{
+					Alphabetical: "asc",
+					Limit:        3,
+				},
+			},
+			want: []Result{
+				{
+					ID:  "47251697",
+					SHA: "81ef8654bff2d5fba88dcf9cf874b3adc425d6b7",
+					Tag: "0.2.2",
+				},
+				{
+					ID:  "47382767",
+					SHA: "dc27269a47e66923dbd8bdecf465a23092097f9e",
+					Tag: "2.0.0",
+				},
+				{
+					ID:  "47448304",
+					SHA: "e0864b6e205dc7755cd7b2f47f89273b31f7189d",
+					Tag: "2.0.1",
+				},
+			},
+		},
+		{
+			name: "sorts tags alphabetically in descending order",
+			opts: Options{
+				Token: os.Getenv("GITHUB_TOKEN"),
+				URL:   "https://gitlab.com/stefanprodan/podinfo",
+				Filters: Filters{
+					Alphabetical: "desc",
+					Limit:        3,
+				},
+			},
+			want: []Result{
+				{
+					ID:  "95093100",
+					SHA: "6c8a85a5ab953874c7c83d50317359a0e5a352a9",
+					Tag: "v1.8.0",
+				},
+				{
+					ID:  "94896491",
+					SHA: "18af1ea3a6c340c252e97b7875e929a97e7b0b8f",
+					Tag: "v1.7.0",
+				},
+				{
+					ID:  "94699882",
+					SHA: "44f588dd4c76ee5d78f7865ab016510c901096da",
+					Tag: "v1.6.0",
+				},
+			},
+		},
+		{
+			name: "sorts tags numerically in ascending order",
+			opts: Options{
+				Token: os.Getenv("GITHUB_TOKEN"),
+				URL:   "https://gitlab.com/stefanprodan/podinfo",
+				Filters: Filters{
+					Numerical: "asc",
+					Limit:     3,
+				},
+			},
+			want: []Result{
+				{
+					ID:  "95093100",
+					SHA: "6c8a85a5ab953874c7c83d50317359a0e5a352a9",
+					Tag: "123456",
+				},
+				{
+					ID:  "94896491",
+					SHA: "18af1ea3a6c340c252e97b7875e929a97e7b0b8f",
+					Tag: "234567",
+				},
+				{
+					ID:  "94699882",
+					SHA: "44f588dd4c76ee5d78f7865ab016510c901096da",
+					Tag: "345678",
+				},
+			},
+		},
+		{
+			name: "sorts tags numerically in descending order",
+			opts: Options{
+				Token: os.Getenv("GITHUB_TOKEN"),
+				URL:   "https://gitlab.com/stefanprodan/podinfo",
+				Filters: Filters{
+					Numerical: "desc",
+					Limit:     3,
+				},
+			},
+			want: []Result{
+				{
+					ID:  "94699882",
+					SHA: "44f588dd4c76ee5d78f7865ab016510c901096da",
+					Tag: "345678",
+				},
+				{
+					ID:  "94896491",
+					SHA: "18af1ea3a6c340c252e97b7875e929a97e7b0b8f",
+					Tag: "234567",
+				},
+				{
+					ID:  "95093100",
+					SHA: "6c8a85a5ab953874c7c83d50317359a0e5a352a9",
+					Tag: "123456",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/gitprovider/options.go
+++ b/internal/gitprovider/options.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 
 	"github.com/Masterminds/semver/v3"
 )
@@ -27,6 +28,8 @@ type Filters struct {
 	Labels            []string
 	Limit             int
 	SemverConstraints *semver.Constraints
+	Alphabetical      string
+	Numerical         string
 }
 
 // matchBranch returns true if the branch matches the include and exclude regex filters.
@@ -57,12 +60,7 @@ func matchLabels(opt Options, labels []string) bool {
 
 // sortSemver filters the tags based the provided semver range
 // and sorts them in descending order.
-func sortSemver(opt Options, tags []string) []string {
-	constraint := opt.Filters.SemverConstraints
-	if constraint == nil {
-		return tags
-	}
-
+func sortSemver(constraint *semver.Constraints, tags []string) []string {
 	var versions []*semver.Version
 	for _, tag := range tags {
 		if v, err := semver.NewVersion(tag); err == nil {
@@ -83,4 +81,52 @@ func sortSemver(opt Options, tags []string) []string {
 	}
 
 	return sortedTags
+}
+
+// sortAlphabetically sorts the tags in ascending or descending order
+// based on the specified alphabetical order.
+func sortAlphabetically(alphabetical string, tags []string) []string {
+	if alphabetical == "desc" {
+		sort.Sort(sort.Reverse(sort.StringSlice(tags)))
+	} else {
+		sort.Strings(tags)
+	}
+	return tags
+}
+
+// sortNumerically sorts the tags in ascending or descending order
+// based on the specified numerical order.
+func sortNumerically(numerical string, tags []string) []string {
+	var nums []float64
+	m := make(map[float64]string)
+	for _, tag := range tags {
+		if n, err := strconv.ParseFloat(tag, 64); err == nil {
+			nums = append(nums, n)
+			m[n] = tag
+		}
+	}
+	if numerical == "desc" {
+		sort.Sort(sort.Reverse(sort.Float64Slice(nums)))
+	} else {
+		sort.Float64s(nums)
+	}
+	tags = make([]string, 0, len(nums))
+	for _, n := range nums {
+		tags = append(tags, m[n])
+	}
+	return tags
+}
+
+// sortTags sorts the tags based on the provided options.
+func sortTags(opt Options, tags []string) []string {
+	switch {
+	case opt.Filters.SemverConstraints != nil:
+		return sortSemver(opt.Filters.SemverConstraints, tags)
+	case opt.Filters.Alphabetical != "":
+		return sortAlphabetically(opt.Filters.Alphabetical, tags)
+	case opt.Filters.Numerical != "":
+		return sortNumerically(opt.Filters.Numerical, tags)
+	default:
+		return tags
+	}
 }


### PR DESCRIPTION
I thought about first introducing sorting alphabetically and numerically to make sure we iterate on the RSIP API in a consistent way. We introduced `semver` in `filter`, now it's time for these other two orders, which can be useful in practice to select latest tags as a simple mechanism.