### PR TITLE
cli: Add `flux-operator trace` command

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -126,6 +126,17 @@ including their reconciliation status and the amount of cumulative storage used 
 
 - `flux-operator stats`: Displays statistics about the Flux resources in the cluster.
 
+### Trace Command
+
+This command is used to trace Kubernetes objects throughout the GitOps delivery pipeline
+to identify which Flux reconciler manages them and from which source they originate.
+
+- `flux-operator trace <kind>/<name>`: Trace a Kubernetes object to its Flux reconciler and source.
+
+Arguments:
+
+- `-n, --namespace`: Specifies the namespace scope of the command.
+
 ### Create Secret Commands
 
 The `flux-operator create secret` commands are used to create Kubernetes secrets specific to Flux.

--- a/cmd/cli/trace.go
+++ b/cmd/cli/trace.go
@@ -1,0 +1,186 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var traceCmd = &cobra.Command{
+	Use:   "trace [kind/name]",
+	Short: "Trace in-cluster objects throughout the GitOps delivery pipeline",
+	Example: `  # Trace a Kubernetes Deployment
+  flux-operator -n flux-system trace deploy/source-controller
+
+  # Trace a Kubernetes Pod
+  flux-operator -n redis trace pod/redis-master-0
+
+  # Trace a Kubernetes Namespace
+  flux-operator trace ns/flux-system
+
+  # Trace a Kubernetes custom resource
+  flux-operator -n flux-system trace ResourceSet/apps
+`,
+	RunE: traceCmdRun,
+}
+
+func init() {
+	rootCmd.AddCommand(traceCmd)
+}
+
+func traceCmdRun(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	obj, err := getObjectByKindName(args)
+	if err != nil {
+		return err
+	}
+
+	managedObj := NewFluxManagedObject(obj)
+
+	reconciler, err := getFluxReconcilerFromOwner(ctx, kubeClient, obj)
+	if err != nil {
+		return fmt.Errorf("failed to trace '%s/%s': %w", obj.GetKind(), obj.GetName(), err)
+	}
+
+	err = managedObj.Compute(ctx, kubeClient, reconciler)
+	if err != nil {
+		return fmt.Errorf("failed to trace '%s/%s': %w", obj.GetKind(), obj.GetName(), err)
+	}
+
+	// Build template from the managed object and print the trace
+	tmpl, err := template.New("trace").Parse(traceTmpl)
+	if err != nil {
+		return fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	err = tmpl.Execute(cmd.OutOrStdout(), managedObj)
+	if err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return nil
+}
+
+// getFluxReconciler retrieves the Flux reconciler information
+// from the labels of the provided unstructured object.
+func getFluxReconciler(obj *unstructured.Unstructured) (*FluxManagedObjectReconciler, error) {
+	manager := &FluxManagedObjectReconciler{}
+
+	for k, v := range obj.GetLabels() {
+		if k == "app.kubernetes.io/managed-by" && v == "flux-operator" {
+			manager.Kind = "FluxInstance"
+			manager.Name = obj.GetLabels()["fluxcd.controlplane.io/name"]
+			manager.Namespace = obj.GetLabels()["fluxcd.controlplane.io/namespace"]
+			break
+		}
+
+		if !strings.Contains(k, "fluxcd.") {
+			continue
+		}
+
+		if strings.HasSuffix(k, "/name") {
+			parts := strings.Split(k, ".")
+			if len(parts) > 0 {
+				switch parts[0] {
+				case "kustomize":
+					manager.Kind = "Kustomization"
+				case "helm":
+					manager.Kind = "HelmRelease"
+				case "resourceset":
+					manager.Kind = "ResourceSet"
+				}
+			}
+			manager.Name = v
+		} else if strings.HasSuffix(k, "/namespace") {
+			manager.Namespace = v
+		}
+	}
+
+	if manager.Kind == "" || manager.Name == "" || manager.Namespace == "" {
+		return nil, errors.New("object not managed by Flux")
+	}
+	return manager, nil
+}
+
+// getFluxReconcilerFromOwner recursively retrieves the Flux manager
+// from the owner references of an object.
+func getFluxReconcilerFromOwner(ctx context.Context, kubeClient client.Client, obj *unstructured.Unstructured) (*FluxManagedObjectReconciler, error) {
+	if m, err := getFluxReconciler(obj); err == nil {
+		return m, nil
+	}
+
+	for _, reference := range obj.GetOwnerReferences() {
+		owner := &unstructured.Unstructured{}
+		gv, err := schema.ParseGroupVersion(reference.APIVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		owner.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   gv.Group,
+			Version: gv.Version,
+			Kind:    reference.Kind,
+		})
+
+		ownerName := types.NamespacedName{
+			Namespace: obj.GetNamespace(),
+			Name:      reference.Name,
+		}
+
+		err = kubeClient.Get(ctx, ownerName, owner)
+		if err != nil {
+			return nil, err
+		}
+
+		if m, err := getFluxReconciler(owner); err == nil {
+			return m, nil
+		}
+
+		if len(owner.GetOwnerReferences()) > 0 {
+			return getFluxReconcilerFromOwner(ctx, kubeClient, owner)
+		}
+	}
+
+	return nil, errors.New("object not managed by Flux")
+}
+
+var traceTmpl = `Object:          {{.ID}}
+{{- if .Reconciler }}
+{{- if eq .Reconciler.Ready "False" }}
+Status:          Last reconciliation failed at {{.Reconciler.LastReconciled}}
+{{- else }}
+Status:          Last reconciled at {{.Reconciler.LastReconciled}}
+{{- end }}
+Revision:        {{.Reconciler.Revision}}
+Reconciler:      {{.Reconciler.Kind}}/{{.Reconciler.Namespace}}/{{.Reconciler.Name}}
+{{- if .Source }}
+Source:          {{.Source.Kind}}/{{.Source.Namespace}}/{{.Source.Name}}
+Source URL:      {{.Source.URL}}
+{{- if .Source.OriginURL }}
+Origin URL:      {{.Source.OriginURL}}
+{{- end }}
+{{- if .Source.OriginRevision }}
+Origin Revision: {{.Source.OriginRevision}}
+{{- end }}
+{{- end }}
+Message:         {{.Reconciler.ReadyMessage}}
+{{- end }}
+`

