### PR TITLE
Introduce OCI artifact tags for ResourceSetInputProvider

### DIFF
--- a/api/v1/resourceset_types.go
+++ b/api/v1/resourceset_types.go
@@ -124,7 +124,12 @@ type Dependency struct {
 type ResourceSetInput map[string]*apiextensionsv1.JSON
 
 // NewResourceSetInput creates a new ResourceSetInput from a map[string]any.
-func NewResourceSetInput(m map[string]any) (ResourceSetInput, error) {
+func NewResourceSetInput(defaults, m map[string]any) (ResourceSetInput, error) {
+	for k, v := range defaults {
+		if _, ok := m[k]; !ok {
+			m[k] = v
+		}
+	}
 	res := make(ResourceSetInput)
 	for k, v := range m {
 		b, err := json.Marshal(v)

--- a/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
@@ -60,8 +60,10 @@ spec:
                   - a PEM-encoded CA certificate (`ca.crt`)
                   - a PEM-encoded client certificate (`tls.crt`) and private key (`tls.key`)
 
-                  When connecting to a Git provider that uses self-signed certificates, the CA certificate
+                  When connecting to a Git or OCI provider that uses self-signed certificates, the CA certificate
                   must be set in the Secret under the 'ca.crt' key to establish the trust relationship.
+                  When connecting to an OCI provider that supports client certificates (mTLS), the client certificate
+                  and private key must be set in the Secret under the 'tls.crt' and 'tls.key' keys, respectively.
                 properties:
                   name:
                     description: Name of the referent.
@@ -98,6 +100,7 @@ spec:
                       type: string
                     type: array
                   limit:
+                    default: 100
                     description: |-
                       Limit specifies the maximum number of input sets to return.
                       When not set, the default limit is 100.
@@ -135,10 +138,12 @@ spec:
               secretRef:
                 description: |-
                   SecretRef specifies the Kubernetes Secret containing the basic-auth credentials
-                  to access the input provider. The secret must contain the keys
-                  'username' and 'password'.
-                  When connecting to a Git provider, the password should be a personal access token
+                  to access the input provider.
+                  When connecting to a Git provider, the secret must contain the keys
+                  'username' and 'password', and the password should be a personal access token
                   that grants read-only access to the repository.
+                  When connecting to an OCI provider, the secret must contain a Kubernetes
+                  Image Pull Secret, as if created by `kubectl create secret docker-registry`.
                 properties:
                   name:
                     description: Name of the referent.
@@ -171,12 +176,14 @@ spec:
                 - AzureDevOpsBranch
                 - AzureDevOpsTag
                 - AzureDevOpsPullRequest
+                - OCIArtifactTag
                 type: string
               url:
                 description: |-
-                  URL specifies the HTTP/S address of the input provider API.
+                  URL specifies the HTTP/S or OCI address of the input provider API.
                   When connecting to a Git provider, the URL should point to the repository address.
-                pattern: ^((http|https)://.*){0,1}$
+                  When connecting to an OCI provider, the URL should point to the OCI repository address.
+                pattern: ^((http|https|oci)://.*){0,1}$
                 type: string
             required:
             - type
@@ -186,6 +193,15 @@ spec:
               rule: self.type != 'Static' || !has(self.url)
             - message: spec.url must not be empty when spec.type is not 'Static'
               rule: self.type == 'Static' || has(self.url)
+            - message: spec.url must start with 'http://' or 'https://' when spec.type
+                is a Git provider
+              rule: '!self.type.startsWith(''Git'') || self.url.startsWith(''http'')'
+            - message: spec.url must start with 'http://' or 'https://' when spec.type
+                is a Git provider
+              rule: '!self.type.startsWith(''AzureDevOps'') || self.url.startsWith(''http'')'
+            - message: spec.url must start with 'oci://' when spec.type is an OCI
+                provider
+              rule: '!self.type.endsWith(''ArtifactTag'') || self.url.startsWith(''oci'')'
           status:
             description: ResourceSetInputProviderStatus defines the observed state
               of ResourceSetInputProvider.

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fluxcd/pkg/runtime v0.60.0
 	github.com/fluxcd/pkg/ssa v0.48.0
 	github.com/fluxcd/pkg/tar v0.12.0
+	github.com/fluxcd/pkg/version v0.8.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-task/slim-sprig/v3 v3.0.0
 	github.com/golang-jwt/jwt/v4 v4.5.2

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/fluxcd/pkg/ssh v0.18.0 h1:SB0RrZ/YZIla3chTUulsfVmiCzJv5pEWfHM3dHMC8AU
 github.com/fluxcd/pkg/ssh v0.18.0/go.mod h1:G5o0ZD7iR3KFoG5gPnFelX243ciI/PIiVW7J4eBrt5Y=
 github.com/fluxcd/pkg/tar v0.12.0 h1:og6F+ivnWNRbNJSq0ukCTVs7YrGIlzjxSVZU+E8NprM=
 github.com/fluxcd/pkg/tar v0.12.0/go.mod h1:Ra5Cj++MD5iCy7bZGKJJX3GpOeMPv+ZDkPO9bBwpDeU=
+github.com/fluxcd/pkg/version v0.8.0 h1:dA0EyXkQWDW/4nG71khXZXbl0gg5/8ZGWHF/O/3t13g=
+github.com/fluxcd/pkg/version v0.8.0/go.mod h1:V1OLccMojNC2O4LC+ZC9+18MtCy6m7pvINvPHNUn2rQ=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/internal/controller/resourceset_controller_test.go
+++ b/internal/controller/resourceset_controller_test.go
@@ -757,7 +757,7 @@ spec:
 		err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(conditions.IsReady(result)).To(BeTrue())
-		rsipID[i] = inputs.Checksum(string(result.GetUID()))
+		rsipID[i] = inputs.ID(string(result.GetUID()))
 	}
 	rsipZeroID := rsipID[0]
 	rsipOneID := rsipID[1]
@@ -944,7 +944,7 @@ spec:
 		err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(conditions.IsReady(result)).To(BeTrue())
-		return inputs.Checksum(string(result.GetUID()))
+		return inputs.ID(string(result.GetUID()))
 	}
 	deleteRSIP := func(name string) {
 		err := testClient.Delete(ctx, &fluxcdv1.ResourceSetInputProvider{

--- a/internal/controller/resourcesetinputprovider_controller_oci_test.go
+++ b/internal/controller/resourcesetinputprovider_controller_oci_test.go
@@ -1,0 +1,169 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/testutils"
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/runtime/conditions"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
+)
+
+func TestResourceSetInputProviderReconciler_OCIArtifactTag_LifeCycle(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	rsetReconciler := getResourceSetReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	objDef := fmt.Sprintf(`
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: test
+  namespace: "%[1]s"
+  labels:
+    app: test
+spec:
+  type: OCIArtifactTag
+  url: "oci://ghcr.io/stefanprodan/podinfo"
+  filter:
+    semver: "6.0.x"
+    limit: 1
+`, ns.Name)
+
+	setDef := fmt.Sprintf(`
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: test
+  namespace: "%[1]s"
+spec:
+  inputsFrom:
+    - kind: ResourceSetInputProvider
+      selector:
+        matchLabels:
+          app: test
+  resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-<< inputs.id >>
+        namespace: << inputs.provider.namespace >>
+      data:
+        tag: << inputs.tag | quote >>
+        digest: << inputs.digest | quote >>
+`, ns.Name)
+
+	obj := &fluxcdv1.ResourceSetInputProvider{}
+	err = yaml.Unmarshal([]byte(objDef), obj)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Create the ResourceSetInputProvider.
+	err = testEnv.Create(ctx, obj)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Initialize the ResourceSetInputProvider.
+	r, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(r.Requeue).To(BeTrue())
+
+	// Retrieve the inputs.
+	r, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(r.Requeue).To(BeFalse())
+
+	// Check if the ResourceSetInputProvider was marked as ready.
+	result := &fluxcdv1.ResourceSetInputProvider{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	testutils.LogObjectStatus(t, result)
+	g.Expect(conditions.GetReason(result, meta.ReadyCondition)).To(BeIdenticalTo(meta.ReconciliationSucceededReason))
+	g.Expect(result.Status.LastExportedRevision).To(BeIdenticalTo("sha256:b7d3334b3411cccf4c9c08b328ec7ae141fcda58e45e1e3d098f59791c033ced"))
+
+	// Create a ResourceSet referencing the ResourceSetInputProvider.
+	rset := &fluxcdv1.ResourceSet{}
+	err = yaml.Unmarshal([]byte(setDef), rset)
+	g.Expect(err).ToNot(HaveOccurred())
+	err = testEnv.Create(ctx, rset)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Initialize the ResourceSet.
+	_, err = rsetReconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(rset),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Reconcile the ResourceSet.
+	_, err = rsetReconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(rset),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Check if the ResourceSet generated the ConfigMap.
+	resultCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-48955639",
+			Namespace: ns.Name,
+		},
+	}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(resultCM), resultCM)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resultCM.Data).To(HaveKeyWithValue("tag", "6.0.4"))
+	g.Expect(resultCM.Data).To(HaveKeyWithValue("digest", "sha256:d4ec9861522d4961b2acac5a070ef4f92d732480dff2062c2f3a1dcf9a5d1e91"))
+}
+
+func TestResourceSetInputProviderReconciler_InvalidOCIURL(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "test-invalid-oci-url")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	for _, tt := range []struct {
+		provider string
+	}{
+		{provider: fluxcdv1.InputProviderOCIArtifactTag},
+	} {
+		t.Run(tt.provider, func(t *testing.T) {
+			g := NewWithT(t)
+
+			obj := &fluxcdv1.ResourceSetInputProvider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: ns.Name,
+				},
+				Spec: fluxcdv1.ResourceSetInputProviderSpec{
+					Type: tt.provider,
+					URL:  "ghcr.io/stefanprodan/podinfo",
+				},
+			}
+
+			err = testEnv.Create(ctx, obj)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(
+				"spec.url must start with 'oci://' when spec.type is an OCI provider"))
+		})
+	}
+}

