### PR TITLE
builder: Improve component images extraction

### DIFF
--- a/internal/builder/build.go
+++ b/internal/builder/build.go
@@ -48,6 +48,11 @@ func Build(srcDir, tmpDir string, options Options) (*Result, error) {
 	}
 	sort.Sort(ssa.SortableUnstructureds(objects))
 
+	images, err := ExtractComponentImagesFromObjects(objects, options)
+	if err != nil {
+		return nil, fmt.Errorf("extract component images failed: %w", err)
+	}
+
 	d := digest.FromBytes(data)
 
 	return &Result{
@@ -55,7 +60,7 @@ func Build(srcDir, tmpDir string, options Options) (*Result, error) {
 		Objects:         objects,
 		Digest:          d.String(),
 		Revision:        fmt.Sprintf("%s@%s", options.Version, d.String()),
-		ComponentImages: options.ComponentImages,
+		ComponentImages: images,
 	}, nil
 }
 

--- a/internal/builder/build_test.go
+++ b/internal/builder/build_test.go
@@ -201,7 +201,7 @@ func TestBuild_ProfileClusterSize(t *testing.T) {
 			g.Expect(string(genK)).To(Equal(string(goldenK)))
 
 			for _, obj := range result.Objects {
-				if obj.GetKind() == "Deployment" {
+				if obj.GetKind() == deploymentKind {
 					g.Expect(obj.GetAnnotations()).To(HaveKeyWithValue("fluxcd.controlplane.io/profile", tc.profile))
 				}
 			}

--- a/internal/controller/fluxinstance_controller_test.go
+++ b/internal/controller/fluxinstance_controller_test.go
@@ -285,8 +285,8 @@ func TestFluxInstanceReconciler_LifeCycle(t *testing.T) {
 
 	// Check if components images were updated.
 	g.Expect(resultFinal.Status.Components).To(HaveLen(2))
-	g.Expect(resultFinal.Status.Components[0].Repository).To(Equal("docker.io/fluxcd/source-controller"))
-	g.Expect(resultFinal.Status.Components[1].Repository).To(Equal("docker.io/fluxcd/kustomize-controller"))
+	g.Expect(resultFinal.Status.Components[0].Repository).To(Equal("index.docker.io/fluxcd/source-controller"))
+	g.Expect(resultFinal.Status.Components[1].Repository).To(Equal("index.docker.io/fluxcd/kustomize-controller"))
 
 	// Check if the history was updated.
 	g.Expect(resultFinal.Status.History).To(HaveLen(2))


### PR DESCRIPTION
This PR  improves the components reporting in the `FluxInstance.status.components` by extracting the images with digests after building the disto manifests. This ensures that image replacements in `.spec.kustomize.patches` are taking into account.

This is a prerequisite for being able to verify the signatures of Flux images before the deployment in-cluster.  