--- a/cmd/cli/trace_test.go
+++ b/cmd/cli/trace_test.go
@@ -1,0 +1,184 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestFluxManagedObjectReconciler(t *testing.T) {
+	tests := []struct {
+		name        string
+		obj         *unstructured.Unstructured
+		expected    *FluxManagedObjectReconciler
+		expectError bool
+	}{
+		{
+			name: "FluxInstance managed object",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ServiceAccount",
+					"metadata": map[string]any{
+						"name":      "kustomize-controller",
+						"namespace": "flux-system",
+						"labels": map[string]any{
+							"app.kubernetes.io/managed-by":     "flux-operator",
+							"fluxcd.controlplane.io/name":      "flux",
+							"fluxcd.controlplane.io/namespace": "flux-system",
+						},
+					},
+				},
+			},
+			expected: &FluxManagedObjectReconciler{
+				Kind:      "FluxInstance",
+				Name:      "flux",
+				Namespace: "flux-system",
+			},
+			expectError: false,
+		},
+		{
+			name: "Kustomization managed object",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "test-cm",
+						"namespace": "default",
+						"labels": map[string]any{
+							"kustomize.toolkit.fluxcd.io/name":      "podinfo",
+							"kustomize.toolkit.fluxcd.io/namespace": "default",
+						},
+					},
+				},
+			},
+			expected: &FluxManagedObjectReconciler{
+				Kind:      "Kustomization",
+				Name:      "podinfo",
+				Namespace: "default",
+			},
+			expectError: false,
+		},
+		{
+			name: "HelmRelease managed object",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"metadata": map[string]any{
+						"name":      "test-secret",
+						"namespace": "default",
+						"labels": map[string]any{
+							"helm.toolkit.fluxcd.io/name":      "nginx",
+							"helm.toolkit.fluxcd.io/namespace": "nginx-system",
+						},
+					},
+				},
+			},
+			expected: &FluxManagedObjectReconciler{
+				Kind:      "HelmRelease",
+				Name:      "nginx",
+				Namespace: "nginx-system",
+			},
+			expectError: false,
+		},
+		{
+			name: "ResourceSet managed object",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Service",
+					"metadata": map[string]any{
+						"name":      "test-svc",
+						"namespace": "default",
+						"labels": map[string]any{
+							"resourceset.fluxcd.controlplane.io/name":      "my-resources",
+							"resourceset.fluxcd.controlplane.io/namespace": "flux-system",
+						},
+					},
+				},
+			},
+			expected: &FluxManagedObjectReconciler{
+				Kind:      "ResourceSet",
+				Name:      "my-resources",
+				Namespace: "flux-system",
+			},
+			expectError: false,
+		},
+		{
+			name: "Object not managed by Flux",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "test-cm",
+						"namespace": "default",
+						"labels": map[string]any{
+							"app": "my-app",
+						},
+					},
+				},
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "Object with incomplete Flux labels",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "test-cm",
+						"namespace": "default",
+						"labels": map[string]any{
+							"kustomize.toolkit.fluxcd.io/name": "podinfo",
+							// Missing namespace label
+						},
+					},
+				},
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "Object with no labels",
+			obj: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "test-cm",
+						"namespace": "default",
+					},
+				},
+			},
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result, err := getFluxReconciler(tt.obj)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result.Kind).To(Equal(tt.expected.Kind))
+			g.Expect(result.Name).To(Equal(tt.expected.Name))
+			g.Expect(result.Namespace).To(Equal(tt.expected.Namespace))
+		})
+	}
+}

