### PR TITLE
Introduce regex filters for tags in ResourceSetInputProvider

### DIFF
--- a/api/v1/resourcesetinputprovider_types.go
+++ b/api/v1/resourcesetinputprovider_types.go
@@ -34,6 +34,8 @@ const (
 
 	ReasonInvalidDefaultValues  = "InvalidDefaultValues"
 	ReasonInvalidExportedInputs = "InvalidExportedInputs"
+
+	DefaultResourceSetInputProviderFilterLimit = 100
 )
 
 // ResourceSetInputProviderSpec defines the desired state of ResourceSetInputProvider
@@ -119,6 +121,16 @@ type ResourceSetInputFilter struct {
 	// +optional
 	ExcludeBranch string `json:"excludeBranch,omitempty"`
 
+	// IncludeTag specifies the regular expression to filter the tags
+	// that the input provider should include.
+	// +optional
+	IncludeTag string `json:"includeTag,omitempty"`
+
+	// ExcludeTag specifies the regular expression to filter the tags
+	// that the input provider should exclude.
+	// +optional
+	ExcludeTag string `json:"excludeTag,omitempty"`
+
 	// Labels specifies the list of labels to filter the input provider response.
 	// +optional
 	Labels []string `json:"labels,omitempty"`
@@ -129,7 +141,10 @@ type ResourceSetInputFilter struct {
 	// +optional
 	Limit int `json:"limit,omitempty"`
 
-	// Semver specifies the semantic version range to filter and order the tags.
+	// Semver specifies a semantic version range to filter and sort the tags.
+	// If this field is not specified, the tags will be sorted in reverse
+	// alphabetical order.
+	// Supported only for tags at the moment.
 	// +optional
 	Semver string `json:"semver,omitempty"`
 }
@@ -255,7 +270,7 @@ func (in *ResourceSetInputProvider) GetFilterLimit() int {
 	if f := in.Spec.Filter; f != nil && f.Limit > 0 {
 		return f.Limit
 	}
-	return 100 // default limit
+	return DefaultResourceSetInputProviderFilterLimit
 }
 
 // GetLastHandledReconcileRequest returns the last handled reconcile request.

--- a/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
@@ -88,9 +88,19 @@ spec:
                       ExcludeBranch specifies the regular expression to filter the branches
                       that the input provider should exclude.
                     type: string
+                  excludeTag:
+                    description: |-
+                      ExcludeTag specifies the regular expression to filter the tags
+                      that the input provider should exclude.
+                    type: string
                   includeBranch:
                     description: |-
                       IncludeBranch specifies the regular expression to filter the branches
+                      that the input provider should include.
+                    type: string
+                  includeTag:
+                    description: |-
+                      IncludeTag specifies the regular expression to filter the tags
                       that the input provider should include.
                     type: string
                   labels:
@@ -106,8 +116,11 @@ spec:
                       When not set, the default limit is 100.
                     type: integer
                   semver:
-                    description: Semver specifies the semantic version range to filter
-                      and order the tags.
+                    description: |-
+                      Semver specifies a semantic version range to filter and sort the tags.
+                      If this field is not specified, the tags will be sorted in reverse
+                      alphabetical order.
+                      Supported only for tags at the moment.
                     type: string
                 type: object
               schedule:

--- a/docs/api/v1/resourcesetinputprovider.md
+++ b/docs/api/v1/resourcesetinputprovider.md
@@ -164,6 +164,8 @@ The following filters are supported:
 - `labels`: filter GitHub Pull Requests or GitLab Merge Requests by labels.
 - `includeBranch`: regular expression to include branches by name.
 - `excludeBranch`: regular expression to exclude branches by name.
+- `includeTag`: regular expression to include tags by name.
+- `excludeTag`: regular expression to exclude tags by name.
 - `semver`: sematic version range to filter and sort tags.
 
 Example of a filter configuration for GitLab Merge Requests:
@@ -176,6 +178,15 @@ spec:
       - "deploy::flux-preview"
     includeBranch: "^feat/.*"
     excludeBranch: "^feat/not-this-one$"
+```
+
+Example of a filter configuration for filtering tags by inclusion and exclusion:
+
+```yaml
+spec:
+  filter:
+    includeTag: "^v[0-9]+\\.[0-9]+\\.[0-9]+$" # include tags like v1.2.3
+    excludeTag: "^v0" # exclude tags like v0.1.0
 ```
 
 Example of a filter configuration for fetching only the latest tag according to semver:

--- a/internal/filtering/filters.go
+++ b/internal/filtering/filters.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package filtering
+
+import (
+	"regexp"
+	"slices"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/fluxcd/pkg/version"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+// DefaultLimit is the default limit for the number of results returned by the filters.
+const DefaultLimit = 100
+
+// Filters holds the filters for the input provider responses.
+type Filters struct {
+	// Labels is used for a "match labels" filter.
+	Labels []string
+
+	// Include is used for including tags or branches.
+	Include *regexp.Regexp
+
+	// Exclude is used for excluding tags or branches.
+	Exclude *regexp.Regexp
+
+	// SemVer is used for sorting and filtering tags.
+	// Supported only for tags at the moment.
+	SemVer *semver.Constraints
+
+	// Limit is used to limit the number of results.
+	Limit int
+}
+
+// MatchLabels returns true if the given labels include all the label filters.
+func (f *Filters) MatchLabels(labels []string) bool {
+	for _, label := range f.Labels {
+		if !slices.Contains(labels, label) {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchString returns true if the string matches the include and exclude regex filters.
+func (f *Filters) MatchString(s string) bool {
+	if f.Include != nil {
+		if !f.Include.MatchString(s) {
+			return false
+		}
+	}
+	if f.Exclude != nil {
+		if f.Exclude.MatchString(s) {
+			return false
+		}
+	}
+	return true
+}
+
+// Tags applies all the filters supported for tags to a list of tags.
+// nolint:prealloc
+func (f *Filters) Tags(tags []string) []string {
+
+	var filtered []string
+
+	// Apply include and exclude.
+	for _, tag := range tags {
+		if f.MatchString(tag) {
+			filtered = append(filtered, tag)
+		}
+	}
+
+	// Apply semver or sort in reverse alphabetical order.
+	switch {
+	case f.SemVer != nil:
+		filtered = version.Sort(f.SemVer, filtered)
+	default:
+		slices.Sort(filtered)
+		slices.Reverse(filtered)
+	}
+
+	// Apply limit.
+	lim := fluxcdv1.DefaultResourceSetInputProviderFilterLimit
+	if f.Limit > 0 {
+		lim = f.Limit
+	}
+	lim = min(lim, len(filtered))
+	return slices.Clone(filtered[:lim])
+}

--- a/internal/filtering/filters_test.go
+++ b/internal/filtering/filters_test.go
@@ -1,0 +1,230 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package filtering_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	. "github.com/onsi/gomega"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/filtering"
+)
+
+func TestFilters_MatchLabels(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		filterLabels []string
+		labels       []string
+		want         bool
+	}{
+		{
+			name:         "no filter labels",
+			filterLabels: nil,
+			labels:       []string{"foo", "bar"},
+			want:         true,
+		},
+		{
+			name:         "empty filter labels",
+			filterLabels: []string{},
+			labels:       []string{"foo", "bar"},
+			want:         true,
+		},
+		{
+			name:         "match all labels",
+			filterLabels: []string{"foo", "bar"},
+			labels:       []string{"foo", "bar"},
+			want:         true,
+		},
+		{
+			name:         "match some labels",
+			filterLabels: []string{"foo", "baz"},
+			labels:       []string{"foo", "bar"},
+			want:         false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			f := &filtering.Filters{Labels: tt.filterLabels}
+			got := f.MatchLabels(tt.labels)
+
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestFilters_MatchString(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		include *regexp.Regexp
+		exclude *regexp.Regexp
+		input   string
+		want    bool
+	}{
+		{
+			name:    "no include or exclude",
+			include: nil,
+			exclude: nil,
+			input:   "main",
+			want:    true,
+		},
+		{
+			name:    "include only",
+			include: regexp.MustCompile(`^main$`),
+			exclude: nil,
+			input:   "main",
+			want:    true,
+		},
+		{
+			name:    "include only - no match",
+			include: regexp.MustCompile(`^main$`),
+			exclude: nil,
+			input:   "develop",
+			want:    false,
+		},
+		{
+			name:    "exclude only",
+			include: nil,
+			exclude: regexp.MustCompile(`^develop$`),
+			input:   "main",
+			want:    true,
+		},
+		{
+			name:    "exclude only - match",
+			include: nil,
+			exclude: regexp.MustCompile(`^develop$`),
+			input:   "develop",
+			want:    false,
+		},
+		{
+			name:    "include and exclude",
+			include: regexp.MustCompile(`^main$`),
+			exclude: regexp.MustCompile(`^develop$`),
+			input:   "main",
+			want:    true,
+		},
+		{
+			name:    "include and exclude - no match",
+			include: regexp.MustCompile(`^main$`),
+			exclude: regexp.MustCompile(`^develop$`),
+			input:   "develop",
+			want:    false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			f := &filtering.Filters{
+				Include: tt.include,
+				Exclude: tt.exclude,
+			}
+			got := f.MatchString(tt.input)
+
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestFilters_Tags(t *testing.T) {
+	newConstraint := func(s string) *semver.Constraints {
+		c, err := semver.NewConstraint(s)
+		if err != nil {
+			panic(err)
+		}
+		return c
+	}
+
+	for _, tt := range []struct {
+		name     string
+		filters  *filtering.Filters
+		tags     []string
+		expected []string
+	}{
+		{
+			name:     "no filters - sorts in reverse alphabetical order",
+			filters:  &filtering.Filters{},
+			tags:     []string{"v1.0.0", "v1.1.0", "v2.0.0"},
+			expected: []string{"v2.0.0", "v1.1.0", "v1.0.0"},
+		},
+		{
+			name: "include filter - sorts in reverse alphabetical order",
+			filters: &filtering.Filters{
+				Include: regexp.MustCompile(`^v1\.`),
+			},
+			tags:     []string{"v1.0.0", "v1.1.0", "v2.0.0"},
+			expected: []string{"v1.1.0", "v1.0.0"},
+		},
+		{
+			name: "exclude filter - sorts in reverse alphabetical order",
+			filters: &filtering.Filters{
+				Exclude: regexp.MustCompile(`^v2\.`),
+			},
+			tags:     []string{"v1.0.0", "v1.1.0", "v2.0.0"},
+			expected: []string{"v1.1.0", "v1.0.0"},
+		},
+		{
+			name: "include and exclude filters - sorts in reverse alphabetical order",
+			filters: &filtering.Filters{
+				Include: regexp.MustCompile(`^v1\.`),
+				Exclude: regexp.MustCompile(`^v1\.0\.0$`),
+			},
+			tags:     []string{"v1.0.0", "v1.1.0", "v2.0.0", "v1.2.0"},
+			expected: []string{"v1.2.0", "v1.1.0"},
+		},
+		{
+			name: "semver filter - sorts in reverse order",
+			filters: &filtering.Filters{
+				SemVer: newConstraint(">= 1.0.0 < 2.0.0"),
+			},
+			tags:     []string{"v1.0.0", "v1.1.0", "v2.0.0", "v1.2.0"},
+			expected: []string{"v1.2.0", "v1.1.0", "v1.0.0"},
+		},
+		{
+			name: "limit filter - limits the number of results",
+			filters: &filtering.Filters{
+				Limit: 2,
+			},
+			tags:     []string{"v1.0.0", "v1.1.0", "v2.0.0", "v1.2.0"},
+			expected: []string{"v2.0.0", "v1.2.0"},
+		},
+		{
+			name: "semver and limit filters - sorts and limits the number of results",
+			filters: &filtering.Filters{
+				SemVer: newConstraint(">= 1.0.0 < 2.0.0"),
+				Limit:  1,
+			},
+			tags:     []string{"v1.0.0", "v1.1.0", "v2.0.0", "v1.2.0"},
+			expected: []string{"v1.2.0"},
+		},
+		{
+			name: "include, exclude, semver and limit filters - applies all filters",
+			filters: &filtering.Filters{
+				Include: regexp.MustCompile(`^v1\.`),
+				Exclude: regexp.MustCompile(`^v1\.0\.0$`),
+				SemVer:  newConstraint(">= 1.0.0 < 2.0.0"),
+				Limit:   2,
+			},
+			tags:     []string{"v1.0.0", "v1.1.0", "v2.0.0", "v1.2.0", "rubbish", "garbage"},
+			expected: []string{"v1.2.0", "v1.1.0"},
+		},
+		{
+			name: "calver works with alphabetical sorting",
+			filters: &filtering.Filters{
+				Limit: 1,
+			},
+			tags:     []string{"2024.01.01", "2024.01.02", "2024.01.03"},
+			expected: []string{"2024.01.03"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got := tt.filters.Tags(tt.tags)
+
+			g.Expect(got).To(Equal(tt.expected))
+		})
+	}
+}

--- a/internal/gitprovider/azuredevops.go
+++ b/internal/gitprovider/azuredevops.go
@@ -67,7 +67,7 @@ func (p *AzureDevOpsProvider) ListTags(ctx context.Context, opts Options) ([]Res
 	}
 
 	tagMap := make(map[string]string)
-	semverList := make([]string, 0, len(azRefs.Value))
+	tags := make([]string, 0, len(azRefs.Value))
 
 	for _, gitRef := range azRefs.Value {
 		if gitRef.Name == nil || gitRef.ObjectId == nil {
@@ -75,14 +75,11 @@ func (p *AzureDevOpsProvider) ListTags(ctx context.Context, opts Options) ([]Res
 		}
 		tagName := strings.TrimPrefix(*gitRef.Name, "refs/tags/")
 		tagMap[tagName] = *gitRef.ObjectId
-		semverList = append(semverList, tagName)
+		tags = append(tags, tagName)
 	}
 
-	// semver sorting
-	semverResults := sortSemver(opts, semverList)
-
 	results := make([]Result, 0)
-	for _, tagName := range semverResults {
+	for _, tagName := range opts.Filters.Tags(tags) {
 		objectID := tagMap[tagName]
 		sha := objectID // fallback for lightweight tag
 
@@ -103,10 +100,6 @@ func (p *AzureDevOpsProvider) ListTags(ctx context.Context, opts Options) ([]Res
 			SHA: sha,
 			Tag: tagName,
 		})
-
-		if opts.Filters.Limit > 0 && len(results) >= opts.Filters.Limit {
-			break
-		}
 	}
 
 	return results, nil
@@ -129,7 +122,7 @@ func (p *AzureDevOpsProvider) ListBranches(ctx context.Context, opts Options) ([
 			continue
 		}
 
-		if !matchBranch(opts, *branch.Name) {
+		if !opts.Filters.MatchString(*branch.Name) {
 			continue
 		}
 
@@ -167,7 +160,7 @@ func (p *AzureDevOpsProvider) ListRequests(ctx context.Context, opts Options) ([
 
 		sourceBranch := strings.TrimPrefix(*pr.SourceRefName, "refs/heads/")
 
-		if !matchBranch(opts, sourceBranch) {
+		if !opts.Filters.MatchString(sourceBranch) {
 			continue
 		}
 
@@ -179,7 +172,7 @@ func (p *AzureDevOpsProvider) ListRequests(ctx context.Context, opts Options) ([
 			}
 		}
 
-		if !matchLabels(opts, prLabels) {
+		if !opts.Filters.MatchLabels(prLabels) {
 			continue
 		}
 

--- a/internal/gitprovider/azuredevops_test.go
+++ b/internal/gitprovider/azuredevops_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/gomega"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/filtering"
 )
 
 func TestAzureDevOpsProvider_ListTags(t *testing.T) {
@@ -32,8 +34,8 @@ func TestAzureDevOpsProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("> 6.0.1 < 6.1.0"),
+				Filters: filtering.Filters{
+					SemVer: newConstraint("> 6.0.1 < 6.1.0"),
 				},
 			},
 			want: []Result{
@@ -59,9 +61,9 @@ func TestAzureDevOpsProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("6.0.x"),
-					Limit:             1,
+				Filters: filtering.Filters{
+					SemVer: newConstraint("6.0.x"),
+					Limit:  1,
 				},
 			},
 			want: []Result{
@@ -77,8 +79,8 @@ func TestAzureDevOpsProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("0.0.x"),
+				Filters: filtering.Filters{
+					SemVer: newConstraint("0.0.x"),
 				},
 			},
 			want: []Result{},
@@ -117,9 +119,9 @@ func TestAzureDevOpsProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`test*`),
-					ExcludeBranchRe: regexp.MustCompile(`^feat/.*`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`test*`),
+					Exclude: regexp.MustCompile(`^feat/.*`),
 				},
 			},
 			want: []Result{
@@ -150,9 +152,9 @@ func TestAzureDevOpsProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`ma*`),
-					Limit:           1,
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`ma*`),
+					Limit:   1,
 				},
 			},
 			want: []Result{
@@ -251,7 +253,7 @@ func TestAzureDevOpsProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
+				Filters: filtering.Filters{
 					Limit:  2,
 					Labels: []string{"fix"},
 				},
@@ -282,8 +284,8 @@ func TestAzureDevOpsProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("AZURE_TOKEN"),
 				URL:   "https://dev.azure.com/stefanprodan/fluxcd-testing/_git/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^feat/.*`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^feat/.*`),
 				},
 			},
 			want: []Result{

--- a/internal/gitprovider/github_test.go
+++ b/internal/gitprovider/github_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/gomega"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/filtering"
 )
 
 func TestGitHubProvider_ListTags(t *testing.T) {
@@ -32,8 +34,8 @@ func TestGitHubProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/stefanprodan/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("> 6.0.1 < 6.1.0"),
+				Filters: filtering.Filters{
+					SemVer: newConstraint("> 6.0.1 < 6.1.0"),
 				},
 			},
 			want: []Result{
@@ -59,9 +61,9 @@ func TestGitHubProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/stefanprodan/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("6.0.x"),
-					Limit:             1,
+				Filters: filtering.Filters{
+					SemVer: newConstraint("6.0.x"),
+					Limit:  1,
 				},
 			},
 			want: []Result{
@@ -77,8 +79,8 @@ func TestGitHubProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/stefanprodan/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("0.0.x"),
+				Filters: filtering.Filters{
+					SemVer: newConstraint("0.0.x"),
 				},
 			},
 			want: []Result{},
@@ -117,9 +119,9 @@ func TestGitHubProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/fluxcd-testing/pr-testing",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^stefanprodan-patch-.*`),
-					ExcludeBranchRe: regexp.MustCompile(`^stefanprodan-patch-4`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^stefanprodan-patch-.*`),
+					Exclude: regexp.MustCompile(`^stefanprodan-patch-4`),
 				},
 			},
 			want: []Result{
@@ -145,9 +147,9 @@ func TestGitHubProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/fluxcd-testing/pr-testing",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^stefanprodan-patch-.*`),
-					Limit:           1,
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^stefanprodan-patch-.*`),
+					Limit:   1,
 				},
 			},
 			want: []Result{
@@ -241,7 +243,7 @@ func TestGitHubProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/fluxcd-testing/pr-testing",
-				Filters: Filters{
+				Filters: filtering.Filters{
 					Limit:  2,
 					Labels: []string{"enhancement"},
 				},
@@ -270,8 +272,8 @@ func TestGitHubProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITHUB_TOKEN"),
 				URL:   "https://github.com/fluxcd-testing/pr-testing",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^feat/.*`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^feat/.*`),
 				},
 			},
 			want: []Result{

--- a/internal/gitprovider/gitlab_test.go
+++ b/internal/gitprovider/gitlab_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/gomega"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/filtering"
 )
 
 func TestGitLabProvider_ListTags(t *testing.T) {
@@ -32,8 +34,8 @@ func TestGitLabProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("5.0.x"),
+				Filters: filtering.Filters{
+					SemVer: newConstraint("5.0.x"),
 				},
 			},
 			want: []Result{
@@ -64,9 +66,9 @@ func TestGitLabProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
-					SemverConstraints: newConstraint("6.0.x"),
-					Limit:             1,
+				Filters: filtering.Filters{
+					SemVer: newConstraint("6.0.x"),
+					Limit:  1,
 				},
 			},
 			want: []Result{
@@ -82,15 +84,15 @@ func TestGitLabProvider_ListTags(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
+				Filters: filtering.Filters{
 					Limit: 1,
 				},
 			},
 			want: []Result{
 				{
-					ID:  "49283322",
-					SHA: "450796ddb2ab6724ee1cc32a4be56da032d1cca0",
-					Tag: "6.1.6",
+					ID:  "95093100",
+					SHA: "6c8a85a5ab953874c7c83d50317359a0e5a352a9",
+					Tag: "v1.8.0",
 				},
 			},
 		},
@@ -128,9 +130,9 @@ func TestGitLabProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^patch-.*`),
-					ExcludeBranchRe: regexp.MustCompile(`^patch-4`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^patch-.*`),
+					Exclude: regexp.MustCompile(`^patch-4`),
 				},
 			},
 			want: []Result{
@@ -162,9 +164,9 @@ func TestGitLabProvider_ListBranches(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^patch-.*`),
-					Limit:           1,
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^patch-.*`),
+					Limit:   1,
 				},
 			},
 			want: []Result{
@@ -260,7 +262,7 @@ func TestGitLabProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
+				Filters: filtering.Filters{
 					Limit:  2,
 					Labels: []string{"enhancement"},
 				},
@@ -289,8 +291,8 @@ func TestGitLabProvider_ListRequests(t *testing.T) {
 			opts: Options{
 				Token: os.Getenv("GITLAB_TOKEN"),
 				URL:   "https://gitlab.com/stefanprodan/podinfo",
-				Filters: Filters{
-					IncludeBranchRe: regexp.MustCompile(`^feat/.*`),
+				Filters: filtering.Filters{
+					Include: regexp.MustCompile(`^feat/.*`),
 				},
 			},
 			want: []Result{

--- a/internal/gitprovider/options.go
+++ b/internal/gitprovider/options.go
@@ -5,11 +5,8 @@ package gitprovider
 
 import (
 	"crypto/x509"
-	"regexp"
-	"slices"
 
-	"github.com/Masterminds/semver/v3"
-	"github.com/fluxcd/pkg/version"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/filtering"
 )
 
 // Options holds the configuration for the Git SaaS provider.
@@ -17,50 +14,5 @@ type Options struct {
 	URL      string
 	CertPool *x509.CertPool
 	Token    string
-	Filters  Filters
-}
-
-// Filters holds the filters for the Git SaaS responses.
-type Filters struct {
-	IncludeBranchRe   *regexp.Regexp
-	ExcludeBranchRe   *regexp.Regexp
-	Labels            []string
-	Limit             int
-	SemverConstraints *semver.Constraints
-}
-
-// matchBranch returns true if the branch matches the include and exclude regex filters.
-func matchBranch(opt Options, branch string) bool {
-	if opt.Filters.IncludeBranchRe != nil {
-		if !opt.Filters.IncludeBranchRe.MatchString(branch) {
-			return false
-		}
-	}
-
-	if opt.Filters.ExcludeBranchRe != nil {
-		if opt.Filters.ExcludeBranchRe.MatchString(branch) {
-			return false
-		}
-	}
-	return true
-}
-
-// matchLabels returns true if the given labels include all the label filters.
-func matchLabels(opt Options, labels []string) bool {
-	for _, label := range opt.Filters.Labels {
-		if !slices.Contains(labels, label) {
-			return false
-		}
-	}
-	return true
-}
-
-// sortSemver filters the tags based the provided semver range
-// and sorts them in descending order.
-func sortSemver(opt Options, tags []string) []string {
-	constraint := opt.Filters.SemverConstraints
-	if constraint == nil {
-		return tags
-	}
-	return version.Sort(constraint, tags)
+	Filters  filtering.Filters
 }


### PR DESCRIPTION
Closes: #151 

This PR introduces the fields `.spec.filter.includeTag` and `.spec.filter.excludeTag`. The fields are regex patterns that are applied to the listed tags for eliminating the undesired ones from the RSIP exported inputs, similar to `.spec.filter.includeBranch` and `.spec.filter.excludeBranch`.

Additionally, this PR is also now sorting the tags in reverse alphabetical order if `.spec.filter.semver` is not specified.