### PR TITLE
Introduce regex and latest filters for tags in ResourceSetInputProvider

### DIFF
--- a/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
@@ -88,10 +88,35 @@ spec:
                       ExcludeBranch specifies the regular expression to filter the branches
                       that the input provider should exclude.
                     type: string
+                  excludeTag:
+                    description: |-
+                      ExcludeTag specifies the regular expression to filter the tags
+                      that the input provider should exclude.
+                    type: string
+                  groupKey:
+                    description: |-
+                      GroupKey is a template that can be expanded using the IncludeBranch
+                      or IncludeTag regular expression matching results to expand a group
+                      key from the branch or tag name for usage with another filter.
+                      The strings with the same key will placed in the same group.
+                      If the template always expands to the same value, all strings will
+                      be placed in the same group, resulting in a single group (this is the
+                      default behavior).
+                      Supported only by the LatestPolicy filter.
+                    type: string
                   includeBranch:
                     description: |-
                       IncludeBranch specifies the regular expression to filter the branches
-                      that the input provider should include.
+                      that the input provider should include. Can be used alongside
+                      the Value and GroupKey fields to expand a value and group key
+                      respectively from the branch name for usage with another filter.
+                    type: string
+                  includeTag:
+                    description: |-
+                      IncludeTag specifies the regular expression to filter the tags
+                      that the input provider should include. Can be used alongside
+                      the Value and GroupKey fields to expand a value and group key
+                      respectively from the tag name for usage with another filter.
                     type: string
                   labels:
                     description: Labels specifies the list of labels to filter the
@@ -99,15 +124,43 @@ spec:
                     items:
                       type: string
                     type: array
+                  latestPolicy:
+                    description: |-
+                      LatestPolicy is the order for sorting each group of tags.
+                      After sorting each group, the last tag is selected as
+                      the "latest" in the group. When this field is set, the
+                      Limit filter is ignored, and only the latest tags from
+                      each group are exported as inputs. When Value and IncludeTag
+                      are set, the expanded value is used for sorting instead of
+                      the tag name itself.
+                      Supported only for tags at the moment.
+                    enum:
+                    - SemVer
+                    - Alphabetical
+                    - ReverseAlphabetical
+                    - Numerical
+                    - ReverseNumerical
+                    type: string
                   limit:
                     default: 100
                     description: |-
                       Limit specifies the maximum number of input sets to return.
                       When not set, the default limit is 100.
+                      When LatestPolicy is set, the limit is ignored.
                     type: integer
                   semver:
-                    description: Semver specifies the semantic version range to filter
-                      and order the tags.
+                    description: |-
+                      Semver specifies a semantic version range to filter and sort the tags.
+                      When both Value and IncludeTag are set, the expanded value is
+                      checked against the range instead of the tag name itself.
+                      Supported only for tags at the moment.
+                    type: string
+                  value:
+                    description: |-
+                      Value is a template that can be expanded using the IncludeBranch
+                      or IncludeTag regular expression matching results to expand a
+                      value from the branch or tag name for usage with another filter.
+                      Supported by the SemVer and LatestPolicy filters.
                     type: string
                 type: object
               schedule:

--- a/internal/controller/resourcesetinputprovider_controller.go
+++ b/internal/controller/resourcesetinputprovider_controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/fluxcd/pkg/git/github"
 	"github.com/fluxcd/pkg/runtime/conditions"
 	"github.com/fluxcd/pkg/runtime/patch"
-	"github.com/fluxcd/pkg/version"
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/opencontainers/go-digest"
@@ -43,6 +42,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/filtering"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/gitprovider"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/inputs"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/notifier"
@@ -350,44 +350,65 @@ func (r *ResourceSetInputProviderReconciler) newGitProvider(ctx context.Context,
 	}
 }
 
