### PR TITLE
cli: Add `--inputs-from-provider` flag to `flux-operator build rset` command 

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -50,6 +50,7 @@ The following commands are available:
 - `flux-operator build rset`: Generates the Kubernetes manifests from a ResourceSet definition.
     - `-f, --file`: Path to the ResourceSet YAML manifest (required).
     - `--inputs-from`: Path to the ResourceSet inputs YAML manifest.
+    - `--inputs-from-provider`: Path to the ResourceSetInputProvider static type YAML manifest.
 
 ### Get Commands
 

--- a/cmd/cli/build_resourceset_test.go
+++ b/cmd/cli/build_resourceset_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+/*
+To regenerate the golden file:
+make cli-build
+./bin/flux-operator-cli build resourceset \
+-f cmd/cli/testdata/build_resourceset/rset-with-rsip.yaml \
+--inputs-from-provider cmd/cli/testdata/build_resourceset/rsip.yaml \
+> cmd/cli/testdata/build_resourceset/golden.yaml
+*/
+
+func TestBuildResourceSetCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "standalone resourceset",
+			args: []string{"build", "resourceset", "-f", "testdata/build_resourceset/rset-standalone.yaml"},
+		},
+		{
+			name: "resourceset with input provider",
+			args: []string{"build", "resourceset", "-f", "testdata/build_resourceset/rset-with-rsip.yaml", "--inputs-from-provider", "testdata/build_resourceset/rsip.yaml"},
+		},
+		{
+			name:        "no filename flag",
+			args:        []string{"build", "resourceset"},
+			expectError: true,
+			errorMsg:    "--filename is required",
+		},
+		{
+			name:        "invalid filename",
+			args:        []string{"build", "resourceset", "-f", "nonexistent.yaml"},
+			expectError: true,
+			errorMsg:    "must point to an existing file",
+		},
+		{
+			name:        "resourceset with inputsFrom but no provider",
+			args:        []string{"build", "resourceset", "-f", "testdata/build_resourceset/rset-with-rsip.yaml"},
+			expectError: true,
+			errorMsg:    "please provide the inputs with --inputs-from",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			output, err := executeCommand(tt.args)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorMsg != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorMsg))
+				}
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(output).ToNot(BeEmpty())
+
+			// Read expected golden output
+			expectedBytes, err := os.ReadFile("testdata/build_resourceset/golden.yaml")
+			g.Expect(err).ToNot(HaveOccurred())
+			expected := string(expectedBytes)
+
+			g.Expect(output).To(Equal(expected))
+		})
+	}
+}
+
+func TestBuildResourceSetCmdWithInputsFile(t *testing.T) {
+	g := NewWithT(t)
+	rsetFile := "testdata/build_resourceset/rset-with-rsip.yaml"
+	inputsFile := "testdata/build_resourceset/inputs.yaml"
+
+	// Execute command with inputs file
+	output, err := executeCommand([]string{"build", "rset", "-f", rsetFile, "--inputs-from", inputsFile})
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).ToNot(BeEmpty())
+
+	// Read expected golden output
+	expectedBytes, err := os.ReadFile("testdata/build_resourceset/golden.yaml")
+	g.Expect(err).ToNot(HaveOccurred())
+	expected := string(expectedBytes)
+
+	g.Expect(output).To(Equal(expected))
+}

--- a/cmd/cli/testdata/build_resourceset/golden.yaml
+++ b/cmd/cli/testdata/build_resourceset/golden.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  annotations:
+    fluxcd.controlplane.io/id: "340788154"
+  labels:
+    resourceset.fluxcd.controlplane.io/name: apps
+    resourceset.fluxcd.controlplane.io/namespace: test
+  name: app1
+  namespace: team1-staging
+spec:
+  interval: 10m
+  ref:
+    tag: v1.0.1
+  url: oci://registry.example.com/app1
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  annotations:
+    fluxcd.controlplane.io/id: "340788154"
+  labels:
+    resourceset.fluxcd.controlplane.io/name: apps
+    resourceset.fluxcd.controlplane.io/namespace: test
+  name: app1
+  namespace: team1-staging
+spec:
+  interval: 1h
+  path: ./
+  prune: true
+  sourceRef:
+    kind: OCIRepository
+    name: app1
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  annotations:
+    fluxcd.controlplane.io/id: "340788154"
+  labels:
+    resourceset.fluxcd.controlplane.io/name: apps
+    resourceset.fluxcd.controlplane.io/namespace: test
+  name: app1
+  namespace: team1-production
+spec:
+  interval: 10m
+  ref:
+    tag: v1.0.0
+  url: oci://registry.example.com/app1
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  annotations:
+    fluxcd.controlplane.io/id: "340788154"
+  labels:
+    resourceset.fluxcd.controlplane.io/name: apps
+    resourceset.fluxcd.controlplane.io/namespace: test
+  name: app1
+  namespace: team1-production
+spec:
+  interval: 1h
+  path: ./
+  prune: true
+  sourceRef:
+    kind: OCIRepository
+    name: app1

