### PR TITLE
Add ResourceSet stats to `FluxReport.spec.reconcilers`

### DIFF
--- a/docs/api/v1/fluxreport.md
+++ b/docs/api/v1/fluxreport.md
@@ -57,6 +57,18 @@ spec:
     platform: linux/arm64
     version: v0.24.0
   reconcilers:
+    - apiVersion: fluxcd.controlplane.io/v1
+      kind: ResourceSet
+      stats:
+        failing: 0
+        running: 5
+        suspended: 1
+    - apiVersion: fluxcd.controlplane.io/v1
+      kind: ResourceSetInputProvider
+      stats:
+        failing: 1
+        running: 5
+        suspended: 1
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       stats:

--- a/internal/controller/fluxreport_controller_test.go
+++ b/internal/controller/fluxreport_controller_test.go
@@ -117,9 +117,9 @@ func TestFluxReportReconciler_Reconcile(t *testing.T) {
 	g.Expect(report.Spec.Distribution.ManagedBy).To(Equal("flux-operator"))
 
 	// Check reported reconcilers.
-	g.Expect(report.Spec.ReconcilersStatus).To(HaveLen(10))
-	g.Expect(report.Spec.ReconcilersStatus[9].Kind).To(Equal("OCIRepository"))
-	g.Expect(report.Spec.ReconcilersStatus[9].Stats.Running).To(Equal(1))
+	g.Expect(report.Spec.ReconcilersStatus).To(HaveLen(12))
+	g.Expect(report.Spec.ReconcilersStatus[11].Kind).To(Equal("OCIRepository"))
+	g.Expect(report.Spec.ReconcilersStatus[11].Stats.Running).To(Equal(1))
 
 	// Check reported sync.
 	g.Expect(report.Spec.SyncStatus).ToNot(BeNil())

--- a/internal/reporter/reconcilers.go
+++ b/internal/reporter/reconcilers.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/fluxcd/cli-utils/pkg/kstatus/status"
 	"github.com/fluxcd/pkg/apis/meta"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -75,9 +77,69 @@ func (r *FluxStatusReporter) getReconcilersStatus(ctx context.Context, crds []me
 		}
 	}
 
+	opStats, err := r.getOperatorReconcilersStatus(ctx)
+	if err != nil {
+		multiErr = kerrors.NewAggregate([]error{multiErr, err})
+	} else {
+		resStats = append(resStats, opStats...)
+	}
+
 	slices.SortStableFunc(resStats, func(i, j fluxcdv1.FluxReconcilerStatus) int {
 		return cmp.Compare(i.APIVersion+i.Kind, j.APIVersion+j.Kind)
 	})
+
+	return resStats, multiErr
+}
+
+func (r *FluxStatusReporter) getOperatorReconcilersStatus(ctx context.Context) ([]fluxcdv1.FluxReconcilerStatus, error) {
+	var multiErr error
+	crds := []schema.GroupVersionKind{
+		fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind),
+		fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind),
+	}
+	resStats := make([]fluxcdv1.FluxReconcilerStatus, len(crds))
+	for i, gvk := range crds {
+		var total int
+		var suspended int
+		var failing int
+
+		list := unstructured.UnstructuredList{
+			Object: map[string]any{
+				"apiVersion": gvk.Group + "/" + gvk.Version,
+				"kind":       gvk.Kind,
+			},
+		}
+
+		if err := r.List(ctx, &list, client.InNamespace("")); err == nil {
+			total = len(list.Items)
+
+			for _, item := range list.Items {
+				if ssautil.AnyInMetadata(&item, map[string]string{fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue}) {
+					suspended++
+				}
+
+				if obj, err := status.GetObjectWithConditions(item.Object); err == nil {
+					for _, cond := range obj.Status.Conditions {
+						if cond.Type == meta.ReadyCondition && cond.Status == corev1.ConditionFalse {
+							failing++
+						}
+					}
+				}
+			}
+		} else {
+			multiErr = kerrors.NewAggregate([]error{multiErr, err})
+		}
+
+		resStats[i] = fluxcdv1.FluxReconcilerStatus{
+			APIVersion: gvk.Group + "/" + gvk.Version,
+			Kind:       gvk.Kind,
+			Stats: fluxcdv1.FluxReconcilerStats{
+				Running:   total - suspended,
+				Failing:   failing,
+				Suspended: suspended,
+			},
+		}
+	}
 
 	return resStats, multiErr
 }


### PR DESCRIPTION
This PR adds `ResourceSet` and `ResourceSetInputProvider` reconcile statistics to the `FluxReport.spec.reconcilers`. 