-// makeGitOptions returns the gitprovider.Options based on the object spec
-// filters and URL, using the default limit.
-func (r *ResourceSetInputProviderReconciler) makeGitOptions(obj *fluxcdv1.ResourceSetInputProvider) (gitprovider.Options, error) {
-	opts := gitprovider.Options{
-		URL: obj.Spec.URL,
-		Filters: gitprovider.Filters{
-			Limit: obj.GetFilterLimit(),
-		},
+// makeFilters returns the *filtering.Filters based on the
+// object spec filters, using the default limit.
+func (r *ResourceSetInputProviderReconciler) makeFilters(
+	obj *fluxcdv1.ResourceSetInputProvider) (*filtering.Filters, error) {
+
+	limit := obj.GetFilterLimit()
+
+	if obj.Spec.Filter == nil {
+		return &filtering.Filters{Limit: limit}, nil
 	}
 
-	if obj.Spec.Filter != nil {
-		if len(obj.Spec.Filter.Labels) > 0 {
-			opts.Filters.Labels = obj.Spec.Filter.Labels
-		}
-		if obj.Spec.Filter.IncludeBranch != "" {
-			inRx, err := regexp.Compile(obj.Spec.Filter.IncludeBranch)
-			if err != nil {
-				return gitprovider.Options{}, fmt.Errorf("invalid includeBranch regex: %w", err)
-			}
-			opts.Filters.IncludeBranchRe = inRx
-		}
-		if obj.Spec.Filter.ExcludeBranch != "" {
-			exRx, err := regexp.Compile(obj.Spec.Filter.ExcludeBranch)
-			if err != nil {
-				return gitprovider.Options{}, fmt.Errorf("invalid excludeBranch regex: %w", err)
-			}
-			opts.Filters.ExcludeBranchRe = exRx
-		}
-		if obj.Spec.Filter.Semver != "" {
-			constraints, err := semver.NewConstraint(obj.Spec.Filter.Semver)
-			if err != nil {
-				return gitprovider.Options{}, fmt.Errorf("invalid semver expression: %w", err)
-			}
-			opts.Filters.SemverConstraints = constraints
-		}
+	filters := &filtering.Filters{
+		Limit:        limit,
+		Labels:       obj.Spec.Filter.Labels,
+		Value:        obj.Spec.Filter.Value,
+		GroupKey:     obj.Spec.Filter.GroupKey,
+		LatestPolicy: obj.Spec.Filter.LatestPolicy,
 	}
 
-	return opts, nil
+	// Regular expressions.
+	if obj.Spec.Filter.IncludeBranch != "" {
+		inRx, err := regexp.Compile(obj.Spec.Filter.IncludeBranch)
+		if err != nil {
+			return nil, fmt.Errorf("invalid includeBranch regex: %w", err)
+		}
+		filters.Include = inRx
+	}
+	if obj.Spec.Filter.IncludeTag != "" {
+		inRx, err := regexp.Compile(obj.Spec.Filter.IncludeTag)
+		if err != nil {
+			return nil, fmt.Errorf("invalid includeTag regex: %w", err)
+		}
+		filters.Include = inRx
+	}
+	if obj.Spec.Filter.ExcludeBranch != "" {
+		exRx, err := regexp.Compile(obj.Spec.Filter.ExcludeBranch)
+		if err != nil {
+			return nil, fmt.Errorf("invalid excludeBranch regex: %w", err)
+		}
+		filters.Exclude = exRx
+	}
+	if obj.Spec.Filter.ExcludeTag != "" {
+		exRx, err := regexp.Compile(obj.Spec.Filter.ExcludeTag)
+		if err != nil {
+			return nil, fmt.Errorf("invalid excludeTag regex: %w", err)
+		}
+		filters.Exclude = exRx
+	}
+
+	// SemVer.
+	if obj.Spec.Filter.Semver != "" {
+		constraints, err := semver.NewConstraint(obj.Spec.Filter.Semver)
+		if err != nil {
+			return nil, fmt.Errorf("invalid semver expression: %w", err)
+		}
+		filters.SemVer = constraints
+	}
+
+	return filters, nil
 }
 
 // restoreSkippedGitProviderResults skip git provider results when matches skip condition.
@@ -450,9 +471,14 @@ func (r *ResourceSetInputProviderReconciler) callGitProvider(ctx context.Context
 
 	var inputSet []fluxcdv1.ResourceSetInput
 
-	opts, err := r.makeGitOptions(obj)
+	filters, err := r.makeFilters(obj)
 	if err != nil {
 		return nil, err
+	}
+
+	opts := gitprovider.Options{
+		URL:     obj.Spec.URL,
+		Filters: *filters,
 	}
 
 	var results []gitprovider.Result
@@ -626,17 +652,11 @@ func (r *ResourceSetInputProviderReconciler) callOCIProvider(ctx context.Context
 	}
 
 	// Filter tags.
-	if f := obj.Spec.Filter; f != nil {
-		if f.Semver != "" {
-			constraint, err := semver.NewConstraint(f.Semver)
-			if err != nil {
-				return nil, fmt.Errorf("invalid semver expression '%s': %w", f.Semver, err)
-			}
-			tags = version.Sort(constraint, tags)
-		}
+	filters, err := r.makeFilters(obj)
+	if err != nil {
+		return nil, err
 	}
-	n := min(obj.GetFilterLimit(), len(tags))
-	tags = slices.Clone(tags[:n]) // free memory in case the received tags are too many
+	tags = filters.Tags(tags)
 
 	// Export inputs.
 	res := make([]fluxcdv1.ResourceSetInput, 0, len(tags))

--- a/internal/filtering/filters.go
+++ b/internal/filtering/filters.go
@@ -1,0 +1,310 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package filtering
+
+import (
+	"cmp"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/fluxcd/pkg/version"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+// DefaultLimit is the default limit for the number of results returned by the filters.
+const DefaultLimit = 100
+
+// Filters holds the filters for the input provider responses.
+type Filters struct {
+	// Labels is used for a "match labels" filter.
+	Labels []string
+
+	// Include is used for including tags or branches.
+	// When set together with Value or GroupKey, can be used
+	// to expand a value or group key from the branch or tag
+	// name for usage with another filter.
+	Include *regexp.Regexp
+
+	// Exclude is used for excluding tags or branches.
+	Exclude *regexp.Regexp
+
+	// Value is an optional template that can be expanded using the regex
+	// matching results of Include against a branch or tag to expand a value
+	// that can be used with another filter.
+	// Supported by the SemVer and LatestPolicy filters.
+	Value string
+
+	// GroupKey is an optional template that can be expanded using the regex
+	// matching results of Include against a branch or tag to expand a value
+	// that can be used with another filter.
+	// Supported only by the LatestPolicy filter.
+	GroupKey string
+
+	// LatestPolicy is the order for sorting each group of tags.
+	// After sorting each group, the last tag is selected as
+	// the "latest" in the group. When this field is set, only
+	// the latest tags from each group are exported as inputs.
+	// Supported only for tags at the moment.
+	LatestPolicy string
+
+	// SemVer is used for sorting and filtering tags.
+	// When both Value and Include are set, the expanded
+	// value is checked against the SemVer range instead of
+	// the tag name itself.
+	// Supported only for tags at the moment.
+	SemVer *semver.Constraints
+
+	// Limit is used to limit the number of results.
+	Limit int
+}
+
+// MatchLabels returns true if the given labels include all the label filters.
+func (f *Filters) MatchLabels(labels []string) bool {
+	for _, label := range f.Labels {
+		if !slices.Contains(labels, label) {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchBranch returns true if the branch matches the include and exclude regex filters.
+func (f *Filters) MatchBranch(branch string) bool {
+	if f.Include != nil {
+		if !f.Include.MatchString(branch) {
+			return false
+		}
+	}
+	if f.Exclude != nil {
+		if f.Exclude.MatchString(branch) {
+			return false
+		}
+	}
+	return true
+}
+
+// Tags applies all the filters supported for tags to a list of tags.
+// nolint:prealloc
+func (f *Filters) Tags(tags []string) []string {
+
+	var filtered []string
+
+	// Apply include and exclude, compute expanded values and group keys.
+	var expanded []*tagOrBranchExpandedValueAndGroupKey
+	expandTemplates := f.Include != nil && (f.Value != "" || f.GroupKey != "")
+	for _, tag := range tags {
+		if f.Exclude != nil && f.Exclude.MatchString(tag) {
+			continue
+		}
+		if f.Include == nil || (!expandTemplates && f.Include.MatchString(tag)) {
+			filtered = append(filtered, tag)
+			continue
+		}
+		if !expandTemplates { // f.Include does not match tag.
+			continue
+		}
+		// Match with Include was not tested above because
+		// we need the indexes of the matches to expand
+		// the value and/or group key.
+		matching := f.Include.FindStringSubmatchIndex(tag)
+		if len(matching) == 0 {
+			continue
+		}
+		e := newExpandedTagOrBranch(tag)
+		if f.Value != "" {
+			e.value = string(f.Include.ExpandString(nil, f.Value, tag, matching))
+		}
+		if f.GroupKey != "" {
+			e.groupKey = string(f.Include.ExpandString(nil, f.GroupKey, tag, matching))
+		}
+		filtered = append(filtered, tag)
+		expanded = append(expanded, e)
+	}
+
+	// Apply semver.
+	if f.SemVer != nil {
+		hasValue := f.Include != nil && f.Value != ""
+		semverList := filtered
+		tagsByValue := make(map[string][]*tagOrBranchExpandedValueAndGroupKey)
+
+		// Use the semver value from the tag if expansion is configured,
+		// and store the original tags for the same expanded value in the
+		// original order.
+		if hasValue {
+			semverList = nil
+			for _, e := range expanded {
+				value := e.value
+				semverList = append(semverList, value)
+				tagsByValue[value] = append(tagsByValue[value], e)
+			}
+		}
+
+		// Filter and sort by semver.
+		filtered = version.Sort(f.SemVer, semverList)
+
+		// Recover the original tags for each expanded value
+		// in the sorted order of semver, but keeping the original
+		// order of the tags with the same expanded value.
+		if hasValue {
+			semverList = filtered
+			filtered = nil
+			expanded = nil
+			for _, value := range semverList {
+				for _, e := range tagsByValue[value] {
+					filtered = append(filtered, e.tagOrBranch)
+					expanded = append(expanded, e)
+				}
+			}
+		}
+	}
+
+	// Apply latest policy.
+	if f.LatestPolicy != "" {
+		compare := getCompareFunc(f.LatestPolicy)
+
+		if !expandTemplates { // Let's build the expanded slice with the defaults.
+			expanded = make([]*tagOrBranchExpandedValueAndGroupKey, 0, len(filtered))
+			for _, tag := range filtered {
+				expanded = append(expanded, newExpandedTagOrBranch(tag))
+			}
+		}
+
+		// Separate in groups. In this construction it's guaranteed that
+		// each group will have at least one tag or branch.
+		tagsByGroup := make(map[string][]*tagOrBranchExpandedValueAndGroupKey)
+		for _, e := range expanded {
+			tagsByGroup[e.groupKey] = append(tagsByGroup[e.groupKey], e)
+		}
+
+		// Sort groups.
+		for _, group := range tagsByGroup {
+			slices.SortFunc(group, compare)
+		}
+
+		// Select the latest tag from each group.
+		filtered = make([]string, 0, len(tagsByGroup))
+		for _, group := range tagsByGroup {
+			filtered = append(filtered, group[0].tagOrBranch) // [0] is guaranteed
+		}
+
+		// Make output stable (map order is random)
+		slices.Sort(filtered)
+
+		return filtered
+	}
+
+	// Apply limit.
+	lim := fluxcdv1.DefaultResourceSetInputProviderFilterLimit
+	if f.Limit > 0 {
+		lim = f.Limit
+	}
+	lim = min(lim, len(filtered))
+	return slices.Clone(filtered[:lim])
+}
+
+type tagOrBranchExpandedValueAndGroupKey struct {
+	tagOrBranch string
+	value       string
+	groupKey    string
+}
+
+// newExpandedTagOrBranch creates a default tagOrBranchExpandedValueAndGroupKey
+// from a tag or branch name.
+func newExpandedTagOrBranch(tagOrBranch string) *tagOrBranchExpandedValueAndGroupKey {
+	return &tagOrBranchExpandedValueAndGroupKey{
+		tagOrBranch: tagOrBranch,
+		value:       tagOrBranch, // the default is the tag or branch itself
+		groupKey:    "",          // the default is a single group with all tags or branches
+	}
+}
+
+// compareSemVer compares two tagOrBranchExpandedValueAndGroupKey
+// placing the latest version first.
+func compareSemVer(a, b *tagOrBranchExpandedValueAndGroupKey) int {
+	aVer, aErr := version.ParseVersion(a.value)
+	bVer, bErr := version.ParseVersion(b.value)
+
+	// If both versions are invalid, they are considered equal.
+	if aErr != nil && bErr != nil {
+		return 0
+	}
+
+	// We put valid versions before invalid ones.
+	if bErr != nil {
+		return -1
+	}
+	if aErr != nil {
+		return 1
+	}
+
+	// We compare SemVer in reverse order as we want the first
+	// element in a slice to be the latest version.
+	return -aVer.Compare(bVer)
+}
+
+// compareAlphabetical compares two tagOrBranchExpandedValueAndGroupKey
+// placing the alphabetically latest tag or branch first.
+func compareAlphabetical(a, b *tagOrBranchExpandedValueAndGroupKey) int {
+	return -strings.Compare(a.value, b.value)
+}
+
+// compareReverseAlphabetical compares two tagOrBranchExpandedValueAndGroupKey
+// placing the alphabetically earliest tag or branch first.
+func compareReverseAlphabetical(a, b *tagOrBranchExpandedValueAndGroupKey) int {
+	return -compareAlphabetical(a, b)
+}
+
+// compareNumerical compares two tagOrBranchExpandedValueAndGroupKey
+// placing the numerically latest tag or branch first.
+func compareNumerical(a, b *tagOrBranchExpandedValueAndGroupKey) int {
+	aNum, aErr := strconv.ParseFloat(a.value, 64)
+	bNum, bErr := strconv.ParseFloat(b.value, 64)
+
+	// If both values are invalid, they are considered equal.
+	if aErr != nil && bErr != nil {
+		return 0
+	}
+
+	// We put valid numbers before invalid ones.
+	if bErr != nil {
+		return -1
+	}
+	if aErr != nil {
+		return 1
+	}
+
+	// We compare numbers in reverse order as we want the first
+	// element in a slice to be the latest version.
+	return -cmp.Compare(aNum, bNum)
+}
+
+// compareReverseNumerical compares two tagOrBranchExpandedValueAndGroupKey
+// placing the numerically earliest tag or branch first.
+func compareReverseNumerical(a, b *tagOrBranchExpandedValueAndGroupKey) int {
+	return -compareNumerical(a, b)
+}
+
+// getCompareFunc assumes the latest policy is one of the
+// fluxcdv1.LatestPolicy* constants and returns the appropriate
+// comparison function for sorting tags or branches.
+func getCompareFunc(latestPolicy string) func(a, b *tagOrBranchExpandedValueAndGroupKey) int {
+	switch latestPolicy {
+	case fluxcdv1.LatestPolicySemVer:
+		return compareSemVer
+	case fluxcdv1.LatestPolicyAlphabetical:
+		return compareAlphabetical
+	case fluxcdv1.LatestPolicyReverseAlphabetical:
+		return compareReverseAlphabetical
+	case fluxcdv1.LatestPolicyNumerical:
+		return compareNumerical
+	case fluxcdv1.LatestPolicyReverseNumerical:
+		return compareReverseNumerical
+	default:
+		return nil
+	}
+}

--- a/internal/gitprovider/azuredevops_test.go
+++ b/internal/gitprovider/azuredevops_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/gomega"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/filtering"
 )
 
 func TestAzureDevOpsProvider_ListTags(t *testing.T) {
@@ -32,8 +34,8 @@ func TestAzureDevOpsProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("> 6.0.1 < 6.1.0"),
+				Filters: filtering.Filters{
+					SemVer: newConstraint("> 6.0.1 < 6.1.0"),
 				},
 			},
 			want: []Result{
@@ -59,9 +61,9 @@ func TestAzureDevOpsProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("6.0.x"),
-					Limit:             1,
+				Filters: filtering.Filters{
+					SemVer: newConstraint("6.0.x"),
+					Limit:  1,
 				},
 			},
 			want: []Result{
@@ -77,8 +79,8 @@ func TestAzureDevOpsProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("0.0.x"),
+				Filters: filtering.Filters{
+					SemVer: newConstraint("0.0.x"),
 				},
 			},
 			want: []Result{},
@@ -117,9 +119,9 @@ func TestAzureDevOpsProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`test*`),
-					ExcludeBranchRe: regexp.MustCompile(`^feat/.*`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`test*`),
+					Exclude: regexp.MustCompile(`^feat/.*`),
 				},
 			},
 			want: []Result{
@@ -150,9 +152,9 @@ func TestAzureDevOpsProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`ma*`),
-					Limit:           1,
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`ma*`),
+					Limit:   1,
 				},
 			},
 			want: []Result{
@@ -251,7 +253,7 @@ func TestAzureDevOpsProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
+				Filters: filtering.Filters{
 					Limit:  2,
 					Labels: []string{"fix"},
 				},
@@ -282,8 +284,8 @@ func TestAzureDevOpsProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^feat/.*`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^feat/.*`),
 				},
 			},
 			want: []Result{

--- a/internal/gitprovider/github_test.go
+++ b/internal/gitprovider/github_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/gomega"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/filtering"
 )
 
 func TestGitHubProvider_ListTags(t *testing.T) {
@@ -32,8 +34,8 @@ func TestGitHubProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/stefanprodan/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("> 6.0.1 < 6.1.0"),
+				Filters: filtering.Filters{
+					SemVer: newConstraint("> 6.0.1 < 6.1.0"),
 				},
 			},
 			want: []Result{
@@ -59,9 +61,9 @@ func TestGitHubProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/stefanprodan/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("6.0.x"),
-					Limit:             1,
+				Filters: filtering.Filters{
+					SemVer: newConstraint("6.0.x"),
+					Limit:  1,
 				},
 			},
 			want: []Result{
@@ -77,8 +79,8 @@ func TestGitHubProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/stefanprodan/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("0.0.x"),
+				Filters: filtering.Filters{
+					SemVer: newConstraint("0.0.x"),
 				},
 			},
 			want: []Result{},
