### PR TITLE
cli: Add `flux-operator export` commands

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -110,6 +110,16 @@ Arguments:
 - `-n, --namespace`: Specifies the namespace to filter the resources.
 - `-A, --all-namespaces`: Retrieves resources from all namespaces.
 
+### Export Commands
+
+The `flux-operator export` commands are used to export the Flux Operator resources in YAML format.
+The exported resources can be used for backup, migration, or inspection purposes.
+
+The following commands are available:
+
+- `flux-operator export report`: Exports the FluxReport resource containing the distribution status and version information.
+- `flux-operator export resource <kind>/<name> -n <namespace>`: Exports a Flux resource from the specified namespace.
+
 ### Reconcile Commands
 
 The `flux-operator reconcile` commands are used to trigger the reconciliation of the Flux Operator resources.

--- a/cmd/cli/completion.go
+++ b/cmd/cli/completion.go
@@ -76,27 +76,128 @@ func resourceNamesCompletionFunc(gvk schema.GroupVersionKind) func(cmd *cobra.Co
 	}
 }
 
-// resourceKindCompletionFunc returns a function that can be used as a completion function for Flux resource kinds.
-func resourceKindCompletionFunc() func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// FluxKind represents a Flux resource kind with its properties.
+type FluxKind struct {
+	Name         string
+	Reconcilable bool
+}
+
+// fluxKinds contains all Flux resource kinds with their properties.
+var fluxKinds = []FluxKind{
+	// Flux Operator resources
+	{Name: "FluxInstance", Reconcilable: true},
+	{Name: "FluxReport", Reconcilable: true},
+	{Name: "ResourceSet", Reconcilable: true},
+	{Name: "ResourceSetInputProvider", Reconcilable: true},
+
+	// Flux sources
+	{Name: "GitRepository", Reconcilable: true},
+	{Name: "OCIRepository", Reconcilable: true},
+	{Name: "Bucket", Reconcilable: true},
+	{Name: "HelmRepository", Reconcilable: true},
+	{Name: "HelmChart", Reconcilable: true},
+
+	// Flux appliers
+	{Name: "HelmRelease", Reconcilable: true},
+	{Name: "Kustomization", Reconcilable: true},
+
+	// Flux image automation
+	{Name: "ImageRepository", Reconcilable: true},
+	{Name: "ImagePolicy", Reconcilable: false},
+	{Name: "ImageUpdateAutomation", Reconcilable: true},
+
+	// Flux notifications
+	{Name: "Alert", Reconcilable: false},
+	{Name: "Provider", Reconcilable: false},
+	{Name: "Receiver", Reconcilable: true},
+}
+
+// getFluxKinds returns a list of Flux kind names, optionally filtered by reconcilable status.
+func getFluxKinds(reconcilableOnly bool) []string {
+	var kinds []string
+	for _, kind := range fluxKinds {
+		if !reconcilableOnly || kind.Reconcilable {
+			kinds = append(kinds, kind.Name+"/")
+		}
+	}
+	return kinds
+}
+
+// resourceKindNameCompletionFunc returns a function that provides completion for <kind>/<name> format.
+// If the input doesn't contain a slash, it returns available kinds.
+// If the input contains a slash with a kind, it returns resource names for that kind.
+func resourceKindNameCompletionFunc(reconcilableOnly bool) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// These are the Flux kinds that react to the reconcileAt annotation.
-		kinds := []string{
-			"GitRepository/",
-			"OCIRepository/",
-			"Bucket/",
-			"HelmRepository/",
-			"HelmChart/",
-			"HelmRelease/",
-			"Kustomization/",
-			"ImageRepository/",
-			"ImageUpdateAutomation/",
-			"Receiver/",
+		// If input doesn't contain a slash, return kinds
+		if !strings.Contains(toComplete, "/") {
+			kinds := getFluxKinds(reconcilableOnly)
+			var comps []string
+			for _, kind := range kinds {
+				if strings.HasPrefix(kind, toComplete) {
+					comps = append(comps, kind)
+				}
+			}
+			return comps, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		// If input contains a slash, extract the kind and return resource names
+		parts := strings.Split(toComplete, "/")
+		if len(parts) != 2 {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		kind := parts[0]
+		namePrefix := parts[1]
+
+		// Get the GVK for the kind
+		gvk, err := preferredFluxGVK(kind, kubeconfigArgs)
+		if err != nil {
+			return completionError(err)
+		}
+
+		// Get resource names from the cluster
+		ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+		defer cancel()
+
+		cfg, err := kubeconfigArgs.ToRESTConfig()
+		if err != nil {
+			return completionError(err)
+		}
+
+		mapper, err := kubeconfigArgs.ToRESTMapper()
+		if err != nil {
+			return completionError(err)
+		}
+
+		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			return completionError(err)
+		}
+
+		kubeClient, err := dynamic.NewForConfig(cfg)
+		if err != nil {
+			return completionError(err)
+		}
+
+		var dr dynamic.ResourceInterface
+		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+			dr = kubeClient.Resource(mapping.Resource).Namespace(*kubeconfigArgs.Namespace)
+		} else {
+			dr = kubeClient.Resource(mapping.Resource)
+		}
+
+		list, err := dr.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return completionError(err)
 		}
 
 		var comps []string
-		for _, kind := range kinds {
-			if strings.HasPrefix(kind, toComplete) {
-				comps = append(comps, kind)
+		for _, item := range list.Items {
+			name := item.GetName()
+			fullName := kind + "/" + name
+
+			if strings.HasPrefix(name, namePrefix) {
+				comps = append(comps, fullName)
 			}
 		}
 

--- a/cmd/cli/export.go
+++ b/cmd/cli/export.go
@@ -1,0 +1,17 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export Flux Operator resources",
+}
+
+func init() {
+	rootCmd.AddCommand(exportCmd)
+}

--- a/cmd/cli/export_report.go
+++ b/cmd/cli/export_report.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+var exportReportCmd = &cobra.Command{
+	Use:   "report",
+	Short: "Export the FluxReport resource in YAML format",
+	Example: `  # Export the FluxReport to standard output
+  flux-operator export report
+
+  # Export the FluxReport to a YAML file
+  flux-operator export report > flux-report.yaml`,
+	RunE: exportReportCmdRun,
+	Args: cobra.NoArgs,
+}
+
+func init() {
+	exportCmd.AddCommand(exportReportCmd)
+}
+
+func exportReportCmdRun(_ *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client: %w", err)
+	}
+
+	var reportList unstructured.UnstructuredList
+	reportList.SetGroupVersionKind(fluxcdv1.GroupVersion.WithKind("FluxReportList"))
+
+	if err := kubeClient.List(ctx, &reportList); err != nil {
+		return fmt.Errorf("unable to list FluxReport resources: %w", err)
+	}
+
+	if len(reportList.Items) == 0 {
+		return fmt.Errorf("no FluxReport resources found")
+	}
+
+	report := &reportList.Items[0]
+	cleanObjectForExport(report)
+
+	output, err := yaml.Marshal(report.Object)
+	if err != nil {
+		return fmt.Errorf("unable to marshal output to YAML: %w", err)
+	}
+
+	_, err = rootCmd.OutOrStdout().Write(output)
+	return err
+}

