### PR TITLE
cli: Add `flux-operator get resources` command

### DIFF
--- a/cmd/cli/get_resources.go
+++ b/cmd/cli/get_resources.go
@@ -1,0 +1,184 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+var getResourcesCmd = &cobra.Command{
+	Use:   "resources",
+	Short: "List Flux custom resources and their status",
+	Example: `  # List Flux resources in all namespaces
+  flux-operator get resources -A
+
+  # List Flux resources by specific kinds and namespace
+  flux-operator -n flux-system get resources --kind ResourceSet,GitRepository,Kustomization
+
+  # List Flux resources in JSON format
+  flux-operator get resources -A --output json | jq
+`,
+	RunE: geResourcesCmdRun,
+	Args: cobra.NoArgs,
+}
+
+type getResourcesFlags struct {
+	allNamespaces bool
+	kinds         []string
+	output        string
+}
+
+var getResourcesArgs getResourcesFlags
+
+func init() {
+	getResourcesCmd.Flags().BoolVarP(&getResourcesArgs.allNamespaces, "all-namespaces", "A", false,
+		"List resources in all namespaces.")
+	getResourcesCmd.Flags().StringSliceVar(&getResourcesArgs.kinds, "kind", nil,
+		"List only resources of the specified kinds, accepts comma-separated values.")
+	getResourcesCmd.Flags().StringVarP(&getResourcesArgs.output, "output", "o", "table",
+		"Output format. One of: table, json, yaml.")
+	getCmd.AddCommand(getResourcesCmd)
+}
+
+type ResourceStatus struct {
+	Kind           string `json:"kind"`
+	Name           string `json:"name"`
+	LastReconciled string `json:"lastReconciled"`
+	Ready          string `json:"ready"`
+	ReadyMessage   string `json:"message"`
+}
+
+func geResourcesCmdRun(cmd *cobra.Command, args []string) error {
+	result := make([]ResourceStatus, 0)
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	lsOpts := &client.ListOptions{}
+	if !getResourcesArgs.allNamespaces {
+		lsOpts.Namespace = *kubeconfigArgs.Namespace
+	}
+
+	kinds := []string{
+		"ResourceSet",
+		"ResourceSetInputProvider",
+		"GitRepository",
+		"OCIRepository",
+		"Bucket",
+		"HelmRepository",
+		"HelmChart",
+		"HelmRelease",
+		"Kustomization",
+	}
+	if len(getResourcesArgs.kinds) > 0 {
+		kinds = getResourcesArgs.kinds
+	}
+
+	for _, kind := range kinds {
+		gvk, err := preferredFluxGVK(kind, kubeconfigArgs)
+		if err != nil {
+			return fmt.Errorf("unable to get gvk for kind %s : %w", kind, err)
+		}
+
+		list := unstructured.UnstructuredList{
+			Object: map[string]any{
+				"apiVersion": gvk.Group + "/" + gvk.Version,
+				"kind":       gvk.Kind,
+			},
+		}
+
+		if err := kubeClient.List(ctx, &list, lsOpts); err != nil {
+			return fmt.Errorf("unable to list resources for kind %s : %w", kind, err)
+		}
+
+		for _, obj := range list.Items {
+			name := fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
+			ready := "Unknown"
+			readyMsg := "Not initialized"
+			lastReconciled := "Unknown"
+			if conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions"); found && err == nil {
+				for _, cond := range conditions {
+					if condition, ok := cond.(map[string]any); ok && condition["type"] == meta.ReadyCondition {
+						ready = condition["status"].(string)
+						if msg, exists := condition["message"]; exists {
+							readyMsg = msg.(string)
+						}
+						if lastTransitionTime, exists := condition["lastTransitionTime"]; exists {
+							lastReconciled = lastTransitionTime.(string)
+						}
+					}
+				}
+			}
+
+			if ssautil.AnyInMetadata(&obj,
+				map[string]string{fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue}) {
+				ready = "Suspended"
+			}
+
+			if suspend, found, err := unstructured.NestedBool(obj.Object, "spec", "suspend"); suspend && found && err == nil {
+				ready = "Suspended"
+			}
+
+			result = append(result, ResourceStatus{
+				Kind:           gvk.Kind,
+				Name:           name,
+				LastReconciled: lastReconciled,
+				Ready:          ready,
+				ReadyMessage:   readyMsg,
+			})
+		}
+	}
+
+	if len(result) == 0 {
+		return fmt.Errorf("no resources found")
+	}
+
+	switch getResourcesArgs.output {
+	case "json":
+		output, err := json.Marshal(result)
+		if err != nil {
+			return fmt.Errorf("unable to marshal output to JSON: %w", err)
+		}
+		_, err = rootCmd.OutOrStdout().Write(output)
+		return err
+	case "yaml":
+		output, err := yaml.Marshal(result)
+		if err != nil {
+			return fmt.Errorf("unable to marshal output to YAML: %w", err)
+		}
+		_, err = rootCmd.OutOrStdout().Write(output)
+		return err
+	default:
+		rows := make([][]string, 0, len(result))
+		for _, res := range result {
+			row := []string{
+				res.Kind,
+				res.Name,
+				res.LastReconciled,
+				res.Ready,
+				res.ReadyMessage,
+			}
+			rows = append(rows, row)
+		}
+		header := []string{"Kind", "Name", "Last Reconciled", "Ready", "Message"}
+		printTable(rootCmd.OutOrStdout(), header, rows)
+	}
+
+	return nil
+}

