### PR TITLE
Fix GitHub Enterprise Server authentication in ResourceSetInputProvider

### DIFF
--- a/internal/gitprovider/github.go
+++ b/internal/gitprovider/github.go
@@ -50,6 +50,9 @@ func NewGitHubProvider(ctx context.Context, opts Options) (*GitHubProvider, erro
 			}
 			ctxCA := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr})
 			httpClient = oauth2.NewClient(ctxCA, ts)
+		} else {
+			// Create OAuth2 client without custom cert pool
+			httpClient = oauth2.NewClient(ctx, ts)
 		}
 		client, err = github.NewClient(httpClient).WithEnterpriseURLs(host, host)
 		if err != nil {


### PR DESCRIPTION
Fixes #324 

As reported in the issue, authentication for GitHub Enterprise Server does not work without specifying a CA. This PR fixes the bug.

I was able to spin up a free trial of GitHub Enterprise Server and test a few different combinations:

* I was able to reproduce the issue with a valid Let's Encrypt cert without specifying the CA and a classic PAT. I got the same error message reported in the issue.

After introducing the fix:

* I was able to reconcile an RSIP with a valid Let's Encrypt cert without specifying the CA and a classic PAT. (**Fixed!**)
* I was able to reconcile an RSIP with the built-in self-signed cert specified as the CA and a classic PAT.
* I was able to reconcile an RSIP with a valid Let's Encrypt cert specifying the CA chain and a classic PAT.