--- a/cmd/cli/export_report_test.go
+++ b/cmd/cli/export_report_test.go
@@ -1,0 +1,169 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestExportReportCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupReport bool
+		expectError bool
+	}{
+		{
+			name:        "no report",
+			expectError: true,
+		},
+		{
+			name:        "with report",
+			setupReport: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			g := NewWithT(t)
+
+			// Create FluxReport if needed
+			if tt.setupReport {
+				ns, err := testEnv.CreateNamespace(ctx, "test")
+				g.Expect(err).ToNot(HaveOccurred())
+
+				report := &fluxcdv1.FluxReport{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "flux",
+						Namespace: ns.Name,
+						Labels: map[string]string{
+							"app.kubernetes.io/name": "flux-operator",
+							"fluxcd.io/name":         "flux",
+							"fluxcd.io/namespace":    ns.Name,
+						},
+						Annotations: map[string]string{
+							meta.ReconcileRequestAnnotation: "2024-01-01T00:00:00Z",
+						},
+					},
+					Spec: fluxcdv1.FluxReportSpec{
+						Distribution: fluxcdv1.FluxDistributionStatus{
+							Entitlement: "oss",
+							Status:      "ready",
+							Version:     "v1.2.3",
+						},
+						Operator: &fluxcdv1.OperatorInfo{
+							APIVersion: "v1",
+							Version:    "v1.2.3",
+							Platform:   "linux/amd64",
+						},
+					},
+				}
+
+				err = testClient.Create(ctx, report)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Set status to ready
+				report.Status = fluxcdv1.FluxReportStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               meta.ReadyCondition,
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1,
+							LastTransitionTime: metav1.Now(),
+							Reason:             meta.ReconciliationSucceededReason,
+							Message:            "report is ready",
+						},
+					},
+				}
+				err = testClient.Status().Update(ctx, report)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				defer func() {
+					_ = testClient.Delete(ctx, report)
+				}()
+			}
+
+			// Execute command
+			output, err := executeCommand([]string{"export", "report"})
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Parse output as unstructured object
+			obj := &unstructured.Unstructured{}
+			err = yaml.Unmarshal([]byte(output), &obj.Object)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Verify basic structure
+			g.Expect(obj.GetAPIVersion()).To(Equal("fluxcd.controlplane.io/v1"))
+			g.Expect(obj.GetKind()).To(Equal("FluxReport"))
+			g.Expect(obj.GetName()).To(Equal("flux"))
+			g.Expect(obj.GetNamespace()).ToNot(BeEmpty())
+
+			// Verify spec content using unstructured.Get
+			entitlement, found, err := unstructured.NestedString(obj.Object, "spec", "distribution", "entitlement")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(entitlement).To(Equal("oss"))
+
+			status, found, err := unstructured.NestedString(obj.Object, "spec", "distribution", "status")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(status).To(Equal("ready"))
+
+			version, found, err := unstructured.NestedString(obj.Object, "spec", "distribution", "version")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(version).To(Equal("v1.2.3"))
+
+			operatorVersion, found, err := unstructured.NestedString(obj.Object, "spec", "operator", "version")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(operatorVersion).To(Equal("v1.2.3"))
+
+			// Verify clean export - status and unwanted metadata should be removed
+			_, found, err = unstructured.NestedSlice(obj.Object, "status", "conditions")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeFalse())
+
+			_, found, err = unstructured.NestedString(obj.Object, "metadata", "resourceVersion")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeFalse())
+
+			_, found, err = unstructured.NestedString(obj.Object, "metadata", "uid")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeFalse())
+
+			_, found, err = unstructured.NestedString(obj.Object, "metadata", "creationTimestamp")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeFalse())
+
+			// Verify Flux annotations and labels are removed
+			_, found, err = unstructured.NestedStringMap(obj.Object, "metadata", "annotations")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).ToNot(BeTrue())
+
+			labels, found, err := unstructured.NestedStringMap(obj.Object, "metadata", "labels")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(labels).ToNot(HaveKey("fluxcd.io/name"))
+			g.Expect(labels).ToNot(HaveKey("fluxcd.io/namespace"))
+		})
+	}
+}

