### PR TITLE
cli: Add `flux-operator reconcile resource` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,14 @@ enable self-service for developers and platform teams.
 Guides:
 
 - [Using ResourceSets for Application Definitions](https://fluxcd.control-plane.io/operator/resourcesets/app-definition/)
+- [Using ResourceSets for Time-Based Delivery](https://fluxcd.control-plane.io/operator/resourcesets/time-based-delivery/)
 - [Ephemeral Environments for GitHub Pull Requests](https://fluxcd.control-plane.io/operator/resourcesets/github-pull-requests/)
 - [Ephemeral Environments for GitLab Merge Requests](https://fluxcd.control-plane.io/operator/resourcesets/gitlab-merge-requests/)
 
 ## Documentation
 
 - Installation
-  - [Flux operator installation](https://fluxcd.control-plane.io/operator/install/)
+  - [Flux Operator installation](https://fluxcd.control-plane.io/operator/install/)
 - Flux Configuration
   - [Flux controllers configuration](https://fluxcd.control-plane.io/operator/flux-config/)
   - [Flux instance customization](https://fluxcd.control-plane.io/operator/flux-kustomize/)
@@ -191,6 +192,8 @@ Guides:
   - [FluxReport API reference](https://fluxcd.control-plane.io/operator/fluxreport/)
   - [ResourceSet API reference](https://fluxcd.control-plane.io/operator/resourceset/)
   - [ResourceSetInputProvider API reference](https://fluxcd.control-plane.io/operator/resourcesetinputprovider/)
+- CLI reference
+  - [Flux Operator CLI](https://fluxcd.control-plane.io/operator/cli/)
 
 ## Contributing
 

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -1,0 +1,136 @@
+---
+title: Flux Operator CLI
+description: Flux Operator command line tool installation and usage guide
+---
+
+# Flux Operator CLI
+
+The Flux Operator CLI is a command line tool that allows you to manage the Flux Operator resources
+in your Kubernetes clusters. It provides a convenient way to interact with the operator
+and perform various operations.
+
+## Installation
+
+The Flux Operator CLI is available as a binary executable for Linux, macOS, and Windows. The binaries
+can be downloaded from GitHub [releases page](https://github.com/controlplaneio-fluxcd/flux-operator/releases).
+
+If you are using macOS or Linux, you can install the CLI using Homebrew:
+
+```shell
+brew install controlplaneio-fluxcd/tap/flux-operator
+```
+
+To configure your shell to load `flux-operator` Bash completions add to your profile:
+
+```shell
+echo "source <(flux-operator completion bash)" >> ~/.bash_profile
+```
+
+Zsh, Fish, and PowerShell are also supported with their own sub-commands.
+
+## Commands
+
+The Flux Operator CLI provides commands to manage the Flux Operator resources.
+Except for the `build` commands, all others require access to the Kubernetes cluster
+and the Flux Operator to be installed.
+
+The CLI connects to the cluster using the `~.kube/config` file, similar to `kubectl`.
+
+### Build Commands
+
+The `flux-operator build` commands are used to build and validate the Flux Operator resources.
+These commands do not require access to a Kubernetes cluster and can be run in any environment.
+
+#### `flux-operator build instance`
+
+The build instance command performs the following steps:
+
+1. Reads the FluxInstance YAML manifest from the specified file.
+2. Validates the instance definition and sets default values.
+3. Pulls the distribution OCI artifact from the registry using the Docker config file for authentication.
+   If not specified, the artifact is pulled from 'oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests'.
+4. Builds the Flux Kubernetes manifests according to the instance specifications and kustomize patches.
+5. Prints the multi-doc YAML containing the Flux Kubernetes manifests to stdout.
+
+Example usage:
+
+```shell
+# Build the given FluxInstance and print the generated manifests
+flux-operator build instance -f flux.yaml
+
+# Pipe the FluxInstance definition to the build command
+cat flux.yaml | flux-operator build instance -f -
+
+# Build a FluxInstance and print a diff of the generated manifests
+flux-operator build instance -f flux.yaml | \
+  kubectl diff --server-side --field-manager=flux-operator -f -
+```
+
+#### `flux-operator build rset`
+
+The build rset command performs the following steps:
+
+1. Reads the ResourceSet YAML manifest from the specified file.
+2. Validates the ResourceSet definition and sets default values.
+3. Extracts the inputs from the ResourceSet and validates the templates.
+4. Builds the Kubernetes manifests according to the ResourceSet specifications and templates.
+5. Prints the multi-doc YAML containing the Kubernetes manifests to stdout.
+
+Example usage:
+
+```shell
+# Build the given ResourceSet and print the generated objects
+flux-operator build rset -f my-resourceset.yaml
+
+# Build a ResourceSet by providing the inputs from a file
+flux-operator build rset -f my-resourceset.yaml \
+--inputs-from my-resourceset-inputs.yaml
+
+# Pipe the ResourceSet manifest to the build command
+cat my-resourceset.yaml | flux-operator build rset -f -
+
+# Build a ResourceSet and print a diff of the generated objects
+flux-operator build rset -f my-resourceset.yaml | \
+kubectl diff --server-side --field-manager=flux-operator -f -
+```
+
+### Get Commands
+
+The `flux-operator get` commands are used to retrieve information about the Flux Operator resources in the cluster.
+
+The following commands are available:
+
+- `flux-operator get instance`: Retrieves the FluxInstance resource in the cluster.
+- `flux-operator get rset`: Retrieves the ResourceSet resources in the cluster.
+- `flux-operator get rsip`: Retrieves the ResourceSetInputProvider resources in the cluster.
+- `flux-operator get resources`: Retrieves all Flux resources in the cluster.
+
+Arguments:
+
+- `-n, --namespace`: Specifies the namespace to filter the resources.
+- `-A, --all-namespaces`: Retrieves resources from all namespaces.
+
+### Reconcile Commands
+
+The `flux-operator reconcile` commands are used to trigger the reconciliation of the Flux Operator resources.
+
+The following commands are available:
+
+- `flux-operator reconcile instance <name> -n <namespace>`: Reconciles the FluxInstance resource in the cluster.
+- `flux-operator reconcile rset <name> -n <namespace>`: Reconciles the ResourceSet resource in the cluster.
+- `flux-operator reconcile rsip <name> -n <namespace>`: Reconciles the ResourceSetInputProvider resource in the cluster.
+- `flux-operator reconcile resource <kind>/<name> -n <namespace>`: Reconciles a Flux resource in the specified namespace.
+
+### Suspend/Resume Commands
+
+The `flux-operator suspend` and `flux-operator resume` commands are used
+to suspend or resume the reconciliation of the Flux Operator resources.
+
+The following commands are available:
+
+- `flux-operator suspend instance <name> -n <namespace>`: Suspends the reconciliation of the FluxInstance resource in the cluster.
+- `flux-operator resume instance <name> -n <namespace>`: Resumes the reconciliation of the FluxInstance resource in the cluster.
+- `flux-operator suspend rset <name> -n <namespace>`: Suspends the reconciliation of the ResourceSet resource in the cluster.
+- `flux-operator resume rset <name> -n <namespace>`: Resumes the reconciliation of the ResourceSet resource in the cluster.
+- `flux-operator suspend rsip <name> -n <namespace>`: Suspends the reconciliation of the ResourceSetInputProvider resource in the cluster.
+- `flux-operator resume rsip <name> -n <namespace>`: Resumes the reconciliation of the ResourceSetInputProvider resource in the cluster.

--- a/cmd/cli/completion.go
+++ b/cmd/cli/completion.go
@@ -76,6 +76,33 @@ func resourceNamesCompletionFunc(gvk schema.GroupVersionKind) func(cmd *cobra.Co
 	}
 }
 
+// resourceKindCompletionFunc returns a function that can be used as a completion function for Flux resource kinds.
+func resourceKindCompletionFunc() func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// These are the Flux kinds that react to the reconcileAt annotation.
+		kinds := []string{
+			"GitRepository/",
+			"OCIRepository/",
+			"Bucket/",
+			"HelmRepository/",
+			"HelmChart/",
+			"HelmRelease/",
+			"Kustomization/",
+			"ImageRepository/",
+			"Receiver/",
+		}
+
+		var comps []string
+		for _, kind := range kinds {
+			if strings.HasPrefix(kind, toComplete) {
+				comps = append(comps, kind)
+			}
+		}
+
+		return comps, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
 // completionError is a helper function to handle errors in completion functions.
 func completionError(err error) ([]string, cobra.ShellCompDirective) {
 	cobra.CompError(err.Error())

--- a/cmd/cli/reconcile_inputprovider.go
+++ b/cmd/cli/reconcile_inputprovider.go
@@ -59,27 +59,20 @@ func reconcileInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	now := metav1.Now().String()
+	annotations := map[string]string{
+		meta.ReconcileRequestAnnotation: now,
+	}
 
-	if !reconcileInputProviderArgs.force {
-		err := annotateResource(ctx,
-			gvk,
-			name,
-			*kubeconfigArgs.Namespace,
-			meta.ReconcileRequestAnnotation,
-			now)
-		if err != nil {
-			return err
-		}
+	if reconcileInputProviderArgs.force {
+		annotations[meta.ForceRequestAnnotation] = now
 	}
 
 	err := annotateResourceWithMap(ctx,
 		gvk,
 		name,
 		*kubeconfigArgs.Namespace,
-		map[string]string{
-			meta.ReconcileRequestAnnotation: now,
-			meta.ForceRequestAnnotation:     now,
-		})
+		annotations,
+	)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/reconcile_resource.go
+++ b/cmd/cli/reconcile_resource.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var reconcileResourceCmd = &cobra.Command{
+	Use:   "resource",
+	Short: "Trigger Flux resource reconciliation",
+	Example: `  # Trigger the reconciliation of a Flux Kustomization
+  flux-operator -n apps reconcile resource Kustomization/my-app
+
+  # Force reconcile a Flux HelmRelease
+  flux-operator -n apps reconcile resource HelmRelease/my-release --force
+
+  # Trigger the reconciliation of an OCIRepository without waiting for it to become ready
+  flux-operator -n apps reconcile resource OCIRepository/my-app --wait=false
+`,
+	Args:              cobra.ExactArgs(1),
+	RunE:              reconcileResourceCmdRun,
+	ValidArgsFunction: resourceKindCompletionFunc(),
+}
+
+type reconcileResourceFlags struct {
+	force bool
+	wait  bool
+}
+
+var reconcileeResourceArgs reconcileResourceFlags
+
+func init() {
+	reconcileResourceCmd.Flags().BoolVar(&reconcileeResourceArgs.force, "force", false,
+		"Force the reconciliation of the resource, applies only to Flux HelmReleases.")
+	reconcileResourceCmd.Flags().BoolVar(&reconcileeResourceArgs.wait, "wait", true, "Wait for the resource to become ready.")
+	reconcileCmd.AddCommand(reconcileResourceCmd)
+}
+
+func reconcileResourceCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("resource name is required")
+	}
+
+	parts := strings.Split(args[0], "/")
+	if len(parts) != 2 {
+		return fmt.Errorf("resource name must be in the format <kind>/<name>, e.g., HelmRelease/my-app")
+	}
+
+	kind := parts[0]
+	name := parts[1]
+
+	gvk, err := preferredFluxGVK(kind, kubeconfigArgs)
+	if err != nil {
+		return fmt.Errorf("unable to get gvk for kind %s : %w", kind, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	now := metav1.Now().String()
+	annotations := map[string]string{
+		meta.ReconcileRequestAnnotation: now,
+	}
+
+	if reconcileeResourceArgs.force {
+		annotations[meta.ForceRequestAnnotation] = now
+	}
+
+	err = annotateResourceWithMap(ctx,
+		*gvk,
+		name,
+		*kubeconfigArgs.Namespace,
+		annotations,
+	)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`►`, "Reconciliation triggered")
+	if reconcileeResourceArgs.wait {
+		rootCmd.Println(`◎`, "Waiting for reconciliation...")
+		msg, err := waitForResourceReconciliation(ctx,
+			*gvk,
+			name,
+			*kubeconfigArgs.Namespace,
+			now,
+			rootArgs.timeout)
+		if err != nil {
+			return err
+		}
+		rootCmd.Println(`✔`, msg)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds a new command for reconciling Flux custom resources:

```
Usage:
  flux-operator reconcile resource [flags]

Examples:
  # Trigger the reconciliation of a Flux Kustomization
  flux-operator -n apps reconcile resource Kustomization/my-app

  # Force reconcile a Flux HelmRelease
  flux-operator -n apps reconcile resource HelmRelease/my-release --force

  # Trigger the reconciliation of an OCIRepository without waiting for it to become ready
  flux-operator -n apps reconcile resource OCIRepository/my-app --wait=false


Flags:
      --force   Force the reconciliation of the resource, applies only to Flux HelmReleases.
  -h, --help    help for resource
      --wait    Wait for the resource to become ready. (default true)
```
