### PR TITLE
test: Use latest Flux version in reporting tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMG ?= ghcr.io/controlplaneio-fluxcd/flux-operator:latest
 FLUX_OPERATOR_VERSION ?= $(shell gh release view --json tagName -q '.tagName')
 FLUX_OPERATOR_DEV_VERSION?=0.0.0-$(shell git rev-parse --abbrev-ref HEAD)-$(shell git rev-parse --short HEAD)-$(shell date +%s)
 FLUX_VERSION = $(shell gh release view --repo fluxcd/flux2 --json tagName -q '.tagName')
-ENVTEST_K8S_VERSION = 1.34.0
+ENVTEST_K8S_VERSION = 1.34.1
 
 # Get the currently used golang install path
 # (in GOPATH/bin, unless GOBIN is set).

--- a/internal/controller/fluxreport_controller_test.go
+++ b/internal/controller/fluxreport_controller_test.go
@@ -44,6 +44,8 @@ func TestFluxReportReconciler_CELNameValidation(t *testing.T) {
 func TestFluxReportReconciler_Reconcile(t *testing.T) {
 	g := NewWithT(t)
 	instRec := getFluxInstanceReconciler(t)
+	instSpec := getDefaultFluxSpec(t)
+	instSpec.Distribution.Version = "2.x"
 	reportRec := getFluxReportReconciler()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -67,7 +69,7 @@ func TestFluxReportReconciler_Reconcile(t *testing.T) {
 			Name:      "flux",
 			Namespace: ns.Name,
 		},
-		Spec: getDefaultFluxSpec(t),
+		Spec: instSpec,
 	}
 	err = testEnv.Create(ctx, instance)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -171,6 +173,8 @@ func TestFluxReportReconciler_Reconcile(t *testing.T) {
 func TestFluxReportReconciler_CustomSyncName(t *testing.T) {
 	g := NewWithT(t)
 	instRec := getFluxInstanceReconciler(t)
+	instSpec := getDefaultFluxSpec(t)
+	instSpec.Distribution.Version = "2.x"
 	reportRec := getFluxReportReconciler()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -194,7 +198,7 @@ func TestFluxReportReconciler_CustomSyncName(t *testing.T) {
 			Name:      "flux",
 			Namespace: ns.Name,
 		},
-		Spec: getDefaultFluxSpec(t),
+		Spec: instSpec,
 	}
 
 	// Set custom sync name.


### PR DESCRIPTION
Update Kubernetes in e2e from 1.34.0 to 1.34.1 to fix the OpenAPI validation issue `unrecognized format int64`