### PR TITLE
RSIP: Introduce reliable skip mechanism for updating commits in change requests

### DIFF
--- a/api/v1/resourcesetinputprovider_types.go
+++ b/api/v1/resourcesetinputprovider_types.go
@@ -151,10 +151,20 @@ type ResourceSetInputFilter struct {
 
 // ResourceSetInputSkip defines whether we need to skip input updates.
 type ResourceSetInputSkip struct {
-	// Labels specifies list of labels to skip input provider response when any of the label conditions matched.
-	// When prefixed with !, input provider response will be skipped if it does not have this label.
+	// Labels specifies a list of labels to skip the input provider response when any of the label
+	// conditions matched.
+	// When prefixed with !, the input provider response will be skipped if it does not have this label.
 	// +optional
 	Labels []string `json:"labels,omitempty"`
+
+	// Toggle defines a label whose presence needs to alternate between two scans for a new scan
+	// to be taken into account. If the label was previously present, then updating the exported
+	// inputs will be skipped until the label is removed. If the label was previously absent,
+	// then updating the exported inputs will be skipped until the label is added.
+	// This allows for safely transitioning between pull/merge request commits without running into
+	// race conditions.
+	// +optional
+	Toggle string `json:"toggle,omitempty"`
 }
 
 // ResourceSetInputProviderStatus defines the observed state of ResourceSetInputProvider.

--- a/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
@@ -178,11 +178,21 @@ spec:
                 properties:
                   labels:
                     description: |-
-                      Labels specifies list of labels to skip input provider response when any of the label conditions matched.
-                      When prefixed with !, input provider response will be skipped if it does not have this label.
+                      Labels specifies a list of labels to skip the input provider response when any of the label
+                      conditions matched.
+                      When prefixed with !, the input provider response will be skipped if it does not have this label.
                     items:
                       type: string
                     type: array
+                  toggle:
+                    description: |-
+                      Toggle defines a label whose presence needs to alternate between two scans for a new scan
+                      to be taken into account. If the label was previously present, then updating the exported
+                      inputs will be skipped until the label is removed. If the label was previously absent,
+                      then updating the exported inputs will be skipped until the label is added.
+                      This allows for safely transitioning between pull/merge request commits without running into
+                      race conditions.
+                    type: string
                 type: object
               type:
                 description: Type specifies the type of the input provider.


### PR DESCRIPTION
This PR implements what's described [here](https://github.com/controlplaneio-fluxcd/flux-operator/issues/372#issuecomment-3143631023).

I'll wait for a review before adding docs/tests.

After publishing the artifacts, the CI can do this:

```bash
if [ "$(gh pr view --json labels --jq '.labels | any(.name == "deploy/flux-operator-togglel")')" = "true" ]; then
    gh pr edit 23 --remove-label "deploy/flux-operator-toggle"
else
    gh pr edit 23 --add-label "deploy/flux-operator-toggle"
fi
```

This can be wrapped in a GitHub Action in the https://github.com/controlplaneio-fluxcd/distribution repo called `toggle-rsip-label` with the following inputs:

```yaml
  - uses: controlplaneio-fluxcd/distribution/actions/toggle-rsip-label@main
    with:
      toggle: deploy/flux-operator-toggle
```