### PR TITLE
cli: Add `flux-operator wait` commands 

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -165,6 +165,24 @@ Arguments:
 
 - `-n, --namespace`: Specifies the namespace scope of the command.
 
+### Wait Commands
+
+The `flux-operator wait` commands are used to wait for Flux Operator resources to become ready.
+These commands will poll the resource status until it reaches a ready state or times out.
+If the resource is not created or its status is not ready within the specified timeout,
+the command will return an error.
+
+The following commands are available:
+
+- `flux-operator wait instance <name>`: Wait for a FluxInstance to become ready.
+- `flux-operator wait rset <name>`: Wait for a ResourceSet to become ready.
+- `flux-operator wait rsip <name>`: Wait for a ResourceSetInputProvider to become ready.
+
+Arguments:
+
+- `-n, --namespace`: Specifies the namespace scope of the command.
+- `--timeout`: The length of time to wait before giving up (default 1m).
+
 ### Create Secret Commands
 
 The `flux-operator create secret` commands are used to create Kubernetes secrets specific to Flux.

--- a/cmd/cli/create_secret_basicauth_test.go
+++ b/cmd/cli/create_secret_basicauth_test.go
@@ -27,40 +27,40 @@ func TestCreateSecretBasicAuthCmd(t *testing.T) {
 	}{
 		{
 			name:        "create basic auth secret",
-			args:        []string{"create", "secret", "basic-auth", "test-secret", "--username=admin", "--password=secret", "-n", ns.Name},
+			args:        []string{"create", "secret", "basic-auth", "test-secret", "--username=admin", "--password=secret"},
 			expectError: false,
 		},
 		{
 			name:         "create basic auth secret with export",
-			args:         []string{"create", "secret", "basic-auth", "test-secret", "--username=admin", "--password=secret", "--export", "-n", ns.Name},
+			args:         []string{"create", "secret", "basic-auth", "test-secret", "--username=admin", "--password=secret", "--export"},
 			expectError:  false,
 			expectExport: true,
 		},
 		{
 			name:        "create basic auth secret with annotations and labels",
-			args:        []string{"create", "secret", "basic-auth", "test-secret", "--username=admin", "--password=secret", "--annotation=test.io/annotation=value", "--label=test.io/label=value", "-n", ns.Name},
+			args:        []string{"create", "secret", "basic-auth", "test-secret", "--username=admin", "--password=secret", "--annotation=test.io/annotation=value", "--label=test.io/label=value"},
 			expectError: false,
 		},
 		{
 			name:        "create immutable basic auth secret",
-			args:        []string{"create", "secret", "basic-auth", "test-secret", "--username=admin", "--password=secret", "--immutable", "-n", ns.Name},
+			args:        []string{"create", "secret", "basic-auth", "test-secret", "--username=admin", "--password=secret", "--immutable"},
 			expectError: false,
 		},
 		{
 			name:         "missing username",
-			args:         []string{"create", "secret", "basic-auth", "test-secret", "--password=secret", "--export", "-n", ns.Name},
+			args:         []string{"create", "secret", "basic-auth", "test-secret", "--password=secret", "--export"},
 			expectError:  true,
 			expectExport: true,
 		},
 		{
 			name:         "missing password",
-			args:         []string{"create", "secret", "basic-auth", "test-secret", "--username=admin", "--export", "-n", ns.Name},
+			args:         []string{"create", "secret", "basic-auth", "test-secret", "--username=admin", "--export"},
 			expectError:  true,
 			expectExport: true,
 		},
 		{
 			name:        "missing secret name",
-			args:        []string{"create", "secret", "basic-auth", "--username=admin", "--password=secret", "-n", ns.Name},
+			args:        []string{"create", "secret", "basic-auth", "--username=admin", "--password=secret"},
 			expectError: true,
 		},
 	}