--- a/cmd/cli/trace_types.go
+++ b/cmd/cli/trace_types.go
@@ -1,0 +1,292 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+// FluxManagedObject represents a Kubernetes object managed by a Flux reconciler.
+// It contains an identifier for the object and information about the Flux reconciler
+// that manages it.
+type FluxManagedObject struct {
+	ID         string
+	Reconciler *FluxManagedObjectReconciler
+	Source     *FluxManagedObjectSource
+}
+
+// FluxManagedObjectReconciler represents a Flux reconciler (such as Kustomization,
+// HelmRelease, or ResourceSet) that manages Kubernetes objects. It contains the
+// reconciler's identity, status, and operational information.
+type FluxManagedObjectReconciler struct {
+	Kind           string
+	Name           string
+	Namespace      string
+	Ready          string
+	ReadyMessage   string
+	LastReconciled string
+	Revision       string
+}
+
+// FluxManagedObjectSource holds the Flux source info of a managed object.
+// It includes the upstream URL, origin URL, and origin revision.
+type FluxManagedObjectSource struct {
+	Kind           string
+	Name           string
+	Namespace      string
+	URL            string
+	OriginURL      string
+	OriginRevision string
+}
+
+// NewFluxManagedObject creates a new FluxManagedObject from a Kubernetes object.
+// It generates an ID based on the object's kind, namespace, and name.
+func NewFluxManagedObject(obj *unstructured.Unstructured) *FluxManagedObject {
+	id := fmt.Sprintf("%s/%s", obj.GetKind(), obj.GetName())
+	if obj.GetNamespace() != "" {
+		id = fmt.Sprintf("%s/%s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+	}
+
+	return &FluxManagedObject{
+		ID: id,
+	}
+}
+
+// Compute queries the cluster for the reconciler and the source of the Flux managed object.
+func (f *FluxManagedObject) Compute(
+	ctx context.Context,
+	kubeClient client.Client,
+	reconciler *FluxManagedObjectReconciler,
+) error {
+	gvk, err := preferredFluxGVK(reconciler.Kind, kubeconfigArgs)
+	if err != nil {
+		return fmt.Errorf("unable to get gvk for kind %s: %w", reconciler.Kind, err)
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(*gvk)
+
+	namespacedName := types.NamespacedName{
+		Namespace: reconciler.Namespace,
+		Name:      reconciler.Name,
+	}
+
+	err = kubeClient.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return fmt.Errorf("unable to get %s %s: %w", reconciler.Kind, namespacedName, err)
+	}
+
+	// Extract reconciler status information
+	extractReconcilerStatus(obj, reconciler)
+
+	// Extract source information
+	source, err := f.extractSource(ctx, kubeClient, obj, reconciler)
+	if err == nil {
+		f.Source = source
+	}
+
+	f.Reconciler = reconciler
+	return nil
+}
+
+// extractReconcilerStatus extracts status information from a reconciler object.
+func extractReconcilerStatus(obj *unstructured.Unstructured, reconciler *FluxManagedObjectReconciler) {
+	// Initialize defaults
+	reconciler.Ready = "Unknown"
+	reconciler.ReadyMessage = "Not initialized"
+	reconciler.LastReconciled = "Unknown"
+	reconciler.Revision = "Unknown"
+
+	// Extract the ready status from conditions
+	if conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions"); found && err == nil {
+		for _, cond := range conditions {
+			if condition, ok := cond.(map[string]any); ok && condition["type"] == meta.ReadyCondition {
+				reconciler.Ready = condition["status"].(string)
+				if msg, exists := condition["message"]; exists {
+					reconciler.ReadyMessage = msg.(string)
+				}
+				if lastTransitionTime, exists := condition["lastTransitionTime"]; exists {
+					reconciler.LastReconciled = lastTransitionTime.(string)
+				}
+			}
+		}
+	}
+
+	// Check for suspend annotation
+	if ssautil.AnyInMetadata(obj,
+		map[string]string{fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue}) {
+		reconciler.Ready = "Suspended"
+	}
+
+	// Check for suspend spec field
+	if suspend, found, err := unstructured.NestedBool(obj.Object, "spec", "suspend"); suspend && found && err == nil {
+		reconciler.Ready = "Suspended"
+	}
+
+	// Extract the revision from status
+	if lastAttemptedRevision, found, err := unstructured.NestedString(obj.Object, "status", "lastAttemptedRevision"); found && err == nil {
+		reconciler.Revision = lastAttemptedRevision
+	}
+	if lastAppliedRevision, found, err := unstructured.NestedString(obj.Object, "status", "lastAppliedRevision"); found && err == nil {
+		reconciler.Revision = lastAppliedRevision
+	}
+}
+
+// extractSource extracts source information from a reconciler object.
+func (f *FluxManagedObject) extractSource(
+	ctx context.Context,
+	kubeClient client.Client,
+	obj *unstructured.Unstructured,
+	reconciler *FluxManagedObjectReconciler,
+) (*FluxManagedObjectSource, error) {
+	switch reconciler.Kind {
+	case "Kustomization":
+		if sourceRef, found, err := unstructured.NestedMap(obj.Object, "spec", "sourceRef"); found && err == nil {
+			if name, exists := sourceRef["name"]; exists {
+				if kind, exists := sourceRef["kind"]; exists {
+					namespace := reconciler.Namespace // Default to reconciler's namespace
+					if ns, exists := sourceRef["namespace"]; exists && ns != "" {
+						namespace = ns.(string)
+					}
+					return f.buildSourceFromRef(ctx, kubeClient, kind.(string), namespace, name.(string))
+				}
+			}
+		}
+	case "HelmRelease":
+		// Try spec.chartRef (direct chart reference)
+		if chartRef, found, err := unstructured.NestedMap(obj.Object, "spec", "chartRef"); found && err == nil {
+			if name, exists := chartRef["name"]; exists {
+				if kind, exists := chartRef["kind"]; exists {
+					namespace := reconciler.Namespace // Default to reconciler's namespace
+					if ns, exists := chartRef["namespace"]; exists && ns != "" {
+						namespace = ns.(string)
+					}
+					return f.buildSourceFromRef(ctx, kubeClient, kind.(string), namespace, name.(string))
+				}
+			}
+		} else if chartSourceRef, found, err := unstructured.NestedMap(obj.Object, "spec", "chart", "spec", "sourceRef"); found && err == nil {
+			// Fall back to spec.chart.spec.sourceRef (chart from Git/Helm repository)
+			if name, exists := chartSourceRef["name"]; exists {
+				if kind, exists := chartSourceRef["kind"]; exists {
+					namespace := reconciler.Namespace // Default to reconciler's namespace
+					if ns, exists := chartSourceRef["namespace"]; exists && ns != "" {
+						namespace = ns.(string)
+					}
+					return f.buildSourceFromRef(ctx, kubeClient, kind.(string), namespace, name.(string))
+				}
+			}
+		}
+	}
+	return nil, fmt.Errorf("no source reference found")
+}
+
+// buildSourceFromRef builds a FluxManagedObjectSource from source reference information.
+func (f *FluxManagedObject) buildSourceFromRef(
+	ctx context.Context,
+	kubeClient client.Client,
+	kind, namespace, name string,
+) (*FluxManagedObjectSource, error) {
+	s, err := extractSourceURL(ctx, kubeClient, kind, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FluxManagedObjectSource{
+		Kind:           kind,
+		Name:           name,
+		Namespace:      namespace,
+		URL:            s.URL,
+		OriginURL:      s.OriginURL,
+		OriginRevision: s.OriginRevision,
+	}, nil
+}
+
+// extractSourceURL fetches a source object from the cluster and extracts its URL and origin.
+// The origin info is only available for OCI Artifacts.
+func extractSourceURL(
+	ctx context.Context,
+	kubeClient client.Client,
+	kind, namespace, name string,
+) (*FluxManagedObjectSource, error) {
+	gvk, err := preferredFluxGVK(kind, kubeconfigArgs)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get gvk for kind %s: %w", kind, err)
+	}
+
+	sourceObj := &unstructured.Unstructured{}
+	sourceObj.SetGroupVersionKind(*gvk)
+
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	err = kubeClient.Get(ctx, namespacedName, sourceObj)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get %s %s: %w", kind, namespacedName, err)
+	}
+
+	var url, originURL, originRevision string
+
+	switch kind {
+	case "HelmChart":
+		// For HelmChart, the URL is in its sourceRef object
+		if sourceRef, found, err := unstructured.NestedMap(sourceObj.Object, "spec", "sourceRef"); found && err == nil {
+			if chartSourceName, exists := sourceRef["name"]; exists {
+				if chartSourceKind, exists := sourceRef["kind"]; exists {
+					chartSourceNamespace := sourceObj.GetNamespace()
+					if ns, exists := sourceRef["namespace"]; exists && ns != "" {
+						chartSourceNamespace = ns.(string)
+					}
+					return extractSourceURL(
+						ctx,
+						kubeClient, chartSourceKind.(string),
+						chartSourceNamespace,
+						chartSourceName.(string),
+					)
+				}
+			}
+		}
+	case "Bucket":
+		// For Bucket, the URL is in spec.endpoint
+		if endpoint, found, err := unstructured.NestedString(sourceObj.Object, "spec", "endpoint"); found && err == nil {
+			url = endpoint
+		}
+	default:
+		// For all other types, the URL is in spec.url
+		if sourceURL, found, err := unstructured.NestedString(sourceObj.Object, "spec", "url"); found && err == nil {
+			url = sourceURL
+		}
+	}
+
+	// Extract origin from status.artifact.metadata['org.opencontainers.image.source']
+	// and optionally include 'org.opencontainers.image.revision' if available
+	if annotations, found, err := unstructured.NestedStringMap(sourceObj.Object, "status", "artifact", "metadata"); found && err == nil {
+		if sourceOrigin, exists := annotations["org.opencontainers.image.source"]; exists {
+			originURL = sourceOrigin
+			if revision, exists := annotations["org.opencontainers.image.revision"]; exists {
+				originRevision = revision
+			}
+		}
+	}
+
+	if url == "" {
+		return nil, fmt.Errorf("no URL found in %s/%s/%s", kind, namespace, name)
+	}
+
+	return &FluxManagedObjectSource{
+		URL:            url,
+		OriginURL:      originURL,
+		OriginRevision: originRevision,
+	}, nil
+}


