### PR TITLE
Add support for Flux distro digest pinning when using registry mirrors

### DIFF
--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -87,6 +87,12 @@ type Distribution struct {
 	// +required
 	Registry string `json:"registry"`
 
+	// Variant specifies the Flux distribution flavor stored
+	// in the registry.
+	// +kubebuilder:validation:Enum=upstream-alpine;enterprise-alpine;enterprise-distroless
+	// +optional
+	Variant string `json:"variant,omitempty"`
+
 	// ImagePullSecret is the name of the Kubernetes secret
 	// to use for pulling images.
 	// +optional

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -196,6 +196,15 @@ spec:
                       Registry address to pull the distribution images from
                       e.g. 'ghcr.io/fluxcd'.
                     type: string
+                  variant:
+                    description: |-
+                      Variant specifies the Flux distribution flavor stored
+                      in the registry.
+                    enum:
+                    - upstream-alpine
+                    - enterprise-alpine
+                    - enterprise-distroless
+                    type: string
                   version:
                     description: Version semver expression e.g. '2.x', '2.3.x'.
                     type: string

--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -216,6 +216,34 @@ spec:
     registry: "ghcr.io/fluxcd"
 ```
 
+#### Distribution registry mirrors
+
+The `.spec.distribution.variant` field is required, when specifying a third-party
+registry where the Flux distribution images are pulled from. This is useful for registry
+mirrors, for example in corporate environments.
+
+Valid values are `upstream-alpine`, `enterprise-alpine` and `enterprise-distroless`.
+
+Example using a hypothetical `ghcr.io` mirror:
+
+```yaml
+spec:
+  distribution:
+    version: "2.x"
+    registry: "my-ghcr-mirror.io/fluxcd"
+    variant: "upstream-alpine"
+```
+
+Example using a hypothetical mirror of the ControlPlane enterprise registry:
+
+```yaml
+spec:
+  distribution:
+    version: "2.x"
+    registry: "my-ghcr-mirror.io/controlplaneio-fluxcd/distroless"
+    variant: "enterprise-distroless"
+```
+
 #### Distribution image pull secret
 
 The `.spec.distribution.imagePullSecret` field is optional and specifies the name of the Kubernetes secret

--- a/internal/builder/images_test.go
+++ b/internal/builder/images_test.go
@@ -63,10 +63,38 @@ func TestBuild_ExtractImagesWithDigest(t *testing.T) {
 		},
 	))
 
+	opts.Registry = "registry-mirror.io/ghcr.io/fluxcd"
+	opts.Variant = "upstream-alpine"
+
+	images, err = ExtractComponentImagesWithDigest(imagePath, opts)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(images).To(HaveLen(6))
+	g.Expect(images).To(ContainElements(
+		ComponentImage{
+			Name:       "source-controller",
+			Repository: "registry-mirror.io/ghcr.io/fluxcd/source-controller",
+			Tag:        "v1.3.0",
+			Digest:     "sha256:161da425b16b64dda4b3cec2ba0f8d7442973aba29bb446db3b340626181a0bc",
+		},
+		ComponentImage{
+			Name:       "kustomize-controller",
+			Repository: "registry-mirror.io/ghcr.io/fluxcd/kustomize-controller",
+			Tag:        "v1.3.0",
+			Digest:     "sha256:48a032574dd45c39750ba0f1488e6f1ae36756a38f40976a6b7a588d83acefc1",
+		},
+	))
+
 	opts.Registry = "registry.local/fluxcd"
+	opts.Variant = ""
 	_, err = ExtractComponentImagesWithDigest(imagePath, opts)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("unsupported registry"))
+
+	opts.Registry = "registry.local/fluxcd"
+	opts.Variant = "downstream-ubuntu"
+	_, err = ExtractComponentImagesWithDigest(imagePath, opts)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("unsupported variant"))
 }
 
 func TestBuild_ExtractImagesWithDigest_AWS(t *testing.T) {
@@ -84,6 +112,21 @@ func TestBuild_ExtractImagesWithDigest_AWS(t *testing.T) {
 		ComponentImage{
 			Name:       "source-controller",
 			Repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/controlplane/fluxcd/source-controller",
+			Tag:        "v1.3.0",
+			Digest:     "sha256:3b34a63a635779b2b3ea67ec02f5925704dc93d39efc4b92243e2170907615af",
+		},
+	))
+
+	opts.Registry = "registry-mirror.io/709825985650.dkr.ecr.us-east-1.amazonaws.com/controlplane/fluxcd"
+	opts.Variant = "enterprise-distroless"
+
+	images, err = ExtractComponentImagesWithDigest(imagePath, opts)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(images).To(HaveLen(6))
+	g.Expect(images).To(ContainElements(
+		ComponentImage{
+			Name:       "source-controller",
+			Repository: "registry-mirror.io/709825985650.dkr.ecr.us-east-1.amazonaws.com/controlplane/fluxcd/source-controller",
 			Tag:        "v1.3.0",
 			Digest:     "sha256:3b34a63a635779b2b3ea67ec02f5925704dc93d39efc4b92243e2170907615af",
 		},

--- a/internal/builder/options.go
+++ b/internal/builder/options.go
@@ -18,6 +18,7 @@ type Options struct {
 	ComponentImages                                 []ComponentImage
 	EventsAddr                                      string
 	Registry                                        string
+	Variant                                         string
 	ImagePullSecret                                 string
 	WatchAllNamespaces                              bool
 	NetworkPolicy                                   bool
@@ -50,6 +51,7 @@ func MakeDefaultOptions() Options {
 		},
 		EventsAddr:         "",
 		Registry:           "ghcr.io/fluxcd",
+		Variant:            "",
 		ImagePullSecret:    "",
 		WatchAllNamespaces: true,
 		NetworkPolicy:      true,

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -343,6 +343,7 @@ func (r *FluxInstanceReconciler) build(ctx context.Context,
 	options := builder.MakeDefaultOptions()
 	options.Version = ver
 	options.Registry = obj.GetDistribution().Registry
+	options.Variant = obj.GetDistribution().Variant
 	options.ImagePullSecret = obj.GetDistribution().ImagePullSecret
 	options.Namespace = obj.GetNamespace()
 	options.Components = obj.GetComponents()


### PR DESCRIPTION
To support custom registries (i.e. for mirrors), we need to expose the distribution option.