--- a/cmd/cli/export_resource.go
+++ b/cmd/cli/export_resource.go
@@ -24,8 +24,9 @@ var exportResourceCmd = &cobra.Command{
   # Export a OCIRepository to a YAML file
   flux-operator -n apps export resource OCIRepository/my-app > my-app.yaml
 `,
-	RunE: exportResourceCmdRun,
-	Args: cobra.ExactArgs(1),
+	RunE:              exportResourceCmdRun,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: resourceKindNameCompletionFunc(false),
 }
 
 func init() {

--- a/cmd/cli/export_resource.go
+++ b/cmd/cli/export_resource.go
@@ -1,0 +1,134 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+var exportResourceCmd = &cobra.Command{
+	Use:   "resource",
+	Short: "Export a Flux custom resource in YAML format",
+	Example: `  # Export a ResourceSet to standard output
+  flux-operator -n flux-system export resource ResourceSet/apps
+
+  # Export a OCIRepository to a YAML file
+  flux-operator -n apps export resource OCIRepository/my-app > my-app.yaml
+`,
+	RunE: exportResourceCmdRun,
+	Args: cobra.ExactArgs(1),
+}
+
+func init() {
+	exportCmd.AddCommand(exportResourceCmd)
+}
+
+func exportResourceCmdRun(_ *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("resource name is required")
+	}
+
+	parts := strings.Split(args[0], "/")
+	if len(parts) != 2 {
+		return fmt.Errorf("resource name must be in the format <kind>/<name>, e.g., ResourceSet/my-app")
+	}
+
+	kind := parts[0]
+	name := parts[1]
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client: %w", err)
+	}
+
+	gvk, err := preferredFluxGVK(kind, kubeconfigArgs)
+	if err != nil {
+		return fmt.Errorf("unable to get gvk for kind %s: %w", kind, err)
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(*gvk)
+	objKey := client.ObjectKey{
+		Namespace: *kubeconfigArgs.Namespace,
+		Name:      name,
+	}
+
+	if err := kubeClient.Get(ctx, objKey, obj); err != nil {
+		return fmt.Errorf("unable to get resource %s/%s: %w", kind, name, err)
+	}
+
+	cleanObjectForExport(obj)
+
+	output, err := yaml.Marshal(obj.Object)
+	if err != nil {
+		return fmt.Errorf("unable to marshal output to YAML: %w", err)
+	}
+	_, err = rootCmd.OutOrStdout().Write(output)
+	return err
+}
+
+// cleanObjectForExport removes fields that shouldn't be included in exports
+func cleanObjectForExport(obj *unstructured.Unstructured) {
+	// Remove status subresource
+	unstructured.RemoveNestedField(obj.Object, "status")
+
+	// Remove runtime metadata - keep only name, namespace, labels, and annotations
+	metadata := obj.Object["metadata"].(map[string]any)
+	cleanMetadata := make(map[string]any)
+
+	// Preserve essential fields
+	if name, exists := metadata["name"]; exists {
+		cleanMetadata["name"] = name
+	}
+	if namespace, exists := metadata["namespace"]; exists {
+		cleanMetadata["namespace"] = namespace
+	}
+	if labels, exists := metadata["labels"]; exists {
+		cleanMetadata["labels"] = labels
+	}
+	if annotations, exists := metadata["annotations"]; exists {
+		cleanMetadata["annotations"] = annotations
+	}
+
+	// Remove Flux CLI annotations from clean metadata
+	if annotations, exists := cleanMetadata["annotations"]; exists {
+		if annotationMap, ok := annotations.(map[string]any); ok {
+			delete(annotationMap, meta.ReconcileRequestAnnotation)
+			// Remove annotations map if empty after cleanup
+			if len(annotationMap) == 0 {
+				delete(cleanMetadata, "annotations")
+			}
+		}
+	}
+
+	// Remove Flux ownership labels from clean metadata
+	if labels, exists := cleanMetadata["labels"]; exists {
+		if labelMap, ok := labels.(map[string]any); ok {
+			for key := range labelMap {
+				if strings.Contains(key, "fluxcd") &&
+					(strings.HasSuffix(key, "/name") || strings.HasSuffix(key, "/namespace")) {
+					delete(labelMap, key)
+				}
+			}
+			// Remove labels map if empty after cleanup
+			if len(labelMap) == 0 {
+				delete(cleanMetadata, "labels")
+			}
+		}
+	}
+
+	// Replace metadata with the clean version
+	obj.Object["metadata"] = cleanMetadata
+}

--- a/cmd/cli/export_resource_test.go
+++ b/cmd/cli/export_resource_test.go
@@ -1,0 +1,202 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestExportResourceCmd(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupResource bool
+		resourceArg   string
+		expectError   bool
+	}{
+		{
+			name:        "no resource",
+			resourceArg: "ResourceSet/nonexistent",
+			expectError: true,
+		},
+		{
+			name:          "with ResourceSet",
+			setupResource: true,
+			resourceArg:   "ResourceSet/config-template",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			g := NewWithT(t)
+
+			// Create ResourceSet if needed
+			if tt.setupResource {
+				ns, err := testEnv.CreateNamespace(ctx, "test")
+				g.Expect(err).ToNot(HaveOccurred())
+
+				objDef := fmt.Sprintf(`
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: config-template
+  namespace: "%[1]s"
+  labels:
+    app.kubernetes.io/name: flux-operator
+    fluxcd.io/name: config-template
+    fluxcd.io/namespace: "%[1]s"
+  annotations:
+    %[2]s: "2024-01-01T00:00:00Z"
+spec:
+  commonMetadata:
+    annotations:
+      owner: "%[1]s"
+  inputs:
+    - appName: my-app
+      environment: staging
+  resourcesTemplate: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: << .inputs.appName >>-config
+      namespace: "%[1]s"
+    data:
+      app.name: "<< .inputs.appName >>"
+      app.environment: "<< .inputs.environment >>"
+      config.yaml: |
+        app:
+          name: << .inputs.appName >>
+          environment: << .inputs.environment >>
+          debug: false
+`, ns.Name, meta.ReconcileRequestAnnotation)
+
+				obj := &fluxcdv1.ResourceSet{}
+				err = yaml.Unmarshal([]byte(objDef), obj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				err = testClient.Create(ctx, obj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Set status to ready
+				obj.Status = fluxcdv1.ResourceSetStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               meta.ReadyCondition,
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1,
+							LastTransitionTime: metav1.Now(),
+							Reason:             meta.ReconciliationSucceededReason,
+							Message:            "ResourceSet reconciliation succeeded",
+						},
+					},
+					Inventory: &fluxcdv1.ResourceInventory{
+						Entries: []fluxcdv1.ResourceRef{
+							{
+								ID:      fmt.Sprintf("%s_my-app-config_%s_ConfigMap", ns.Name, ""),
+								Version: "v1",
+							},
+						},
+					},
+					LastAppliedRevision: "sha256:abc123",
+				}
+				err = testClient.Status().Update(ctx, obj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Set up the resource argument with namespace
+				kubeconfigArgs.Namespace = &ns.Name
+
+				defer func() {
+					_ = testClient.Delete(ctx, obj)
+				}()
+			}
+
+			// Execute command
+			output, err := executeCommand([]string{"export", "resource", tt.resourceArg})
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Parse output as unstructured object
+			obj := &unstructured.Unstructured{}
+			err = yaml.Unmarshal([]byte(output), &obj.Object)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Verify basic structure
+			g.Expect(obj.GetAPIVersion()).To(Equal("fluxcd.controlplane.io/v1"))
+			g.Expect(obj.GetKind()).To(Equal("ResourceSet"))
+			g.Expect(obj.GetName()).To(Equal("config-template"))
+			g.Expect(obj.GetNamespace()).ToNot(BeEmpty())
+
+			// Verify spec content
+			inputs, found, err := unstructured.NestedSlice(obj.Object, "spec", "inputs")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(inputs).To(HaveLen(1))
+
+			// Verify the input content
+			inputMap, ok := inputs[0].(map[string]any)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(inputMap["appName"]).To(Equal("my-app"))
+			g.Expect(inputMap["environment"]).To(Equal("staging"))
+
+			// Verify resourcesTemplate
+			template, found, err := unstructured.NestedString(obj.Object, "spec", "resourcesTemplate")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(template).To(ContainSubstring("kind: ConfigMap"))
+			g.Expect(template).To(ContainSubstring("<< .inputs.appName >>"))
+			g.Expect(template).To(ContainSubstring("<< .inputs.environment >>"))
+
+			// Verify commonMetadata
+			annotations, found, err := unstructured.NestedStringMap(obj.Object, "spec", "commonMetadata", "annotations")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(annotations).To(HaveKey("owner"))
+
+			// Verify clean export - status and unwanted metadata should be removed
+			_, found, err = unstructured.NestedSlice(obj.Object, "status", "conditions")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeFalse())
+
+			_, found, err = unstructured.NestedString(obj.Object, "metadata", "resourceVersion")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeFalse())
+
+			_, found, err = unstructured.NestedString(obj.Object, "metadata", "uid")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeFalse())
+
+			_, found, err = unstructured.NestedString(obj.Object, "metadata", "creationTimestamp")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeFalse())
+
+			// Verify Flux annotations and labels are removed
+			_, found, err = unstructured.NestedStringMap(obj.Object, "metadata", "annotations")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).ToNot(BeTrue())
+
+			labels, found, err := unstructured.NestedStringMap(obj.Object, "metadata", "labels")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(labels).ToNot(HaveKey("fluxcd.io/name"))
+			g.Expect(labels).ToNot(HaveKey("fluxcd.io/namespace"))
+		})
+	}
+}

--- a/cmd/cli/get_inputprovider_test.go
+++ b/cmd/cli/get_inputprovider_test.go
@@ -1,0 +1,376 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestGetInputProviderCmd(t *testing.T) {
+	var (
+		defaultColumns       = []string{"NAME", "INPUTS", "READY", "MESSAGE", "LAST RECONCILED", "NEXT SCHEDULE"}
+		allNamespacesColumns = []string{"NAMESPACE", "NAME", "INPUTS", "READY", "MESSAGE", "LAST RECONCILED", "NEXT SCHEDULE"}
+	)
+
+	fixedTransitionTime := metav1.Now()
+	expectedTime := fixedTransitionTime.Format("2006-01-02 15:04:05 -0700 MST")
+	scheduleTime := metav1.NewTime(time.Now().Add(time.Hour))
+	expectedScheduleTime := scheduleTime.Format("2006-01-02 15:04:05 -0700 MST")
+
+	tests := []struct {
+		name           string
+		setupResources bool
+		args           []string
+		allNamespaces  bool
+		expectError    bool
+		expectOutput   []string
+	}{
+		{
+			name:         "no resources",
+			expectOutput: []string{},
+		},
+		{
+			name:           "single namespace with ready resource",
+			setupResources: true,
+			expectOutput: []string{
+				"ready-provider", "1", "True", "ResourceSetInputProvider reconciliation succeeded",
+				expectedTime,
+			},
+		},
+		{
+			name:           "single namespace with failed resource",
+			setupResources: true,
+			expectOutput: []string{
+				"failed-provider", "0", "False", "ResourceSetInputProvider reconciliation failed",
+				expectedTime,
+			},
+		},
+		{
+			name:           "all namespaces",
+			setupResources: true,
+			allNamespaces:  true,
+			expectOutput: []string{
+				"ready-provider", "1", "True", "ResourceSetInputProvider reconciliation succeeded",
+				"failed-provider", "0", "False", "ResourceSetInputProvider reconciliation failed",
+				"suspended-provider", "0", "Suspended",
+			},
+		},
+		{
+			name:           "specific resource by name",
+			setupResources: true,
+			args:           []string{"ready-provider"},
+			expectOutput: []string{
+				"ready-provider", "1", "True", "ResourceSetInputProvider reconciliation succeeded",
+				expectedTime,
+			},
+		},
+		{
+			name:           "suspended resource",
+			setupResources: true,
+			allNamespaces:  true,
+			expectOutput: []string{
+				"suspended-provider", "0", "Suspended",
+			},
+		},
+		{
+			name:           "resource with next schedule",
+			setupResources: true,
+			expectOutput: []string{
+				"scheduled-provider", "0", "True", "ResourceSetInputProvider reconciliation succeeded",
+				expectedTime, expectedScheduleTime,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			g := NewWithT(t)
+
+			var ns1, ns2 *corev1.Namespace
+
+			// Create ResourceSetInputProviders if needed
+			if tt.setupResources {
+				var err error
+				ns1, err = testEnv.CreateNamespace(ctx, "test1")
+				g.Expect(err).ToNot(HaveOccurred())
+				ns2, err = testEnv.CreateNamespace(ctx, "test2")
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Create ready ResourceSetInputProvider in ns1
+				readyDefaultValues, err := fluxcdv1.NewResourceSetInput(nil, map[string]any{
+					"env": "staging",
+					"app": "my-app",
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				readyProvider := &fluxcdv1.ResourceSetInputProvider{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ready-provider",
+						Namespace: ns1.Name,
+					},
+					Spec: fluxcdv1.ResourceSetInputProviderSpec{
+						Type:          fluxcdv1.InputProviderStatic,
+						DefaultValues: readyDefaultValues,
+					},
+				}
+				err = testClient.Create(ctx, readyProvider)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Create exported input for ready provider
+				readyExportedInput, err := fluxcdv1.NewResourceSetInput(nil, map[string]any{
+					"id":  readyProvider.UID,
+					"env": "staging",
+					"app": "my-app",
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Set ready status with exported inputs
+				readyProvider.Status = fluxcdv1.ResourceSetInputProviderStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               meta.ReadyCondition,
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1,
+							LastTransitionTime: fixedTransitionTime,
+							Reason:             meta.ReconciliationSucceededReason,
+							Message:            "ResourceSetInputProvider reconciliation succeeded",
+						},
+					},
+					ExportedInputs: []fluxcdv1.ResourceSetInput{
+						readyExportedInput,
+					},
+					LastExportedRevision: "sha256:abc123",
+				}
+				err = testClient.Status().Update(ctx, readyProvider)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Create failed ResourceSetInputProvider in ns1
+				failedDefaultValues, err := fluxcdv1.NewResourceSetInput(nil, map[string]any{
+					"env": "production",
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				failedProvider := &fluxcdv1.ResourceSetInputProvider{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "failed-provider",
+						Namespace: ns1.Name,
+					},
+					Spec: fluxcdv1.ResourceSetInputProviderSpec{
+						Type:          fluxcdv1.InputProviderStatic,
+						DefaultValues: failedDefaultValues,
+					},
+				}
+				err = testClient.Create(ctx, failedProvider)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Set failed status
+				failedProvider.Status = fluxcdv1.ResourceSetInputProviderStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               meta.ReadyCondition,
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 1,
+							LastTransitionTime: fixedTransitionTime,
+							Reason:             meta.ReconciliationFailedReason,
+							Message:            "ResourceSetInputProvider reconciliation failed",
+						},
+					},
+				}
+				err = testClient.Status().Update(ctx, failedProvider)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Create suspended ResourceSetInputProvider in ns2
+				suspendedDefaultValues, err := fluxcdv1.NewResourceSetInput(nil, map[string]any{
+					"env": "development",
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				suspendedProvider := &fluxcdv1.ResourceSetInputProvider{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "suspended-provider",
+						Namespace: ns2.Name,
+						Annotations: map[string]string{
+							fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue,
+						},
+					},
+					Spec: fluxcdv1.ResourceSetInputProviderSpec{
+						Type:          fluxcdv1.InputProviderStatic,
+						DefaultValues: suspendedDefaultValues,
+					},
+				}
+				err = testClient.Create(ctx, suspendedProvider)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				suspendedProvider.Status = fluxcdv1.ResourceSetInputProviderStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               meta.ReadyCondition,
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1,
+							LastTransitionTime: fixedTransitionTime,
+							Reason:             meta.ReconciliationSucceededReason,
+							Message:            "ResourceSetInputProvider reconciliation succeeded",
+						},
+					},
+				}
+				err = testClient.Status().Update(ctx, suspendedProvider)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Create scheduled ResourceSetInputProvider in ns1 for specific test case
+				var scheduledProvider *fluxcdv1.ResourceSetInputProvider
+				if tt.name == "resource with next schedule" {
+					scheduledDefaultValues, err := fluxcdv1.NewResourceSetInput(nil, map[string]any{
+						"env": "scheduled",
+					})
+					g.Expect(err).ToNot(HaveOccurred())
+
+					scheduledProvider = &fluxcdv1.ResourceSetInputProvider{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "scheduled-provider",
+							Namespace: ns1.Name,
+						},
+						Spec: fluxcdv1.ResourceSetInputProviderSpec{
+							Type:          fluxcdv1.InputProviderStatic,
+							DefaultValues: scheduledDefaultValues,
+							Schedule: []fluxcdv1.Schedule{
+								{
+									Cron:     "0 10 * * *",
+									TimeZone: "UTC",
+								},
+							},
+						},
+					}
+					err = testClient.Create(ctx, scheduledProvider)
+					g.Expect(err).ToNot(HaveOccurred())
+
+					scheduledProvider.Status = fluxcdv1.ResourceSetInputProviderStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               meta.ReadyCondition,
+								Status:             metav1.ConditionTrue,
+								ObservedGeneration: 1,
+								LastTransitionTime: fixedTransitionTime,
+								Reason:             meta.ReconciliationSucceededReason,
+								Message:            "ResourceSetInputProvider reconciliation succeeded",
+							},
+						},
+						NextSchedule: &fluxcdv1.NextSchedule{
+							Schedule: fluxcdv1.Schedule{
+								Cron:     "0 10 * * *",
+								TimeZone: "UTC",
+							},
+							When: scheduleTime,
+						},
+					}
+					err = testClient.Status().Update(ctx, scheduledProvider)
+					g.Expect(err).ToNot(HaveOccurred())
+				}
+
+				defer func() {
+					_ = testClient.Delete(ctx, readyProvider)
+					_ = testClient.Delete(ctx, failedProvider)
+					_ = testClient.Delete(ctx, suspendedProvider)
+					if scheduledProvider != nil {
+						_ = testClient.Delete(ctx, scheduledProvider)
+					}
+				}()
+
+				// Set namespace for single namespace tests
+				if !tt.allNamespaces {
+					kubeconfigArgs.Namespace = &ns1.Name
+				}
+			}
+
+			// Prepare command arguments
+			args := []string{"get", "inputprovider"}
+			if tt.allNamespaces {
+				args = append(args, "--all-namespaces")
+			}
+			if len(tt.args) > 0 {
+				args = append(args, tt.args...)
+			}
+
+			// Execute command
+			output, err := executeCommand(args)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Split output into lines
+			lines := strings.Split(strings.TrimSpace(output), "\n")
+			if len(lines) == 1 && lines[0] == "" {
+				lines = []string{}
+			}
+
+			// Verify column headers
+			if len(lines) > 0 {
+				headerLine := lines[0]
+				expectedColumns := defaultColumns
+				if tt.allNamespaces {
+					expectedColumns = allNamespacesColumns
+				}
+				for _, expectedColumn := range expectedColumns {
+					g.Expect(headerLine).To(ContainSubstring(expectedColumn))
+				}
+			}
+
+			// Verify expected content
+			for _, expectedContent := range tt.expectOutput {
+				g.Expect(output).To(ContainSubstring(expectedContent))
+			}
+
+			// Verify table structure
+			if tt.setupResources {
+				// Should have header + data rows
+				if tt.allNamespaces {
+					// Should show resources from both namespaces
+					g.Expect(len(lines)).To(BeNumerically(">=", 3)) // header + 2+ rows
+
+					// Verify namespace columns are present
+					dataLines := lines[1:]
+					foundNs1, foundNs2 := false, false
+					for _, line := range dataLines {
+						if strings.Contains(line, ns1.Name) {
+							foundNs1 = true
+						}
+						if strings.Contains(line, ns2.Name) {
+							foundNs2 = true
+						}
+					}
+					g.Expect(foundNs1).To(BeTrue())
+					g.Expect(foundNs2).To(BeTrue())
+				} else {
+					// Single namespace should show only resources from that namespace
+					if len(tt.args) == 0 {
+						// List all in namespace - should have header + 2 rows (ready + failed)
+						g.Expect(len(lines)).To(BeNumerically(">=", 2))
+					} else {
+						// Specific resource - should have header + 1 row
+						g.Expect(lines).To(HaveLen(2))
+					}
+				}
+			} else {
+				// No resources should show only header or empty
+				g.Expect(len(lines)).To(BeNumerically("<=", 1))
+			}
+		})
+	}
+}

--- a/cmd/cli/get_resourceset_test.go
+++ b/cmd/cli/get_resourceset_test.go
@@ -1,0 +1,320 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestGetResourceSetCmd(t *testing.T) {
+	var (
+		defaultColumns       = []string{"NAME", "RESOURCES", "READY", "MESSAGE", "LAST RECONCILED"}
+		allNamespacesColumns = []string{"NAMESPACE", "NAME", "RESOURCES", "READY", "MESSAGE", "LAST RECONCILED"}
+	)
+	tests := []struct {
+		name           string
+		setupResources bool
+		args           []string
+		allNamespaces  bool
+		expectError    bool
+		expectOutput   []string
+	}{
+		{
+			name:         "no resources",
+			expectOutput: []string{},
+		},
+		{
+			name:           "single namespace with ready resource",
+			setupResources: true,
+			expectOutput: []string{
+				"ready-app", "1", "True", "ResourceSet reconciliation succeeded",
+			},
+		},
+		{
+			name:           "single namespace with failed resource",
+			setupResources: true,
+			expectOutput: []string{
+				"failed-app", "0", "False", "ResourceSet reconciliation failed",
+			},
+		},
+		{
+			name:           "all namespaces",
+			setupResources: true,
+			allNamespaces:  true,
+			expectOutput: []string{
+				"ready-app", "1", "True", "ResourceSet reconciliation succeeded",
+				"failed-app", "0", "False", "ResourceSet reconciliation failed",
+				"suspended-app", "0", "Suspended",
+			},
+		},
+		{
+			name:           "specific resource by name",
+			setupResources: true,
+			args:           []string{"ready-app"},
+			expectOutput: []string{
+				"ready-app", "1", "True", "ResourceSet reconciliation succeeded",
+			},
+		},
+		{
+			name:           "suspended resource",
+			setupResources: true,
+			allNamespaces:  true,
+			expectOutput: []string{
+				"suspended-app", "0", "Suspended",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			g := NewWithT(t)
+
+			var ns1, ns2 *corev1.Namespace
+
+			// Create ResourceSets if needed
+			if tt.setupResources {
+				var err error
+				ns1, err = testEnv.CreateNamespace(ctx, "test1")
+				g.Expect(err).ToNot(HaveOccurred())
+				ns2, err = testEnv.CreateNamespace(ctx, "test2")
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Create ready ResourceSet in ns1
+				readyInput, err := fluxcdv1.NewResourceSetInput(nil, map[string]any{
+					"app": "my-app",
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				readyResourceSet := &fluxcdv1.ResourceSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ready-app",
+						Namespace: ns1.Name,
+					},
+					Spec: fluxcdv1.ResourceSetSpec{
+						Inputs: []fluxcdv1.ResourceSetInput{readyInput},
+						ResourcesTemplate: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: << .inputs.app >>-config
+data:
+  app: "<< .inputs.app >>"`,
+					},
+				}
+				err = testClient.Create(ctx, readyResourceSet)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Set ready status
+				readyResourceSet.Status = fluxcdv1.ResourceSetStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               meta.ReadyCondition,
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1,
+							LastTransitionTime: metav1.Now(),
+							Reason:             meta.ReconciliationSucceededReason,
+							Message:            "ResourceSet reconciliation succeeded",
+						},
+					},
+					Inventory: &fluxcdv1.ResourceInventory{
+						Entries: []fluxcdv1.ResourceRef{
+							{
+								ID:      fmt.Sprintf("%s_my-app-config_%s_ConfigMap", ns1.Name, ""),
+								Version: "v1",
+							},
+						},
+					},
+				}
+				err = testClient.Status().Update(ctx, readyResourceSet)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Create failed ResourceSet in ns1
+				failedInput, err := fluxcdv1.NewResourceSetInput(nil, map[string]any{
+					"app": "broken-app",
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				failedResourceSet := &fluxcdv1.ResourceSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "failed-app",
+						Namespace: ns1.Name,
+					},
+					Spec: fluxcdv1.ResourceSetSpec{
+						Inputs: []fluxcdv1.ResourceSetInput{failedInput},
+						ResourcesTemplate: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: << .inputs.app >>-config
+  namespace: nonexistent-namespace
+data:
+  app: "<< .inputs.app >>"`,
+					},
+				}
+				err = testClient.Create(ctx, failedResourceSet)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Set failed status
+				failedResourceSet.Status = fluxcdv1.ResourceSetStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               meta.ReadyCondition,
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 1,
+							LastTransitionTime: metav1.Now(),
+							Reason:             meta.ReconciliationFailedReason,
+							Message:            "ResourceSet reconciliation failed",
+						},
+					},
+				}
+				err = testClient.Status().Update(ctx, failedResourceSet)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Create suspended ResourceSet in ns2
+				suspendedInput, err := fluxcdv1.NewResourceSetInput(nil, map[string]any{
+					"app": "suspended-app",
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				suspendedResourceSet := &fluxcdv1.ResourceSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "suspended-app",
+						Namespace: ns2.Name,
+						Annotations: map[string]string{
+							fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue,
+						},
+					},
+					Spec: fluxcdv1.ResourceSetSpec{
+						Inputs: []fluxcdv1.ResourceSetInput{suspendedInput},
+						ResourcesTemplate: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: << .inputs.app >>-config
+data:
+  app: "<< .inputs.app >>"`,
+					},
+				}
+				err = testClient.Create(ctx, suspendedResourceSet)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				suspendedResourceSet.Status = fluxcdv1.ResourceSetStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               meta.ReadyCondition,
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1,
+							LastTransitionTime: metav1.Now(),
+							Reason:             meta.ReconciliationSucceededReason,
+							Message:            "ResourceSet reconciliation succeeded",
+						},
+					},
+				}
+				err = testClient.Status().Update(ctx, suspendedResourceSet)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				defer func() {
+					_ = testClient.Delete(ctx, readyResourceSet)
+					_ = testClient.Delete(ctx, failedResourceSet)
+					_ = testClient.Delete(ctx, suspendedResourceSet)
+				}()
+
+				// Set namespace for single namespace tests
+				if !tt.allNamespaces {
+					kubeconfigArgs.Namespace = &ns1.Name
+				}
+			}
+
+			// Prepare command arguments
+			args := []string{"get", "resourceset"}
+			if tt.allNamespaces {
+				args = append(args, "--all-namespaces")
+			}
+			if len(tt.args) > 0 {
+				args = append(args, tt.args...)
+			}
+
+			// Execute command
+			output, err := executeCommand(args)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Split output into lines
+			lines := strings.Split(strings.TrimSpace(output), "\n")
+			if len(lines) == 1 && lines[0] == "" {
+				lines = []string{}
+			}
+
+			// Verify column headers
+			if len(lines) > 0 {
+				headerLine := lines[0]
+				expectedColumns := defaultColumns
+				if tt.allNamespaces {
+					expectedColumns = allNamespacesColumns
+				}
+				for _, expectedColumn := range expectedColumns {
+					g.Expect(headerLine).To(ContainSubstring(expectedColumn))
+				}
+			}
+
+			// Verify expected content
+			for _, expectedContent := range tt.expectOutput {
+				g.Expect(output).To(ContainSubstring(expectedContent))
+			}
+
+			// Verify table structure
+			if tt.setupResources {
+				// Should have header + data rows
+				if tt.allNamespaces {
+					// Should show resources from both namespaces
+					g.Expect(len(lines)).To(BeNumerically(">=", 3)) // header + 2+ rows
+
+					// Verify namespace columns are present
+					dataLines := lines[1:]
+					foundNs1, foundNs2 := false, false
+					for _, line := range dataLines {
+						if strings.Contains(line, ns1.Name) {
+							foundNs1 = true
+						}
+						if strings.Contains(line, ns2.Name) {
+							foundNs2 = true
+						}
+					}
+					g.Expect(foundNs1).To(BeTrue())
+					g.Expect(foundNs2).To(BeTrue())
+				} else {
+					// Single namespace should show only resources from that namespace
+					if len(tt.args) == 0 {
+						// List all in namespace - should have header + 2 rows (ready + failed)
+						g.Expect(len(lines)).To(BeNumerically(">=", 2))
+					} else {
+						// Specific resource - should have header + 1 row
+						g.Expect(lines).To(HaveLen(2))
+					}
+				}
+			} else {
+				// No resources should show only header or empty
+				g.Expect(len(lines)).To(BeNumerically("<=", 1))
+			}
+		})
+	}
+}

