### PR TITLE
Update Go to 1.25

### DIFF
--- a/.github/workflows/e2e-olm.yml
+++ b/.github/workflows/e2e-olm.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
           cache-dependency-path: |
             **/go.sum
             **/go.mod

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
           cache-dependency-path: |
             **/go.sum
             **/go.mod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Unshallow
         run: git fetch --prune --unshallow
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: 1.25.x
       - name: Setup Kustomize
         uses: fluxcd/pkg/actions/kustomize@main
       - name: Setup Flux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary using the Docker's Debian image.
-FROM --platform=${BUILDPLATFORM} golang:1.24 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.25 AS builder
 ARG VERSION
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -215,12 +215,12 @@ KUSTOMIZE_VERSION ?= v5.7.0
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 GOLANGCI_LINT_VERSION ?= v2.4.0
-OPERATOR_SDK_VERSION ?= v1.34.2
+OPERATOR_SDK_VERSION ?= v1.41.1
 
 .PHONY: operator-sdk
 operator-sdk: $(OPERATOR_SDK) ## Download operator-sdk locally if necessary.
 $(OPERATOR_SDK): $(LOCALBIN)
-	$(call go-install-tool,$(OPERATOR_SDK),github.com/operator-framework/operator-sdk/cmd/operator-sdk,$(OPERATOR_SDK_VERSION))
+	./hack/install-operator-sdk.sh $(OPERATOR_SDK_VERSION)
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk-$(OPERATOR_SDK_VERSION)
 KUSTOMIZE_VERSION ?= v5.7.0
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
-GOLANGCI_LINT_VERSION ?= v2.1.6
+GOLANGCI_LINT_VERSION ?= v2.4.0
 OPERATOR_SDK_VERSION ?= v1.34.2
 
 .PHONY: operator-sdk

--- a/cmd/cli/Dockerfile
+++ b/cmd/cli/Dockerfile
@@ -1,5 +1,5 @@
 # Build the Flux Operator CLI binary using Docker's Debian image.
-FROM --platform=${BUILDPLATFORM} golang:1.24 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION

--- a/cmd/mcp/Dockerfile
+++ b/cmd/mcp/Dockerfile
@@ -1,5 +1,5 @@
 # Build the Flux MCP server binary using Docker's Debian image.
-FROM --platform=${BUILDPLATFORM} golang:1.24 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION

--- a/config/olm/bundle/metadata/annotations.yaml
+++ b/config/olm/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: flux-operator
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.29.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.41.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -75,7 +75,7 @@
 
 ### Prerequisites
 
-- [Go](https://golang.org/doc/install) 1.24+
+- [Go](https://golang.org/doc/install) 1.25+
 - [Docker](https://docs.docker.com/get-docker/)
 - [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
@@ -150,3 +150,14 @@ To clean up the resources, run:
 kubectl -n flux-system delete fluxinstance/flux
 make undeploy
 ```
+
+### Upgrading the Go Version
+
+To upgrade Go to the latest minor version, follow these steps:
+
+1. Bump the `go` minor version in the `go.mod` file.
+2. Bump `GOLANGCI_LINT_VERSION` to match the new Go version.
+3. Run `make` to validate that the build and tests pass with the new Go version.
+4. Bump the `golang` image tag in all `Dockerfile`s.
+5. Bump the `go-version` in all GitHub workflows.
+6. Bump the Go version in [prerequisites](#prerequisites) section of this document.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/controlplaneio-fluxcd/flux-operator
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.0

--- a/hack/install-operator-sdk.sh
+++ b/hack/install-operator-sdk.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 Stefan Prodan.
+# SPDX-License-Identifier: AGPL-3.0
+
+set -euo pipefail
+
+VERSION=$1
+REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
+DEST_DIR="${REPOSITORY_ROOT}/bin"
+
+info() {
+    echo '[INFO] ' "$@"
+}
+
+fatal() {
+    echo '[ERROR] ' "$@" >&2
+    exit 1
+}
+
+OS=$(echo "${RUNNER_OS}" | tr '[:upper:]' '[:lower:]')
+if [[ "$OS" == "macos" ]]; then
+  OS="darwin"
+fi
+
+ARCH=$(echo "${RUNNER_ARCH}" | tr '[:upper:]' '[:lower:]')
+if [[ "$ARCH" == "x64" ]]; then
+  ARCH="amd64"
+elif [[ "$ARCH" == "x86" ]]; then
+  ARCH="386"
+fi
+
+mkdir -p "${DEST_DIR}"
+
+DOWNLOAD_URL="https://github.com/operator-framework/operator-sdk/releases/download/${VERSION}/operator-sdk_${OS}_${ARCH}"
+EXEC_FILE="operator-sdk-${VERSION}"
+
+info "Downloading operator-sdk ${VERSION} for ${OS}/${ARCH}..."
+curl -sL "${DOWNLOAD_URL}" -o "${DEST_DIR}/${EXEC_FILE}"
+chmod +x "${DEST_DIR}/${EXEC_FILE}"
+
+${DEST_DIR}/${EXEC_FILE} version


### PR DESCRIPTION
Go 1.25 comes with a major improvment for Kubernetes, it now reads the cgroup CPU limits set in the container and automatically adjusts `GOMAXPROCS`.