@@ -117,9 +119,9 @@ func TestGitHubProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/fluxcd-testing/pr-testing",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^stefanprodan-patch-.*`),
-					ExcludeBranchRe: regexp.MustCompile(`^stefanprodan-patch-4`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^stefanprodan-patch-.*`),
+					Exclude: regexp.MustCompile(`^stefanprodan-patch-4`),
 				},
 			},
 			want: []Result{
@@ -145,9 +147,9 @@ func TestGitHubProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/fluxcd-testing/pr-testing",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^stefanprodan-patch-.*`),
-					Limit:           1,
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^stefanprodan-patch-.*`),
+					Limit:   1,
 				},
 			},
 			want: []Result{
@@ -241,7 +243,7 @@ func TestGitHubProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/fluxcd-testing/pr-testing",
-				Filters: Filters{
+				Filters: filtering.Filters{
 					Limit:  2,
 					Labels: []string{"enhancement"},
 				},
@@ -270,8 +272,8 @@ func TestGitHubProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/fluxcd-testing/pr-testing",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^feat/.*`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^feat/.*`),
 				},
 			},
 			want: []Result{

--- a/internal/gitprovider/gitlab.go
+++ b/internal/gitprovider/gitlab.go
@@ -64,13 +64,13 @@ func (p *GitLabProvider) ListTags(ctx context.Context, opts Options) ([]Result, 
 		},
 	}
 
-	tags := make([]*gitlab.Tag, 0)
+	gitlabTags := make([]*gitlab.Tag, 0)
 	for {
 		page, resp, err := p.Client.Tags.ListTags(p.Project, glOpts)
 		if err != nil {
 			return nil, fmt.Errorf("could not list tags: %v", err)
 		}
-		tags = append(tags, page...)
+		gitlabTags = append(gitlabTags, page...)
 
 		if resp.NextPage == 0 {
 			break
@@ -78,16 +78,15 @@ func (p *GitLabProvider) ListTags(ctx context.Context, opts Options) ([]Result, 
 		glOpts.Page = resp.NextPage
 	}
 
-	tagMap := make(map[string]*gitlab.Tag, len(tags))
-	semverList := make([]string, 0, len(tags))
-	for _, tag := range tags {
-		semverList = append(semverList, tag.Name)
+	tagMap := make(map[string]*gitlab.Tag, len(gitlabTags))
+	tags := make([]string, 0, len(gitlabTags))
+	for _, tag := range gitlabTags {
+		tags = append(tags, tag.Name)
 		tagMap[tag.Name] = tag
 	}
 
 	results := make([]Result, 0)
-	semverResults := sortSemver(opts, semverList)
-	for _, version := range semverResults {
+	for _, version := range opts.Filters.Tags(tags) {
 		tag, ok := tagMap[version]
 		if !ok {
 			return nil, fmt.Errorf("could not find tag %s", version)
@@ -112,8 +111,8 @@ func (p *GitLabProvider) ListBranches(ctx context.Context, opts Options) ([]Resu
 			PerPage: 100,
 		},
 	}
-	if opts.Filters.IncludeBranchRe != nil {
-		glOpts.Regex = gitlab.Ptr(opts.Filters.IncludeBranchRe.String())
+	if opts.Filters.Include != nil {
+		glOpts.Regex = gitlab.Ptr(opts.Filters.Include.String())
 	}
 
 	results := make([]Result, 0)
@@ -124,7 +123,7 @@ func (p *GitLabProvider) ListBranches(ctx context.Context, opts Options) ([]Resu
 		}
 
 		for _, branch := range branches {
-			if !matchBranch(opts, branch.Name) {
+			if !opts.Filters.MatchBranch(branch.Name) {
 				continue
 			}
 
@@ -171,7 +170,7 @@ func (p *GitLabProvider) ListRequests(ctx context.Context, opts Options) ([]Resu
 		}
 
 		for _, mr := range msrs {
-			if !matchBranch(opts, mr.SourceBranch) {
+			if !opts.Filters.MatchBranch(mr.SourceBranch) {
 				continue
 			}
 

--- a/internal/gitprovider/gitlab_test.go
+++ b/internal/gitprovider/gitlab_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/gomega"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/filtering"
 )
 
 func TestGitLabProvider_ListTags(t *testing.T) {
@@ -32,8 +34,8 @@ func TestGitLabProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("5.0.x"),
+				Filters: filtering.Filters{
+					SemVer: newConstraint("5.0.x"),
 				},
 			},
 			want: []Result{
@@ -64,9 +66,9 @@ func TestGitLabProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("6.0.x"),
-					Limit:             1,
+				Filters: filtering.Filters{
+					SemVer: newConstraint("6.0.x"),
+					Limit:  1,
 				},
 			},
 			want: []Result{
@@ -82,7 +84,7 @@ func TestGitLabProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
+				Filters: filtering.Filters{
 					Limit: 1,
 				},
 			},
@@ -128,9 +130,9 @@ func TestGitLabProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^patch-.*`),
-					ExcludeBranchRe: regexp.MustCompile(`^patch-4`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^patch-.*`),
+					Exclude: regexp.MustCompile(`^patch-4`),
 				},
 			},
 			want: []Result{
@@ -162,9 +164,9 @@ func TestGitLabProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^patch-.*`),
-					Limit:           1,
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^patch-.*`),
+					Limit:   1,
 				},
 			},
 			want: []Result{
@@ -260,7 +262,7 @@ func TestGitLabProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
+				Filters: filtering.Filters{
 					Limit:  2,
 					Labels: []string{"enhancement"},
 				},
@@ -289,8 +291,8 @@ func TestGitLabProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^feat/.*`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^feat/.*`),
 				},
 			},
 			want: []Result{

--- a/internal/gitprovider/options.go
+++ b/internal/gitprovider/options.go
@@ -5,11 +5,8 @@ package gitprovider
 
 import (
 	"crypto/x509"
-	"regexp"
-	"slices"
 
-	"github.com/Masterminds/semver/v3"
-	"github.com/fluxcd/pkg/version"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/filtering"
 )
 
 // Options holds the configuration for the Git SaaS provider.
@@ -17,50 +14,5 @@ type Options struct {
 	URL      string
 	CertPool *x509.CertPool
 	Token    string
-	Filters  Filters
-}
-
-// Filters holds the filters for the Git SaaS responses.
-type Filters struct {
-	IncludeBranchRe   *regexp.Regexp
-	ExcludeBranchRe   *regexp.Regexp
-	Labels            []string
-	Limit             int
-	SemverConstraints *semver.Constraints
-}
-
-// matchBranch returns true if the branch matches the include and exclude regex filters.
-func matchBranch(opt Options, branch string) bool {
-	if opt.Filters.IncludeBranchRe != nil {
-		if !opt.Filters.IncludeBranchRe.MatchString(branch) {
-			return false
-		}
-	}
-
-	if opt.Filters.ExcludeBranchRe != nil {
-		if opt.Filters.ExcludeBranchRe.MatchString(branch) {
-			return false
-		}
-	}
-	return true
-}
-
-// matchLabels returns true if the given labels include all the label filters.
-func matchLabels(opt Options, labels []string) bool {
-	for _, label := range opt.Filters.Labels {
-		if !slices.Contains(labels, label) {
-			return false
-		}
-	}
-	return true
-}
-
-// sortSemver filters the tags based the provided semver range
-// and sorts them in descending order.
-func sortSemver(opt Options, tags []string) []string {
-	constraint := opt.Filters.SemverConstraints
-	if constraint == nil {
-		return tags
-	}
-	return version.Sort(constraint, tags)
+	Filters  filtering.Filters
 }


### PR DESCRIPTION
This PR introduces the fields `.spec.filter.value` and `.spec.filter.groupKey`, which can be set alongside `.spec.filter.includeTag`. They are templates that can be expanded using the `.includeTag` regex matching results into a value and a group key from a tag name for usage with other filters. The `.value` can be used with `.semver` and `.latestPolicy` (see next), and `.groupKey` can be used only with `.latestPolicy` for now.

Introduces also `.spec.filter.latestPolicy`, which can be one of `SemVer`, `Alphabetical`, `ReverseAlphabetical`, `Numerical` and `ReverseNumerical`. This filter uses the expanded group keys to group tags together, then applies the specified "latest policy" to each group individually using the expanded values. When `.groupKey` is not specified, all tags are considered to belong to a single group, and only a single latest tag will be exported. When `.value` is not specified, the value used for comparison is the tag itself.

The `.spec.filter.limit` is ignored when `.spec.filter.latestPolicy` is set.

Examples:

```yaml
spec:
  filter:
    includeTag: ^([a-z]+)-([a-z]+)-(v.+)$
    groupKey: $1-$2
    value: $3
    semver: ">=1.0.0 <2.0.0" # uses the expanded template from .value
    latestPolicy: SemVer     # uses both .value and .groupKey
```

```yaml
spec:
  filter:
    includeTag: ^([a-z]+)-([a-z]+)-(.+)$
    groupKey: $1-$2
    value: $3
    latestPolicy: Alphabetical # uses both .value and .groupKey
```