@@ -73,6 +73,7 @@ func TestCreateSecretBasicAuthCmd(t *testing.T) {
 			g := NewWithT(t)
 
 			// Execute command
+			kubeconfigArgs.Namespace = &ns.Name
 			output, err := executeCommand(tt.args)
 
 			if tt.expectError {

--- a/cmd/cli/create_secret_proxy_test.go
+++ b/cmd/cli/create_secret_proxy_test.go
@@ -27,39 +27,39 @@ func TestCreateSecretProxyCmd(t *testing.T) {
 	}{
 		{
 			name:        "create proxy secret",
-			args:        []string{"create", "secret", "proxy", "test-proxy", "--address=proxy.example.com:8080", "--username=admin", "--password=secret", "-n", ns.Name},
+			args:        []string{"create", "secret", "proxy", "test-proxy", "--address=proxy.example.com:8080", "--username=admin", "--password=secret"},
 			expectError: false,
 		},
 		{
 			name:         "create proxy secret with export",
-			args:         []string{"create", "secret", "proxy", "test-proxy", "--address=proxy.example.com:8080", "--username=admin", "--password=secret", "--export", "-n", ns.Name},
+			args:         []string{"create", "secret", "proxy", "test-proxy", "--address=proxy.example.com:8080", "--username=admin", "--password=secret", "--export"},
 			expectError:  false,
 			expectExport: true,
 		},
 		{
 			name:        "create proxy secret with annotations and labels",
-			args:        []string{"create", "secret", "proxy", "test-proxy", "--address=proxy.example.com:8080", "--username=admin", "--password=secret", "--annotation=test.io/annotation=value", "--label=test.io/label=value", "-n", ns.Name},
+			args:        []string{"create", "secret", "proxy", "test-proxy", "--address=proxy.example.com:8080", "--username=admin", "--password=secret", "--annotation=test.io/annotation=value", "--label=test.io/label=value"},
 			expectError: false,
 		},
 		{
 			name:        "create immutable proxy secret",
-			args:        []string{"create", "secret", "proxy", "test-proxy", "--address=proxy.example.com:8080", "--username=admin", "--password=secret", "--immutable", "-n", ns.Name},
+			args:        []string{"create", "secret", "proxy", "test-proxy", "--address=proxy.example.com:8080", "--username=admin", "--password=secret", "--immutable"},
 			expectError: false,
 		},
 		{
 			name:        "create proxy secret without username/password",
-			args:        []string{"create", "secret", "proxy", "test-proxy", "--address=proxy.example.com:8080", "-n", ns.Name},
+			args:        []string{"create", "secret", "proxy", "test-proxy", "--address=proxy.example.com:8080"},
 			expectError: false,
 		},
 		{
 			name:         "missing address",
-			args:         []string{"create", "secret", "proxy", "test-proxy", "--username=admin", "--password=secret", "--export", "-n", ns.Name},
+			args:         []string{"create", "secret", "proxy", "test-proxy", "--username=admin", "--password=secret", "--export"},
 			expectError:  true,
 			expectExport: true,
 		},
 		{
 			name:        "missing secret name",
-			args:        []string{"create", "secret", "proxy", "--address=proxy.example.com:8080", "--username=admin", "--password=secret", "-n", ns.Name},
+			args:        []string{"create", "secret", "proxy", "--address=proxy.example.com:8080", "--username=admin", "--password=secret"},
 			expectError: true,
 		},
 	}
@@ -72,6 +72,7 @@ func TestCreateSecretProxyCmd(t *testing.T) {
 			g := NewWithT(t)
 
 			// Execute command
+			kubeconfigArgs.Namespace = &ns.Name
 			output, err := executeCommand(tt.args)
 
 			if tt.expectError {

--- a/cmd/cli/create_secret_registry_test.go
+++ b/cmd/cli/create_secret_registry_test.go
@@ -28,46 +28,46 @@ func TestCreateSecretRegistryCmd(t *testing.T) {
 	}{
 		{
 			name:        "create registry secret",
-			args:        []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--username=admin", "--password=secret", "-n", ns.Name},
+			args:        []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--username=admin", "--password=secret"},
 			expectError: false,
 		},
 		{
 			name:         "create registry secret with export",
-			args:         []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--username=admin", "--password=secret", "--export", "-n", ns.Name},
+			args:         []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--username=admin", "--password=secret", "--export"},
 			expectError:  false,
 			expectExport: true,
 		},
 		{
 			name:        "create registry secret with annotations and labels",
-			args:        []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--username=admin", "--password=secret", "--annotation=test.io/annotation=value", "--label=test.io/label=value", "-n", ns.Name},
+			args:        []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--username=admin", "--password=secret", "--annotation=test.io/annotation=value", "--label=test.io/label=value"},
 			expectError: false,
 		},
 		{
 			name:        "create immutable registry secret",
-			args:        []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--username=admin", "--password=secret", "--immutable", "-n", ns.Name},
+			args:        []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--username=admin", "--password=secret", "--immutable"},
 			expectError: false,
 		},
 		{
 			name:         "missing server",
-			args:         []string{"create", "secret", "registry", "test-registry", "--username=admin", "--password=secret", "--export", "-n", ns.Name},
+			args:         []string{"create", "secret", "registry", "test-registry", "--username=admin", "--password=secret", "--export"},
 			expectError:  true,
 			expectExport: true,
 		},
 		{
 			name:         "missing username",
-			args:         []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--password=secret", "--export", "-n", ns.Name},
+			args:         []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--password=secret", "--export"},
 			expectError:  true,
 			expectExport: true,
 		},
 		{
 			name:         "missing password",
-			args:         []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--username=admin", "--export", "-n", ns.Name},
+			args:         []string{"create", "secret", "registry", "test-registry", "--server=ghcr.io", "--username=admin", "--export"},
 			expectError:  true,
 			expectExport: true,
 		},
 		{
 			name:        "missing secret name",
-			args:        []string{"create", "secret", "registry", "--server=ghcr.io", "--username=admin", "--password=secret", "-n", ns.Name},
+			args:        []string{"create", "secret", "registry", "--server=ghcr.io", "--username=admin", "--password=secret"},
 			expectError: true,
 		},
 	}
@@ -80,6 +80,7 @@ func TestCreateSecretRegistryCmd(t *testing.T) {
 			g := NewWithT(t)
 
 			// Execute command
+			kubeconfigArgs.Namespace = &ns.Name
 			output, err := executeCommand(tt.args)
 
 			if tt.expectError {

--- a/cmd/cli/create_secret_sops_test.go
+++ b/cmd/cli/create_secret_sops_test.go
@@ -32,14 +32,14 @@ func TestCreateSecretSOPSCmd(t *testing.T) {
 	}{
 		{
 			name:         "create sops secret with age key from stdin",
-			args:         []string{"create", "secret", "sops", "test-sops", "--age-key-stdin", "-n", ns.Name},
+			args:         []string{"create", "secret", "sops", "test-sops", "--age-key-stdin"},
 			stdin:        "AGE-SECRET-KEY-1EXAMPLE123456789ABCDEF",
 			expectError:  false,
 			expectAgeKey: true,
 		},
 		{
 			name:         "create sops secret with age key from stdin and export",
-			args:         []string{"create", "secret", "sops", "test-sops", "--age-key-stdin", "--export", "-n", ns.Name},
+			args:         []string{"create", "secret", "sops", "test-sops", "--age-key-stdin", "--export"},
 			stdin:        "AGE-SECRET-KEY-1EXAMPLE123456789ABCDEF",
 			expectError:  false,
 			expectExport: true,
@@ -47,14 +47,14 @@ func TestCreateSecretSOPSCmd(t *testing.T) {
 		},
 		{
 			name:         "create sops secret with gpg key from stdin",
-			args:         []string{"create", "secret", "sops", "test-sops", "--gpg-key-stdin", "-n", ns.Name},
+			args:         []string{"create", "secret", "sops", "test-sops", "--gpg-key-stdin"},
 			stdin:        "-----BEGIN PGP PRIVATE KEY BLOCK-----\n...test gpg key content...\n-----END PGP PRIVATE KEY BLOCK-----",
 			expectError:  false,
 			expectGPGKey: true,
 		},
 		{
 			name:         "create sops secret with gpg key from stdin and export",
-			args:         []string{"create", "secret", "sops", "test-sops", "--gpg-key-stdin", "--export", "-n", ns.Name},
+			args:         []string{"create", "secret", "sops", "test-sops", "--gpg-key-stdin", "--export"},
 			stdin:        "-----BEGIN PGP PRIVATE KEY BLOCK-----\n...test gpg key content...\n-----END PGP PRIVATE KEY BLOCK-----",
 			expectError:  false,
 			expectExport: true,
@@ -62,32 +62,32 @@ func TestCreateSecretSOPSCmd(t *testing.T) {
 		},
 		{
 			name:        "create sops secret with both age and gpg keys from stdin",
-			args:        []string{"create", "secret", "sops", "test-sops", "--age-key-stdin", "--gpg-key-stdin", "-n", ns.Name},
+			args:        []string{"create", "secret", "sops", "test-sops", "--age-key-stdin", "--gpg-key-stdin"},
 			stdin:       "AGE-SECRET-KEY-1EXAMPLE123456789ABCDEF\n-----BEGIN PGP PRIVATE KEY BLOCK-----\n...test gpg key content...\n-----END PGP PRIVATE KEY BLOCK-----",
 			expectError: true,
 		},
 		{
 			name:         "create sops secret with annotations and labels",
-			args:         []string{"create", "secret", "sops", "test-sops", "--age-key-stdin", "--annotation=test.io/annotation=value", "--label=test.io/label=value", "-n", ns.Name},
+			args:         []string{"create", "secret", "sops", "test-sops", "--age-key-stdin", "--annotation=test.io/annotation=value", "--label=test.io/label=value"},
 			stdin:        "AGE-SECRET-KEY-1EXAMPLE123456789ABCDEF",
 			expectError:  false,
 			expectAgeKey: true,
 		},
 		{
 			name:         "create immutable sops secret",
-			args:         []string{"create", "secret", "sops", "test-sops", "--age-key-stdin", "--immutable", "-n", ns.Name},
+			args:         []string{"create", "secret", "sops", "test-sops", "--age-key-stdin", "--immutable"},
 			stdin:        "AGE-SECRET-KEY-1EXAMPLE123456789ABCDEF",
 			expectError:  false,
 			expectAgeKey: true,
 		},
 		{
 			name:        "missing keys",
-			args:        []string{"create", "secret", "sops", "test-sops", "-n", ns.Name},
+			args:        []string{"create", "secret", "sops", "test-sops"},
 			expectError: true,
 		},
 		{
 			name:        "missing secret name",
-			args:        []string{"create", "secret", "sops", "--age-key-stdin", "-n", ns.Name},
+			args:        []string{"create", "secret", "sops", "--age-key-stdin"},
 			stdin:       "AGE-SECRET-KEY-1EXAMPLE123456789ABCDEF",
 			expectError: true,
 		},
@@ -108,6 +108,7 @@ func TestCreateSecretSOPSCmd(t *testing.T) {
 			}
 
 			// Execute command
+			kubeconfigArgs.Namespace = &ns.Name
 			output, err := executeCommand(tt.args)
 
 			if tt.expectError {

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -125,6 +125,10 @@ func executeCommand(args []string) (string, error) {
 // resetCmdArgs resets all command-specific flags to their default values.
 // This should be called between tests to ensure clean state.
 func resetCmdArgs() {
+	rootArgs.timeout = timeout
+	defaultNamespace := ""
+	kubeconfigArgs.Namespace = &defaultNamespace
+
 	// Version command
 	versionArgs = versionFlags{}
 

--- a/cmd/cli/wait.go
+++ b/cmd/cli/wait.go
@@ -1,0 +1,17 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var waitCmd = &cobra.Command{
+	Use:   "wait",
+	Short: "Wait for Flux Operator resources to become ready",
+}
+
+func init() {
+	rootCmd.AddCommand(waitCmd)
+}

--- a/cmd/cli/wait_inputprovider.go
+++ b/cmd/cli/wait_inputprovider.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+var waitInputProviderCmd = &cobra.Command{
+	Use:     "inputprovider [name]",
+	Aliases: []string{"rsip", "resourcesetinputprovider"},
+	Short:   "Wait for ResourceSetInputProvider to become ready",
+	Example: `  # Wait for an ResourceSetInputProvider to become ready
+  flux-operator -n flux-system wait inputprovider my-inputprovider
+
+  # Wait for an ResourceSetInputProvider to become ready with a custom timeout
+  flux-operator -n flux-system wait rsip my-inputprovider --timeout=5m
+`,
+	Args:              cobra.ExactArgs(1),
+	RunE:              waitInputProviderCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)),
+}
+
+func init() {
+	waitCmd.AddCommand(waitInputProviderCmd)
+}
+
+func waitInputProviderCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("name is required")
+	}
+
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetInputProviderKind)
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	rootCmd.Println(`◎`, "Waiting for inputprovider to become ready...")
+	msg, err := waitForResourceReconciliation(ctx, gvk, name, *kubeconfigArgs.Namespace, "", rootArgs.timeout)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, msg)
+	return nil
+}

--- a/cmd/cli/wait_inputprovider_test.go
+++ b/cmd/cli/wait_inputprovider_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestWaitInputProviderCmd(t *testing.T) {
+	gt := NewWithT(t)
+	ctxInit, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctxInit, "test-wait-inputprovider")
+	gt.Expect(err).ToNot(HaveOccurred())
+
+	// Create inputprovider
+	defaultValues, err := fluxcdv1.NewResourceSetInput(nil, map[string]any{
+		"env": "test",
+	})
+	gt.Expect(err).ToNot(HaveOccurred())
+
+	inputprovider := &fluxcdv1.ResourceSetInputProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-inputprovider",
+			Namespace: ns.Name,
+		},
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type:          fluxcdv1.InputProviderStatic,
+			DefaultValues: defaultValues,
+		},
+	}
+	gt.Expect(testClient.Create(ctxInit, inputprovider)).To(Succeed())
+	defer func() {
+		_ = testClient.Delete(ctxInit, inputprovider)
+	}()
+
+	tests := []struct {
+		name           string
+		readyCondition metav1.Condition
+		expectError    bool
+		expectOutput   string
+	}{
+		{
+			name: "inputprovider with no Ready condition",
+			readyCondition: metav1.Condition{
+				Type:               meta.HealthyCondition,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "test",
+				Message:            "test",
+			},
+			expectError:  true,
+			expectOutput: fmt.Sprintf("waiting for %s/%s to become ready", ns.Name, inputprovider.Name),
+		},
+		{
+			name: "inputprovider with Ready condition False",
+			readyCondition: metav1.Condition{
+				Type:               meta.ReadyCondition,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "ReconciliationFailed",
+				Message:            "ResourceSetInputProvider reconciliation failed",
+			},
+			expectError:  true,
+			expectOutput: "ReconciliationFailed: ResourceSetInputProvider reconciliation failed",
+		},
+		{
+			name: "inputprovider with Ready condition Unknown",
+			readyCondition: metav1.Condition{
+				Type:               meta.ReadyCondition,
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Progressing",
+				Message:            "ResourceSetInputProvider reconciliation is in progress",
+			},
+			expectError:  true,
+			expectOutput: "timed out waiting",
+		},
+		{
+			name: "inputprovider with Ready condition True",
+			readyCondition: metav1.Condition{
+				Type:               meta.ReadyCondition,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "ReconciliationSucceeded",
+				Message:            "ResourceSetInputProvider reconciliation succeeded",
+			},
+			expectError:  false,
+			expectOutput: "succeeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			inputprovider.Status = fluxcdv1.ResourceSetInputProviderStatus{
+				Conditions: []metav1.Condition{tt.readyCondition},
+			}
+			g.Expect(testClient.Status().Update(ctx, inputprovider)).To(Succeed())
+
+			// Execute command
+			rootArgs.timeout = 4 * time.Second
+			kubeconfigArgs.Namespace = &ns.Name
+			output, err := executeCommand([]string{"wait", "inputprovider", "test-inputprovider"})
+
+			// Check expectations
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectOutput))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(output).To(ContainSubstring(tt.expectOutput))
+			}
+		})
+	}
+}

