### PR TITLE
cli: Add `flux-operator suspend/resume resource` commands

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -134,6 +134,8 @@ The following commands are available:
 - `flux-operator resume rset <name> -n <namespace>`: Resumes the reconciliation of the ResourceSet resource in the cluster.
 - `flux-operator suspend rsip <name> -n <namespace>`: Suspends the reconciliation of the ResourceSetInputProvider resource in the cluster.
 - `flux-operator resume rsip <name> -n <namespace>`: Resumes the reconciliation of the ResourceSetInputProvider resource in the cluster.
+- `flux-operator suspend resource <kind>/<name> -n <namespace>`: Suspends the reconciliation of the Flux resource in the cluster.
+- `flux-operator resume resource <kind>/<name> -n <namespace>`: Resumes the reconciliation of the Flux resource in the cluster.
 
 ### Statistics Command
 

--- a/cmd/cli/client.go
+++ b/cmd/cli/client.go
@@ -271,3 +271,8 @@ func preferredFluxGVK(kind string, cf *cliopts.ConfigFlags) (*schema.GroupVersio
 
 	return &mapping.GroupVersionKind, nil
 }
+
+// timeNow returns the current time in RFC3339Nano format.
+func timeNow() string {
+	return metav1.Now().Format(time.RFC3339Nano)
+}

--- a/cmd/cli/client.go
+++ b/cmd/cli/client.go
@@ -173,6 +173,69 @@ func isResourceReconciledFunc(kubeClient client.Client, obj *unstructured.Unstru
 	}
 }
 
