### PR TITLE
cli: Add `flux-operator tree` commands

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -137,6 +137,20 @@ Arguments:
 
 - `-n, --namespace`: Specifies the namespace scope of the command.
 
+### Tree Commands
+
+The `flux-operator tree` commands are used to visualize the Flux-managed Kubernetes objects in a tree format
+by recursively traversing the Flux resources such as ResourceSets, Kustomizations and HelmReleases.
+
+The following commands are available:
+
+- `flux-operator tree rset <name>`: Print a tree view of the ResourceSet managed objects.
+- `flux-operator tree ks <name>`: Print a tree view of the Flux Kustomization managed objects.
+
+Arguments:
+
+- `-n, --namespace`: Specifies the namespace scope of the command.
+
 ### Create Secret Commands
 
 The `flux-operator create secret` commands are used to create Kubernetes secrets specific to Flux.

--- a/cmd/cli/tree.go
+++ b/cmd/cli/tree.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"strings"
+
+	"github.com/fluxcd/cli-utils/pkg/object"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	"github.com/spf13/cobra"
+)
+
+var treeCmd = &cobra.Command{
+	Use:   "tree",
+	Short: "Print a tree view of resources reconciled by Flux Operator",
+}
+
+func init() {
+	rootCmd.AddCommand(treeCmd)
+}
+
+const (
+	newLine      = "\n"
+	emptySpace   = "    "
+	middleItem   = "├── "
+	continueItem = "│   "
+	lastItem     = "└── "
+)
+
+type (
+	objMetadataTree struct {
+		Resource     object.ObjMetadata `json:"resource"`
+		ResourceTree []ObjMetadataTree  `json:"resources,omitempty"`
+	}
+
+	ObjMetadataTree interface {
+		Add(objMetadata object.ObjMetadata) ObjMetadataTree
+		AddTree(tree ObjMetadataTree)
+		Items() []ObjMetadataTree
+		Text() string
+		Print() string
+	}
+
+	treePrinter struct {
+	}
+
+	TreePrinter interface {
+		Print(ObjMetadataTree) string
+	}
+)
+
+func NewTree(objMetadata object.ObjMetadata) ObjMetadataTree {
+	return &objMetadataTree{
+		Resource:     objMetadata,
+		ResourceTree: []ObjMetadataTree{},
+	}
+}
+
+func (t *objMetadataTree) Add(objMetadata object.ObjMetadata) ObjMetadataTree {
+	n := NewTree(objMetadata)
+	t.ResourceTree = append(t.ResourceTree, n)
+	return n
+}
+
+func (t *objMetadataTree) AddTree(tree ObjMetadataTree) {
+	t.ResourceTree = append(t.ResourceTree, tree)
+}
+
+func (t *objMetadataTree) Text() string {
+	return ssautil.FmtObjMetadata(t.Resource)
+}
+
+func (t *objMetadataTree) Items() []ObjMetadataTree {
+	return t.ResourceTree
+}
+
+func (t *objMetadataTree) Print() string {
+	return newPrinter().Print(t)
+}
+
+func newPrinter() TreePrinter {
+	return &treePrinter{}
+}
+
+func (p *treePrinter) Print(t ObjMetadataTree) string {
+	return t.Text() + newLine + p.printItems(t.Items(), []bool{})
+}
+
+func (p *treePrinter) printText(text string, spaces []bool, last bool) string {
+	var result string
+	for _, space := range spaces {
+		if space {
+			result += emptySpace
+		} else {
+			result += continueItem
+		}
+	}
+
+	indicator := middleItem
+	if last {
+		indicator = lastItem
+	}
+
+	var out string
+	lines := strings.Split(text, "\n")
+	for i := range lines {
+		text := lines[i]
+		if i == 0 {
+			out += result + indicator + text + newLine
+			continue
+		}
+		if last {
+			indicator = emptySpace
+		} else {
+			indicator = continueItem
+		}
+		out += result + indicator + text + newLine
+	}
+
+	return out
+}
+
+func (p *treePrinter) printItems(t []ObjMetadataTree, spaces []bool) string {
+	var result string
+	for i, f := range t {
+		last := i == len(t)-1
+		result += p.printText(f.Text(), spaces, last)
+		if len(f.Items()) > 0 {
+			spacesChild := append(spaces, last)
+			result += p.printItems(f.Items(), spacesChild)
+		}
+	}
+	return result
+}