--- a/cmd/cli/reconcile_inputprovider.go
+++ b/cmd/cli/reconcile_inputprovider.go
@@ -52,6 +52,9 @@ func reconcileInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("name is required")
 	}
 
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)
+
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
@@ -59,7 +62,8 @@ func reconcileInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 
 	if !reconcileInputProviderArgs.force {
 		err := annotateResource(ctx,
-			fluxcdv1.ResourceSetInputProviderKind, args[0],
+			gvk,
+			name,
 			*kubeconfigArgs.Namespace,
 			meta.ReconcileRequestAnnotation,
 			now)
@@ -69,7 +73,8 @@ func reconcileInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	err := annotateResourceWithMap(ctx,
-		fluxcdv1.ResourceSetInputProviderKind, args[0],
+		gvk,
+		name,
 		*kubeconfigArgs.Namespace,
 		map[string]string{
 			meta.ReconcileRequestAnnotation: now,
@@ -83,8 +88,8 @@ func reconcileInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 	if reconcileInputProviderArgs.wait {
 		rootCmd.Println(`◎`, "Waiting for reconciliation...")
 		msg, err := waitForResourceReconciliation(ctx,
-			fluxcdv1.ResourceSetInputProviderKind,
-			args[0],
+			gvk,
+			name,
 			*kubeconfigArgs.Namespace,
 			now,
 			rootArgs.timeout)

--- a/cmd/cli/reconcile_instance.go
+++ b/cmd/cli/reconcile_instance.go
@@ -45,13 +45,17 @@ func reconcileInstanceCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("name is required")
 	}
 
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)
+
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
 	now := metav1.Now().String()
 
 	err := annotateResource(ctx,
-		fluxcdv1.FluxInstanceKind, args[0],
+		gvk,
+		name,
 		*kubeconfigArgs.Namespace,
 		meta.ReconcileRequestAnnotation,
 		now)
@@ -63,8 +67,8 @@ func reconcileInstanceCmdRun(cmd *cobra.Command, args []string) error {
 	if reconcileInstanceArgs.wait {
 		rootCmd.Println(`◎`, "Waiting for reconciliation...")
 		msg, err := waitForResourceReconciliation(ctx,
-			fluxcdv1.FluxInstanceKind,
-			args[0],
+			gvk,
+			name,
 			*kubeconfigArgs.Namespace,
 			now,
 			rootArgs.timeout)

--- a/cmd/cli/reconcile_resourceset.go
+++ b/cmd/cli/reconcile_resourceset.go
@@ -45,12 +45,16 @@ func reconcileResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("name is required")
 	}
 
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)
+
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
 	now := metav1.Now().String()
 	err := annotateResource(ctx,
-		fluxcdv1.ResourceSetKind, args[0],
+		gvk,
+		name,
 		*kubeconfigArgs.Namespace,
 		meta.ReconcileRequestAnnotation,
 		now)
@@ -62,8 +66,8 @@ func reconcileResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 	if reconcileResourceSetArgs.wait {
 		rootCmd.Println(`◎`, "Waiting for reconciliation...")
 		msg, err := waitForResourceReconciliation(ctx,
-			fluxcdv1.ResourceSetKind,
-			args[0],
+			gvk,
+			name,
 			*kubeconfigArgs.Namespace,
 			now,
 			rootArgs.timeout)

--- a/cmd/cli/resume_inputprovider.go
+++ b/cmd/cli/resume_inputprovider.go
@@ -29,11 +29,15 @@ func resumeInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("name is required")
 	}
 
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)
+
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
 	err := annotateResource(ctx,
-		fluxcdv1.ResourceSetInputProviderKind, args[0],
+		gvk,
+		name,
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.EnabledValue)

--- a/cmd/cli/resume_instance.go
+++ b/cmd/cli/resume_instance.go
@@ -28,11 +28,15 @@ func resumeInstanceCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("name is required")
 	}
 
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)
+
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
 	err := annotateResource(ctx,
-		fluxcdv1.FluxInstanceKind, args[0],
+		gvk,
+		name,
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.EnabledValue)