### PR DESCRIPTION
The `flux-operator trace` command is used to trace Kubernetes objects throughout the GitOps delivery pipeline
to identify which Flux reconciler manages them and from which source they originate.

Closes: #355

Example output:

```console
$ flux-operator -n flux-system trace hr/flux-operator
Object:          HelmRelease/flux-system/flux-operator
Status:          Last reconciled at 2025-07-20T14:53:37Z
Revision:        sha256:b8642ac25eea3e9f3ff543592922492aabcd9e7be27d7e30136c26b40da6ec9b
Reconciler:      ResourceSet/flux-system/flux-operator
Message:         Reconciliation finished in 28ms

$ flux-operator -n flux-system trace rset/flux-operator
Object:          ResourceSet/flux-system/flux-operator
Status:          Last reconciled at 2025-07-20T15:26:18Z
Revision:        latest@sha256:8baf628224c9a7fbd2431e572dd12ecee99f02a021d529f58e676e474a07200c
Reconciler:      Kustomization/flux-system/flux-system
Source:          OCIRepository/flux-system/flux-system
Source URL:      oci://ghcr.io/controlplaneio-fluxcd/d2-fleet
Origin URL:      https://github.com/controlplaneio-fluxcd/d2-fleet
Origin Revision: refs/heads/main@sha1:d93a3e5419ac8271da0b6bc0c7d6133c5778417e
Message:         Applied revision: latest@sha256:8baf628224c9a7fbd2431e572dd12ecee99f02a021d529f58e676e474a07200c

$ flux-operator -n flux-system trace deploy/flux-operator
Object:          Deployment/flux-system/flux-operator
Status:          Last reconciled at 2025-07-12T07:44:48Z
Revision:        0.24.1+4eee80005a1d
Reconciler:      HelmRelease/flux-system/flux-operator
Source:          OCIRepository/flux-system/flux-operator
Source URL:      oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
Origin URL:      https://github.com/controlplaneio-fluxcd/flux-operator
Message:         Helm upgrade succeeded for release flux-system/flux-operator.v4 with chart flux-operator@0.24.1+4eee80005a1d

$ flux-operator -n flux-system trace po/source-controller-ffb777895-4zx2g
Object:          Pod/flux-system/source-controller-ffb777895-4zx2g
Status:          Last reconciled at 2025-07-20T14:54:10Z
Revision:        v2.6.4@sha256:258de855927dcd5ffdde768de6cfba8528fbe7885efd54d35ca95d136daf5c05
Reconciler:      FluxInstance/flux-system/flux
Message:         Reconciliation finished in 2s
```