### PR TITLE
cli: Add `flux-operator create secret` commands

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -36,63 +36,20 @@ and the Flux Operator to be installed.
 
 The CLI connects to the cluster using the `~.kube/config` file, similar to `kubectl`.
 
+All commands display help information and example usage when run with the `-h` or `--help` flag.
+
 ### Build Commands
 
 The `flux-operator build` commands are used to build and validate the Flux Operator resources.
 These commands do not require access to a Kubernetes cluster and can be run in any environment.
 
-#### `flux-operator build instance`
+The following commands are available:
 
-The build instance command performs the following steps:
-
-1. Reads the FluxInstance YAML manifest from the specified file.
-2. Validates the instance definition and sets default values.
-3. Pulls the distribution OCI artifact from the registry using the Docker config file for authentication.
-   If not specified, the artifact is pulled from 'oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests'.
-4. Builds the Flux Kubernetes manifests according to the instance specifications and kustomize patches.
-5. Prints the multi-doc YAML containing the Flux Kubernetes manifests to stdout.
-
-Example usage:
-
-```shell
-# Build the given FluxInstance and print the generated manifests
-flux-operator build instance -f flux.yaml
-
-# Pipe the FluxInstance definition to the build command
-cat flux.yaml | flux-operator build instance -f -
-
-# Build a FluxInstance and print a diff of the generated manifests
-flux-operator build instance -f flux.yaml | \
-  kubectl diff --server-side --field-manager=flux-operator -f -
-```
-
-#### `flux-operator build rset`
-
-The build rset command performs the following steps:
-
-1. Reads the ResourceSet YAML manifest from the specified file.
-2. Validates the ResourceSet definition and sets default values.
-3. Extracts the inputs from the ResourceSet and validates the templates.
-4. Builds the Kubernetes manifests according to the ResourceSet specifications and templates.
-5. Prints the multi-doc YAML containing the Kubernetes manifests to stdout.
-
-Example usage:
-
-```shell
-# Build the given ResourceSet and print the generated objects
-flux-operator build rset -f my-resourceset.yaml
-
-# Build a ResourceSet by providing the inputs from a file
-flux-operator build rset -f my-resourceset.yaml \
---inputs-from my-resourceset-inputs.yaml
-
-# Pipe the ResourceSet manifest to the build command
-cat my-resourceset.yaml | flux-operator build rset -f -
-
-# Build a ResourceSet and print a diff of the generated objects
-flux-operator build rset -f my-resourceset.yaml | \
-kubectl diff --server-side --field-manager=flux-operator -f -
-```
+- `flux-operator build instance`: Generates the Flux Kubernetes manifests from a FluxInstance definition.
+    - `-f, --file`: Path to the FluxInstance YAML manifest (required).
+- `flux-operator build rset`: Generates the Kubernetes manifests from a ResourceSet definition.
+    - `-f, --file`: Path to the ResourceSet YAML manifest (required).
+    - `--inputs-from`: Path to the ResourceSet inputs YAML manifest.
 
 ### Get Commands
 
@@ -118,7 +75,11 @@ The exported resources can be used for backup, migration, or inspection purposes
 The following commands are available:
 
 - `flux-operator export report`: Exports the FluxReport resource containing the distribution status and version information.
-- `flux-operator export resource <kind>/<name> -n <namespace>`: Exports a Flux resource from the specified namespace.
+- `flux-operator export resource <kind>/<name>`: Exports a Flux resource from the specified namespace.
+
+Arguments:
+
+- `-n, --namespace`: Specifies the namespace scope of the command.
 
 ### Reconcile Commands
 
@@ -126,10 +87,15 @@ The `flux-operator reconcile` commands are used to trigger the reconciliation of
 
 The following commands are available:
 
-- `flux-operator reconcile instance <name> -n <namespace>`: Reconciles the FluxInstance resource in the cluster.
-- `flux-operator reconcile rset <name> -n <namespace>`: Reconciles the ResourceSet resource in the cluster.
-- `flux-operator reconcile rsip <name> -n <namespace>`: Reconciles the ResourceSetInputProvider resource in the cluster.
-- `flux-operator reconcile resource <kind>/<name> -n <namespace>`: Reconciles a Flux resource in the specified namespace.
+- `flux-operator reconcile instance <name>`: Reconciles the FluxInstance resource in the cluster.
+- `flux-operator reconcile rset <name>`: Reconciles the ResourceSet resource in the cluster.
+- `flux-operator reconcile rsip <name>`: Reconciles the ResourceSetInputProvider resource in the cluster.
+- `flux-operator reconcile resource <kind>/<name>`: Reconciles a Flux resource in the specified namespace.
+
+Arguments:
+
+- `-n, --namespace`: Specifies the namespace scope of the command.
+- `--wait`: Waits for the reconciliation to complete before returning.
 
 ### Suspend/Resume Commands
 
@@ -138,25 +104,76 @@ to suspend or resume the reconciliation of the Flux Operator resources.
 
 The following commands are available:
 
-- `flux-operator suspend instance <name> -n <namespace>`: Suspends the reconciliation of the FluxInstance resource in the cluster.
-- `flux-operator resume instance <name> -n <namespace>`: Resumes the reconciliation of the FluxInstance resource in the cluster.
-- `flux-operator suspend rset <name> -n <namespace>`: Suspends the reconciliation of the ResourceSet resource in the cluster.
-- `flux-operator resume rset <name> -n <namespace>`: Resumes the reconciliation of the ResourceSet resource in the cluster.
-- `flux-operator suspend rsip <name> -n <namespace>`: Suspends the reconciliation of the ResourceSetInputProvider resource in the cluster.
-- `flux-operator resume rsip <name> -n <namespace>`: Resumes the reconciliation of the ResourceSetInputProvider resource in the cluster.
-- `flux-operator suspend resource <kind>/<name> -n <namespace>`: Suspends the reconciliation of the Flux resource in the cluster.
-- `flux-operator resume resource <kind>/<name> -n <namespace>`: Resumes the reconciliation of the Flux resource in the cluster.
-
-### Statistics Command
-
-The `flux-operator stats` command is used to retrieve statistics about the Flux resources
-including their reconciliation status and the amount of cumulative storage used for each source type.
-
-### Version Command
-
-The `flux-operator version` command is used to display the version of the CLI, of the Flux Operator
-and of the Flux distribution running in the cluster.
+- `flux-operator suspend instance <name>`: Suspends the reconciliation of the FluxInstance resource in the cluster.
+- `flux-operator resume instance <name>`: Resumes the reconciliation of the FluxInstance resource in the cluster.
+- `flux-operator suspend rset <name>`: Suspends the reconciliation of the ResourceSet resource in the cluster.
+- `flux-operator resume rset <name>`: Resumes the reconciliation of the ResourceSet resource in the cluster.
+- `flux-operator suspend rsip <name>`: Suspends the reconciliation of the ResourceSetInputProvider resource in the cluster.
+- `flux-operator resume rsip <name>`: Resumes the reconciliation of the ResourceSetInputProvider resource in the cluster.
+- `flux-operator suspend resource <kind>/<name>`: Suspends the reconciliation of the Flux resource in the cluster.
+- `flux-operator resume resource <kind>/<name>`: Resumes the reconciliation of the Flux resource in the cluster.
 
 Arguments:
 