--- a/cmd/cli/resume_resourceset.go
+++ b/cmd/cli/resume_resourceset.go
@@ -29,11 +29,15 @@ func resumeResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("name is required")
 	}
 
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)
+
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
 	err := annotateResource(ctx,
-		fluxcdv1.ResourceSetKind, args[0],
+		gvk,
+		name,
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.EnabledValue)

--- a/cmd/cli/suspend_inputprovider.go
+++ b/cmd/cli/suspend_inputprovider.go
@@ -29,11 +29,15 @@ func suspendInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("name is required")
 	}
 
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)
+
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
 	err := annotateResource(ctx,
-		fluxcdv1.ResourceSetInputProviderKind, args[0],
+		gvk,
+		name,
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.DisabledValue)

--- a/cmd/cli/suspend_instance.go
+++ b/cmd/cli/suspend_instance.go
@@ -28,11 +28,15 @@ func suspendInstanceCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("name is required")
 	}
 
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)
+
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
 	err := annotateResource(ctx,
-		fluxcdv1.FluxInstanceKind, args[0],
+		gvk,
+		name,
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.DisabledValue)

--- a/cmd/cli/suspend_resourceset.go
+++ b/cmd/cli/suspend_resourceset.go
@@ -29,11 +29,15 @@ func suspendResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("name is required")
 	}
 
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)
+
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
 	err := annotateResource(ctx,
-		fluxcdv1.ResourceSetKind, args[0],
+		gvk,
+		name,
 		*kubeconfigArgs.Namespace,
 		fluxcdv1.ReconcileAnnotation,
 		fluxcdv1.DisabledValue)


### PR DESCRIPTION
This PR adds a new get command for listing all Flux custom resources and their status:

```
Usage:
  flux-operator get resources [flags]

Examples:
  # List Flux resources in all namespaces
  flux-operator get resources -A

  # List Flux resources by specific kinds and namespace
  flux-operator -n flux-system get resources --kind GitRepository,Kustomization

  # List Flux resources in JSON format
  flux-operator get resources -A --output json | jq


Flags:
  -A, --all-namespaces   List resources in all namespaces.
  -h, --help             help for resources
      --kind strings     List only resources of the specified kinds, accepts comma-separated values.
  -o, --output string    Output format. One of: table, json, yaml. (default "table")
```

Example output:

