### PR TITLE
cli: Distribute the CLI as a container image

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -1,4 +1,4 @@
-name: push-mcp
+name: push-images
 on:
   workflow_dispatch:
   workflow_run:
@@ -9,10 +9,15 @@ permissions:
   contents: read
 
 env:
-  IMAGE: ${{ github.event.repository.name }}-mcp
+  IMAGE: ghcr.io/controlplaneio-fluxcd/${{ github.event.repository.name }}
 
 jobs:
   docker:
+    strategy:
+      matrix:
+        pkg:
+          - cli
+          - mcp
     runs-on: ubuntu-latest
     permissions:
       id-token: write # for creating OIDC tokens for signing.
@@ -43,7 +48,7 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: |
-            ghcr.io/controlplaneio-fluxcd/${{ env.IMAGE }}
+            ${{ env.IMAGE }}-${{ matrix.pkg }}
           tags: |
             type=raw,value=${{ steps.prep.outputs.VERSION }}
       - name: Publish images
@@ -55,7 +60,7 @@ jobs:
           push: true
           builder: ${{ steps.buildx.outputs.name }}
           context: .
-          file: ./cmd/mcp/Dockerfile
+          file: ./cmd/${{ matrix.pkg }}/Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -65,4 +70,5 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: 1
         run: |
-          cosign sign --yes ghcr.io/controlplaneio-fluxcd/${{ env.IMAGE }}@${{ steps.build-push.outputs.digest }}
+          cosign sign --yes \
+          ${{ env.IMAGE }}-${{ matrix.pkg }}@${{ steps.build-push.outputs.digest }}

--- a/cmd/cli/Dockerfile
+++ b/cmd/cli/Dockerfile
@@ -1,0 +1,50 @@
+# Build the Flux Operator CLI binary using Docker's Debian image.
+FROM --platform=${BUILDPLATFORM} golang:1.24 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION
+ARG KUBECTL_VER=1.33.0
+WORKDIR /workspace
+
+RUN apt-get -y install curl
+
+# Copy the Go Modules manifests.
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Cache the Go Modules
+RUN go mod download
+
+# Copy the Go sources.
+COPY cmd/cli/ cmd/cli/
+COPY api/ api/
+COPY internal/ internal/
+
+# Build the Flux Operator CLI binary.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags="-s -w -X main.VERSION=${VERSION}" \
+    -a -o /usr/local/bin/flux-operator ./cmd/cli/
+
+# Verify the Flux Operator CLI binary.
+RUN flux-operator version --client
+
+# Download the kubectl binary.
+RUN curl -sL https://dl.k8s.io/release/v${KUBECTL_VER}/bin/${TARGETOS}/${TARGETARCH}/kubectl \
+    -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+
+# Verify the kubectl binary.
+RUN kubectl version --client
+
+# Distribute the binaries using Google's Distroless image.
+FROM gcr.io/distroless/static:nonroot
+
+# Copy the license.
+COPY LICENSE /licenses/LICENSE
+
+# Copy the binaries.
+COPY --from=builder --chmod=777 /usr/local/bin/flux-operator /usr/local/bin/
+COPY --from=builder --chmod=777 /usr/local/bin/kubectl /usr/local/bin/
+
+# Run the binaries under a non-root user.
+USER 65532:65532
+ENTRYPOINT ["flux-operator"]

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -28,6 +28,20 @@ echo "source <(flux-operator completion bash)" >> ~/.bash_profile
 
 Zsh, Fish, and PowerShell are also supported with their own sub-commands.
 
+### Container Image
+
+The Flux Operator CLI is also available as a container image, which can be used in CI pipelines
+or Kubernetes Jobs. The image contains the `flux-operator` CLI binary and the `kubectl` binary.
+
+The multi-arch image (Linux AMD64/ARM64) is hosted on GitHub Container Registry at
+`ghcr.io/controlplaneio-fluxcd/flux-operator-cli`.
+
+```shell
+version=$(gh release view --repo controlplaneio-fluxcd/flux-operator --json tagName -q '.tagName')
+docker run --rm -it --entrypoint=flux-operator ghcr.io/controlplaneio-fluxcd/flux-operator-cli:$version help
+docker run --rm -it --entrypoint=kubectl ghcr.io/controlplaneio-fluxcd/flux-operator-cli:$version help
+```
+
 ## Commands
 
 The Flux Operator CLI provides commands to manage the Flux Operator resources.


### PR DESCRIPTION
Push CLI binary to `ghcr.io/controlplaneio-fluxcd/flux-operator-cli` from GHA at release time.