-- `--client`: If true, shows the client version only (no server required).
+- `-n, --namespace`: Specifies the namespace scope of the command.
+- `--wait`: On resume, waits for the reconciliation to complete before returning.
+
+### Statistics Command
+
+This command is used to retrieve statistics about the Flux resources
+including their reconciliation status and the amount of cumulative storage used for each source type.
+
+- `flux-operator stats`: Displays statistics about the Flux resources in the cluster.
+
+### Create Secret Commands
+
+The `flux-operator create secret` commands are used to create Kubernetes secrets specific to Flux.
+These commands can be used to create or update secrets directly in the cluster, or to export them in YAML format.
+
+The following commands are available:
+
+- `flux-operator create secret basic-auth`: Create a Kubernetes Secret containing basic auth credentials.
+  - `--username`: Set the username for basic authentication (required).
+  - `--password`: Set the password for basic authentication (required if --password-stdin is not used).
+  - `--password-stdin`: Read the password from stdin.
+- `flux-operator create secret githubapp`: Create a Kubernetes Secret containing GitHub App credentials.
+  - `--app-id`: GitHub App ID (required).
+  - `--app-installation-id`: GitHub App Installation ID (required).
+  - `--app-private-key-file`: Path to GitHub App private key file (required).
+  - `--app-base-url`: GitHub base URL for GitHub Enterprise Server (optional).
+- `flux-operator create secret proxy`: Create a Kubernetes Secret containing HTTP/S proxy credentials.
+  - `--address`: Set the proxy address (required).
+  - `--username`: Set the username for proxy authentication (optional).
+  - `--password`: Set the password for proxy authentication (optional).
+  - `--password-stdin`: Read the password from stdin.
+- `flux-operator create secret registry`: Create a Kubernetes Secret containing registry credentials.
+  - `--server`: Set the registry server (required).
+  - `--username`: Set the username for registry authentication (required).
+  - `--password`: Set the password for registry authentication (required if --password-stdin is not used).
+  - `--password-stdin`: Read the password from stdin.
+- `flux-operator create secret ssh`: Create a Kubernetes Secret containing SSH credentials.
+  - `--private-key-file`: Path to SSH private key file (required).
+  - `--public-key-file`: Path to SSH public key file (optional).
+  - `--knownhosts-file`: Path to SSH known_hosts file (required).
+  - `--password`: Password for encrypted SSH private key (optional).
+  - `--password-stdin`: Read the password from stdin.
+- `flux-operator create secret tls`: Create a Kubernetes Secret containing TLS certs.
+  - `--tls-crt-file`: Path to TLS client certificate file.
+  - `--tls-key-file`: Path to TLS client private key file.
+  - `--ca-crt-file`: Path to CA certificate file (optional).
+
+Arguments:
+
+- `-n, --namespace`: Specifies the namespace to create the secret in.
+- `--annotation`: Set annotations on the resource (can specify multiple annotations with commas: annotation1=value1,annotation2=value2).
+- `--label`: Set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2).
+- `--immutable`: Set the immutable flag on the Secret.
+- `--export`: Export secret in YAML format to stdout instead of creating it in the cluster.
+
+### Version Command
+
+This command is used to display the version of the CLI, of the Flux Operator
+and of the Flux distribution running in the cluster.
+
+- `flux-operator version`: Displays the version information for the CLI and the Flux Operator.
+    - `--client`:  If true, shows the client version only (no server required).

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -151,6 +151,11 @@ The following commands are available:
   - `--username`: Set the username for registry authentication (required).
   - `--password`: Set the password for registry authentication (required if --password-stdin is not used).
   - `--password-stdin`: Read the password from stdin.
+- `flux-operator create secret sops`: Create a Kubernetes Secret containing SOPS decryption keys.
+  - `--age-key-file`: Path to Age private key file (can be used multiple times).
+  - `--gpg-key-file`: Path to GPG private key file (can be used multiple times).
+  - `--age-key-stdin`: Read Age private key from stdin.
+  - `--gpg-key-stdin`: Read GPG private key from stdin.
 - `flux-operator create secret ssh`: Create a Kubernetes Secret containing SSH credentials.
   - `--private-key-file`: Path to SSH private key file (required).
   - `--public-key-file`: Path to SSH public key file (optional).

--- a/cmd/cli/create.go
+++ b/cmd/cli/create.go
@@ -1,0 +1,17 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create Kubernetes resources",
+}
+
+func init() {
+	rootCmd.AddCommand(createCmd)
+}

--- a/cmd/cli/create_secret.go
+++ b/cmd/cli/create_secret.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/yaml"
+)
+
+var createSecretCmd = &cobra.Command{
+	Use:   "secret",
+	Short: "Create Kubernetes Secret resources",
+}
+
+func init() {
+	createCmd.AddCommand(createSecretCmd)
+}
+
+func printSecret(secret *corev1.Secret) error {
+	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+	output, err := yaml.Marshal(secret)
+	if err != nil {
+		return fmt.Errorf("unable to marshal Secret to YAML: %w", err)
+	}
+
+	output = bytes.Replace(output, []byte("  creationTimestamp: null\n"), []byte(""), 1)
+	output = []byte("---\n" + string(output))
+
+	_, err = rootCmd.OutOrStdout().Write(output)
+	return err
+}
+
+func setSecretMetadata(secret *corev1.Secret, annotations, labels []string) error {
+	// parse annotations
+	if len(annotations) > 0 {
+		parsedAnnotations, err := parseMetadata(annotations)
+		if err != nil {
+			return fmt.Errorf("invalid annotations: %w", err)
+		}
+		if secret.ObjectMeta.Annotations == nil {
+			secret.ObjectMeta.Annotations = make(map[string]string)
+		}
+		for k, v := range parsedAnnotations {
+			secret.ObjectMeta.Annotations[k] = v
+		}
+	}
+
+	// parse labels
+	if len(labels) > 0 {
+		parsedLabels, err := parseMetadata(labels)
+		if err != nil {
+			return fmt.Errorf("invalid labels: %w", err)
+		}
+		if secret.ObjectMeta.Labels == nil {
+			secret.ObjectMeta.Labels = make(map[string]string)
+		}
+		for k, v := range parsedLabels {
+			secret.ObjectMeta.Labels[k] = v
+		}
+	}
+
+	return nil
+}
+
+// parseMetadata parses a slice of strings in the format "key=value" into a map.
+func parseMetadata(meta []string) (map[string]string, error) {
+	result := make(map[string]string)
+	for _, label := range meta {
+		parts := strings.Split(label, "=")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid format '%s', must be key=value", label)
+		}
+
+		// validate name
+		if errors := validation.IsQualifiedName(parts[0]); len(errors) > 0 {
+			return nil, fmt.Errorf("invalid '%s': %v", parts[0], errors)
+		}
+
+		// validate value
+		if errors := validation.IsValidLabelValue(parts[1]); len(errors) > 0 {
+			return nil, fmt.Errorf("invalid value '%s': %v", parts[1], errors)
+		}
+
+		result[parts[0]] = parts[1]
+	}
+
+	return result, nil
+}

