### PR TITLE
Include OpenVEX documents in the distro artifact

### DIFF
--- a/config/data/flux-vex/v2.2.json
+++ b/config/data/flux-vex/v2.2.json
@@ -1,0 +1,39 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-f843e58a33079b9f9344d4b4e72a3dcc0ee7ad51825e087b96692dccaf21f2d8",
+  "author": "flux-enterprise@control-plane.io",
+  "role": "Enterprise Flux Maintainers",
+  "timestamp": "2024-05-23T17:26:04.422544+03:00",
+  "last_updated": "2024-05-24T00:38:58.404614+03:00",
+  "version": 3,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2019-25210"
+      },
+      "timestamp": "2024-05-24T00:38:51.232345+03:00",
+      "products": [
+        {
+          "@id": "pkg:oci/source-controller"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "This CVE has been dismissed by the Helm team https://helm.sh/blog/response-cve-2019-25210/"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2019-25210"
+      },
+      "timestamp": "2024-05-24T00:38:58.404614+03:00",
+      "products": [
+        {
+          "@id": "pkg:oci/helm-controller"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "This CVE has been dismissed by the Helm team https://helm.sh/blog/response-cve-2019-25210/"
+    }
+  ]
+}

--- a/config/data/flux-vex/v2.3.json
+++ b/config/data/flux-vex/v2.3.json
@@ -1,0 +1,92 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-f843e58a33079b9f9344d4b4e72a3dcc0ee7ad51825e087b96692dccaf21f2d8",
+  "author": "flux-enterprise@control-plane.io",
+  "role": "Enterprise Flux Maintainers",
+  "timestamp": "2024-05-23T17:26:04.422544+03:00",
+  "last_updated": "2024-06-17T09:15:06.353901+03:00",
+  "version": 2,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2024-4741"
+      },
+      "timestamp": "2024-06-17T09:15:06.353901+03:00",
+      "products": [
+        {
+          "@id": "pkg:apk/alpine/libssl3@3.3.0-r2"
+        },
+        {
+          "@id": "pkg:apk/alpine/libssl3"
+        },
+        {
+          "@id": "pkg:apk/alpine/libcrypto3@3.3.0-r2"
+        },
+        {
+          "@id": "pkg:apk/alpine/libcrypto3"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerable code is not executed by Flux"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-42365"
+      },
+      "timestamp": "2024-06-17T09:15:06.353901+03:00",
+      "products": [
+        {
+          "@id": "pkg:apk/alpine/busybox@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox-binsh@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox-binsh"
+        },
+        {
+          "@id": "pkg:apk/alpine/ssl_client@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/ssl_client"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerable code is not executed by Flux"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-42364"
+      },
+      "timestamp": "2024-06-17T09:15:06.353901+03:00",
+      "products": [
+        {
+          "@id": "pkg:apk/alpine/busybox@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox-binsh@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox-binsh"
+        },
+        {
+          "@id": "pkg:apk/alpine/ssl_client@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/ssl_client"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerable code is not executed by Flux"
+    }
+  ]
+}

--- a/config/data/flux-vex/v2.4.json
+++ b/config/data/flux-vex/v2.4.json
@@ -1,0 +1,11 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-f843e58a33079b9f9344d4b4e72a3dcc0ee7ad51825e087b96692dccaf21f2d8",
+  "author": "flux-enterprise@control-plane.io",
+  "role": "Enterprise Flux Maintainers",
+  "timestamp": "2024-09-30T17:26:04.422544+03:00",
+  "last_updated": "2024-09-30T17:26:04.422544+03:00",
+  "version": 2,
+  "statements": [
+  ]
+}

--- a/config/data/flux-vex/v2.5.json
+++ b/config/data/flux-vex/v2.5.json
@@ -1,0 +1,25 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-f843e58a33079b9f9344d4b4e72a3dcc0ee7ad51825e087b96692dccaf21f2d8",
+  "author": "flux-enterprise@control-plane.io",
+  "role": "Enterprise Flux Maintainers",
+  "timestamp": "2024-02-20T17:26:04.422544+03:00",
+  "last_updated": "2025-04-16T12:20:00.000000+01:00",
+  "version": 2,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-29087"
+      },
+      "timestamp": "2025-04-16T12:20:00.000000+01:00",
+      "products": [
+        {
+          "@id": "pkg:apk/alpine/sqlite-libs@3.48.0-r0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerable code is not executed by Flux"
+    }
+  ]
+}

