### PR TITLE
controller: Fix instance health check on subsequent reconciliations

### DIFF
--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -536,12 +536,13 @@ func (r *FluxInstanceReconciler) apply(ctx context.Context,
 	}
 
 	// Wait for the resources to become ready.
-	if obj.GetWait() && len(resultSet.Entries) > 0 {
-		if err := resourceManager.WaitForSet(resultSet.ToObjMetadataSet(), ssa.WaitOptions{
+	if obj.GetWait() && len(changeSet.Entries) > 0 {
+		if err := resourceManager.WaitForSet(changeSet.ToObjMetadataSet(), ssa.WaitOptions{
 			Interval: 5 * time.Second,
 			Timeout:  obj.GetTimeout(),
 		}); err != nil {
-			return err
+			readyStatus := aggregateNotReadyStatus(ctx, kubeClient, objects)
+			return fmt.Errorf("%w\n%s", err, readyStatus)
 		}
 		log.Info("Health check completed", "revision", buildResult.Revision)
 	}

--- a/internal/controller/resourceset_controller.go
+++ b/internal/controller/resourceset_controller.go
@@ -456,23 +456,21 @@ func (r *ResourceSetReconciler) apply(ctx context.Context,
 			"kustomize.toolkit.fluxcd.io/name",
 			"kustomize.toolkit.fluxcd.io/namespace",
 		},
-		// Take ownership of the Flux resources if they
-		// were previously managed by other tools.
+		// Undo changes made by kubectl.
 		FieldManagers: []ssa.FieldManager{
 			{
-				Name:          "flux",
+				// to undo changes made with 'kubectl apply --server-side --force-conflicts'
+				Name:          "kubectl",
 				OperationType: metav1.ManagedFieldsOperationApply,
 			},
 			{
-				Name:          "kustomize-controller",
-				OperationType: metav1.ManagedFieldsOperationApply,
-			},
-			{
-				Name:          "helm",
+				// to undo changes made with 'kubectl apply'
+				Name:          "kubectl",
 				OperationType: metav1.ManagedFieldsOperationUpdate,
 			},
 			{
-				Name:          "kubectl",
+				// to undo changes made with 'kubectl apply'
+				Name:          "before-first-apply",
 				OperationType: metav1.ManagedFieldsOperationUpdate,
 			},
 		},


### PR DESCRIPTION
Ensure that on subsequent reconciliations of a `FluxInstance`, the health check is performed on all Flux resources. 

In addition, this PR improves the error reporting by adding the `sync` ready message to the `FluxInstance` failure events and status.