--- a/cmd/cli/create_secret_basicauth.go
+++ b/cmd/cli/create_secret_basicauth.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fluxcd/pkg/runtime/secrets"
+	"github.com/spf13/cobra"
+)
+
+var createSecretBasicAuthCmd = &cobra.Command{
+	Use:   "basic-auth [name]",
+	Short: "Create a Kubernetes Secret containing basic auth credentials",
+	Example: `  # Create or update a secret with a GitHub PAT for Flux operations
+  echo $GITHUB_TOKEN | flux-operator create secret basic-auth github-auth \
+  --namespace=flux-system \
+  --username=flux \
+  --password-stdin
+
+  # Generate a basic auth secret and export it to a YAML file
+  flux-operator -n apps create secret basic-auth podinfo-auth \
+  --username=admin \
+  --password=secret \
+  --export > podinfo-auth.yaml
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: createSecretBasicAuthCmdRun,
+}
+
+type createSecretBasicAuthFlags struct {
+	username      string
+	password      string
+	passwordStdin bool
+
+	annotations []string
+	labels      []string
+	immutable   bool
+	export      bool
+}
+
+var createSecretBasicAuthArgs createSecretBasicAuthFlags
+
+func init() {
+	createSecretBasicAuthCmd.Flags().StringVar(&createSecretBasicAuthArgs.username, "username", "",
+		"set the username for basic authentication (required)")
+	createSecretBasicAuthCmd.Flags().StringVar(&createSecretBasicAuthArgs.password, "password", "",
+		"set the password for basic authentication (required if --password-stdin is not used)")
+	createSecretBasicAuthCmd.Flags().BoolVar(&createSecretBasicAuthArgs.passwordStdin, "password-stdin", false,
+		"read the password from stdin")
+	createSecretBasicAuthCmd.Flags().StringSliceVar(&createSecretBasicAuthArgs.annotations, "annotation", nil,
+		"set annotations on the resource (can specify multiple annotations with commas: annotation1=value1,annotation2=value2)")
+	createSecretBasicAuthCmd.Flags().StringSliceVar(&createSecretBasicAuthArgs.labels, "label", nil,
+		"set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)")
+	createSecretBasicAuthCmd.Flags().BoolVar(&createSecretBasicAuthArgs.immutable, "immutable", false,
+		"set the immutable flag on the Secret")
+	createSecretBasicAuthCmd.Flags().BoolVar(&createSecretBasicAuthArgs.export, "export", false,
+		"export resource in YAML format to stdout")
+	createSecretCmd.AddCommand(createSecretBasicAuthCmd)
+}
+
+func createSecretBasicAuthCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("a single name can be specified")
+	}
+	name := args[0]
+	password := createSecretBasicAuthArgs.password
+
+	// Read the password from stdin if the flag is set
+	if createSecretBasicAuthArgs.passwordStdin {
+		var input string
+		_, err := fmt.Scan(&input)
+		if err != nil {
+			return fmt.Errorf("unable to read password from stdin: %w", err)
+		}
+		password = input
+	}
+
+	// Build the secret
+	secret, err := secrets.MakeBasicAuthSecret(
+		name,
+		*kubeconfigArgs.Namespace,
+		createSecretBasicAuthArgs.username,
+		password,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Set annotations and labels if provided
+	if err := setSecretMetadata(
+		secret,
+		createSecretBasicAuthArgs.annotations,
+		createSecretBasicAuthArgs.labels,
+	); err != nil {
+		return fmt.Errorf("unable to set metadata on secret: %w", err)
+	}
+
+	// Export the secret if the export flag is set
+	if createSecretBasicAuthArgs.export {
+		return printSecret(secret)
+	}
+
+	// Apply the secret to the cluster
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	err = secrets.Apply(
+		ctx,
+		kubeClient,
+		secret,
+		secrets.WithForce(),
+		secrets.WithImmutable(createSecretBasicAuthArgs.immutable),
+	)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, fmt.Sprintf("Secret %s/%s applied succefuly", secret.GetNamespace(), secret.GetName()))
+	return nil
+}

--- a/cmd/cli/create_secret_githubapp.go
+++ b/cmd/cli/create_secret_githubapp.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/fluxcd/pkg/runtime/secrets"
+	"github.com/spf13/cobra"
+)
+
+var createSecretGitHubAppCmd = &cobra.Command{
+	Use:   "githubapp [name]",
+	Short: "Create a Kubernetes Secret containing GitHub App credentials",
+	Example: `  # Create or update a secret with GitHub App credentials for Flux operations
+  flux-operator create secret githubapp github-app-auth \
+  --namespace=flux-system \
+  --app-id=123456 \
+  --app-installation-id=78901234 \
+  --app-private-key-file=./private-key.pem
+
+  # Create a secret with GitHub Enterprise Server base URL
+  flux-operator create secret githubapp github-enterprise-auth \
+  --namespace=flux-system \
+  --app-id=123456 \
+  --app-installation-id=78901234 \
+  --app-private-key-file=./private-key.pem \
+  --app-base-url=https://github.example.com/api/v3
+
+  # Generate a secret and export it to a YAML file
+  flux-operator -n apps create secret githubapp github-app \
+  --app-id=123456 \
+  --app-installation-id=78901234 \
+  --app-private-key-file=./private-key.pem \
+  --export > github-app.yaml
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: createSecretGitHubAppCmdRun,
+}
+
+type createSecretGitHubAppFlags struct {
+	appID          string
+	installationID string
+	privateKeyFile string
+	baseURL        string
+
+	annotations []string
+	labels      []string
+	immutable   bool
+	export      bool
+}
+
+var createSecretGitHubAppArgs createSecretGitHubAppFlags
+
+func init() {
+	createSecretGitHubAppCmd.Flags().StringVar(&createSecretGitHubAppArgs.appID, "app-id", "",
+		"GitHub App ID (required)")
+	createSecretGitHubAppCmd.Flags().StringVar(&createSecretGitHubAppArgs.installationID, "app-installation-id", "",
+		"GitHub App Installation ID (required)")
+	createSecretGitHubAppCmd.Flags().StringVar(&createSecretGitHubAppArgs.privateKeyFile, "app-private-key-file", "",
+		"path to GitHub App private key file (required)")
+	createSecretGitHubAppCmd.Flags().StringVar(&createSecretGitHubAppArgs.baseURL, "app-base-url", "",
+		"GitHub base URL for GitHub Enterprise Server (optional)")
+	createSecretGitHubAppCmd.Flags().StringSliceVar(&createSecretGitHubAppArgs.annotations, "annotation", nil,
+		"set annotations on the resource (can specify multiple annotations with commas: annotation1=value1,annotation2=value2)")
+	createSecretGitHubAppCmd.Flags().StringSliceVar(&createSecretGitHubAppArgs.labels, "label", nil,
+		"set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)")
+	createSecretGitHubAppCmd.Flags().BoolVar(&createSecretGitHubAppArgs.immutable, "immutable", false,
+		"set the immutable flag on the Secret")
+	createSecretGitHubAppCmd.Flags().BoolVar(&createSecretGitHubAppArgs.export, "export", false,
+		"export resource in YAML format to stdout")
+
+	createSecretCmd.AddCommand(createSecretGitHubAppCmd)
+}
+
+func createSecretGitHubAppCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("a single name can be specified")
+	}
+	name := args[0]
+
+	// Read private key file
+	privateKey, err := os.ReadFile(createSecretGitHubAppArgs.privateKeyFile)
+	if err != nil {
+		return fmt.Errorf("unable to read private key file: %w", err)
+	}
+
+	// Build the secret
+	secret, err := secrets.MakeGitHubAppSecret(
+		name,
+		*kubeconfigArgs.Namespace,
+		createSecretGitHubAppArgs.appID,
+		createSecretGitHubAppArgs.installationID,
+		string(privateKey),
+		createSecretGitHubAppArgs.baseURL,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Set annotations and labels if provided
+	if err := setSecretMetadata(
+		secret,
+		createSecretGitHubAppArgs.annotations,
+		createSecretGitHubAppArgs.labels,
+	); err != nil {
+		return fmt.Errorf("unable to set metadata on secret: %w", err)
+	}
+
+	// Export the secret if the export flag is set
+	if createSecretGitHubAppArgs.export {
+		return printSecret(secret)
+	}
+
+	// Apply the secret to the cluster
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	err = secrets.Apply(
+		ctx,
+		kubeClient,
+		secret,
+		secrets.WithForce(),
+		secrets.WithImmutable(createSecretGitHubAppArgs.immutable),
+	)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, fmt.Sprintf("Secret %s/%s applied succefuly", secret.GetNamespace(), secret.GetName()))
+	return nil
+}