--- a/internal/controller/resourcesetinputprovider_controller_test.go
+++ b/internal/controller/resourcesetinputprovider_controller_test.go
@@ -70,7 +70,7 @@ spec:
 	exportedInput := fmt.Sprintf(`
 id: "%[1]s"
 env: staging
-foo: bar `, inputs.Checksum(string(obj.UID)))
+foo: bar `, inputs.ID(string(obj.UID)))
 
 	// Initialize the ResourceSetInputProvider.
 	r, err := reconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/gitprovider/azuredevops.go
+++ b/internal/gitprovider/azuredevops.go
@@ -98,7 +98,7 @@ func (p *AzureDevOpsProvider) ListTags(ctx context.Context, opts Options) ([]Res
 		}
 
 		results = append(results, Result{
-			ID:  inputs.Checksum(tagName),
+			ID:  inputs.ID(tagName),
 			SHA: sha,
 			Tag: tagName,
 		})
@@ -133,7 +133,7 @@ func (p *AzureDevOpsProvider) ListBranches(ctx context.Context, opts Options) ([
 		}
 
 		results = append(results, Result{
-			ID:     inputs.Checksum(*branch.Name),
+			ID:     inputs.ID(*branch.Name),
 			SHA:    *branch.Commit.CommitId,
 			Branch: *branch.Name,
 		})

--- a/internal/gitprovider/github.go
+++ b/internal/gitprovider/github.go
@@ -99,7 +99,7 @@ func (p *GitHubProvider) ListTags(ctx context.Context, opts Options) ([]Result, 
 		}
 
 		results = append(results, Result{
-			ID:  inputs.Checksum(tag.GetName()),
+			ID:  inputs.ID(tag.GetName()),
 			SHA: tag.GetCommit().GetSHA(),
 			Tag: tag.GetName(),
 		})
@@ -131,7 +131,7 @@ func (p *GitHubProvider) ListBranches(ctx context.Context, opts Options) ([]Resu
 			}
 
 			results = append(results, Result{
-				ID:     inputs.Checksum(branch.GetName()),
+				ID:     inputs.ID(branch.GetName()),
 				SHA:    branch.GetCommit().GetSHA(),
 				Branch: branch.GetName(),
 			})

--- a/internal/gitprovider/gitlab.go
+++ b/internal/gitprovider/gitlab.go
@@ -94,7 +94,7 @@ func (p *GitLabProvider) ListTags(ctx context.Context, opts Options) ([]Result, 
 		}
 
 		results = append(results, Result{
-			ID:  inputs.Checksum(tag.Name),
+			ID:  inputs.ID(tag.Name),
 			SHA: tag.Commit.ID,
 			Tag: tag.Name,
 		})
@@ -129,7 +129,7 @@ func (p *GitLabProvider) ListBranches(ctx context.Context, opts Options) ([]Resu
 			}
 
 			results = append(results, Result{
-				ID:     inputs.Checksum(branch.Name),
+				ID:     inputs.ID(branch.Name),
 				SHA:    branch.Commit.ID,
 				Branch: branch.Name,
 			})

--- a/internal/gitprovider/options.go
+++ b/internal/gitprovider/options.go
@@ -7,9 +7,9 @@ import (
 	"crypto/x509"
 	"regexp"
 	"slices"
-	"sort"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/fluxcd/pkg/version"
 )
 
 // Options holds the configuration for the Git SaaS provider.
@@ -62,25 +62,5 @@ func sortSemver(opt Options, tags []string) []string {
 	if constraint == nil {
 		return tags
 	}
-
-	var versions []*semver.Version
-	for _, tag := range tags {
-		if v, err := semver.NewVersion(tag); err == nil {
-			if constraint.Check(v) {
-				versions = append(versions, v)
-			}
-		}
-	}
-
-	if len(tags) == 0 || len(versions) == 0 {
-		return nil
-	}
-
-	sort.Sort(sort.Reverse(semver.Collection(versions)))
-	sortedTags := make([]string, 0, len(versions))
-	for _, v := range versions {
-		sortedTags = append(sortedTags, v.Original())
-	}
-
-	return sortedTags
+	return version.Sort(constraint, tags)
 }

--- a/internal/gitprovider/result.go
+++ b/internal/gitprovider/result.go
@@ -4,7 +4,6 @@
 package gitprovider
 
 import (
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
@@ -51,17 +50,6 @@ func (r *Result) ToMap() map[string]any {
 	return m
 }
 
-// ToMapWithDefaults converts the result into a map with default values.
-func (r *Result) ToMapWithDefaults(defaults map[string]any) map[string]any {
-	m := r.ToMap()
-	for k, v := range defaults {
-		if _, ok := m[k]; !ok {
-			m[k] = v
-		}
-	}
-	return m
-}
-
 // OverrideFromExportedInputs override result fields from exportedInput.
 func (r *Result) OverrideFromExportedInputs(input map[string]any) error {
 	var err error
@@ -80,21 +68,14 @@ func (r *Result) OverrideFromExportedInputs(input map[string]any) error {
 }
 
 // MakeInputs converts a list of results into a list of ResourceSet inputs with defaults.
-func MakeInputs(results []Result, defaults map[string]any) ([]map[string]*apiextensionsv1.JSON, error) {
-	inputs := make([]map[string]*apiextensionsv1.JSON, 0, len(results))
-
-	list := make([]map[string]any, 0, len(results))
-	for _, r := range results {
-		list = append(list, r.ToMapWithDefaults(defaults))
-	}
-
-	for _, item := range list {
-		input, err := fluxcdv1.NewResourceSetInput(item)
+func MakeInputs(results []Result, defaults map[string]any) ([]fluxcdv1.ResourceSetInput, error) {
+	inputs := make([]fluxcdv1.ResourceSetInput, 0, len(results))
+	for _, item := range results {
+		input, err := fluxcdv1.NewResourceSetInput(defaults, item.ToMap())
 		if err != nil {
 			return nil, err
 		}
 		inputs = append(inputs, input)
 	}
-
 	return inputs, nil
 }

--- a/internal/inputs/id.go
+++ b/internal/inputs/id.go
@@ -8,7 +8,7 @@ import (
 	"hash/adler32"
 )
 
-// Checksum computes the checksum of a string using the Adler-32 algorithm.
-func Checksum(s string) string {
+// ID returns a short, opaque ID for input sets.
+func ID(s string) string {
 	return fmt.Sprintf("%v", adler32.Checksum([]byte(s)))
 }


### PR DESCRIPTION
Part of: #151 

In this PR we are implementing the ability to list tags from generic OCI repositories, with or without a semver filter. For example:

```yaml
apiVersion: fluxcd.controlplane.io/v1
kind: ResourceSetInputProvider
metadata:
  name: app-microservices-tags
  namespace: default
  annotations:
    fluxcd.controlplane.io/reconcile: "enabled"
    fluxcd.controlplane.io/reconcileEvery: "5m"
spec:
    type: OCIArtifactTag
    url: oci://ghcr.io/<org>/<mono-repo>
    secretRef:
      name: ghcr-pull-secret
    filter:
      semver: ">=1.0.0 <2.0.0"
      limit: 1
```

This will export only the latest tag in the semver range `>=1.0.0 <2.0.0`:

```yaml
status:
  exportedInputs:
  - id: "059e0169"
    tag: v1.3.2
    digest: sha256:639798659bf761152f5e1a0555e5d22fd3221e6801c7ce089878f562412344fe
```

Without `.spec.filter` all the tags would be exported.