### PR TITLE
Prevent kustomize-controller from pruning the instance namespace

### DIFF
--- a/internal/builder/templates.go
+++ b/internal/builder/templates.go
@@ -310,6 +310,7 @@ metadata:
   name: annotations
 annotations:
   kustomize.toolkit.fluxcd.io/ssa: Ignore
+  kustomize.toolkit.fluxcd.io/prune: Disabled
 fieldSpecs:
   - path: metadata/annotations
     create: true

--- a/internal/controller/fluxinstance_controller_test.go
+++ b/internal/controller/fluxinstance_controller_test.go
@@ -189,6 +189,13 @@ func TestFluxInstanceReconciler_LifeCycle(t *testing.T) {
 		},
 	))
 
+	// Check that the namespace is protected from pruning.
+	resultNS := &corev1.Namespace{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(ns), resultNS)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resultNS.Annotations).To(HaveKeyWithValue(fluxcdv1.PruneAnnotation, fluxcdv1.DisabledValue))
+	g.Expect(resultNS.Annotations).To(HaveKeyWithValue("kustomize.toolkit.fluxcd.io/prune", "Disabled"))
+
 	// Check if components images were recorded.
 	g.Expect(result.Status.Components).To(HaveLen(4))
 	g.Expect(result.Status.Components[0].Repository).To(Equal("ghcr.io/fluxcd/source-controller"))


### PR DESCRIPTION
Prevent mistakes where users handoff the `flux-system` namespace management to some Flux Kustomization that can result in catastrophic failures with Flux deleting it's own namespace.  

xref: https://github.com/fluxcd/flux2/discussions/5472