--- a/cmd/cli/create_secret_proxy.go
+++ b/cmd/cli/create_secret_proxy.go
@@ -1,0 +1,134 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fluxcd/pkg/runtime/secrets"
+	"github.com/spf13/cobra"
+)
+
+var createSecretProxyCmd = &cobra.Command{
+	Use:   "proxy [name]",
+	Short: "Create a Kubernetes Secret containing HTTP/S proxy credentials",
+	Example: `  # Create or update a secret with proxy credentials for Flux operations
+  echo $PROXY_PASSWORD | flux-operator create secret proxy proxy-auth \
+  --namespace=flux-system \
+  --address=proxy.example.com:8080 \
+  --username=proxyuser \
+  --password-stdin
+
+  # Generate a proxy secret and export it to a YAML file
+  flux-operator -n apps create secret proxy proxy-auth \
+  --address=proxy.example.com:8080 \
+  --username=admin \
+  --password=secret \
+  --export > proxy-auth.yaml
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: createSecretProxyCmdRun,
+}
+
+type createSecretProxyFlags struct {
+	username      string
+	password      string
+	passwordStdin bool
+	address       string
+
+	annotations []string
+	labels      []string
+	immutable   bool
+	export      bool
+}
+
+var createSecretProxyArgs createSecretProxyFlags
+
+func init() {
+	createSecretProxyCmd.Flags().StringVar(&createSecretProxyArgs.username, "username", "",
+		"set the username for proxy authentication")
+	createSecretProxyCmd.Flags().StringVar(&createSecretProxyArgs.password, "password", "",
+		"set the password for proxy authentication")
+	createSecretProxyCmd.Flags().BoolVar(&createSecretProxyArgs.passwordStdin, "password-stdin", false,
+		"read the password from stdin")
+	createSecretProxyCmd.Flags().StringVar(&createSecretProxyArgs.address, "address", "",
+		"set the proxy address (required)")
+	createSecretProxyCmd.Flags().StringSliceVar(&createSecretProxyArgs.annotations, "annotation", nil,
+		"set annotations on the resource (can specify multiple annotations with commas: annotation1=value1,annotation2=value2)")
+	createSecretProxyCmd.Flags().StringSliceVar(&createSecretProxyArgs.labels, "label", nil,
+		"set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)")
+	createSecretProxyCmd.Flags().BoolVar(&createSecretProxyArgs.immutable, "immutable", false,
+		"set the immutable flag on the Secret")
+	createSecretProxyCmd.Flags().BoolVar(&createSecretProxyArgs.export, "export", false,
+		"export resource in YAML format to stdout")
+	createSecretCmd.AddCommand(createSecretProxyCmd)
+}
+
+func createSecretProxyCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("a single name can be specified")
+	}
+	name := args[0]
+	password := createSecretProxyArgs.password
+
+	// Read the password from stdin if the flag is set
+	if createSecretProxyArgs.passwordStdin {
+		var input string
+		_, err := fmt.Scan(&input)
+		if err != nil {
+			return fmt.Errorf("unable to read password from stdin: %w", err)
+		}
+		password = input
+	}
+
+	// Build the secret
+	secret, err := secrets.MakeProxySecret(
+		name,
+		*kubeconfigArgs.Namespace,
+		createSecretProxyArgs.username,
+		password,
+		createSecretProxyArgs.address,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Set annotations and labels if provided
+	if err := setSecretMetadata(
+		secret,
+		createSecretProxyArgs.annotations,
+		createSecretProxyArgs.labels,
+	); err != nil {
+		return fmt.Errorf("unable to set metadata on secret: %w", err)
+	}
+
+	// Export the secret if the export flag is set
+	if createSecretProxyArgs.export {
+		return printSecret(secret)
+	}
+
+	// Apply the secret to the cluster
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	err = secrets.Apply(
+		ctx,
+		kubeClient,
+		secret,
+		secrets.WithForce(),
+		secrets.WithImmutable(createSecretProxyArgs.immutable),
+	)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, fmt.Sprintf("Secret %s/%s applied succefuly", secret.GetNamespace(), secret.GetName()))
+	return nil
+}

--- a/cmd/cli/create_secret_registry.go
+++ b/cmd/cli/create_secret_registry.go
@@ -1,0 +1,134 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fluxcd/pkg/runtime/secrets"
+	"github.com/spf13/cobra"
+)
+
+var createSecretRegistryCmd = &cobra.Command{
+	Use:   "registry [name]",
+	Short: "Create a Kubernetes Secret containing OCI registry credentials",
+	Example: `  # Create or update a secret with GHCR credentials for Flux operations
+  echo $GITHUB_TOKEN | flux-operator create secret registry ghcr-auth \
+  --namespace=flux-system \
+  --server=ghcr.io \
+  --username=flux \
+  --password-stdin
+
+  # Generate a registry secret and export it to a YAML file
+  flux-operator -n apps create secret registry registry-auth \
+  --server=registry.example.com \
+  --username=admin \
+  --password=secret \
+  --export > registry-auth.yaml
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: createSecretRegistryCmdRun,
+}
+
+type createSecretRegistryFlags struct {
+	username      string
+	password      string
+	passwordStdin bool
+	server        string
+
+	annotations []string
+	labels      []string
+	immutable   bool
+	export      bool
+}
+
+var createSecretRegistryArgs createSecretRegistryFlags
+
+func init() {
+	createSecretRegistryCmd.Flags().StringVar(&createSecretRegistryArgs.username, "username", "",
+		"set the username for registry authentication (required)")
+	createSecretRegistryCmd.Flags().StringVar(&createSecretRegistryArgs.password, "password", "",
+		"set the password for registry authentication (required if --password-stdin is not used)")
+	createSecretRegistryCmd.Flags().BoolVar(&createSecretRegistryArgs.passwordStdin, "password-stdin", false,
+		"read the password from stdin")
+	createSecretRegistryCmd.Flags().StringVar(&createSecretRegistryArgs.server, "server", "",
+		"set the registry server (required)")
+	createSecretRegistryCmd.Flags().StringSliceVar(&createSecretRegistryArgs.annotations, "annotation", nil,
+		"set annotations on the resource (can specify multiple annotations with commas: annotation1=value1,annotation2=value2)")
+	createSecretRegistryCmd.Flags().StringSliceVar(&createSecretRegistryArgs.labels, "label", nil,
+		"set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)")
+	createSecretRegistryCmd.Flags().BoolVar(&createSecretRegistryArgs.immutable, "immutable", false,
+		"set the immutable flag on the Secret")
+	createSecretRegistryCmd.Flags().BoolVar(&createSecretRegistryArgs.export, "export", false,
+		"export resource in YAML format to stdout")
+	createSecretCmd.AddCommand(createSecretRegistryCmd)
+}
+
+func createSecretRegistryCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("a single name can be specified")
+	}
+	name := args[0]
+	password := createSecretRegistryArgs.password
+
+	// Read the password from stdin if the flag is set
+	if createSecretRegistryArgs.passwordStdin {
+		var input string
+		_, err := fmt.Scan(&input)
+		if err != nil {
+			return fmt.Errorf("unable to read password from stdin: %w", err)
+		}
+		password = input
+	}
+
+	// Build the secret
+	secret, err := secrets.MakeRegistrySecret(
+		name,
+		*kubeconfigArgs.Namespace,
+		createSecretRegistryArgs.username,
+		password,
+		createSecretRegistryArgs.server,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Set annotations and labels if provided
+	if err := setSecretMetadata(
+		secret,
+		createSecretRegistryArgs.annotations,
+		createSecretRegistryArgs.labels,
+	); err != nil {
+		return fmt.Errorf("unable to set metadata on secret: %w", err)
+	}
+
+	// Export the secret if the export flag is set
+	if createSecretRegistryArgs.export {
+		return printSecret(secret)
+	}
+
+	// Apply the secret to the cluster
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	err = secrets.Apply(
+		ctx,
+		kubeClient,
+		secret,
+		secrets.WithForce(),
+		secrets.WithImmutable(createSecretRegistryArgs.immutable),
+	)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, fmt.Sprintf("Secret %s/%s applied succefuly", secret.GetNamespace(), secret.GetName()))
+	return nil
+}