--- a/cmd/cli/wait_instance.go
+++ b/cmd/cli/wait_instance.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+var waitInstanceCmd = &cobra.Command{
+	Use:   "instance [name]",
+	Short: "Wait for FluxInstance to become ready",
+	Example: `  # Wait for an instance to become ready
+  flux-operator -n flux-system wait instance flux
+
+  # Wait for an instance to become ready with a custom timeout
+  flux-operator -n flux-system wait instance flux --timeout=5m
+`,
+	Args:              cobra.ExactArgs(1),
+	RunE:              waitInstanceCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)),
+}
+
+func init() {
+	waitCmd.AddCommand(waitInstanceCmd)
+}
+
+func waitInstanceCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("name is required")
+	}
+
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind)
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	rootCmd.Println(`◎`, "Waiting for instance to become ready...")
+	msg, err := waitForResourceReconciliation(ctx, gvk, name, *kubeconfigArgs.Namespace, "", rootArgs.timeout)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, msg)
+	return nil
+}

--- a/cmd/cli/wait_instance_test.go
+++ b/cmd/cli/wait_instance_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestWaitInstanceCmd(t *testing.T) {
+	gt := NewWithT(t)
+	ctxInit, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctxInit, "test-wait-instance")
+	gt.Expect(err).ToNot(HaveOccurred())
+
+	// Create instance
+	instance := &fluxcdv1.FluxInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flux",
+			Namespace: ns.Name,
+		},
+		Spec: fluxcdv1.FluxInstanceSpec{
+			Distribution: fluxcdv1.Distribution{
+				Version:  "2.x",
+				Registry: "ghcr.io/fluxcd",
+			},
+		},
+	}
+	gt.Expect(testClient.Create(ctxInit, instance)).To(Succeed())
+	defer func() {
+		_ = testClient.Delete(ctxInit, instance)
+	}()
+
+	tests := []struct {
+		name           string
+		readyCondition metav1.Condition
+		expectError    bool
+		expectOutput   string
+	}{
+		{
+			name: "instance with no Ready condition",
+			readyCondition: metav1.Condition{
+				Type:               meta.HealthyCondition,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "test",
+				Message:            "test",
+			},
+			expectError:  true,
+			expectOutput: fmt.Sprintf("waiting for %s/%s to become ready", ns.Name, instance.Name),
+		},
+		{
+			name: "instance with Ready condition False",
+			readyCondition: metav1.Condition{
+				Type:               meta.ReadyCondition,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "ReconciliationFailed",
+				Message:            "validation error",
+			},
+			expectError:  true,
+			expectOutput: "ReconciliationFailed: validation error",
+		},
+		{
+			name: "instance with Ready condition Unknown",
+			readyCondition: metav1.Condition{
+				Type:               meta.ReadyCondition,
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Progressing",
+				Message:            "reconciliation is in progress",
+			},
+			expectError:  true,
+			expectOutput: "timed out waiting",
+		},
+		{
+			name: "instance with Ready condition True",
+			readyCondition: metav1.Condition{
+				Type:               meta.ReadyCondition,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "ReconciliationSucceeded",
+				Message:            "Reconciliation succeeded",
+			},
+			expectError:  false,
+			expectOutput: "succeeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			instance.Status = fluxcdv1.FluxInstanceStatus{
+				Conditions: []metav1.Condition{tt.readyCondition},
+			}
+			g.Expect(testClient.Status().Update(ctx, instance)).To(Succeed())
+
+			// Execute command
+			rootArgs.timeout = 4 * time.Second
+			kubeconfigArgs.Namespace = &ns.Name
+			output, err := executeCommand([]string{"wait", "instance", "flux"})
+
+			// Check expectations
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectOutput))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(output).To(ContainSubstring(tt.expectOutput))
+			}
+		})
+	}
+}

