### PR TITLE
cmd: Add `--ready-status` filter to `get resources` command

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -75,7 +75,7 @@ The following commands are available:
 - `flux-operator get instance`: Retrieves the FluxInstance resource in the cluster.
 - `flux-operator get rset`: Retrieves the ResourceSet resources in the cluster.
 - `flux-operator get rsip`: Retrieves the ResourceSetInputProvider resources in the cluster.
-- `flux-operator get resources`: Retrieves all Flux resources in the cluster.
+- `flux-operator get all`: Retrieves all Flux resources in the cluster (supports filtering by ready status).
 
 Arguments:
 


### PR DESCRIPTION
Changes:

- add `all` alias to `resources` e.g. `flux-operator get all` (fix: #429)
- add ready filtering for `True`, `False`, `Unknown`, `Suspended` e.g. `flux-operator get all -A --ready-status Suspended`