+// toggleSuspension toggles the suspension of a Flux resource by setting or removing the `spec.suspend` field.
+// If the resource is a Flux Operator resource, it uses annotations instead.
+// When resuming a resource, it also sets the ReconcileAt annotation.
+func toggleSuspension(ctx context.Context, gvk schema.GroupVersionKind, name, namespace string, requestTime string, suspend bool) error {
+	resource := &unstructured.Unstructured{}
+	resource.SetGroupVersionKind(gvk)
+	resource.SetName(name)
+	resource.SetNamespace(namespace)
+
+	// Handle Flux Operator resources using annotations.
+	if gvk.GroupVersion() == fluxcdv1.GroupVersion {
+		var annotations map[string]string
+		if suspend {
+			annotations = map[string]string{
+				fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue,
+			}
+		} else {
+			annotations = map[string]string{
+				fluxcdv1.ReconcileAnnotation:    fluxcdv1.EnabledValue,
+				meta.ReconcileRequestAnnotation: requestTime,
+			}
+		}
+
+		return annotateResourceWithMap(ctx, gvk, name, namespace, annotations)
+	}
+
+	// Handle Flux resources by patching the spec.suspend field.
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(resource), resource); err != nil {
+		return fmt.Errorf("unable to read %s/%s/%s error: %w", gvk.Kind, namespace, name, err)
+	}
+
+	patch := client.MergeFrom(resource.DeepCopy())
+
+	if suspend {
+		err := unstructured.SetNestedField(resource.Object, suspend, "spec", "suspend")
+		if err != nil {
+			return fmt.Errorf("unable to set suspend field: %w", err)
+		}
+	} else {
+		unstructured.RemoveNestedField(resource.Object, "spec", "suspend")
+
+		annotations := resource.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		maps.Copy(annotations, map[string]string{
+			meta.ReconcileRequestAnnotation: requestTime,
+		})
+		resource.SetAnnotations(annotations)
+	}
+
+	if err := kubeClient.Patch(ctx, resource, patch); err != nil {
+		return fmt.Errorf("unable to patch %s/%s/%s error: %w", gvk.Kind, namespace, name, err)
+	}
+
+	return nil
+}
+
 // preferredFluxGVK returns the preferred GroupVersionKind for a given Flux kind.
 func preferredFluxGVK(kind string, cf *cliopts.ConfigFlags) (*schema.GroupVersionKind, error) {
 	gk := schema.GroupKind{

--- a/cmd/cli/completion.go
+++ b/cmd/cli/completion.go
@@ -89,6 +89,7 @@ func resourceKindCompletionFunc() func(cmd *cobra.Command, args []string, toComp
 			"HelmRelease/",
 			"Kustomization/",
 			"ImageRepository/",
+			"ImageUpdateAutomation/",
 			"Receiver/",
 		}
 

--- a/cmd/cli/reconcile_inputprovider.go
+++ b/cmd/cli/reconcile_inputprovider.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -58,7 +57,7 @@ func reconcileInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	now := metav1.Now().String()
+	now := timeNow()
 	annotations := map[string]string{
 		meta.ReconcileRequestAnnotation: now,
 	}
@@ -67,12 +66,7 @@ func reconcileInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 		annotations[meta.ForceRequestAnnotation] = now
 	}
 
-	err := annotateResourceWithMap(ctx,
-		gvk,
-		name,
-		*kubeconfigArgs.Namespace,
-		annotations,
-	)
+	err := annotateResourceWithMap(ctx, gvk, name, *kubeconfigArgs.Namespace, annotations)
 	if err != nil {
 		return err
 	}
@@ -80,12 +74,7 @@ func reconcileInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 	rootCmd.Println(`►`, "Reconciliation triggered")
 	if reconcileInputProviderArgs.wait {
 		rootCmd.Println(`◎`, "Waiting for reconciliation...")
-		msg, err := waitForResourceReconciliation(ctx,
-			gvk,
-			name,
-			*kubeconfigArgs.Namespace,
-			now,
-			rootArgs.timeout)
+		msg, err := waitForResourceReconciliation(ctx, gvk, name, *kubeconfigArgs.Namespace, now, rootArgs.timeout)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/reconcile_instance.go
+++ b/cmd/cli/reconcile_instance.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -46,19 +45,13 @@ func reconcileInstanceCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	now := timeNow()
 	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	now := metav1.Now().String()
-
-	err := annotateResource(ctx,
-		gvk,
-		name,
-		*kubeconfigArgs.Namespace,
-		meta.ReconcileRequestAnnotation,
-		now)
+	err := annotateResource(ctx, gvk, name, *kubeconfigArgs.Namespace, meta.ReconcileRequestAnnotation, now)
 	if err != nil {
 		return err
 	}
@@ -66,12 +59,7 @@ func reconcileInstanceCmdRun(cmd *cobra.Command, args []string) error {
 	rootCmd.Println(`►`, "Reconciliation triggered")
 	if reconcileInstanceArgs.wait {
 		rootCmd.Println(`◎`, "Waiting for reconciliation...")
-		msg, err := waitForResourceReconciliation(ctx,
-			gvk,
-			name,
-			*kubeconfigArgs.Namespace,
-			now,
-			rootArgs.timeout)
+		msg, err := waitForResourceReconciliation(ctx, gvk, name, *kubeconfigArgs.Namespace, now, rootArgs.timeout)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/reconcile_resourceset.go
+++ b/cmd/cli/reconcile_resourceset.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -46,18 +45,13 @@ func reconcileResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	now := timeNow()
 	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	now := metav1.Now().String()
-	err := annotateResource(ctx,
-		gvk,
-		name,
-		*kubeconfigArgs.Namespace,
-		meta.ReconcileRequestAnnotation,
-		now)
+	err := annotateResource(ctx, gvk, name, *kubeconfigArgs.Namespace, meta.ReconcileRequestAnnotation, now)
 	if err != nil {
 		return err
 	}
@@ -65,12 +59,7 @@ func reconcileResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 	rootCmd.Println(`►`, "Reconciliation triggered")
 	if reconcileResourceSetArgs.wait {
 		rootCmd.Println(`◎`, "Waiting for reconciliation...")
-		msg, err := waitForResourceReconciliation(ctx,
-			gvk,
-			name,
-			*kubeconfigArgs.Namespace,
-			now,
-			rootArgs.timeout)
+		msg, err := waitForResourceReconciliation(ctx, gvk, name, *kubeconfigArgs.Namespace, now, rootArgs.timeout)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/resume_inputprovider.go
+++ b/cmd/cli/resume_inputprovider.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -16,11 +17,20 @@ var resumeInputProviderCmd = &cobra.Command{
 	Use:               "inputprovider",
 	Aliases:           []string{"rsip", "resourcesetinputprovider"},
 	Short:             "Resume ResourceSetInputProvider reconciliation",
+	Args:              cobra.ExactArgs(1),
 	RunE:              resumeInputProviderCmdRun,
 	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)),
 }
 
+type resumeInputProviderFlags struct {
+	wait bool
+}
+
+var resumeInputProviderArgs resumeInputProviderFlags
+
 func init() {
+	resumeInputProviderCmd.Flags().BoolVar(&resumeInputProviderArgs.wait, "wait", true,
+		"Wait for the resource to become ready.")
 	resumeCmd.AddCommand(resumeInputProviderCmd)
 }
 
@@ -30,21 +40,33 @@ func resumeInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	now := metav1.Now().String()
 	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	err := annotateResource(ctx,
-		gvk,
-		name,
-		*kubeconfigArgs.Namespace,
-		fluxcdv1.ReconcileAnnotation,
-		fluxcdv1.EnabledValue)
+	err := toggleSuspension(ctx, gvk, name, *kubeconfigArgs.Namespace, now, false)
 	if err != nil {
 		return err
 	}
 
-	rootCmd.Println(`✔`, "Reconciliation resumed")
+	if resumeInstanceArgs.wait {
+		rootCmd.Println(`◎`, "Waiting for reconciliation...")
+		msg, err := waitForResourceReconciliation(ctx,
+			gvk,
+			name,
+			*kubeconfigArgs.Namespace,
+			now,
+			rootArgs.timeout)
+		if err != nil {
+			return err
+		}
+
+		rootCmd.Println(`✔`, msg)
+	} else {
+		rootCmd.Println(`✔`, "Reconciliation resumed")
+	}
+
 	return nil
 }

--- a/cmd/cli/resume_inputprovider.go
+++ b/cmd/cli/resume_inputprovider.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -40,7 +39,7 @@ func resumeInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
-	now := metav1.Now().String()
+	now := timeNow()
 	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
@@ -53,12 +52,7 @@ func resumeInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 
 	if resumeInstanceArgs.wait {
 		rootCmd.Println(`◎`, "Waiting for reconciliation...")
-		msg, err := waitForResourceReconciliation(ctx,
-			gvk,
-			name,
-			*kubeconfigArgs.Namespace,
-			now,
-			rootArgs.timeout)
+		msg, err := waitForResourceReconciliation(ctx, gvk, name, *kubeconfigArgs.Namespace, now, rootArgs.timeout)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/resume_instance.go
+++ b/cmd/cli/resume_instance.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -39,7 +38,7 @@ func resumeInstanceCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
-	now := metav1.Now().String()
+	now := timeNow()
 	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
@@ -52,12 +51,7 @@ func resumeInstanceCmdRun(cmd *cobra.Command, args []string) error {
 
 	if resumeInstanceArgs.wait {
 		rootCmd.Println(`◎`, "Waiting for reconciliation...")
-		msg, err := waitForResourceReconciliation(ctx,
-			gvk,
-			name,
-			*kubeconfigArgs.Namespace,
-			now,
-			rootArgs.timeout)
+		msg, err := waitForResourceReconciliation(ctx, gvk, name, *kubeconfigArgs.Namespace, now, rootArgs.timeout)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/resume_resource.go
+++ b/cmd/cli/resume_resource.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var resumeResourceCmd = &cobra.Command{
@@ -47,7 +46,7 @@ func resumeResourceCmdRun(cmd *cobra.Command, args []string) error {
 
 	kind := parts[0]
 	name := parts[1]
-	now := metav1.Now().String()
+	now := timeNow()
 
 	gvk, err := preferredFluxGVK(kind, kubeconfigArgs)
 	if err != nil {
@@ -64,12 +63,7 @@ func resumeResourceCmdRun(cmd *cobra.Command, args []string) error {
 
 	if resumeResourceArgs.wait {
 		rootCmd.Println(`◎`, "Waiting for reconciliation...")
-		msg, err := waitForResourceReconciliation(ctx,
-			*gvk,
-			name,
-			*kubeconfigArgs.Namespace,
-			now,
-			rootArgs.timeout)
+		msg, err := waitForResourceReconciliation(ctx, *gvk, name, *kubeconfigArgs.Namespace, now, rootArgs.timeout)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/resume_resource.go
+++ b/cmd/cli/resume_resource.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var resumeResourceCmd = &cobra.Command{
+	Use:   "resource",
+	Short: "Resume Flux resource reconciliation",
+	Example: `  # Resume the reconciliation of a Flux Kustomization
+  flux-operator -n apps resume resource Kustomization/my-app
+`,
+	Args:              cobra.ExactArgs(1),
+	RunE:              resumeResourceCmdRun,
+	ValidArgsFunction: resourceKindCompletionFunc(),
+}
+
+type resumeResourceFlags struct {
+	wait bool
+}
+
+var resumeResourceArgs resumeResourceFlags
+
+func init() {
+	resumeResourceCmd.Flags().BoolVar(&resumeResourceArgs.wait, "wait", true,
+		"Wait for the resource to become ready.")
+	resumeCmd.AddCommand(resumeResourceCmd)
+}
+
+func resumeResourceCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("resource name is required")
+	}
+
+	parts := strings.Split(args[0], "/")
+	if len(parts) != 2 {
+		return fmt.Errorf("resource name must be in the format <kind>/<name>, e.g., HelmRelease/my-app")
+	}
+
+	kind := parts[0]
+	name := parts[1]
+	now := metav1.Now().String()
+
+	gvk, err := preferredFluxGVK(kind, kubeconfigArgs)
+	if err != nil {
+		return fmt.Errorf("unable to get gvk for kind %s : %w", kind, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	err = toggleSuspension(ctx, *gvk, name, *kubeconfigArgs.Namespace, now, false)
+	if err != nil {
+		return err
+	}
+
+	if resumeResourceArgs.wait {
+		rootCmd.Println(`◎`, "Waiting for reconciliation...")
+		msg, err := waitForResourceReconciliation(ctx,
+			*gvk,
+			name,
+			*kubeconfigArgs.Namespace,
+			now,
+			rootArgs.timeout)
+		if err != nil {
+			return err
+		}
+		rootCmd.Println(`✔`, msg)
+	} else {
+		rootCmd.Println(`✔`, "Reconciliation resumed")
+	}
+
+	return nil
+}

--- a/cmd/cli/resume_resourceset.go
+++ b/cmd/cli/resume_resourceset.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -40,7 +39,7 @@ func resumeResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
-	now := metav1.Now().String()
+	now := timeNow()
 	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
@@ -53,12 +52,7 @@ func resumeResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 
 	if resumeResourceSetArgs.wait {
 		rootCmd.Println(`◎`, "Waiting for reconciliation...")
-		msg, err := waitForResourceReconciliation(ctx,
-			gvk,
-			name,
-			*kubeconfigArgs.Namespace,
-			now,
-			rootArgs.timeout)
+		msg, err := waitForResourceReconciliation(ctx, gvk, name, *kubeconfigArgs.Namespace, now, rootArgs.timeout)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/suspend_inputprovider.go
+++ b/cmd/cli/suspend_inputprovider.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -32,7 +31,7 @@ func suspendInputProviderCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
-	now := metav1.Now().String()
+	now := timeNow()
 	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)

--- a/cmd/cli/suspend_instance.go
+++ b/cmd/cli/suspend_instance.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -31,7 +30,7 @@ func suspendInstanceCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
-	now := metav1.Now().String()
+	now := timeNow()
 	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)

--- a/cmd/cli/suspend_resource.go
+++ b/cmd/cli/suspend_resource.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var suspendResourceCmd = &cobra.Command{
+	Use:   "resource",
+	Short: "suspend Flux resource reconciliation",
+	Example: `  # Suspend the reconciliation of a Flux Kustomization
+  flux-operator -n apps suspend resource Kustomization/my-app
+`,
+	Args:              cobra.ExactArgs(1),
+	RunE:              suspendResourceCmdRun,
+	ValidArgsFunction: resourceKindCompletionFunc(),
+}
+
+func init() {
+	suspendCmd.AddCommand(suspendResourceCmd)
+}
+
+func suspendResourceCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("resource name is required")
+	}
+
+	parts := strings.Split(args[0], "/")
+	if len(parts) != 2 {
+		return fmt.Errorf("resource name must be in the format <kind>/<name>, e.g., HelmRelease/my-app")
+	}
+
+	kind := parts[0]
+	name := parts[1]
+	now := metav1.Now().String()
+
+	gvk, err := preferredFluxGVK(kind, kubeconfigArgs)
+	if err != nil {
+		return fmt.Errorf("unable to get gvk for kind %s : %w", kind, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	err = toggleSuspension(ctx, *gvk, name, *kubeconfigArgs.Namespace, now, true)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, "Reconciliation suspended")
+	return nil
+}

--- a/cmd/cli/suspend_resource.go
+++ b/cmd/cli/suspend_resource.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var suspendResourceCmd = &cobra.Command{
@@ -39,7 +38,7 @@ func suspendResourceCmdRun(cmd *cobra.Command, args []string) error {
 
 	kind := parts[0]
 	name := parts[1]
-	now := metav1.Now().String()
+	now := timeNow()
 
 	gvk, err := preferredFluxGVK(kind, kubeconfigArgs)
 	if err != nil {

--- a/cmd/cli/suspend_resourceset.go
+++ b/cmd/cli/suspend_resourceset.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -32,7 +31,7 @@ func suspendResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
-	now := metav1.Now().String()
+	now := timeNow()
 	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)

--- a/cmd/cli/suspend_resourceset.go
+++ b/cmd/cli/suspend_resourceset.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -16,6 +17,7 @@ var suspendResourceSetCmd = &cobra.Command{
 	Use:               "resourceset",
 	Aliases:           []string{"rset"},
 	Short:             "Suspend ResourceSet reconciliation",
+	Args:              cobra.ExactArgs(1),
 	RunE:              suspendResourceSetCmdRun,
 	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)),
 }
@@ -30,17 +32,13 @@ func suspendResourceSetCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	now := metav1.Now().String()
 	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)
 
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	err := annotateResource(ctx,
-		gvk,
-		name,
-		*kubeconfigArgs.Namespace,
-		fluxcdv1.ReconcileAnnotation,
-		fluxcdv1.DisabledValue)
+	err := toggleSuspension(ctx, gvk, name, *kubeconfigArgs.Namespace, now, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds commands for suspending and resuming Flux resources:

- `flux-operator suspend resource <kind>/<name> -n <namespace>`
- `flux-operator resume resource <kind>/<name> -n <namespace>`

In addition, the `flux-operator resume` commands will wait for a resumed resource to become ready and will print the reconciliation result. Can be disabled with `--wait=false`. 