--- a/cmd/cli/tree_kustomization.go
+++ b/cmd/cli/tree_kustomization.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/cli-utils/pkg/object"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/inventory"
+)
+
+var treeKustomizationCmd = &cobra.Command{
+	Use:     "kustomization [name]",
+	Aliases: []string{"ks"},
+	Short:   "Print a tree view of the Flux Kustomization managed objects",
+	Example: `  # Print the Kubernetes objects managed by a Kustomization
+  flux-operator -n flux-system tree ks flux-system
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: treeKustomizationCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(schema.GroupVersionKind{
+		Group:   "kustomize.toolkit.fluxcd.io",
+		Version: "v1",
+		Kind:    "Kustomization",
+	}),
+}
+
+func init() {
+	treeCmd.AddCommand(treeKustomizationCmd)
+}
+
+func treeKustomizationCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("name is required")
+	}
+
+	name := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	objMeta := object.ObjMetadata{
+		Namespace: *kubeconfigArgs.Namespace,
+		Name:      name,
+		GroupKind: schema.GroupKind{Group: "kustomize.toolkit.fluxcd.io", Kind: "Kustomization"},
+	}
+
+	tree := NewTree(objMeta)
+	err = treeFromKustomization(ctx, kubeClient, inventory.EntryFromObjMetadata(objMeta, "v1"), tree)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(tree.Print())
+	return nil
+}
+
+func treeFromKustomization(ctx context.Context, kubeClient client.Client, ks fluxcdv1.ResourceRef, tree ObjMetadataTree) error {
+	entries, err := inventory.FromStatusOf(ctx, kubeClient, ks)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		objMetadata, err := inventory.EntryToObjMetadata(entry)
+		if err != nil {
+			return fmt.Errorf("unable to parse reference from %s: %w", ks.ID, err)
+		}
+
+		root := tree.Add(objMetadata)
+
+		if strings.Contains(objMetadata.GroupKind.Group, "fluxcd") {
+			switch objMetadata.GroupKind.Kind {
+			case "Kustomization":
+				if entry.ID == ks.ID {
+					// Skip self-referencing Kustomization
+					continue
+				}
+				err := treeFromKustomization(ctx, kubeClient, entry, root)
+				if err != nil {
+					return err
+				}
+			case "HelmRelease":
+				refs, err := inventory.FromHelmRelease(ctx, kubeClient, entry)
+				if err != nil {
+					return err
+				}
+				for _, ref := range refs {
+					refObjMetadata, err := inventory.EntryToObjMetadata(ref)
+					if err != nil {
+						return fmt.Errorf("unable to parse reference from %s: %w", objMetadata.String(), err)
+					}
+					root.Add(refObjMetadata)
+				}
+			case fluxcdv1.ResourceSetKind:
+				err = treeFromResourceSet(ctx, kubeClient, entry, root)
+				if err != nil {
+					return err
+				}
+			case fluxcdv1.FluxInstanceKind:
+				refs, err := inventory.FromStatusOf(ctx, kubeClient, entry)
+				if err != nil {
+					return err
+				}
+				for _, ref := range refs {
+					refObjMetadata, err := inventory.EntryToObjMetadata(ref)
+					if err != nil {
+						return fmt.Errorf("unable to parse reference from %s: %w", objMetadata.String(), err)
+					}
+					root.Add(refObjMetadata)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/cli/tree_resourceset.go
+++ b/cmd/cli/tree_resourceset.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/cli-utils/pkg/object"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/inventory"
+)
+
+var treeResourceSetCmd = &cobra.Command{
+	Use:     "resourceset [name]",
+	Aliases: []string{"rset"},
+	Short:   "Print a tree view of the ResourceSet managed objects",
+	Example: `  # Print the Kubernetes objects managed by a ResourceSet
+  flux-operator -n flux-system tree rset apps
+`,
+	Args:              cobra.ExactArgs(1),
+	RunE:              treeResourceSetCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)),
+}
+
+func init() {
+	treeCmd.AddCommand(treeResourceSetCmd)
+}
+
+func treeResourceSetCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("name is required")
+	}
+
+	name := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	objMeta := object.ObjMetadata{
+		Namespace: *kubeconfigArgs.Namespace,
+		Name:      name,
+		GroupKind: schema.GroupKind{Group: fluxcdv1.GroupVersion.Group, Kind: fluxcdv1.ResourceSetKind},
+	}
+
+	tree := NewTree(objMeta)
+	rootEntry := inventory.EntryFromObjMetadata(objMeta, fluxcdv1.GroupVersion.Version)
+	err = treeFromResourceSet(ctx, kubeClient, rootEntry, tree)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(tree.Print())
+	return nil
+}
+
+func treeFromResourceSet(ctx context.Context, kubeClient client.Client, rset fluxcdv1.ResourceRef, tree ObjMetadataTree) error {
+	entries, err := inventory.FromStatusOf(ctx, kubeClient, rset)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		objMetadata, err := object.ParseObjMetadata(entry.ID)
+		if err != nil {
+			return err
+		}
+
+		root := tree.Add(objMetadata)
+
+		if strings.Contains(objMetadata.GroupKind.Group, "fluxcd") {
+			switch objMetadata.GroupKind.Kind {
+			case "HelmRelease":
+				refs, err := inventory.FromHelmRelease(ctx, kubeClient, entry)
+				if err != nil {
+					return err
+				}
+				for _, ref := range refs {
+					refObjMetadata, err := inventory.EntryToObjMetadata(ref)
+					if err != nil {
+						return fmt.Errorf("unable to parse reference from %s: %w", objMetadata.String(), err)
+					}
+					root.Add(refObjMetadata)
+				}
+			case "Kustomization":
+				err = treeFromKustomization(ctx, kubeClient, entry, root)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/cli/tree_resourceset_test.go
+++ b/cmd/cli/tree_resourceset_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestTreeResourceSetCmd(t *testing.T) {
+	gt := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(context.Background(), "tree-rset")
+	gt.Expect(err).NotTo(HaveOccurred())
+
+	tests := []struct {
+		name           string
+		setupResources bool
+		resourceName   string
+		expectError    bool
+		expectOutput   string
+	}{
+		{
+			name:        "missing resource name argument",
+			expectError: true,
+		},
+		{
+			name:         "nonexistent resource",
+			resourceName: "nonexistent",
+			expectError:  true,
+		},
+		{
+			name:           "resourceset with configmap and serviceaccount",
+			setupResources: true,
+			resourceName:   "test-app",
+			expectOutput: fmt.Sprintf(`
+ResourceSet/%[1]s/test-app
+├── ServiceAccount/%[1]s/test-serviceaccount
+└── ConfigMap/%[1]s/test-configmap`, ns.Name),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			g := NewWithT(t)
+
+			var resourceSet *fluxcdv1.ResourceSet
+
+			// Setup resources if needed
+			if tt.setupResources {
+				// Create a ResourceSet
+				input, err := fluxcdv1.NewResourceSetInput(nil, map[string]any{
+					"app": "test-app",
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				resourceSet = &fluxcdv1.ResourceSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-app",
+						Namespace: ns.Name,
+					},
+					Spec: fluxcdv1.ResourceSetSpec{
+						Inputs:            []fluxcdv1.ResourceSetInput{input},
+						ResourcesTemplate: "---",
+					},
+				}
+				err = testClient.Create(ctx, resourceSet)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Set status with inventory entries for the managed resources
+				resourceSet.Status = fluxcdv1.ResourceSetStatus{
+					Inventory: &fluxcdv1.ResourceInventory{
+						Entries: []fluxcdv1.ResourceRef{
+							{
+								ID:      fmt.Sprintf("%s_test-serviceaccount__ServiceAccount", ns.Name),
+								Version: "v1",
+							},
+							{
+								ID:      fmt.Sprintf("%s_test-configmap__ConfigMap", ns.Name),
+								Version: "v1",
+							},
+						},
+					},
+				}
+				err = testClient.Status().Update(ctx, resourceSet)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				defer func() {
+					_ = testClient.Delete(ctx, resourceSet)
+				}()
+
+				// Set namespace for command
+				kubeconfigArgs.Namespace = &ns.Name
+			}
+
+			// Prepare command arguments
+			args := []string{"tree", "resourceset"}
+			if tt.resourceName != "" {
+				args = append(args, tt.resourceName)
+			}
+
+			// Execute command
+			output, err := executeCommand(args)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Verify expected output
+			g.Expect(strings.TrimSpace(output)).To(BeIdenticalTo(strings.TrimSpace(tt.expectOutput)))
+		})
+	}
+}

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -6,11 +6,10 @@ package inventory
 import (
 	"sort"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/fluxcd/cli-utils/pkg/object"
 	"github.com/fluxcd/pkg/ssa"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -122,4 +121,36 @@ func Diff(inv *fluxcdv1.ResourceInventory, target *fluxcdv1.ResourceInventory) (
 
 	sort.Sort(ssa.SortableUnstructureds(objects))
 	return objects, nil
+}
+
+// EntryFromObjMetadata converts an object.ObjMetadata to a ResourceRef entry.
+func EntryFromObjMetadata(objMetadata object.ObjMetadata, version string) fluxcdv1.ResourceRef {
+	return fluxcdv1.ResourceRef{
+		ID:      objMetadata.String(),
+		Version: version,
+	}
+}
+
+// EntryToObjMetadata converts a ResourceRef entry to an object.ObjMetadata.
+func EntryToObjMetadata(entry fluxcdv1.ResourceRef) (object.ObjMetadata, error) {
+	return object.ParseObjMetadata(entry.ID)
+}
+
+// EntryToUnstructured converts a ResourceRef entry to an unstructured.Unstructured object.
+func EntryToUnstructured(entry fluxcdv1.ResourceRef) (*unstructured.Unstructured, error) {
+	objMetadata, err := EntryToObjMetadata(entry)
+	if err != nil {
+		return nil, err
+	}
+
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   objMetadata.GroupKind.Group,
+		Kind:    objMetadata.GroupKind.Kind,
+		Version: entry.Version,
+	})
+	u.SetName(objMetadata.Name)
+	u.SetNamespace(objMetadata.Namespace)
+
+	return u, nil
 }

--- a/internal/inventory/reader.go
+++ b/internal/inventory/reader.go
@@ -1,0 +1,241 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package inventory
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/fluxcd/cli-utils/pkg/object"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+// FromStatusOf inspects the status of a Kubernetes object and extracts the
+// inventory entries from it. This function is suitable for the following kinds:
+// Flux Kustomization, ResourceSet, and FluxInstance.
+func FromStatusOf(
+	ctx context.Context,
+	kubeClient client.Client,
+	ref fluxcdv1.ResourceRef,
+) ([]fluxcdv1.ResourceRef, error) {
+	result := make([]fluxcdv1.ResourceRef, 0)
+
+	obj, err := EntryToUnstructured(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	objKey := client.ObjectKey{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+
+	// Get the object whose status we want to inspect.
+	if err := kubeClient.Get(ctx, objKey, obj); err != nil {
+		return nil, fmt.Errorf("failed to get %s/%s: %w", obj.GetKind(), objKey.String(), err)
+	}
+
+	// If the object has a status.inventory.entries field, extract the entries.
+	if entries, exists, _ := unstructured.NestedSlice(obj.Object, "status", "inventory", "entries"); exists && len(entries) > 0 {
+		for _, entry := range entries {
+			if entryMap, ok := entry.(map[string]any); ok {
+				id, found := entryMap["id"].(string)
+				if !found {
+					continue
+				}
+				v, found := entryMap["v"].(string)
+				if !found {
+					continue
+				}
+				result = append(result, fluxcdv1.ResourceRef{ID: id, Version: v})
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// HelmStorage is a struct used to decode the Helm storage secret.
+type HelmStorage struct {
+	Name     string `json:"name,omitempty"`
+	Manifest string `json:"manifest,omitempty"`
+}
+
+// HelmHistory is a struct used to decode the release
+// history from the HelmRelease status.
+type HelmHistory struct {
+	ChartName string `json:"chartName,omitempty"`
+	Version   int64  `json:"version,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// FromHelmRelease returns the inventory of Kubernetes object refs
+// that are managed by the HelmRelease. It extracts the metadata from the
+// Helm storage secret belonging to the latest release version.
+func FromHelmRelease(
+	ctx context.Context,
+	kubeClient client.Client,
+	hr fluxcdv1.ResourceRef,
+) ([]fluxcdv1.ResourceRef, error) {
+	result := make([]fluxcdv1.ResourceRef, 0)
+
+	hrObj, err := EntryToUnstructured(hr)
+	if err != nil {
+		return nil, err
+	}
+
+	hrKey := client.ObjectKey{
+		Namespace: hrObj.GetNamespace(),
+		Name:      hrObj.GetName(),
+	}
+
+	// Get the HelmRelease object
+	if err := kubeClient.Get(ctx, hrKey, hrObj); err != nil {
+		return nil, fmt.Errorf("failed to get HelmRelease/%s: %w", hrKey.String(), err)
+	}
+
+	if _, found, _ := unstructured.NestedFieldCopy(hrObj.Object, "spec", "kubeConfig"); found {
+		// Skip release if it targets a remote cluster
+		return nil, nil
+	}
+
+	storageNamespace, _, _ := unstructured.NestedString(hrObj.Object, "status", "storageNamespace")
+	history, _, _ := unstructured.NestedSlice(hrObj.Object, "status", "history")
+	if storageNamespace == "" || len(history) == 0 {
+		// Skip release with no history
+		return nil, nil
+	}
+
+	// Get the latest release from the history
+	latest := &HelmHistory{}
+	latest.ChartName = history[0].(map[string]any)["chartName"].(string)
+	latest.Version = history[0].(map[string]any)["version"].(int64)
+	latest.Namespace = history[0].(map[string]any)["namespace"].(string)
+
+	storageKey := client.ObjectKey{
+		Namespace: storageNamespace,
+		Name:      fmt.Sprintf("sh.helm.release.v1.%s.v%v", latest.ChartName, latest.Version),
+	}
+
+	storageSecret := &corev1.Secret{}
+	if err := kubeClient.Get(ctx, storageKey, storageSecret); err != nil {
+		// Skip release if it has no storage
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("storage secret not found for HelmRelease/%s: %w", hrKey.String(), err)
+	}
+
+	releaseData, releaseFound := storageSecret.Data["release"]
+	if !releaseFound {
+		return nil, fmt.Errorf("storage not found for HelmRelease/%s", hrKey.String())
+	}
+
+	rls, err := decodeHelmStorage(releaseData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode storage for HelmRelease/%s: %w", hrKey.String(), err)
+	}
+
+	objects, err := ssautil.ReadObjects(strings.NewReader(rls.Manifest))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read storage for HelmRelease/%s: %w", hrKey.String(), err)
+	}
+
+	// Add the object to the inventory list
+	for _, obj := range objects {
+		// Set the namespace on namespaced objects if missing
+		if obj.GetNamespace() == "" {
+			if isNamespaced, _ := apiutil.IsObjectNamespaced(obj,
+				kubeClient.Scheme(), kubeClient.RESTMapper()); isNamespaced {
+				obj.SetNamespace(latest.Namespace)
+			}
+		}
+		objMetadata := object.UnstructuredToObjMetadata(obj)
+		result = append(result, fluxcdv1.ResourceRef{
+			ID:      objMetadata.String(),
+			Version: obj.GetObjectKind().GroupVersionKind().Version,
+		})
+	}
+
+	// If the HelmRelease has CRDs to upgrade, we need to add them to the inventory
+	if _, found, _ := unstructured.NestedFieldCopy(hrObj.Object, "spec", "upgrade", "crds"); found {
+		selector := client.MatchingLabels{
+			"helm.toolkit.fluxcd.io/name":      hrObj.GetName(),
+			"helm.toolkit.fluxcd.io/namespace": hrObj.GetNamespace(),
+		}
+		crdKind := "CustomResourceDefinition"
+		var list apiextensionsv1.CustomResourceDefinitionList
+		if err := kubeClient.List(ctx, &list, selector); err == nil {
+			for _, crd := range list.Items {
+				found := false
+				for _, obj := range objects {
+					if obj.GetName() == crd.GetName() && obj.GetKind() == crdKind {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					mo := object.ObjMetadata{
+						Name: crd.GetName(),
+						GroupKind: schema.GroupKind{
+							Group: apiextensionsv1.GroupName,
+							Kind:  crdKind,
+						},
+					}
+					result = append(result, fluxcdv1.ResourceRef{
+						ID:      mo.String(),
+						Version: "v1",
+					})
+				}
+			}
+		}
+	}
+	return result, nil
+}
+
+// decodeHelmStorage decodes the Helm storage secret data into a HelmStorage struct.
+// Adapted from https://github.com/helm/helm/blob/02685e94bd3862afcb44f6cd7716dbeb69743567/pkg/storage/driver/util.go
+func decodeHelmStorage(releaseData []byte) (*HelmStorage, error) {
+	var b64 = base64.StdEncoding
+	b, err := b64.DecodeString(string(releaseData))
+	if err != nil {
+		return nil, err
+	}
+	var magicGzip = []byte{0x1f, 0x8b, 0x08}
+	if bytes.Equal(b[0:3], magicGzip) {
+		r, err := gzip.NewReader(bytes.NewReader(b))
+		if err != nil {
+			return nil, err
+		}
+		defer r.Close()
+		b2, err := io.ReadAll(r)
+		if err != nil {
+			return nil, err
+		}
+		b = b2
+	}
+
+	var rls HelmStorage
+	if err := json.Unmarshal(b, &rls); err != nil {
+		return nil, err
+	}
+
+	return &rls, nil
+}

--- a/internal/inventory/reader_test.go
+++ b/internal/inventory/reader_test.go
@@ -1,0 +1,594 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package inventory
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestFromHelmRelease(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create mock Helm storage data
+	manifestContent := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+  namespace: default
+spec:
+  replicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+  namespace: default
+spec:
+  ports:
+  - port: 80
+`
+
+	helmStorage := HelmStorage{
+		Name:     "test-release",
+		Manifest: manifestContent,
+	}
+
+	storageData, err := json.Marshal(helmStorage)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	encodedStorage := base64.StdEncoding.EncodeToString(storageData)
+
+	// Create mock objects
+	mockHelmRelease := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "helm.toolkit.fluxcd.io/v2",
+			"kind":       "HelmRelease",
+			"metadata": map[string]any{
+				"name":      "test-release",
+				"namespace": "default",
+			},
+			"status": map[string]any{
+				"storageNamespace": "default",
+				"history": []any{
+					map[string]any{
+						"chartName": "test-chart",
+						"version":   int64(1),
+						"namespace": "default",
+					},
+				},
+			},
+		},
+	}
+	mockHelmRelease.SetGroupVersionKind(mockHelmRelease.GroupVersionKind())
+
+	mockStorageSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sh.helm.release.v1.test-chart.v1",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"release": []byte(encodedStorage),
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mockHelmRelease, mockStorageSecret).
+		Build()
+
+	tests := []struct {
+		name              string
+		helmRelease       fluxcdv1.ResourceRef
+		expectedResources int
+		expectError       bool
+	}{
+		{
+			name: "successful inventory extraction",
+			helmRelease: fluxcdv1.ResourceRef{
+				ID:      "default_test-release_helm.toolkit.fluxcd.io_HelmRelease",
+				Version: "v2",
+			},
+			expectedResources: 2, // Deployment and Service
+			expectError:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result, err := FromHelmRelease(context.Background(), kubeClient, tt.helmRelease)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(result).To(HaveLen(tt.expectedResources))
+
+				// Verify specific resources
+				resourceIDs := make(map[string]string)
+				for _, resource := range result {
+					resourceIDs[resource.ID] = resource.Version
+				}
+
+				g.Expect(resourceIDs).To(HaveKey("default_test-deployment_apps_Deployment"))
+				g.Expect(resourceIDs["default_test-deployment_apps_Deployment"]).To(Equal("v1"))
+				g.Expect(resourceIDs).To(HaveKey("default_test-service__Service"))
+				g.Expect(resourceIDs["default_test-service__Service"]).To(Equal("v1"))
+			}
+		})
+	}
+}
+
+func TestFromHelmRelease_ErrorCases(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+	tests := []struct {
+		name          string
+		helmRelease   *unstructured.Unstructured
+		storageSecret *corev1.Secret
+		expectNil     bool
+		expectError   bool
+	}{
+		{
+			name: "HelmRelease with kubeConfig should return nil",
+			helmRelease: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "helm.toolkit.fluxcd.io/v2",
+					"kind":       "HelmRelease",
+					"metadata": map[string]any{
+						"name":      "remote-release",
+						"namespace": "default",
+					},
+					"spec": map[string]any{
+						"kubeConfig": map[string]any{
+							"secretRef": map[string]any{
+								"name": "kubeconfig",
+							},
+						},
+					},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "HelmRelease with no history should return nil",
+			helmRelease: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "helm.toolkit.fluxcd.io/v2",
+					"kind":       "HelmRelease",
+					"metadata": map[string]any{
+						"name":      "no-history-release",
+						"namespace": "default",
+					},
+					"status": map[string]any{
+						"storageNamespace": "default",
+						"history":          []any{},
+					},
+				},
+			},
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			kubeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.helmRelease).
+				Build()
+
+			resourceRef := fluxcdv1.ResourceRef{
+				ID:      "default_" + tt.helmRelease.GetName() + "_helm.toolkit.fluxcd.io_HelmRelease",
+				Version: "v2",
+			}
+
+			result, err := FromHelmRelease(context.Background(), kubeClient, resourceRef)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+
+			if tt.expectNil {
+				g.Expect(result).To(BeNil())
+			}
+		})
+	}
+}
+
+func TestDecodeHelmStorage(t *testing.T) {
+	g := NewWithT(t)
+
+	testManifest := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value`
+
+	testStorage := HelmStorage{
+		Name:     "test-release",
+		Manifest: testManifest,
+	}
+
+	tests := []struct {
+		name        string
+		setupData   func() []byte
+		expectError bool
+		validate    func(result *HelmStorage)
+	}{
+		{
+			name: "decode uncompressed base64 data",
+			setupData: func() []byte {
+				data, _ := json.Marshal(testStorage)
+				return []byte(base64.StdEncoding.EncodeToString(data))
+			},
+			expectError: false,
+			validate: func(result *HelmStorage) {
+				g.Expect(result.Name).To(Equal("test-release"))
+				g.Expect(result.Manifest).To(Equal(testManifest))
+			},
+		},
+		{
+			name: "decode gzip compressed base64 data",
+			setupData: func() []byte {
+				data, _ := json.Marshal(testStorage)
+
+				// Compress with gzip
+				var buf bytes.Buffer
+				gzipWriter := gzip.NewWriter(&buf)
+				_, _ = gzipWriter.Write(data)
+				_ = gzipWriter.Close()
+
+				// Base64 encode
+				return []byte(base64.StdEncoding.EncodeToString(buf.Bytes()))
+			},
+			expectError: false,
+			validate: func(result *HelmStorage) {
+				g.Expect(result.Name).To(Equal("test-release"))
+				g.Expect(result.Manifest).To(Equal(testManifest))
+			},
+		},
+		{
+			name: "invalid base64 data should return error",
+			setupData: func() []byte {
+				return []byte("invalid-base64-data!")
+			},
+			expectError: true,
+		},
+		{
+			name: "valid base64 but invalid JSON should return error",
+			setupData: func() []byte {
+				return []byte(base64.StdEncoding.EncodeToString([]byte("not-json-data")))
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid gzip data should return error",
+			setupData: func() []byte {
+				// Create data that looks like gzip (has magic bytes) but is corrupted
+				badGzipData := []byte{0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00} // gzip magic + corrupted data
+				return []byte(base64.StdEncoding.EncodeToString(badGzipData))
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			releaseData := tt.setupData()
+			result, err := decodeHelmStorage(releaseData)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(result).To(BeNil())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(result).NotTo(BeNil())
+				if tt.validate != nil {
+					tt.validate(result)
+				}
+			}
+		})
+	}
+}
+
+func TestFromStatusOf(t *testing.T) {
+
+	tests := []struct {
+		name              string
+		setupObject       func() *unstructured.Unstructured
+		resourceRef       fluxcdv1.ResourceRef
+		expectedResources int
+		expectedIDs       []string
+		expectError       bool
+	}{
+		{
+			name: "extract inventory from Kustomization status",
+			setupObject: func() *unstructured.Unstructured {
+				return &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+						"kind":       "Kustomization",
+						"metadata": map[string]any{
+							"name":      "test-kustomization",
+							"namespace": "flux-system",
+						},
+						"status": map[string]any{
+							"inventory": map[string]any{
+								"entries": []any{
+									map[string]any{
+										"id": "default_test-deployment_apps_Deployment",
+										"v":  "v1",
+									},
+									map[string]any{
+										"id": "default_test-service__Service",
+										"v":  "v1",
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			resourceRef: fluxcdv1.ResourceRef{
+				ID:      "flux-system_test-kustomization_kustomize.toolkit.fluxcd.io_Kustomization",
+				Version: "v1",
+			},
+			expectedResources: 2,
+			expectedIDs:       []string{"default_test-deployment_apps_Deployment", "default_test-service__Service"},
+			expectError:       false,
+		},
+		{
+			name: "extract inventory from ResourceSet status",
+			setupObject: func() *unstructured.Unstructured {
+				return &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "fluxcd.controlplane.io/v1",
+						"kind":       "ResourceSet",
+						"metadata": map[string]any{
+							"name":      "test-resourceset",
+							"namespace": "flux-system",
+						},
+						"status": map[string]any{
+							"inventory": map[string]any{
+								"entries": []any{
+									map[string]any{
+										"id": "flux-system_source-controller_apps_Deployment",
+										"v":  "v1",
+									},
+									map[string]any{
+										"id": "flux-system_source-controller__Service",
+										"v":  "v1",
+									},
+									map[string]any{
+										"id": "flux-system_source-controller__ServiceAccount",
+										"v":  "v1",
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			resourceRef: fluxcdv1.ResourceRef{
+				ID:      "flux-system_test-resourceset_fluxcd.controlplane.io_ResourceSet",
+				Version: "v1",
+			},
+			expectedResources: 3,
+			expectedIDs: []string{
+				"flux-system_source-controller_apps_Deployment",
+				"flux-system_source-controller__Service",
+				"flux-system_source-controller__ServiceAccount",
+			},
+			expectError: false,
+		},
+		{
+			name: "object with no inventory status returns empty result",
+			setupObject: func() *unstructured.Unstructured {
+				return &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+						"kind":       "Kustomization",
+						"metadata": map[string]any{
+							"name":      "empty-kustomization",
+							"namespace": "flux-system",
+						},
+						"status": map[string]any{
+							"conditions": []any{
+								map[string]any{
+									"type":   "Ready",
+									"status": "True",
+								},
+							},
+						},
+					},
+				}
+			},
+			resourceRef: fluxcdv1.ResourceRef{
+				ID:      "flux-system_empty-kustomization_kustomize.toolkit.fluxcd.io_Kustomization",
+				Version: "v1",
+			},
+			expectedResources: 0,
+			expectError:       false,
+		},
+		{
+			name: "object with empty inventory entries returns empty result",
+			setupObject: func() *unstructured.Unstructured {
+				return &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+						"kind":       "Kustomization",
+						"metadata": map[string]any{
+							"name":      "empty-inventory-kustomization",
+							"namespace": "flux-system",
+						},
+						"status": map[string]any{
+							"inventory": map[string]any{
+								"entries": []any{},
+							},
+						},
+					},
+				}
+			},
+			resourceRef: fluxcdv1.ResourceRef{
+				ID:      "flux-system_empty-inventory-kustomization_kustomize.toolkit.fluxcd.io_Kustomization",
+				Version: "v1",
+			},
+			expectedResources: 0,
+			expectError:       false,
+		},
+		{
+			name: "skip malformed inventory entries",
+			setupObject: func() *unstructured.Unstructured {
+				return &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+						"kind":       "Kustomization",
+						"metadata": map[string]any{
+							"name":      "malformed-kustomization",
+							"namespace": "flux-system",
+						},
+						"status": map[string]any{
+							"inventory": map[string]any{
+								"entries": []any{
+									map[string]any{
+										"id": "valid_entry_apps_Deployment",
+										"v":  "v1",
+									},
+									map[string]any{
+										"id": "missing_version_entry_apps_Service",
+										// missing "v" field - should be skipped
+									},
+									"not-a-map", // invalid entry type - should be skipped
+									map[string]any{
+										"id": "another_valid_entry__ConfigMap",
+										"v":  "v1",
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			resourceRef: fluxcdv1.ResourceRef{
+				ID:      "flux-system_malformed-kustomization_kustomize.toolkit.fluxcd.io_Kustomization",
+				Version: "v1",
+			},
+			expectedResources: 2, // Only entries with valid types and fields should be extracted
+			expectedIDs:       []string{"valid_entry_apps_Deployment", "another_valid_entry__ConfigMap"},
+			expectError:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			obj := tt.setupObject()
+			obj.SetGroupVersionKind(obj.GroupVersionKind())
+
+			scheme := runtime.NewScheme()
+			kubeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(obj).
+				Build()
+
+			result, err := FromStatusOf(context.Background(), kubeClient, tt.resourceRef)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(result).To(HaveLen(tt.expectedResources))
+
+				if tt.expectedResources > 0 {
+					resultIDs := make([]string, len(result))
+					for i, resource := range result {
+						resultIDs[i] = resource.ID
+						g.Expect(resource.Version).To(Equal("v1"))
+					}
+
+					for _, expectedID := range tt.expectedIDs {
+						g.Expect(resultIDs).To(ContainElement(expectedID))
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFromStatusOf_ErrorCases(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		resourceRef fluxcdv1.ResourceRef
+		expectError bool
+	}{
+		{
+			name: "object not found should return error",
+			resourceRef: fluxcdv1.ResourceRef{
+				ID:      "flux-system_nonexistent-kustomization_kustomize.toolkit.fluxcd.io_Kustomization",
+				Version: "v1",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid resource ref ID should return error",
+			resourceRef: fluxcdv1.ResourceRef{
+				ID:      "invalid-format",
+				Version: "v1",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			scheme := runtime.NewScheme()
+			kubeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+
+			result, err := FromStatusOf(context.Background(), kubeClient, tt.resourceRef)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(result).To(BeNil())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
this PR adds `flux-operator tree` commands that can be used to visualize the Flux-managed Kubernetes objects in a tree format by recursively traversing the Flux resources such as ResourceSets, Kustomizations and HelmReleases.

Examples:

```console
$ flux-operator-cli -n flux-system tree rset apps
ResourceSet/flux-system/apps
├── Namespace/backend
├── Namespace/frontend
├── ServiceAccount/backend/flux
├── ServiceAccount/frontend/flux
├── RoleBinding/backend/flux
├── RoleBinding/frontend/flux
├── ConfigMap/backend/flux-runtime-info
├── ConfigMap/frontend/flux-runtime-info
├── Secret/backend/ghcr-auth
├── Secret/frontend/ghcr-auth
├── Kustomization/backend/apps
│   ├── HelmRelease/backend/memcached
│   │   ├── NetworkPolicy/backend/memcached
│   │   ├── PodDisruptionBudget/backend/memcached
│   │   ├── ServiceAccount/backend/memcached
│   │   ├── Service/backend/memcached
│   │   └── Deployment/backend/memcached
│   ├── HelmRelease/backend/redis
│   │   ├── NetworkPolicy/backend/redis
│   │   ├── PodDisruptionBudget/backend/redis-master
│   │   ├── PodDisruptionBudget/backend/redis-replicas
│   │   ├── ServiceAccount/backend/redis-master
│   │   ├── ServiceAccount/backend/redis-replica
│   │   ├── Secret/backend/redis
│   │   ├── ConfigMap/backend/redis-configuration
│   │   ├── ConfigMap/backend/redis-health
│   │   ├── ConfigMap/backend/redis-scripts
│   │   ├── Service/backend/redis-headless
│   │   ├── Service/backend/redis-master
│   │   ├── Service/backend/redis-replicas
│   │   ├── StatefulSet/backend/redis-master
│   │   └── StatefulSet/backend/redis-replicas
│   ├── OCIRepository/backend/memcached-chart
│   └── OCIRepository/backend/redis-chart
├── Kustomization/frontend/apps
│   ├── HelmRelease/frontend/podinfo
│   │   ├── Service/frontend/podinfo
│   │   ├── Deployment/frontend/podinfo
│   │   ├── Ingress/frontend/podinfo
│   │   └── ServiceMonitor/frontend/podinfo
│   └── OCIRepository/frontend/podinfo-chart
├── OCIRepository/backend/apps
└── OCIRepository/frontend/apps
```

```console
$ flux-operator-cli -n flux-system tree ks flux-system
Kustomization/flux-system/flux-system
├── ConfigMap/flux-system/flux-runtime-info
├── FluxInstance/flux-system/flux
│   ├── CustomResourceDefinition/alerts.notification.toolkit.fluxcd.io
│   ├── CustomResourceDefinition/buckets.source.toolkit.fluxcd.io
│   ├── CustomResourceDefinition/gitrepositories.source.toolkit.fluxcd.io
│   ├── CustomResourceDefinition/helmcharts.source.toolkit.fluxcd.io
│   ├── CustomResourceDefinition/helmreleases.helm.toolkit.fluxcd.io
│   ├── CustomResourceDefinition/helmrepositories.source.toolkit.fluxcd.io
│   ├── CustomResourceDefinition/kustomizations.kustomize.toolkit.fluxcd.io
│   ├── CustomResourceDefinition/ocirepositories.source.toolkit.fluxcd.io
│   ├── CustomResourceDefinition/providers.notification.toolkit.fluxcd.io
│   ├── CustomResourceDefinition/receivers.notification.toolkit.fluxcd.io
│   ├── Namespace/flux-system
│   ├── ClusterRole/crd-controller-flux-system
│   ├── ClusterRole/flux-edit-flux-system
│   ├── ClusterRole/flux-view-flux-system
│   ├── ClusterRoleBinding/cluster-reconciler-flux-system
│   ├── ClusterRoleBinding/crd-controller-flux-system
│   ├── ResourceQuota/flux-system/critical-pods-flux-system
│   ├── ServiceAccount/flux-system/helm-controller
│   ├── ServiceAccount/flux-system/kustomize-controller
│   ├── ServiceAccount/flux-system/notification-controller
│   ├── ServiceAccount/flux-system/source-controller
│   ├── Service/flux-system/notification-controller
│   ├── Service/flux-system/source-controller
│   ├── Service/flux-system/webhook-receiver
│   ├── Deployment/flux-system/helm-controller
│   ├── Deployment/flux-system/kustomize-controller
│   ├── Deployment/flux-system/notification-controller
│   ├── Deployment/flux-system/source-controller
│   ├── Kustomization/flux-system/flux-system
│   ├── NetworkPolicy/flux-system/allow-egress
│   ├── NetworkPolicy/flux-system/allow-scraping
│   ├── NetworkPolicy/flux-system/allow-webhooks
│   └── OCIRepository/flux-system/flux-system
├── ResourceSet/flux-system/flux-operator
│   ├── HelmRelease/flux-system/flux-operator
│   │   ├── ServiceAccount/flux-system/flux-operator
│   │   ├── CustomResourceDefinition/fluxinstances.fluxcd.controlplane.io
│   │   ├── CustomResourceDefinition/fluxreports.fluxcd.controlplane.io
│   │   ├── CustomResourceDefinition/resourcesetinputproviders.fluxcd.controlplane.io
│   │   ├── CustomResourceDefinition/resourcesets.fluxcd.controlplane.io
│   │   ├── ClusterRole/flux-operator-edit
│   │   ├── ClusterRole/flux-operator-view
│   │   ├── ClusterRoleBinding/flux-operator
│   │   ├── Service/flux-system/flux-operator
│   │   └── Deployment/flux-system/flux-operator
│   └── OCIRepository/flux-system/flux-operator
└── Kustomization/flux-system/tenants
    ├── ResourceSet/flux-system/apps
    │   ├── Namespace/backend
    │   ├── Namespace/frontend
    │   ├── ServiceAccount/backend/flux
    │   ├── ServiceAccount/frontend/flux
    │   ├── RoleBinding/backend/flux
    │   ├── RoleBinding/frontend/flux
    │   ├── ConfigMap/backend/flux-runtime-info
    │   ├── ConfigMap/frontend/flux-runtime-info
    │   ├── Secret/backend/ghcr-auth
    │   ├── Secret/frontend/ghcr-auth
    │   ├── Kustomization/backend/apps
    │   │   ├── HelmRelease/backend/memcached
    │   │   │   ├── NetworkPolicy/backend/memcached
    │   │   │   ├── PodDisruptionBudget/backend/memcached
    │   │   │   ├── ServiceAccount/backend/memcached
    │   │   │   ├── Service/backend/memcached
    │   │   │   └── Deployment/backend/memcached
    │   │   ├── HelmRelease/backend/redis
    │   │   │   ├── NetworkPolicy/backend/redis
    │   │   │   ├── PodDisruptionBudget/backend/redis-master
    │   │   │   ├── PodDisruptionBudget/backend/redis-replicas
    │   │   │   ├── ServiceAccount/backend/redis-master
    │   │   │   ├── ServiceAccount/backend/redis-replica
    │   │   │   ├── Secret/backend/redis
    │   │   │   ├── ConfigMap/backend/redis-configuration
    │   │   │   ├── ConfigMap/backend/redis-health
    │   │   │   ├── ConfigMap/backend/redis-scripts
    │   │   │   ├── Service/backend/redis-headless
    │   │   │   ├── Service/backend/redis-master
    │   │   │   ├── Service/backend/redis-replicas
    │   │   │   ├── StatefulSet/backend/redis-master
    │   │   │   └── StatefulSet/backend/redis-replicas
    │   │   ├── OCIRepository/backend/memcached-chart
    │   │   └── OCIRepository/backend/redis-chart
    │   ├── Kustomization/frontend/apps
    │   │   ├── HelmRelease/frontend/podinfo
    │   │   │   ├── Service/frontend/podinfo
    │   │   │   ├── Deployment/frontend/podinfo
    │   │   │   ├── Ingress/frontend/podinfo
    │   │   │   └── ServiceMonitor/frontend/podinfo
    │   │   └── OCIRepository/frontend/podinfo-chart
    │   ├── OCIRepository/backend/apps
    │   └── OCIRepository/frontend/apps
    ├── ResourceSet/flux-system/infra
    │   ├── Namespace/cert-manager
    │   ├── Namespace/monitoring
    │   ├── ClusterRoleBinding/flux-infra-cert-manager
    │   ├── ClusterRoleBinding/flux-infra-monitoring
    │   ├── ServiceAccount/cert-manager/flux
    │   ├── ServiceAccount/monitoring/flux
    │   ├── ConfigMap/cert-manager/flux-runtime-info
    │   ├── ConfigMap/monitoring/flux-runtime-info
    │   ├── Secret/cert-manager/ghcr-auth
    │   ├── Secret/monitoring/ghcr-auth
    │   ├── Kustomization/cert-manager/infra-configs
    │   │   └── ClusterIssuer/letsencrypt
    │   ├── Kustomization/cert-manager/infra-controllers
    │   │   ├── HelmRelease/cert-manager/cert-manager
    │   │   │   ├── ServiceAccount/cert-manager/cert-manager-cainjector
    │   │   │   ├── ServiceAccount/cert-manager/cert-manager
    │   │   │   ├── ServiceAccount/cert-manager/cert-manager-webhook
    │   │   │   ├── CustomResourceDefinition/certificaterequests.cert-manager.io
    │   │   │   ├── CustomResourceDefinition/certificates.cert-manager.io
    │   │   │   ├── CustomResourceDefinition/challenges.acme.cert-manager.io
    │   │   │   ├── CustomResourceDefinition/clusterissuers.cert-manager.io
    │   │   │   ├── CustomResourceDefinition/issuers.cert-manager.io
    │   │   │   ├── CustomResourceDefinition/orders.acme.cert-manager.io
    │   │   │   ├── ClusterRole/cert-manager-cainjector
    │   │   │   ├── ClusterRole/cert-manager-controller-issuers
    │   │   │   ├── ClusterRole/cert-manager-controller-clusterissuers
    │   │   │   ├── ClusterRole/cert-manager-controller-certificates
    │   │   │   ├── ClusterRole/cert-manager-controller-orders
    │   │   │   ├── ClusterRole/cert-manager-controller-challenges
    │   │   │   ├── ClusterRole/cert-manager-controller-ingress-shim
    │   │   │   ├── ClusterRole/cert-manager-cluster-view
    │   │   │   ├── ClusterRole/cert-manager-view
    │   │   │   ├── ClusterRole/cert-manager-edit
    │   │   │   ├── ClusterRole/cert-manager-controller-approve:cert-manager-io
    │   │   │   ├── ClusterRole/cert-manager-controller-certificatesigningrequests
    │   │   │   ├── ClusterRole/cert-manager-webhook:subjectaccessreviews
    │   │   │   ├── ClusterRoleBinding/cert-manager-cainjector
    │   │   │   ├── ClusterRoleBinding/cert-manager-controller-issuers
    │   │   │   ├── ClusterRoleBinding/cert-manager-controller-clusterissuers
    │   │   │   ├── ClusterRoleBinding/cert-manager-controller-certificates
    │   │   │   ├── ClusterRoleBinding/cert-manager-controller-orders
    │   │   │   ├── ClusterRoleBinding/cert-manager-controller-challenges
    │   │   │   ├── ClusterRoleBinding/cert-manager-controller-ingress-shim
    │   │   │   ├── ClusterRoleBinding/cert-manager-controller-approve:cert-manager-io
    │   │   │   ├── ClusterRoleBinding/cert-manager-controller-certificatesigningrequests
    │   │   │   ├── ClusterRoleBinding/cert-manager-webhook:subjectaccessreviews
    │   │   │   ├── Role/kube-system/cert-manager-cainjector:leaderelection
    │   │   │   ├── Role/kube-system/cert-manager:leaderelection
    │   │   │   ├── Role/cert-manager/cert-manager-tokenrequest
    │   │   │   ├── Role/cert-manager/cert-manager-webhook:dynamic-serving
    │   │   │   ├── RoleBinding/kube-system/cert-manager-cainjector:leaderelection
    │   │   │   ├── RoleBinding/kube-system/cert-manager:leaderelection
    │   │   │   ├── RoleBinding/cert-manager/cert-manager-cert-manager-tokenrequest
    │   │   │   ├── RoleBinding/cert-manager/cert-manager-webhook:dynamic-serving
    │   │   │   ├── Service/cert-manager/cert-manager-cainjector
    │   │   │   ├── Service/cert-manager/cert-manager
    │   │   │   ├── Service/cert-manager/cert-manager-webhook
    │   │   │   ├── Deployment/cert-manager/cert-manager-cainjector
    │   │   │   ├── Deployment/cert-manager/cert-manager
    │   │   │   ├── Deployment/cert-manager/cert-manager-webhook
    │   │   │   ├── MutatingWebhookConfiguration/cert-manager-webhook
    │   │   │   └── ValidatingWebhookConfiguration/cert-manager-webhook
    │   │   └── OCIRepository/cert-manager/cert-manager-chart
    │   ├── Kustomization/monitoring/infra-configs
    │   │   ├── ClusterRole/kube-prometheus-stack-admin-role
    │   │   ├── ConfigMap/monitoring/flux-grafana-dashboards-dfh45k26mg
    │   │   ├── PodMonitor/monitoring/flux-system
    │   │   └── ServiceMonitor/monitoring/flux-operator
    │   ├── Kustomization/monitoring/infra-controllers
    │   │   ├── HelmRelease/monitoring/kube-prometheus-stack
    │   │   │   ├── ServiceAccount/monitoring/kube-prometheus-stack-grafana
    │   │   │   ├── ServiceAccount/monitoring/kube-prometheus-stack-kube-state-metrics
    │   │   │   ├── ServiceAccount/monitoring/kube-prometheus-stack-prometheus-node-exporter
    │   │   │   ├── ServiceAccount/monitoring/kube-prometheus-stack-operator
    │   │   │   ├── ServiceAccount/monitoring/kube-prometheus-stack-prometheus
    │   │   │   ├── Secret/monitoring/kube-prometheus-stack-grafana
    │   │   │   ├── ConfigMap/monitoring/kube-prometheus-stack-grafana-config-dashboards
    │   │   │   ├── ConfigMap/monitoring/kube-prometheus-stack-grafana
    │   │   │   ├── ConfigMap/monitoring/kube-prometheus-stack-grafana-datasource
    │   │   │   ├── ClusterRole/kube-prometheus-stack-grafana-clusterrole
    │   │   │   ├── ClusterRole/kube-prometheus-stack-kube-state-metrics
    │   │   │   ├── ClusterRole/kube-prometheus-stack-operator
    │   │   │   ├── ClusterRole/kube-prometheus-stack-prometheus
    │   │   │   ├── ClusterRoleBinding/kube-prometheus-stack-grafana-clusterrolebinding
    │   │   │   ├── ClusterRoleBinding/kube-prometheus-stack-kube-state-metrics
    │   │   │   ├── ClusterRoleBinding/kube-prometheus-stack-operator
    │   │   │   ├── ClusterRoleBinding/kube-prometheus-stack-prometheus
    │   │   │   ├── Role/monitoring/kube-prometheus-stack-grafana
    │   │   │   ├── RoleBinding/monitoring/kube-prometheus-stack-grafana
    │   │   │   ├── Service/monitoring/kube-prometheus-stack-grafana
    │   │   │   ├── Service/monitoring/kube-prometheus-stack-kube-state-metrics
    │   │   │   ├── Service/monitoring/kube-prometheus-stack-prometheus-node-exporter
    │   │   │   ├── Service/kube-system/kube-prometheus-stack-coredns
    │   │   │   ├── Service/kube-system/kube-prometheus-stack-kube-controller-manager
    │   │   │   ├── Service/kube-system/kube-prometheus-stack-kube-etcd
    │   │   │   ├── Service/kube-system/kube-prometheus-stack-kube-proxy
    │   │   │   ├── Service/kube-system/kube-prometheus-stack-kube-scheduler
    │   │   │   ├── Service/monitoring/kube-prometheus-stack-operator
    │   │   │   ├── Service/monitoring/kube-prometheus-stack-prometheus
    │   │   │   ├── DaemonSet/monitoring/kube-prometheus-stack-prometheus-node-exporter
    │   │   │   ├── Deployment/monitoring/kube-prometheus-stack-grafana
    │   │   │   ├── Deployment/monitoring/kube-prometheus-stack-kube-state-metrics
    │   │   │   ├── Deployment/monitoring/kube-prometheus-stack-operator
    │   │   │   ├── MutatingWebhookConfiguration/kube-prometheus-stack-admission
    │   │   │   ├── Prometheus/monitoring/kube-prometheus-stack-prometheus
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-alertmanager.rules
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-config-reloaders
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-etcd
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-general.rules
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-k8s.rules.container-cpu-usage-seconds-tot
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-k8s.rules.container-memory-cache
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-k8s.rules.container-memory-rss
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-k8s.rules.container-memory-swap
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-k8s.rules.container-memory-working-set-by
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-k8s.rules.container-resource
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-k8s.rules.pod-owner
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kube-apiserver-availability.rules
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kube-apiserver-burnrate.rules
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kube-apiserver-histogram.rules
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kube-apiserver-slos
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kube-prometheus-general.rules
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kube-prometheus-node-recording.rules
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kube-scheduler.rules
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kube-state-metrics
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kubelet.rules
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kubernetes-apps
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kubernetes-resources
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kubernetes-storage
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kubernetes-system-apiserver
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kubernetes-system-controller-manager
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kubernetes-system-kube-proxy
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kubernetes-system-kubelet
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kubernetes-system-scheduler
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-kubernetes-system
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-node-exporter.rules
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-node-exporter
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-node-network
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-node.rules
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-prometheus-operator
    │   │   │   ├── PrometheusRule/monitoring/kube-prometheus-stack-prometheus
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-grafana
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-kube-state-metrics
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-prometheus-node-exporter
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-coredns
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-apiserver
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-kube-controller-manager
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-kube-etcd
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-kube-proxy
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-kube-scheduler
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-kubelet
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-operator
    │   │   │   ├── ServiceMonitor/monitoring/kube-prometheus-stack-prometheus
    │   │   │   ├── ValidatingWebhookConfiguration/kube-prometheus-stack-admission
    │   │   │   ├── CustomResourceDefinition/alertmanagerconfigs.monitoring.coreos.com
    │   │   │   ├── CustomResourceDefinition/alertmanagers.monitoring.coreos.com
    │   │   │   ├── CustomResourceDefinition/podmonitors.monitoring.coreos.com
    │   │   │   ├── CustomResourceDefinition/probes.monitoring.coreos.com
    │   │   │   ├── CustomResourceDefinition/prometheusagents.monitoring.coreos.com
    │   │   │   ├── CustomResourceDefinition/prometheuses.monitoring.coreos.com
    │   │   │   ├── CustomResourceDefinition/prometheusrules.monitoring.coreos.com
    │   │   │   ├── CustomResourceDefinition/scrapeconfigs.monitoring.coreos.com
    │   │   │   ├── CustomResourceDefinition/servicemonitors.monitoring.coreos.com
    │   │   │   └── CustomResourceDefinition/thanosrulers.monitoring.coreos.com
    │   │   ├── HelmRelease/monitoring/metrics-server
    │   │   │   ├── ServiceAccount/monitoring/metrics-server
    │   │   │   ├── ClusterRole/system:metrics-server-aggregated-reader
    │   │   │   ├── ClusterRole/system:metrics-server
    │   │   │   ├── ClusterRoleBinding/metrics-server:system:auth-delegator
    │   │   │   ├── ClusterRoleBinding/system:metrics-server
    │   │   │   ├── RoleBinding/kube-system/metrics-server-auth-reader
    │   │   │   ├── Service/monitoring/metrics-server
    │   │   │   ├── Deployment/monitoring/metrics-server
    │   │   │   └── APIService/v1beta1.metrics.k8s.io
    │   │   ├── OCIRepository/monitoring/kube-prometheus-stack
    │   │   └── OCIRepository/monitoring/metrics-server
    │   ├── OCIRepository/cert-manager/infra
    │   └── OCIRepository/monitoring/infra
    └── ResourceSet/flux-system/policies
        ├── ConfigMap/flux-system/flux-allowlist
        ├── ValidatingAdmissionPolicy/source.policy.fluxcd.controlplane.io
        └── ValidatingAdmissionPolicyBinding/flux-tenant-sources

```