--- a/cmd/cli/testdata/build_resourceset/inputs.yaml
+++ b/cmd/cli/testdata/build_resourceset/inputs.yaml
@@ -1,0 +1,9 @@
+- tenantName: team1
+  id: 340788154
+  applications:
+    - name: app1
+      envs:
+        - name: staging
+          version: v1.0.1
+        - name: production
+          version: v1.0.0

--- a/cmd/cli/testdata/build_resourceset/rset-standalone.yaml
+++ b/cmd/cli/testdata/build_resourceset/rset-standalone.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: apps
+  namespace: test
+spec:
+  inputs:
+    - tenantName: team1
+      id: 340788154
+      applications:
+        - name: app1
+          envs:
+            - name: staging
+              version: v1.0.1
+            - name: production
+              version: v1.0.0
+  resourcesTemplate: |
+    <<- $id := inputs.id >>    
+    <<- $tenant := inputs.tenantName >>
+    <<- range $app := inputs.applications >>
+    <<- $appName := $app.name >>
+    <<- range $env := $app.envs >>
+    ---
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: OCIRepository
+    metadata:
+      name: << $appName >>
+      namespace: << $tenant >>-<< $env.name >>
+      annotations:
+        fluxcd.controlplane.io/id: << $id | quote >>
+    spec:
+      interval: 10m
+      url: oci://registry.example.com/<< $appName >>
+      ref:
+        tag: << $env.version >>
+    ---
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    metadata:
+      name: << $appName >>
+      namespace: << $tenant >>-<< $env.name >>
+      annotations:
+        fluxcd.controlplane.io/id: << $id | quote >>
+    spec:
+      interval: 1h
+      prune: true
+      sourceRef:
+        kind: OCIRepository
+        name: << $appName >>
+      path: ./
+    <<- end >>
+    <<- end >>

--- a/cmd/cli/testdata/build_resourceset/rset-with-rsip.yaml
+++ b/cmd/cli/testdata/build_resourceset/rset-with-rsip.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: apps
+  namespace: test
+spec:
+  inputsFrom:
+   - kind: ResourceSetInputProvider
+     selector:
+       matchLabels:
+         fluxcd.controlplane.io/role: provisioning
+  resourcesTemplate: |
+    <<- $id := inputs.id >>
+    <<- $tenant := inputs.tenantName >>
+    <<- range $app := inputs.applications >>
+    <<- $appName := $app.name >>
+    <<- range $env := $app.envs >>
+    ---
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: OCIRepository
+    metadata:
+      name: << $appName >>
+      namespace: << $tenant >>-<< $env.name >>
+      annotations:
+        fluxcd.controlplane.io/id: << $id | quote >>
+    spec:
+      interval: 10m
+      url: oci://registry.example.com/<< $appName >>
+      ref:
+        tag: << $env.version >>
+    ---
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    metadata:
+      name: << $appName >>
+      namespace: << $tenant >>-<< $env.name >>
+      annotations:
+        fluxcd.controlplane.io/id: << $id | quote >>
+    spec:
+      interval: 1h
+      prune: true
+      sourceRef:
+        kind: OCIRepository
+        name: << $appName >>
+      path: ./
+    <<- end >>
+    <<- end >>

--- a/cmd/cli/testdata/build_resourceset/rsip.yaml
+++ b/cmd/cli/testdata/build_resourceset/rsip.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: team1-apps
+  namespace: test
+  labels:
+    fluxcd.controlplane.io/role: provisioning
+spec:
+  type: Static
+  defaultValues:
+    tenantName: team1
+    applications:
+      - name: app1
+        envs:
+          - name: staging
+            version: v1.0.1
+          - name: production
+            version: v1.0.0


### PR DESCRIPTION
Build a ResourceSet by providing the inputs from a static ResourceSetInputProvider:

```
  flux-operator build resourceset -f my-resourceset.yaml \
    --inputs-from-provider my-resourcesetinputprovider.yaml
```