### PR TITLE
Add jitter to ResourceSet requeue interval

### DIFF
--- a/internal/controller/resourceset_controller_test.go
+++ b/internal/controller/resourceset_controller_test.go
@@ -1420,10 +1420,11 @@ func getResourceSetReconciler(t *testing.T) *ResourceSetReconciler {
 	t.Setenv("NOTIFICATIONS_DISABLED", "yes")
 
 	return &ResourceSetReconciler{
-		Client:        testClient,
-		APIReader:     testClient,
-		Scheme:        NewTestScheme(),
-		StatusManager: controllerName,
-		EventRecorder: testEnv.GetEventRecorderFor(controllerName),
+		Client:            testClient,
+		APIReader:         testClient,
+		Scheme:            NewTestScheme(),
+		StatusManager:     controllerName,
+		EventRecorder:     testEnv.GetEventRecorderFor(controllerName),
+		RequeueDependency: 5 * time.Second,
 	}
 }


### PR DESCRIPTION
Add jitter to ResourceSet requeue interval to spread the workqueue rate after a controller restart.

In addition, the dependency requeue interval which was hardcoded to 5sec, can now be changed with the `--requeue-dependency` flag.