--- a/config/data/flux-vex/v2.6.json
+++ b/config/data/flux-vex/v2.6.json
@@ -1,0 +1,53 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-f843e58a33079b9f9344d4b4e72a3dcc0ee7ad51825e087b96692dccaf21f2d8",
+  "author": "flux-enterprise@control-plane.io",
+  "role": "Enterprise Flux Maintainers",
+  "timestamp": "2025-07-09T09:46:14Z",
+  "last_updated": "2025-07-09T09:46:14Z",
+  "version": 2,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-53547"
+      },
+      "timestamp": "2025-07-09T09:46:14Z",
+      "products": [
+        {
+          "@id": "pkg:golang/helm.sh/helm/v3@3.17.3"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The affected code is not executed by Flux."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-53547"
+      },
+      "timestamp": "2025-07-09T09:46:14Z",
+      "products": [
+        {
+          "@id": "pkg:oci/source-controller"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The source-controller implements a custom Helm chart downloader that does not use the vulnerable code path in Helm SDK."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-53547"
+      },
+      "timestamp": "2025-07-09T09:46:14Z",
+      "products": [
+        {
+          "@id": "pkg:oci/helm-controller"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The helm-controller does not downloads Helm charts, and the vulnerable code path in Helm SDK is not used."
+    }
+  ]
+}

--- a/hack/build-dist-manifests.sh
+++ b/hack/build-dist-manifests.sh
@@ -36,9 +36,14 @@ tar xzf main.tar.gz -C "${DEST_DIR}"
 
 mkdir -p "${DEST_DIR}/flux-images"
 cp -r ${DEST_DIR}/distribution-main/images/* ${DEST_DIR}/flux-images/
+info "flux image manifests copied to disto/flux-images"
+
+mkdir -p "${DEST_DIR}/flux-vex"
+cp -r ${DEST_DIR}/distribution-main/vex/* ${DEST_DIR}/flux-vex/
+info "flux OpenVEX documents copied to disto/flux-vex"
+
 rm -rf ${DEST_DIR}/distribution-main
 rm -rf main.tar.gz
-info "flux image manifests copied to disto/flux-images"
 
 info "all manifests generated to disto/"
 tree -d ${DEST_DIR}

--- a/hack/vendor-flux-manifests.sh
+++ b/hack/vendor-flux-manifests.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
 DEST_DIR="${REPOSITORY_ROOT}/config/data/flux"
 IMG_DIR="${REPOSITORY_ROOT}/config/data/flux-images"
+VEX_DIR="${REPOSITORY_ROOT}/config/data/flux-vex"
 
 info() {
     echo '[INFO] ' "$@"
@@ -37,8 +38,11 @@ tar xzf main.tar.gz -C "${DEST_DIR}"
 
 mkdir -p "${IMG_DIR}"
 cp -rf ${DEST_DIR}/distribution-main/images/* ${IMG_DIR}/
+info "flux image manifests copied to flux-images"
+mkdir -p "${VEX_DIR}"
+cp -rf ${DEST_DIR}/distribution-main/vex/* ${VEX_DIR}/
+info "flux OpenVEX documents copied to flux-vex"
 rm -rf ${DEST_DIR}/distribution-main
 rm -rf main.tar.gz
-info "flux image manifests copied to flux-images"
 
 info "all manifests extracted to ${DEST_DIR}"


### PR DESCRIPTION
Ship the [OpenVEX documents](https://github.com/controlplaneio-fluxcd/distribution/tree/main/vex) issued by ControlPlane for Flux Enterprise images.

The OpenVEX documents are included in the distribution OCI artifact `oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests` under the `/flux-vex` dir.