### PR TITLE
Include the managed fields in the storage migration process

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/fluxcd/pkg/git v0.36.0
 	github.com/fluxcd/pkg/kustomize v1.22.0
 	github.com/fluxcd/pkg/runtime v0.86.0
-	github.com/fluxcd/pkg/ssa v0.58.0
+	github.com/fluxcd/pkg/ssa v0.59.0
 	github.com/fluxcd/pkg/tar v0.14.0
 	github.com/fluxcd/pkg/version v0.10.0
 	github.com/go-jose/go-jose/v4 v4.1.2

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/fluxcd/pkg/runtime v0.86.0 h1:q7aBSerJwt0N9hpurPVElG+HWpVhZcs6t96bcNQ
 github.com/fluxcd/pkg/runtime v0.86.0/go.mod h1:Wt9mUzQgMPQMu2D/wKl5pG4zh5vu/tfF5wq9pPobxOQ=
 github.com/fluxcd/pkg/sourceignore v0.14.0 h1:ZiZzbXtXb/Qp7I7JCStsxOlX8ri8rWwCvmvIrJ0UzQQ=
 github.com/fluxcd/pkg/sourceignore v0.14.0/go.mod h1:E3zKvyTyB+oQKqm/2I/jS6Rrt3B7fNuig/4bY2vi3bg=
-github.com/fluxcd/pkg/ssa v0.58.0 h1:W7m2LQFsZxPN9nn3lfGVDwXsZnIgCWWJ/+/K5hpzW+k=
-github.com/fluxcd/pkg/ssa v0.58.0/go.mod h1:iN/QDMqdJaVXKkqwbXqGa4PyWQwtyIy2WkeM2+9kfXA=
+github.com/fluxcd/pkg/ssa v0.59.0 h1:c88Q5w9e0MgrEi3Z7/+FWEVvtJFaVHfA9sxreMJUR7g=
+github.com/fluxcd/pkg/ssa v0.59.0/go.mod h1:iN/QDMqdJaVXKkqwbXqGa4PyWQwtyIy2WkeM2+9kfXA=
 github.com/fluxcd/pkg/ssh v0.21.0 h1:ZmyF0n9je0cTTkOpvFVgIhmdx9qtswnVE60TK4IzJh0=
 github.com/fluxcd/pkg/ssh v0.21.0/go.mod h1:nX+gvJOmjf0E7lxq5mKKzDIdPEL2jOUQZbkBMS+mDtk=
 github.com/fluxcd/pkg/tar v0.14.0 h1:9Gku8FIvPt2bixKldZnzXJ/t+7SloxePlzyVGOK8GVQ=

--- a/internal/builder/semver.go
+++ b/internal/builder/semver.go
@@ -39,6 +39,36 @@ func IsCompatibleVersion(fromVer, toVer string) error {
 	return nil
 }
 
+// IsMinorUpgrade checks if the version upgrade is a minor version upgrade.
+// It returns true if the major version is the same and the minor version is greater.
+func IsMinorUpgrade(fromVer, toVer string) (bool, error) {
+	if fromVer == "" {
+		return false, nil
+	}
+
+	if strings.Contains(fromVer, "@") {
+		fromVer = strings.Split(fromVer, "@")[0]
+	}
+	from, err := semver.NewVersion(fromVer)
+	if err != nil {
+		return false, fmt.Errorf("from version '%s' parse error: %w", fromVer, err)
+	}
+
+	if strings.Contains(toVer, "@") {
+		toVer = strings.Split(toVer, "@")[0]
+	}
+	to, err := semver.NewVersion(toVer)
+	if err != nil {
+		return false, fmt.Errorf("to version '%s' parse error: %w", toVer, err)
+	}
+
+	if to.Major() == from.Major() && to.Minor() > from.Minor() {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // MatchVersion returns the latest version dir path that matches the given semver range.
 func MatchVersion(dataDir, semverRange string) (string, error) {
 	if _, err := os.Stat(dataDir); os.IsNotExist(err) {

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -570,6 +570,10 @@ func (r *FluxInstanceReconciler) apply(ctx context.Context,
 
 	// Migrate all custom resources if the Flux CRDs storage version has changed.
 	if obj.GetMigrateResources() {
+		// Force migration if this is a minor upgrade.
+		if minor, err := builder.IsMinorUpgrade(obj.Status.LastAppliedRevision, buildResult.Revision); err != nil && minor {
+			force = true
+		}
 		if err := r.migrateResources(ctx, client.MatchingLabels{"app.kubernetes.io/part-of": obj.Name}, force); err != nil {
 			log.Error(err, "failed to migrate resources to the latest storage version")
 		}


### PR DESCRIPTION
This PR improves the storage migration of the Flux custom resources after an upgrade by updating the managed fields to the latest stable API version.

The operator will always run the storage migration after minor upgrades.