--- a/cmd/cli/wait_resourceset.go
+++ b/cmd/cli/wait_resourceset.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+var waitResourceSetCmd = &cobra.Command{
+	Use:     "resourceset [name]",
+	Aliases: []string{"rset"},
+	Short:   "Wait for ResourceSet to become ready",
+	Example: `  # Wait for a resourceset to become ready
+  flux-operator -n flux-system wait resourceset my-resourceset
+
+  # Wait for a resourceset to become ready with a custom timeout
+  flux-operator -n flux-system wait rset my-resourceset --timeout=5m
+`,
+	Args:              cobra.ExactArgs(1),
+	RunE:              waitResourceSetCmdRun,
+	ValidArgsFunction: resourceNamesCompletionFunc(fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)),
+}
+
+func init() {
+	waitCmd.AddCommand(waitResourceSetCmd)
+}
+
+func waitResourceSetCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("name is required")
+	}
+
+	name := args[0]
+	gvk := fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind)
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	rootCmd.Println(`◎`, "Waiting for resourceset to become ready...")
+	msg, err := waitForResourceReconciliation(ctx, gvk, name, *kubeconfigArgs.Namespace, "", rootArgs.timeout)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, msg)
+	return nil
+}

--- a/cmd/cli/wait_resourceset_test.go
+++ b/cmd/cli/wait_resourceset_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestWaitResourceSetCmd(t *testing.T) {
+	gt := NewWithT(t)
+	ctxInit, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctxInit, "test-wait-resourceset")
+	gt.Expect(err).ToNot(HaveOccurred())
+
+	// Create resourceset
+	input, err := fluxcdv1.NewResourceSetInput(nil, map[string]any{
+		"app": "test-app",
+	})
+	gt.Expect(err).ToNot(HaveOccurred())
+
+	resourceset := &fluxcdv1.ResourceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-resourceset",
+			Namespace: ns.Name,
+		},
+		Spec: fluxcdv1.ResourceSetSpec{
+			Inputs: []fluxcdv1.ResourceSetInput{input},
+			ResourcesTemplate: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: << .inputs.app >>-config
+data:
+  app: "<< .inputs.app >>"`,
+		},
+	}
+	gt.Expect(testClient.Create(ctxInit, resourceset)).To(Succeed())
+	defer func() {
+		_ = testClient.Delete(ctxInit, resourceset)
+	}()
+
+	tests := []struct {
+		name           string
+		readyCondition metav1.Condition
+		expectError    bool
+		expectOutput   string
+	}{
+		{
+			name: "resourceset with no ObservedGeneration mismatch",
+			readyCondition: metav1.Condition{
+				Type:               meta.ReadyCondition,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 2,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "test",
+				Message:            "test",
+			},
+			expectError:  true,
+			expectOutput: fmt.Sprintf("waiting for %s/%s to become ready", ns.Name, resourceset.Name),
+		},
+		{
+			name: "resourceset with Ready condition False",
+			readyCondition: metav1.Condition{
+				Type:               meta.ReadyCondition,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "ReconciliationFailed",
+				Message:            "ResourceSet reconciliation failed",
+			},
+			expectError:  true,
+			expectOutput: "ReconciliationFailed: ResourceSet reconciliation failed",
+		},
+		{
+			name: "resourceset with Ready condition Unknown",
+			readyCondition: metav1.Condition{
+				Type:               meta.ReadyCondition,
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Progressing",
+				Message:            "ResourceSet reconciliation is in progress",
+			},
+			expectError:  true,
+			expectOutput: "timed out waiting",
+		},
+		{
+			name: "resourceset with Ready condition True",
+			readyCondition: metav1.Condition{
+				Type:               meta.ReadyCondition,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "ReconciliationSucceeded",
+				Message:            "ResourceSet reconciliation succeeded",
+			},
+			expectError:  false,
+			expectOutput: "succeeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			resourceset.Status = fluxcdv1.ResourceSetStatus{
+				Conditions: []metav1.Condition{tt.readyCondition},
+			}
+			g.Expect(testClient.Status().Update(ctx, resourceset)).To(Succeed())
+
+			// Execute command
+			rootArgs.timeout = 4 * time.Second
+			kubeconfigArgs.Namespace = &ns.Name
+			output, err := executeCommand([]string{"wait", "resourceset", "test-resourceset"})
+
+			// Check expectations
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectOutput))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(output).To(ContainSubstring(tt.expectOutput))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `flux-operator wait` commands are used to wait for Flux Operator resources to become ready.
These commands will poll the resource status until it reaches a ready state or times out.
If the resource is not created or its status is not ready within the specified timeout, the command will return an error.

The following commands are available:

- `flux-operator wait instance <name>`: Wait for a FluxInstance to become ready.
- `flux-operator wait rset <name>`: Wait for a ResourceSet to become ready.
- `flux-operator wait rsip <name>`: Wait for a ResourceSetInputProvider to become ready.

Arguments:

- `-n, --namespace`: Specifies the namespace scope of the command.
- `--timeout`: The length of time to wait before giving up (default 1m).