--- a/cmd/cli/create_secret_sops.go
+++ b/cmd/cli/create_secret_sops.go
@@ -1,0 +1,197 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fluxcd/pkg/runtime/secrets"
+	"github.com/spf13/cobra"
+)
+
+var createSecretSOPSCmd = &cobra.Command{
+	Use:   "sops [name]",
+	Short: "Create a Kubernetes Secret containing SOPS decryption keys",
+	Example: `  # Create or update a secret with Age private key for Flux SOPS decryption
+  flux-operator create secret sops sops-age \
+  --namespace=flux-system \
+  --age-key-file=./age-key.txt
+
+  # Create a secret with GPG private key for Flux SOPS decryption
+  flux-operator create secret sops sops-gpg \
+  --namespace=flux-system \
+  --gpg-key-file=./private.asc
+
+  # Create a secret with both Age and GPG keys
+  flux-operator create secret sops sops-keys \
+  --namespace=flux-system \
+  --age-key-file=./age-key1.txt \
+  --age-key-file=./age-key2.txt \
+  --gpg-key-file=./private.asc
+
+  # Create a secret with Age key from stdin
+  cat ./age-key.txt | flux-operator create secret sops sops-age \
+  --namespace=flux-system \
+  --age-key-stdin
+
+  # Create a secret with GPG key from stdin
+  cat ./private.asc | flux-operator create secret sops sops-gpg \
+  --namespace=flux-system \
+  --gpg-key-stdin
+
+  # Generate a secret and export it to a YAML file
+  flux-operator -n apps create secret sops sops-keys \
+  --age-key-file=./age-key.txt \
+  --export > sops-secret.yaml
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: createSecretSOPSCmdRun,
+}
+
+type createSecretSOPSFlags struct {
+	ageKeyFiles []string
+	gpgKeyFiles []string
+	ageKeyStdin bool
+	gpgKeyStdin bool
+
+	annotations []string
+	labels      []string
+	immutable   bool
+	export      bool
+}
+
+var createSecretSOPSArgs createSecretSOPSFlags
+
+func init() {
+	createSecretSOPSCmd.Flags().StringSliceVar(&createSecretSOPSArgs.ageKeyFiles, "age-key-file", nil,
+		"path to Age private key file (can be used multiple times)")
+	createSecretSOPSCmd.Flags().StringSliceVar(&createSecretSOPSArgs.gpgKeyFiles, "gpg-key-file", nil,
+		"path to GPG private key file (can be used multiple times)")
+	createSecretSOPSCmd.Flags().BoolVar(&createSecretSOPSArgs.ageKeyStdin, "age-key-stdin", false,
+		"read Age private key from stdin")
+	createSecretSOPSCmd.Flags().BoolVar(&createSecretSOPSArgs.gpgKeyStdin, "gpg-key-stdin", false,
+		"read GPG private key from stdin")
+	createSecretSOPSCmd.Flags().StringSliceVar(&createSecretSOPSArgs.annotations, "annotation", nil,
+		"set annotations on the resource (can specify multiple annotations with commas: annotation1=value1,annotation2=value2)")
+	createSecretSOPSCmd.Flags().StringSliceVar(&createSecretSOPSArgs.labels, "label", nil,
+		"set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)")
+	createSecretSOPSCmd.Flags().BoolVar(&createSecretSOPSArgs.immutable, "immutable", false,
+		"set the immutable flag on the Secret")
+	createSecretSOPSCmd.Flags().BoolVar(&createSecretSOPSArgs.export, "export", false,
+		"export resource in YAML format to stdout")
+
+	createSecretCmd.AddCommand(createSecretSOPSCmd)
+}
+
+func createSecretSOPSCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("a single name can be specified")
+	}
+	name := args[0]
+
+	// Check that at least one key is provided
+	if len(createSecretSOPSArgs.ageKeyFiles) == 0 && len(createSecretSOPSArgs.gpgKeyFiles) == 0 &&
+		!createSecretSOPSArgs.ageKeyStdin && !createSecretSOPSArgs.gpgKeyStdin {
+		return fmt.Errorf("at least one Age or GPG key must be provided")
+	}
+
+	ageKeys := make([]string, 0)
+	gpgKeys := make([]string, 0)
+
+	// Read Age key files
+	for _, keyFile := range createSecretSOPSArgs.ageKeyFiles {
+		keyData, err := os.ReadFile(keyFile)
+		if err != nil {
+			return fmt.Errorf("unable to read Age key file %s: %w", keyFile, err)
+		}
+		ageKeys = append(ageKeys, string(keyData))
+	}
+
+	// Read GPG key files
+	for _, keyFile := range createSecretSOPSArgs.gpgKeyFiles {
+		keyData, err := os.ReadFile(keyFile)
+		if err != nil {
+			return fmt.Errorf("unable to read GPG key file %s: %w", keyFile, err)
+		}
+		gpgKeys = append(gpgKeys, string(keyData))
+	}
+
+	// Read Age key from stdin
+	if createSecretSOPSArgs.ageKeyStdin {
+		scanner := bufio.NewScanner(rootCmd.InOrStdin())
+		var lines []string
+		for scanner.Scan() {
+			lines = append(lines, scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("unable to read Age key from stdin: %w", err)
+		}
+		ageKeys = append(ageKeys, strings.Join(lines, "\n"))
+	}
+
+	// Read GPG key from stdin
+	if createSecretSOPSArgs.gpgKeyStdin {
+		scanner := bufio.NewScanner(rootCmd.InOrStdin())
+		var lines []string
+		for scanner.Scan() {
+			lines = append(lines, scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("unable to read GPG key from stdin: %w", err)
+		}
+		gpgKeys = append(gpgKeys, strings.Join(lines, "\n"))
+	}
+
+	// Build the secret
+	secret, err := secrets.MakeSOPSSecret(
+		name,
+		*kubeconfigArgs.Namespace,
+		ageKeys,
+		gpgKeys,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Set annotations and labels if provided
+	if err := setSecretMetadata(
+		secret,
+		createSecretSOPSArgs.annotations,
+		createSecretSOPSArgs.labels,
+	); err != nil {
+		return fmt.Errorf("unable to set metadata on secret: %w", err)
+	}
+
+	// Export the secret if the export flag is set
+	if createSecretSOPSArgs.export {
+		return printSecret(secret)
+	}
+
+	// Apply the secret to the cluster
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	err = secrets.Apply(
+		ctx,
+		kubeClient,
+		secret,
+		secrets.WithForce(),
+		secrets.WithImmutable(createSecretSOPSArgs.immutable),
+	)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, fmt.Sprintf("Secret %s/%s applied succefuly", secret.GetNamespace(), secret.GetName()))
+	return nil
+}

--- a/cmd/cli/create_secret_ssh.go
+++ b/cmd/cli/create_secret_ssh.go
@@ -1,0 +1,167 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/fluxcd/pkg/runtime/secrets"
+	"github.com/spf13/cobra"
+)
+
+var createSecretSSHCmd = &cobra.Command{
+	Use:   "ssh [name]",
+	Short: "Create a Kubernetes Secret containing SSH credentials",
+	Example: `  # Create or update a secret with SSH key for Flux operations
+  flux-operator create secret ssh git-ssh-auth \
+  --namespace=flux-system \
+  --private-key-file=./id_rsa \
+  --public-key-file=./id_rsa.pub \
+  --knownhosts-file=./known_hosts
+
+  # Create a secret with password-protected SSH key
+  echo "mysecretpassword" | flux-operator create secret ssh git-ssh-auth \
+  --namespace=flux-system \
+  --private-key-file=./id_rsa \
+  --knownhosts-file=./known_hosts \
+  --password-stdin
+
+  # Generate a secret and export it to a YAML file
+  flux-operator -n apps create secret ssh git-ssh \
+  --private-key-file=./id_rsa \
+  --knownhosts-file=./known_hosts \
+  --export > ssh-secret.yaml
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: createSecretSSHCmdRun,
+}
+
+type createSecretSSHFlags struct {
+	privateKeyFile string
+	publicKeyFile  string
+	knownHostsFile string
+	password       string
+	passwordStdin  bool
+
+	annotations []string
+	labels      []string
+	immutable   bool
+	export      bool
+}
+
+var createSecretSSHArgs createSecretSSHFlags
+
+func init() {
+	createSecretSSHCmd.Flags().StringVar(&createSecretSSHArgs.privateKeyFile, "private-key-file", "",
+		"path to SSH private key file (required)")
+	createSecretSSHCmd.Flags().StringVar(&createSecretSSHArgs.publicKeyFile, "public-key-file", "",
+		"path to SSH public key file (optional)")
+	createSecretSSHCmd.Flags().StringVar(&createSecretSSHArgs.knownHostsFile, "knownhosts-file", "",
+		"path to SSH known_hosts file (required)")
+	createSecretSSHCmd.Flags().StringVar(&createSecretSSHArgs.password, "password", "",
+		"password for encrypted SSH private key")
+	createSecretSSHCmd.Flags().BoolVar(&createSecretSSHArgs.passwordStdin, "password-stdin", false,
+		"read the password from stdin")
+	createSecretSSHCmd.Flags().StringSliceVar(&createSecretSSHArgs.annotations, "annotation", nil,
+		"set annotations on the resource (can specify multiple annotations with commas: annotation1=value1,annotation2=value2)")
+	createSecretSSHCmd.Flags().StringSliceVar(&createSecretSSHArgs.labels, "label", nil,
+		"set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)")
+	createSecretSSHCmd.Flags().BoolVar(&createSecretSSHArgs.immutable, "immutable", false,
+		"set the immutable flag on the Secret")
+	createSecretSSHCmd.Flags().BoolVar(&createSecretSSHArgs.export, "export", false,
+		"export resource in YAML format to stdout")
+
+	createSecretCmd.AddCommand(createSecretSSHCmd)
+}
+
+func createSecretSSHCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("a single name can be specified")
+	}
+	name := args[0]
+	password := createSecretSSHArgs.password
+
+	// Read the password from stdin if the flag is set
+	if createSecretSSHArgs.passwordStdin {
+		var input string
+		_, err := fmt.Scan(&input)
+		if err != nil {
+			return fmt.Errorf("unable to read password from stdin: %w", err)
+		}
+		password = input
+	}
+
+	// Read private key file
+	privateKey, err := os.ReadFile(createSecretSSHArgs.privateKeyFile)
+	if err != nil {
+		return fmt.Errorf("unable to read private key file: %w", err)
+	}
+
+	// Read public key file if provided
+	var publicKey []byte
+	if createSecretSSHArgs.publicKeyFile != "" {
+		publicKey, err = os.ReadFile(createSecretSSHArgs.publicKeyFile)
+		if err != nil {
+			return fmt.Errorf("unable to read public key file: %w", err)
+		}
+	}
+
+	// Read known_hosts file
+	knownHosts, err := os.ReadFile(createSecretSSHArgs.knownHostsFile)
+	if err != nil {
+		return fmt.Errorf("unable to read known_hosts file: %w", err)
+	}
+
+	// Build the secret
+	secret, err := secrets.MakeSSHSecret(
+		name,
+		*kubeconfigArgs.Namespace,
+		string(privateKey),
+		string(publicKey),
+		string(knownHosts),
+		password,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Set annotations and labels if provided
+	if err := setSecretMetadata(
+		secret,
+		createSecretSSHArgs.annotations,
+		createSecretSSHArgs.labels,
+	); err != nil {
+		return fmt.Errorf("unable to set metadata on secret: %w", err)
+	}
+
+	// Export the secret if the export flag is set
+	if createSecretSSHArgs.export {
+		return printSecret(secret)
+	}
+
+	// Apply the secret to the cluster
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	err = secrets.Apply(
+		ctx,
+		kubeClient,
+		secret,
+		secrets.WithForce(),
+		secrets.WithImmutable(createSecretSSHArgs.immutable),
+	)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, fmt.Sprintf("Secret %s/%s applied succefuly", secret.GetNamespace(), secret.GetName()))
+	return nil
+}

