### PR TITLE
Refactor Terraform bootstrap example

### DIFF
--- a/config/olm/bundle/manifests/flux-operator.clusterserviceversion.yaml
+++ b/config/olm/bundle/manifests/flux-operator.clusterserviceversion.yaml
@@ -33,6 +33,7 @@ metadata:
             ],
             "cluster": {
               "type": "openshift",
+              "size": "medium",
               "domain": "cluster.local",
               "networkPolicy": true,
               "multitenant": true,
@@ -237,6 +238,16 @@ spec:
     The operator generates reports, emits events, and exports Prometheus metrics
     to help with monitoring and troubleshooting Flux.
 
+    ### Operator Features
+    
+    The operator extends Flux with self-service capabilities, deployment windows,
+    and preview environments for GitHub, GitLab and Azure DevOps pull requests testing.
+    
+    The operator ResourceSet API enables platform teams to define their own application standard
+    as a group of Flux and Kubernetes resources that can be templated, parameterized and deployed
+    as a single unit on self-service environments. For more information, please see the
+    [ResourceSet documentation](https://fluxcd.control-plane.io/operator/resourcesets/introduction/).
+    
     ### OpenShift Support
 
     The Flux Operator should be installed in a dedicated namespace, e.g. `flux-system`.

--- a/config/terraform/main.tf
+++ b/config/terraform/main.tf
@@ -1,18 +1,3 @@
-terraform {
-  required_version = ">= 1.7"
-
-  required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.27"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = ">= 2.12"
-    }
-  }
-}
-
 // Create the  flux-system namespace.
 resource "kubernetes_namespace" "flux_system" {
   metadata {
@@ -57,7 +42,7 @@ resource "helm_release" "flux_operator" {
   wait       = true
 }
 
-// Configure the Flux instance.
+// Deploy the Flux instance.
 resource "helm_release" "flux_instance" {
   depends_on = [helm_release.flux_operator]
 
@@ -65,45 +50,59 @@ resource "helm_release" "flux_instance" {
   namespace  = "flux-system"
   repository = "oci://ghcr.io/controlplaneio-fluxcd/charts"
   chart      = "flux-instance"
+  wait       = true
 
   // Configure the Flux components and kustomize patches.
   values = [
     file("values/components.yaml")
   ]
 
-  // Configure the Flux distribution.
-  set {
-    name  = "instance.distribution.version"
-    value = var.flux_version
-  }
-  set {
-    name  = "instance.distribution.registry"
-    value = var.flux_registry
-  }
-
-  // Configure Flux Git sync.
-  set {
-    name  = "instance.sync.kind"
-    value = "GitRepository"
-  }
-  set {
-    name  = "instance.sync.url"
-    value = var.git_url
-  }
-  set {
-    name  = "instance.sync.path"
-    value = var.git_path
-  }
-  set {
-    name  = "instance.sync.ref"
-    value = var.git_ref
-  }
-  set {
-    name  = "instance.sync.provider"
-    value = var.github_app_id != "" ? "github" : "generic"
-  }
-  set {
-    name  = "instance.sync.pullSecret"
-    value = var.git_token != "" || var.github_app_id != "" ? "flux-system" : ""
-  }
+  // Configure the Flux distribution, cluster type and Git sync.
+  set = [
+    {
+      name  = "instance.distribution.version"
+      value = var.flux_version
+    },
+    {
+      name  = "instance.distribution.registry"
+      value = var.flux_registry
+    },
+    {
+      name  = "instance.cluster.type"
+      value = var.cluster_type
+    },
+    {
+      name  = "instance.cluster.size"
+      value = var.cluster_size
+    },
+    {
+      name  = "instance.sync.kind"
+      value = "GitRepository"
+    },
+    {
+      name  = "instance.sync.url"
+      value = var.git_url
+    },
+    {
+      name  = "instance.sync.path"
+      value = var.git_path
+    },
+    {
+      name  = "instance.sync.ref"
+      value = var.git_ref
+    },
+    {
+      name  = "instance.sync.provider"
+      value = var.github_app_id != "" ? "github" : "generic"
+    },
+    {
+      name  = "instance.sync.pullSecret"
+      value = var.git_token != "" || var.github_app_id != "" ? "flux-system" : ""
+    },
+    {
+      name  = "healthcheck.enabled"
+      value = "true"
+      type  = "auto"
+    },
+  ]
 }

--- a/config/terraform/providers.tf
+++ b/config/terraform/providers.tf
@@ -3,7 +3,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path = "~/.kube/config"
   }
 }

--- a/config/terraform/values/components.yaml
+++ b/config/terraform/values/components.yaml
@@ -10,11 +10,13 @@ instance:
     patches:
       - target:
           kind: Deployment
-          name: "(kustomize-controller|helm-controller)"
         patch: |
+          - op: replace
+            path: /spec/template/spec/nodeSelector
+            value:
+              kubernetes.io/os: linux
           - op: add
-            path: /spec/template/spec/containers/0/args/-
-            value: --concurrent=10
-          - op: add
-            path: /spec/template/spec/containers/0/args/-
-            value: --requeue-dependency=10s
+            path: /spec/template/spec/tolerations
+            value:
+              - key: "CriticalAddonsOnly"
+                operator: "Exists"

--- a/config/terraform/variables.tf
+++ b/config/terraform/variables.tf
@@ -1,3 +1,27 @@
+variable "flux_version" {
+  description = "Flux version semver range"
+  type        = string
+  default     = "2.x"
+}
+
+variable "flux_registry" {
+  description = "Flux distribution registry"
+  type        = string
+  default     = "ghcr.io/fluxcd"
+}
+
+variable "cluster_type" {
+  description = "Cluster type, e.g. kubernetes, openshift, azure, aws, gcp"
+  type        = string
+  default     = "kubernetes"
+}
+
+variable "cluster_size" {
+  description = "Cluster size, e.g. small, medium, large"
+  type        = string
+  default     = "medium"
+}
+
 variable "git_token" {
   description = "Git PAT"
   sensitive   = true
@@ -40,16 +64,4 @@ variable "git_ref" {
   description = "Git branch or tag in the format refs/heads/main or refs/tags/v1.0.0"
   type        = string
   default     = "refs/heads/main"
-}
-
-variable "flux_version" {
-  description = "Flux version semver range"
-  type        = string
-  default     = "2.x"
-}
-
-variable "flux_registry" {
-  description = "Flux distribution registry"
-  type        = string
-  default     = "ghcr.io/fluxcd"
 }

--- a/config/terraform/versions.tf
+++ b/config/terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.37"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 3.0"
+    }
+  }
+}


### PR DESCRIPTION
Migrate the Terraform module to Helm provider v3, add cluster options and enable instance health check.

In addition, add cluster size to OLM example.