```console
$ flux-operator get resources -A
KIND                    	NAME                            	LAST RECONCILED     	READY	MESSAGE                                                                                                                     
ResourceSet             	flux-system/apps                	2025-06-19T10:15:05Z	True 	Reconciliation finished in 70ms                                                                                            	
ResourceSet             	flux-system/flux-operator       	2025-06-19T09:19:35Z	True 	Reconciliation finished in 35ms                                                                                            	
ResourceSet             	flux-system/flux-operator-mcp   	2025-06-19T09:19:35Z	True 	Reconciliation finished in 43ms                                                                                            	
ResourceSet             	flux-system/infra               	2025-06-19T10:15:05Z	True 	Reconciliation finished in 72ms                                                                                            	
ResourceSet             	flux-system/policies            	2025-06-19T10:14:51Z	True 	Reconciliation finished in 45ms                                                                                            	
ResourceSet             	podinfo-test/podinfo            	2025-06-19T09:37:03Z	True 	Reconciliation finished in 44ms                                                                                            	
ResourceSet             	test/test                       	2025-06-19T09:24:52Z	True 	Reconciliation finished in 27ms                                                                                            	
ResourceSetInputProvider	podinfo-test/podinfo-release    	2025-06-17T16:57:00Z	True 	Reconciliation finished in 318ms                                                                                           	
ResourceSetInputProvider	test/podinfo-releases           	2025-06-19T10:13:30Z	True 	Reconciliation finished in 560ms                                                                                           	
ResourceSetInputProvider	test/test                       	2025-06-19T10:13:34Z	True 	Reconciliation finished in 220ms                                                                                           	
OCIRepository           	backend/apps                    	2025-06-13T15:52:46Z	True 	stored artifact for digest 'latest@sha256:dde968a2fcfae9b2841bf1896f4e7c4658168c9fbd734456d5ae225a755afad2'                	
OCIRepository           	backend/memcached-chart         	2025-06-13T15:52:52Z	True 	stored artifact for digest '7.8.1@sha256:0ccbd4137b2a31f068e342c87ffcce7623aeea756c5ecb344215050b8a87941a'                 	
OCIRepository           	backend/redis-chart             	2025-06-13T15:52:45Z	True 	stored artifact for digest '20.13.4@sha256:6a389e13237e8e639ec0d445e785aa246b57bfce711b087033a196a291d5c8d7'               	
OCIRepository           	cert-manager/cert-manager-chart 	2025-06-13T15:52:52Z	True 	stored artifact for digest 'v1.17.2@sha256:98284110895beebd917f2c2f8ad850e3a7fffc772331c83918c1975dc8084433'               	
OCIRepository           	cert-manager/infra              	2025-06-13T15:52:48Z	True 	stored artifact for digest 'latest@sha256:6144dceffdbb4c05a9adffa35c0db7f553f2891a7a484ff52a2397a2c7b3f7da'                	
OCIRepository           	flux-system/flux-operator       	2025-06-16T14:17:59Z	True 	stored artifact for digest '0.23.0@sha256:1d5852c346845dbd3570ff2f5da72684be12ede6ccf1a313a9d28bc30ef7138f'                	
OCIRepository           	flux-system/flux-operator-mcp   	2025-06-16T14:32:56Z	True 	stored artifact for digest '0.23.0@sha256:968d5f19a697428f558eea88dd8c284ede48f3aefc7d3128c746b91a65ce88aa'                	
OCIRepository           	flux-system/flux-system         	2025-06-13T15:52:55Z	True 	stored artifact for digest 'latest@sha256:7df8086f6b718ce3cdaa75f2f3031aea6a732fb6362cc1e136e1d46988b57594'                	
OCIRepository           	frontend/apps                   	2025-06-13T15:52:58Z	True 	stored artifact for digest 'latest@sha256:49716b1a5296fd453bbfa6c61ad16c864641b7d67e0b5c46576ea31d304e05b5'                	
OCIRepository           	frontend/podinfo-chart          	2025-06-13T15:52:50Z	True 	stored artifact for digest '6.8.0@sha256:2360bdf32ddc50c05f8e128118173343b0a012a338daf145b16e0da9c80081a4'                 	
OCIRepository           	monitoring/infra                	2025-06-13T15:52:58Z	True 	stored artifact for digest 'latest@sha256:423024e816a535e19e2890fc6fdf7d0ee5babe9e2da89d105b5ebdb8054a76dc'                	
OCIRepository           	monitoring/kube-prometheus-stack	2025-06-13T15:52:42Z	True 	stored artifact for digest '73.2.0@sha256:0a30eb248e383cc15833ad3d1f4af4adf23ca94f074e8bd6302282d5d483f36d'                	
OCIRepository           	monitoring/metrics-server       	2025-06-13T15:52:50Z	True 	stored artifact for digest '3.12.2@sha256:75b0ded38b7eb56ae3f373e66ac63bead1047d0febe2a27c39f20657265a824d'                	
OCIRepository           	podinfo-test/podinfo            	2025-06-17T14:14:36Z	True 	stored artifact for digest '6.9.0@sha256:2e3816fefc863c1ee67c587e0def4ec4353ab69019e692f533dc46972fecabcf'                 	
OCIRepository           	test/podinfo-chart              	2025-06-13T15:52:43Z	True 	stored artifact for digest '6.8.0@sha256:2360bdf32ddc50c05f8e128118173343b0a012a338daf145b16e0da9c80081a4'                 	
HelmRelease             	backend/memcached               	2025-05-29T15:25:06Z	True 	Helm upgrade succeeded for release backend/memcached.v2 with chart memcached@7.8.1+0ccbd4137b2a                            	
HelmRelease             	backend/redis                   	2025-05-29T15:24:59Z	True 	Helm upgrade succeeded for release backend/redis.v2 with chart redis@20.13.4+6a389e13237e                                  	
HelmRelease             	cert-manager/cert-manager       	2025-06-10T13:16:54Z	True 	Helm install succeeded for release cert-manager/cert-manager.v1 with chart cert-manager@1.17.2+98284110895b                	
HelmRelease             	flux-system/flux-operator       	2025-06-16T15:28:25Z	True 	Helm upgrade succeeded for release flux-system/flux-operator.v6 with chart flux-operator@0.23.0+1d5852c34684               	
HelmRelease             	flux-system/flux-operator-mcp   	2025-06-16T14:33:02Z	True 	Helm upgrade succeeded for release flux-system/flux-operator-mcp.v3 with chart flux-operator-mcp@0.23.0+968d5f19a697       	
HelmRelease             	frontend/podinfo                	2025-05-29T15:25:03Z	True 	Helm upgrade succeeded for release frontend/podinfo.v13 with chart podinfo@6.8.0+2360bdf32ddc                              	
HelmRelease             	monitoring/kube-prometheus-stack	2025-06-09T08:25:48Z	True 	Helm upgrade succeeded for release monitoring/kube-prometheus-stack.v4 with chart kube-prometheus-stack@73.2.0+0a30eb248e38	
HelmRelease             	monitoring/metrics-server       	2025-05-29T15:25:00Z	True 	Helm install succeeded for release monitoring/metrics-server.v1 with chart metrics-server@3.12.2+75b0ded38b7e              	
HelmRelease             	podinfo-test/podinfo            	2025-06-17T14:15:02Z	True 	Helm install succeeded for release podinfo-test/podinfo.v1 with chart podinfo@6.9.0+2e3816fefc86                           	
HelmRelease             	test/podinfo                    	2025-05-29T15:25:04Z	True 	Helm install succeeded for release test/podinfo.v1 with chart podinfo@6.8.0+2360bdf32ddc                                   	
Kustomization           	backend/apps                    	2025-06-19T10:11:47Z	True 	Applied revision: latest@sha256:dde968a2fcfae9b2841bf1896f4e7c4658168c9fbd734456d5ae225a755afad2                           	
Kustomization           	cert-manager/infra-configs      	2025-06-19T10:13:26Z	True 	Applied revision: latest@sha256:6144dceffdbb4c05a9adffa35c0db7f553f2891a7a484ff52a2397a2c7b3f7da                           	
Kustomization           	cert-manager/infra-controllers  	2025-06-19T10:08:52Z	True 	Applied revision: latest@sha256:6144dceffdbb4c05a9adffa35c0db7f553f2891a7a484ff52a2397a2c7b3f7da                           	
Kustomization           	flux-system/flux-system         	2025-06-19T10:11:47Z	True 	Applied revision: latest@sha256:7df8086f6b718ce3cdaa75f2f3031aea6a732fb6362cc1e136e1d46988b57594                           	
Kustomization           	flux-system/tenants             	2025-06-19T08:50:35Z	True 	Applied revision: latest@sha256:7df8086f6b718ce3cdaa75f2f3031aea6a732fb6362cc1e136e1d46988b57594                           	
Kustomization           	frontend/apps                   	2025-06-19T10:07:35Z	True 	Applied revision: latest@sha256:49716b1a5296fd453bbfa6c61ad16c864641b7d67e0b5c46576ea31d304e05b5                           	
Kustomization           	monitoring/infra-configs        	2025-06-19T10:06:32Z	True 	Applied revision: latest@sha256:423024e816a535e19e2890fc6fdf7d0ee5babe9e2da89d105b5ebdb8054a76dc                           	
Kustomization           	monitoring/infra-controllers    	2025-06-19T09:53:38Z	True 	Applied revision: latest@sha256:423024e816a535e19e2890fc6fdf7d0ee5babe9e2da89d105b5ebdb8054a76dc                           	

```