--- a/cmd/cli/create_secret_tls.go
+++ b/cmd/cli/create_secret_tls.go
@@ -1,0 +1,137 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/fluxcd/pkg/runtime/secrets"
+	"github.com/spf13/cobra"
+)
+
+var createSecretTLSCmd = &cobra.Command{
+	Use:   "tls [name]",
+	Short: "Create a Kubernetes Secret containing TLS certs",
+	Example: `  # Create or update a secret with mTLS certs for Flux operations
+  flux-operator create secret tls tls-auth \
+  --namespace=flux-system \
+  --tls-crt-file=./tls.crt \
+  --tls-key-file=./tls.key \
+  --ca-crt-file=./ca.crt
+
+  # Generate a secret with a TLS CA cert and export it to a YAML file
+  flux-operator -n apps create secret tls tls-ca \
+  --ca-crt-file=./ca.crt \
+  --export > tls-ca.yaml
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: createSecretTLSCmdRun,
+}
+
+type createSecretTLSFlags struct {
+	tlsCrtFile string
+	tlsKeyFile string
+	caCrtFile  string
+
+	annotations []string
+	labels      []string
+	immutable   bool
+	export      bool
+}
+
+var createSecretTLSArgs createSecretTLSFlags
+
+func init() {
+	createSecretTLSCmd.Flags().StringVar(&createSecretTLSArgs.tlsCrtFile, "tls-crt-file", "",
+		"path to TLS client certificate file")
+	createSecretTLSCmd.Flags().StringVar(&createSecretTLSArgs.tlsKeyFile, "tls-key-file", "",
+		"path to TLS client private key file")
+	createSecretTLSCmd.Flags().StringVar(&createSecretTLSArgs.caCrtFile, "ca-crt-file", "",
+		"path to CA certificate file (optional)")
+	createSecretTLSCmd.Flags().StringSliceVar(&createSecretTLSArgs.annotations, "annotation", nil,
+		"set annotations on the resource (can specify multiple annotations with commas: annotation1=value1,annotation2=value2)")
+	createSecretTLSCmd.Flags().StringSliceVar(&createSecretTLSArgs.labels, "label", nil,
+		"set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)")
+	createSecretTLSCmd.Flags().BoolVar(&createSecretTLSArgs.immutable, "immutable", false,
+		"set the immutable flag on the Secret")
+	createSecretTLSCmd.Flags().BoolVar(&createSecretTLSArgs.export, "export", false,
+		"export resource in YAML format to stdout")
+	createSecretCmd.AddCommand(createSecretTLSCmd)
+}
+
+func createSecretTLSCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("a single name can be specified")
+	}
+	name := args[0]
+
+	tlsOpts := []secrets.TLSSecretOption{}
+
+	// Read client certs if provided
+	if createSecretTLSArgs.tlsCrtFile != "" && createSecretTLSArgs.tlsKeyFile != "" {
+		tlsCrt, err := os.ReadFile(createSecretTLSArgs.tlsCrtFile)
+		if err != nil {
+			return fmt.Errorf("unable to read TLS certificate file: %w", err)
+		}
+		tlsKey, err := os.ReadFile(createSecretTLSArgs.tlsKeyFile)
+		if err != nil {
+			return fmt.Errorf("unable to read TLS private key file: %w", err)
+		}
+		tlsOpts = append(tlsOpts, secrets.WithCertKeyPair(tlsCrt, tlsKey))
+	}
+
+	// Read CA file if provided
+	if createSecretTLSArgs.caCrtFile != "" {
+		caCrt, err := os.ReadFile(createSecretTLSArgs.caCrtFile)
+		if err != nil {
+			return fmt.Errorf("unable to read CA certificate file: %w", err)
+		}
+		tlsOpts = append(tlsOpts, secrets.WithCAData(caCrt))
+	}
+
+	// Build the secret
+	secret, err := secrets.MakeTLSSecret(name, *kubeconfigArgs.Namespace, tlsOpts...)
+	if err != nil {
+		return err
+	}
+
+	// Set annotations and labels if provided
+	if err := setSecretMetadata(
+		secret,
+		createSecretTLSArgs.annotations,
+		createSecretTLSArgs.labels,
+	); err != nil {
+		return fmt.Errorf("unable to set metadata on secret: %w", err)
+	}
+
+	// Export the secret if the export flag is set
+	if createSecretTLSArgs.export {
+		return printSecret(secret)
+	}
+
+	// Apply the secret to the cluster
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	err = secrets.Apply(
+		ctx,
+		kubeClient,
+		secret,
+		secrets.WithForce(),
+		secrets.WithImmutable(createSecretTLSArgs.immutable),
+	)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, fmt.Sprintf("Secret %s/%s applied succefuly", secret.GetNamespace(), secret.GetName()))
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/marketplacemetering v1.29.2
 	github.com/fluxcd/cli-utils v0.36.0-flux.14
 	github.com/fluxcd/pkg/apis/kustomize v1.11.0
-	github.com/fluxcd/pkg/apis/meta v1.15.0
+	github.com/fluxcd/pkg/apis/meta v1.16.0
 	github.com/fluxcd/pkg/auth v0.20.0
 	github.com/fluxcd/pkg/cache v0.10.0
 	github.com/fluxcd/pkg/git v0.33.0
 	github.com/fluxcd/pkg/kustomize v1.19.0
-	github.com/fluxcd/pkg/runtime v0.66.0
+	github.com/fluxcd/pkg/runtime v0.68.0
 	github.com/fluxcd/pkg/ssa v0.51.0
 	github.com/fluxcd/pkg/tar v0.13.0
 	github.com/fluxcd/pkg/version v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/fluxcd/pkg/apis/event v0.18.0 h1:PNbWk9gvX8gMIi6VsJapnuDO+giLEeY+6olL
 github.com/fluxcd/pkg/apis/event v0.18.0/go.mod h1:7S/DGboLolfbZ6stO6dcDhG1SfkPWQ9foCULvbiYpiA=
 github.com/fluxcd/pkg/apis/kustomize v1.11.0 h1:0IzDgxZkc4v+5SDNCvgZhfwfkdkQLPXCner7TNaJFWE=
 github.com/fluxcd/pkg/apis/kustomize v1.11.0/go.mod h1:j302mJGDww8cn9qvMsRQ0LJ1HPAPs/IlX7CSsoJV7BI=
-github.com/fluxcd/pkg/apis/meta v1.15.0 h1:kvpju2J2r3DfpOMUFIgHkAE2qwI6219TvezFRGxYi2w=
-github.com/fluxcd/pkg/apis/meta v1.15.0/go.mod h1:97l3hTwBpJbXBY+wetNbqrUsvES8B1jGioKcBUxmqd8=
+github.com/fluxcd/pkg/apis/meta v1.16.0 h1:XbtIDWVH09CGcFApzp+WgWW3NYTNr+lIjq2ZLimIkQE=
+github.com/fluxcd/pkg/apis/meta v1.16.0/go.mod h1:97l3hTwBpJbXBY+wetNbqrUsvES8B1jGioKcBUxmqd8=
 github.com/fluxcd/pkg/auth v0.20.0 h1:uNWkx28InC5YbgeNG7EMcpk9dkZc4w6Q7bUwDga28x0=
 github.com/fluxcd/pkg/auth v0.20.0/go.mod h1:EU+cYkXJNXBIQ+JoeVqx4wFtlsDiTSEjn1iP5Sa4PCk=
 github.com/fluxcd/pkg/cache v0.10.0 h1:M+OGDM4da1cnz7q+sZSBtkBJHpiJsLnKVmR9OdMWxEY=
@@ -119,8 +119,8 @@ github.com/fluxcd/pkg/git v0.33.0 h1:ZzScdBLGkHbJxYqAW2PB14bbUHX1VUi+huNvX0ZTu5A
 github.com/fluxcd/pkg/git v0.33.0/go.mod h1:F9Asm3MlLW4uZx3FF92+bqho+oktdMdnTn/QmXe56NE=
 github.com/fluxcd/pkg/kustomize v1.19.0 h1:2eO8lMx0/H/Yyq35LMTAMhxEElOzMW0Yi9zUNZoimlU=
 github.com/fluxcd/pkg/kustomize v1.19.0/go.mod h1:OCCW9vU3lStDh3jyg9MM/a29MSdNAVk2wjl0lDos5Fs=
-github.com/fluxcd/pkg/runtime v0.66.0 h1:efOrHg/a+q0iUInCZ+dnTZRG8sk89sW340SC93HhnHg=
-github.com/fluxcd/pkg/runtime v0.66.0/go.mod h1:2/cfa1WspakXzEol7tstyzShAQb43pHa8FEXq7vCMf8=
+github.com/fluxcd/pkg/runtime v0.68.0 h1:RtUwUOA7pxlptXZkWpp0iOxiNORkPx1HW1BHDUIQVvs=
+github.com/fluxcd/pkg/runtime v0.68.0/go.mod h1:HkXWJInVIT/1Ej5rLXseAJR658wAlOre/kf9UNOMyx4=
 github.com/fluxcd/pkg/sourceignore v0.13.0 h1:ZvkzX2WsmyZK9cjlqOFFW1onHVzhPZIqDbCh96rPqbU=
 github.com/fluxcd/pkg/sourceignore v0.13.0/go.mod h1:Z9H1GoBx0ljOhptnzoV0PL6Nd/UzwKcSphP27lqb4xI=
 github.com/fluxcd/pkg/ssa v0.51.0 h1:sFarxKZcS0J8sjq9qvs/r+1XiJqNgRodEiPjV75F8R4=


### PR DESCRIPTION
The `flux-operator create secret` commands are used to create Kubernetes secrets specific to Flux.
These commands can be used to create or update secrets directly in the cluster, or to export them in YAML format.

The following commands are available:

- `flux-operator create secret basic-auth`: Create a Kubernetes Secret containing basic auth credentials.
  - `--username`: Set the username for basic authentication (required).
  - `--password`: Set the password for basic authentication (required if --password-stdin is not used).
  - `--password-stdin`: Read the password from stdin.
- `flux-operator create secret githubapp`: Create a Kubernetes Secret containing GitHub App credentials.
  - `--app-id`: GitHub App ID (required).
  - `--app-installation-id`: GitHub App Installation ID (required).
  - `--app-private-key-file`: Path to GitHub App private key file (required).
  - `--app-base-url`: GitHub base URL for GitHub Enterprise Server (optional).
- `flux-operator create secret proxy`: Create a Kubernetes Secret containing HTTP/S proxy credentials.
  - `--address`: Set the proxy address (required).
  - `--username`: Set the username for proxy authentication (optional).
  - `--password`: Set the password for proxy authentication (optional).
  - `--password-stdin`: Read the password from stdin.
- `flux-operator create secret registry`: Create a Kubernetes Secret containing registry credentials.
  - `--server`: Set the registry server (required).
  - `--username`: Set the username for registry authentication (required).
  - `--password`: Set the password for registry authentication (required if --password-stdin is not used).
  - `--password-stdin`: Read the password from stdin.
- `flux-operator create secret sops`: Create a Kubernetes Secret containing SOPS decryption keys.
  - `--age-key-file`: Path to Age private key file (can be used multiple times).
  - `--gpg-key-file`: Path to GPG private key file (can be used multiple times).
  - `--age-key-stdin`: Read Age private key from stdin.
  - `--gpg-key-stdin`: Read GPG private key from stdin.
- `flux-operator create secret ssh`: Create a Kubernetes Secret containing SSH credentials.
  - `--private-key-file`: Path to SSH private key file (required).
  - `--public-key-file`: Path to SSH public key file (optional).
  - `--knownhosts-file`: Path to SSH known_hosts file (required).
  - `--password`: Password for encrypted SSH private key (optional).
  - `--password-stdin`: Read the password from stdin.
- `flux-operator create secret tls`: Create a Kubernetes Secret containing TLS certs.
  - `--tls-crt-file`: Path to TLS client certificate file.
  - `--tls-key-file`: Path to TLS client private key file.
  - `--ca-crt-file`: Path to CA certificate file (optional).

Arguments:

- `-n, --namespace`: Specifies the namespace to create the secret in.
- `--annotation`: Set annotations on the resource (can specify multiple annotations with commas: annotation1=value1,annotation2=value2).
- `--label`: Set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2).
- `--immutable`: Set the immutable flag on the Secret.
- `--export`: Export secret in YAML format to stdout instead of creating it in the cluster.