### PR TITLE
Set the default CPU limit to `2000m` for Flux Operator

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -64,7 +64,7 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 1000m
+            cpu: 2000m
             memory: 1Gi
           requests:
             cpu: 10m

--- a/config/olm/bundle/manifests/flux-operator.clusterserviceversion.yaml
+++ b/config/olm/bundle/manifests/flux-operator.clusterserviceversion.yaml
@@ -373,8 +373,8 @@ spec:
                       periodSeconds: 10
                     resources:
                       limits:
-                        cpu: 1000m
-                        memory: 1Gi
+                        cpu: 2000m
+                        memory: 2Gi
                       requests:
                         cpu: 10m
                         memory: 64Mi


### PR DESCRIPTION
Change default limit to prevent throttling