--- a/cmd/cli/reconcile_resource.go
+++ b/cmd/cli/reconcile_resource.go
@@ -34,12 +34,12 @@ type reconcileResourceFlags struct {
 	wait  bool
 }
 
-var reconcileeResourceArgs reconcileResourceFlags
+var reconcileResourceArgs reconcileResourceFlags
 
 func init() {
-	reconcileResourceCmd.Flags().BoolVar(&reconcileeResourceArgs.force, "force", false,
+	reconcileResourceCmd.Flags().BoolVar(&reconcileResourceArgs.force, "force", false,
 		"Force the reconciliation of the resource, applies only to Flux HelmReleases.")
-	reconcileResourceCmd.Flags().BoolVar(&reconcileeResourceArgs.wait, "wait", true, "Wait for the resource to become ready.")
+	reconcileResourceCmd.Flags().BoolVar(&reconcileResourceArgs.wait, "wait", true, "Wait for the resource to become ready.")
 	reconcileCmd.AddCommand(reconcileResourceCmd)
 }
 
@@ -69,7 +69,7 @@ func reconcileResourceCmdRun(cmd *cobra.Command, args []string) error {
 		meta.ReconcileRequestAnnotation: now,
 	}
 
-	if reconcileeResourceArgs.force {
+	if reconcileResourceArgs.force {
 		annotations[meta.ForceRequestAnnotation] = now
 	}
 
@@ -79,7 +79,7 @@ func reconcileResourceCmdRun(cmd *cobra.Command, args []string) error {
 	}
 
 	rootCmd.Println(`►`, "Reconciliation triggered")
-	if reconcileeResourceArgs.wait {
+	if reconcileResourceArgs.wait {
 		rootCmd.Println(`◎`, "Waiting for reconciliation...")
 		msg, err := waitForResourceReconciliation(ctx, *gvk, name, *kubeconfigArgs.Namespace, now, rootArgs.timeout)
 		if err != nil {

--- a/cmd/cli/reconcile_resource.go
+++ b/cmd/cli/reconcile_resource.go
@@ -26,7 +26,7 @@ var reconcileResourceCmd = &cobra.Command{
 `,
 	Args:              cobra.ExactArgs(1),
 	RunE:              reconcileResourceCmdRun,
-	ValidArgsFunction: resourceKindCompletionFunc(),
+	ValidArgsFunction: resourceKindNameCompletionFunc(true),
 }
 
 type reconcileResourceFlags struct {

--- a/cmd/cli/resume_resource.go
+++ b/cmd/cli/resume_resource.go
@@ -19,7 +19,7 @@ var resumeResourceCmd = &cobra.Command{
 `,
 	Args:              cobra.ExactArgs(1),
 	RunE:              resumeResourceCmdRun,
-	ValidArgsFunction: resourceKindCompletionFunc(),
+	ValidArgsFunction: resourceKindNameCompletionFunc(true),
 }
 
 type resumeResourceFlags struct {

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -1,0 +1,152 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fluxcd/pkg/runtime/testenv"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	// +kubebuilder:scaffold:imports
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+var (
+	timeout    = 30 * time.Second
+	testEnv    *testenv.Environment
+	testClient client.Client
+	testCtx    = ctrl.SetupSignalHandler()
+)
+
+func NewTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(rbacv1.AddToScheme(s))
+	utilruntime.Must(appsv1.AddToScheme(s))
+	utilruntime.Must(apiextensionsv1.AddToScheme(s))
+	utilruntime.Must(fluxcdv1.AddToScheme(s))
+	return s
+}
+
+func TestMain(m *testing.M) {
+	testEnv = testenv.New(
+		testenv.WithCRDPath(
+			filepath.Join("..", "..", "config", "crd", "bases"),
+		),
+		testenv.WithScheme(NewTestScheme()),
+	)
+
+	var err error
+	testClient, err = client.New(testEnv.Config, client.Options{Scheme: NewTestScheme(), Cache: nil})
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create test environment client: %v", err))
+	}
+
+	go func() {
+		fmt.Println("Starting the test environment")
+		if err := testEnv.Start(testCtx); err != nil {
+			panic(fmt.Sprintf("Failed to start the test environment manager: %v", err))
+		}
+	}()
+	<-testEnv.Manager.Elected()
+
+	// Generate a kubeconfig for the testenv-admin user.
+	user, err := testEnv.AddUser(envtest.User{
+		Name:   "testenv-admin",
+		Groups: []string{"system:masters"},
+	}, nil)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create testenv-admin user: %v", err))
+	}
+
+	kubeConfig, err := user.KubeConfig()
+	if err != nil {
+		panic(fmt.Sprintf("failed to create the testenv-admin user kubeconfig: %v", err))
+	}
+
+	tmpDir, err := os.MkdirTemp("", "flux-operator-cmd")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpFilename := filepath.Join(tmpDir, "kubeconfig")
+	if err := os.WriteFile(tmpFilename, kubeConfig, 0644); err != nil {
+		panic(err)
+	}
+	kubeconfigArgs.KubeConfig = &tmpFilename
+
+	code := m.Run()
+
+	fmt.Println("Stopping the test environment")
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop the test environment: %v", err))
+	}
+
+	os.Exit(code)
+}
+
+// executeCommand executes a CLI command with the given args and returns the output and error.
+// This helper function can be reused across all CLI command tests.
+func executeCommand(args []string) (string, error) {
+	defer resetCmdArgs()
+
+	// Capture output
+	buf := new(bytes.Buffer)
+
+	// Set up the command
+	cmd := rootCmd
+	cmd.SetArgs(args)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	// Execute command
+	err := cmd.Execute()
+
+	return buf.String(), err
+}
+
+// resetCmdArgs resets all command-specific flags to their default values.
+// This should be called between tests to ensure clean state.
+func resetCmdArgs() {
+	// Version command
+	versionArgs = versionFlags{}
+
+	// Build commands
+	buildInstanceArgs = buildInstanceFlags{}
+	buildResourceSetArgs = buildResourceSetFlags{}
+
+	// Get commands
+	getInstanceArgs = getInstanceFlags{allNamespaces: true}
+	getResourceSetArgs = getResourceSetFlags{}
+	getInputProviderArgs = getInputProviderFlags{}
+	getResourcesArgs = getResourcesFlags{output: "table"}
+
+	// Reconcile commands
+	reconcileInstanceArgs = reconcileInstanceFlags{}
+	reconcileResourceSetArgs = reconcileResourceSetFlags{}
+	reconcileInputProviderArgs = reconcileInputProviderFlags{}
+	reconcileResourceArgs = reconcileResourceFlags{}
+
+	// Resume commands
+	resumeInstanceArgs = resumeInstanceFlags{}
+	resumeResourceSetArgs = resumeResourceSetFlags{}
+	resumeInputProviderArgs = resumeInputProviderFlags{}
+	resumeResourceArgs = resumeResourceFlags{}
+}

--- a/cmd/cli/suspend_resource.go
+++ b/cmd/cli/suspend_resource.go
@@ -19,7 +19,7 @@ var suspendResourceCmd = &cobra.Command{
 `,
 	Args:              cobra.ExactArgs(1),
 	RunE:              suspendResourceCmdRun,
-	ValidArgsFunction: resourceKindCompletionFunc(),
+	ValidArgsFunction: resourceKindNameCompletionFunc(true),
 }
 
 func init() {

--- a/cmd/cli/version_test.go
+++ b/cmd/cli/version_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestVersionCmd(t *testing.T) {
+	tests := []struct {
+		name            string
+		clientOnly      bool
+		setupReport     bool
+		operatorVer     string
+		distributionVer string
+		expectedOutput  []string
+		expectError     bool
+	}{
+		{
+			name:       "client only",
+			clientOnly: true,
+			expectedOutput: []string{
+				"client: " + VERSION,
+			},
+		},
+		{
+			name:        "no server",
+			expectError: true,
+		},
+		{
+			name:            "with server",
+			setupReport:     true,
+			operatorVer:     "v1.2.3",
+			distributionVer: "v2.4.0",
+			expectedOutput: []string{
+				"client: " + VERSION,
+				"server: v1.2.3",
+				"distribution: v2.4.0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			g := NewWithT(t)
+
+			// Create FluxReport if needed
+			if tt.setupReport {
+				ns, err := testEnv.CreateNamespace(ctx, "test")
+				g.Expect(err).ToNot(HaveOccurred())
+
+				report := &fluxcdv1.FluxReport{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "flux",
+						Namespace: ns.Name,
+					},
+					Spec: fluxcdv1.FluxReportSpec{
+						Distribution: fluxcdv1.FluxDistributionStatus{
+							Entitlement: "oss",
+							Status:      "ready",
+						},
+					},
+				}
+
+				if tt.operatorVer != "" {
+					report.Spec.Operator = &fluxcdv1.OperatorInfo{
+						APIVersion: "v1",
+						Version:    tt.operatorVer,
+						Platform:   "linux/amd64",
+					}
+				}
+
+				if tt.distributionVer != "" {
+					report.Spec.Distribution.Version = tt.distributionVer
+				}
+
+				err = testClient.Create(ctx, report)
+				g.Expect(err).ToNot(HaveOccurred())
+				defer func() {
+					_ = testClient.Delete(ctx, report)
+				}()
+			}
+
+			// Prepare command arguments
+			args := []string{"version"}
+			if tt.clientOnly {
+				args = append(args, "--client")
+			}
+
+			// Execute command
+			output, err := executeCommand(args)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Check output
+			for _, expected := range tt.expectedOutput {
+				g.Expect(output).To(ContainSubstring(expected))
+			}
+		})
+	}
+}

--- a/test/e2e/instance_test.go
+++ b/test/e2e/instance_test.go
@@ -186,9 +186,7 @@ var _ = Describe("FluxInstance", Ordered, func() {
 		It("should run successfully", func() {
 			By("generates FluxReport")
 			verifyFluxReport := func() error {
-				cmd := exec.Command("kubectl", "get", "FluxReport/flux",
-					"-n", namespace, "-o=yaml",
-				)
+				cmd := exec.Command(cli, "export", "report")
 				output, err := Run(cmd, "/test/e2e")
 				ExpectWithOffset(2, err).NotTo(HaveOccurred())
 				ExpectWithOffset(2, output).To(ContainSubstring("nodes: 1"))


### PR DESCRIPTION
The `flux-operator export` commands are used to export the Flux Operator resources in YAML format.
The exported resources can be used for backup, migration, or inspection purposes.

The following commands are available:

- `flux-operator export report`: Exports the FluxReport resource containing the distribution status and version information.
- `flux-operator export resource <kind>/<name> -n <namespace>`: Exports a Flux resource from the specified namespace.
