### PR TITLE
reporter: Add `flux_operator_info` metric

### DIFF
--- a/internal/controller/fluxreport_controller.go
+++ b/internal/controller/fluxreport_controller.go
@@ -80,6 +80,9 @@ func (r *FluxReportReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Set the operator info.
 	report.Operator = r.getInfo()
 
+	// Record the Flux Operator version and platform.
+	reporter.RecordOperatorInfoMetric(report.Operator)
+
 	// Update the FluxReport with the computed spec.
 	obj.Spec = report
 

--- a/internal/reporter/metrics.go
+++ b/internal/reporter/metrics.go
@@ -85,6 +85,16 @@ func RecordMetrics(obj unstructured.Unstructured) {
 	}
 }
 
+// RecordOperatorInfoMetric records the version information of the Flux Operator.
+func RecordOperatorInfoMetric(obj *fluxcdv1.OperatorInfo) {
+	metrics["FluxOperatorInfo"].Reset()
+	metrics["FluxOperatorInfo"].With(prometheus.Labels{
+		"version":     obj.Version,
+		"api_version": obj.APIVersion,
+		"platform":    obj.Platform,
+	}).Set(1)
+}
+
 // ResetMetrics resets the metrics for the given kind.
 func ResetMetrics(kind string) {
 	metrics[kind].Reset()
@@ -138,6 +148,13 @@ var metrics = map[string]*prometheus.GaugeVec{
 			"source_name",
 			"path",
 		),
+	),
+	"FluxOperatorInfo": prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flux_operator_info",
+			Help: "The version information of Flux Operator.",
+		},
+		[]string{"version", "api_version", "platform"},
 	),
 }
 


### PR DESCRIPTION
The `flux_operator_info` Prometheus metric contains the following labels:
- `version` The Flux Operator semver
- `platform` The Flux Operator platform `os/arch`
- `api_version` The Flux Operator API `group/version`
