### PR TITLE
operator: Add missing docs for RSIP lockdown with Helm

### DIFF
--- a/docs/api/v1/resourcesetinputprovider.md
+++ b/docs/api/v1/resourcesetinputprovider.md
@@ -315,6 +315,17 @@ flag can be set in the operator. If this flag is specified and a ResourceSetInpu
 object does not have the field `.spec.serviceAccountName`, the operator will use the
 default service account specified by the flag for reconciling this object.
 
+When installing the Flux Operator with Helm, you can change the default workload identity
+service account name with:
+
+```shell
+helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator \
+  --namespace flux-system \
+  --create-namespace \
+  --set multitenancy.enabledForWorkloadIdentity=true \
+  --set multitenancy.defaultWorkloadIdentityServiceAccount=flux-operator
+```
+
 When installing the Flux Operator on OpenShift from OperatorHub, the default workload identity
 service account name can be changed by setting the `DEFAULT_WORKLOAD_IDENTITY_SERVICE_ACCOUNT`
 environment variable using the OLM


### PR DESCRIPTION
Part of: #379

This PR makes the RSIP docs fully match the RSET docs. In #407 I copied only the OLM env var and missed the Helm values paragraph.