### PR TITLE
cli: Add `install` command to bootstrap Flux Operator and instance

### DIFF
--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -9,25 +9,19 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"text/template"
 	"time"
 
-	"github.com/fluxcd/pkg/runtime/secrets"
 	"github.com/fluxcd/pkg/ssa"
 	ssautil "github.com/fluxcd/pkg/ssa/utils"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
-	"github.com/controlplaneio-fluxcd/flux-operator/internal/builder"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/install"
 )
 
 var installCmd = &cobra.Command{
@@ -109,8 +103,6 @@ type installFlags struct {
 	autoUpdate           bool
 }
 
-const defaultInstallNamespace = "flux-system"
-
 var installArgs installFlags
 
 func init() {
@@ -125,7 +117,7 @@ func init() {
 		"Flux distribution version")
 	installCmd.Flags().StringVar(&installArgs.distributionRegistry, "instance-distribution-registry", "ghcr.io/fluxcd",
 		"container registry to pull Flux images from")
-	installCmd.Flags().StringVar(&installArgs.distributionArtifact, "instance-distribution-artifact", "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest",
+	installCmd.Flags().StringVar(&installArgs.distributionArtifact, "instance-distribution-artifact", install.DefaultArtifactURL,
 		"OCI artifact containing the Flux distribution manifests")
 	installCmd.Flags().StringVar(&installArgs.clusterType, "instance-cluster-type", "kubernetes",
 		"cluster type (kubernetes, openshift, aws, azure, gcp)")
@@ -152,45 +144,27 @@ func init() {
 }
 
 func installCmdRun(cmd *cobra.Command, args []string) error {
-	// Increase the default timeout to 5 minutes if not set explicitly
-	if rootArgs.timeout == time.Minute {
+	// Set a minimum timeout of 5 minutes
+	if rootArgs.timeout < 2*time.Minute {
 		rootArgs.timeout = 5 * time.Minute
 	}
 
 	now := time.Now()
 
+	timeout := rootArgs.timeout - time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
 	defer cancel()
 
-	// Step 1: Load Flux instance from file if specified
+	// Step 1: Generate Flux instance from file, URL or flags
 
-	var instance *fluxcdv1.FluxInstance
-	artifactURL := installArgs.distributionArtifact
-
-	if installArgs.instanceFile != "" {
-		var err error
-		instance, err = instanceFromFile(ctx, installArgs.instanceFile)
-		if err != nil {
-			return fmt.Errorf("failed to load instance: %w", err)
-		}
-
-		// Set namespace to flux-system
-		instance.Namespace = defaultInstallNamespace
-
-		// Use artifact URL from file if present
-		if instance.Spec.Distribution.Artifact != "" {
-			artifactURL = instance.Spec.Distribution.Artifact
-		}
-
-		// Use multitenant setting from file if present
-		if instance.Spec.Cluster != nil && instance.Spec.Cluster.Multitenant {
-			installArgs.clusterMultitenant = true
-		}
+	rootCmd.Println(`◎`, "Downloading artifacts...")
+	instance, artifactURL, err := makeFluxInstance(ctx)
+	if err != nil {
+		return err
 	}
 
 	// Step 2: Download the distribution artifact and extract the manifests
 
-	rootCmd.Println(`◎`, "Downloading distribution artifact...")
 	objects, err := fetchOperatorManifests(artifactURL)
 	if err != nil {
 		return err
@@ -199,47 +173,85 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 
 	// Step 3: Install or upgrade the Flux Operator
 
-	installed, err := isInstalled(ctx)
+	cfg, err := kubeconfigArgs.ToRESTConfig()
+	if err != nil {
+		return fmt.Errorf("loading kubeconfig failed: %w", err)
+	}
+
+	installer, err := install.NewInstaller(ctx, cfg,
+		install.WithArtifactURL(artifactURL),
+		install.WithCredentials(installArgs.syncCreds),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create installer: %w", err)
+	}
+
+	isInstalled, err := installer.IsInstalled(ctx)
 	if err != nil {
 		return err
 	}
 
-	if installed {
+	if isInstalled {
 		rootCmd.Println(`◎`, "Upgrading Flux Operator in flux-system namespace...")
 	} else {
 		rootCmd.Println(`◎`, "Installing Flux Operator in flux-system namespace...")
 	}
-	if err := applyOperatorManifests(ctx, objects); err != nil {
+	cs, err := installer.ApplyOperator(ctx, objects)
+	if err != nil {
 		return err
 	}
+	printChangeSet(cs)
+
+	rootCmd.Println(`◎`, "Waiting for Flux Operator to be ready...")
+	if err := installer.WaitFor(ctx, cs, timeout); err != nil {
+		return err
+	}
+
 	rootCmd.Println(`✔`, "Flux Operator has been installed successfully")
 
 	// Step 4: Create or update the sync credentials secret if specified
 
-	if installArgs.syncCreds != "" {
+	if installArgs.syncCreds != "" && instance.Spec.Sync != nil {
 		rootCmd.Println(`◎`, "Configuring sync credentials...")
-		secretName := defaultInstallNamespace
-		syncURL := installArgs.syncURL
+		secretName := install.DefaultNamespace
+		syncURL := instance.Spec.Sync.URL
 
-		// Override secret name and sync URL if using a file-based instance
-		if instance != nil && instance.Spec.Sync != nil {
-			if instance.Spec.Sync.PullSecret != "" {
-				secretName = instance.Spec.Sync.PullSecret
-			}
-			syncURL = instance.Spec.Sync.URL
+		// Override secret name if specified in the instance
+		if instance.Spec.Sync.PullSecret != "" {
+			secretName = instance.Spec.Sync.PullSecret
 		}
 
-		if err := applySyncSecret(ctx, secretName, syncURL); err != nil {
+		cs, err := installer.ApplyCredentials(ctx, secretName, syncURL)
+		if err != nil {
 			return err
 		}
+		printChangeSet(cs)
 	}
 
 	// Step 5: Install or upgrade the Flux instance
 
 	rootCmd.Println(`◎`, "Installing the Flux instance...")
-	if err := applyFluxInstance(ctx, instance); err != nil {
+	cs, err = installer.ApplyInstance(ctx, instance)
+	if err != nil {
 		return err
 	}
+	printChangeSet(cs)
+
+	rootCmd.Println(`◎`, "Waiting for Flux instance to be ready...")
+	if err := installer.WaitFor(ctx, cs, timeout); err != nil {
+		// Print events for debugging
+		if events, err := installer.GetEvents(ctx, fluxcdv1.FluxInstanceKind, instance.GetName()); err == nil && len(events) > 0 {
+			for _, e := range events {
+				rootCmd.Printf("%s -> %s\n",
+					e.InvolvedObject,
+					strings.TrimSpace(e.Message),
+				)
+			}
+		}
+		return fmt.Errorf("timeout waiting for %s/%s/%s to be ready",
+			fluxcdv1.FluxInstanceKind, instance.GetNamespace(), instance.GetName())
+	}
+
 	rootCmd.Println(`✔`, "Flux has been installed successfully")
 	if err := printSyncInfo(ctx); err != nil {
 		return err
@@ -249,7 +261,23 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 
 	if installArgs.autoUpdate {
 		rootCmd.Println(`◎`, "Configuring automatic updates...")
-		if err := applyAutoUpdate(ctx); err != nil {
+		cs, err := installer.ApplyAutoUpdate(ctx, installArgs.clusterMultitenant)
+		if err != nil {
+			return err
+		}
+		printChangeSet(cs)
+
+		rootCmd.Println(`◎`, "Waiting for auto-update to be ready...")
+		if err := installer.WaitFor(ctx, cs, timeout); err != nil {
+			// Print events for debugging
+			if events, err := installer.GetEvents(ctx, fluxcdv1.ResourceSetKind, "flux-operator"); err == nil && len(events) > 0 {
+				for _, e := range events {
+					rootCmd.Printf("%s -> %s\n",
+						e.InvolvedObject,
+						strings.TrimSpace(e.Message),
+					)
+				}
+			}
 			return err
 		}
 	}
@@ -261,189 +289,51 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// fetchOperatorManifests downloads the Flux Operator distribution artifact
-// and returns the list of Kubernetes objects from the install manifest.
-func fetchOperatorManifests(artifactURL string) ([]*unstructured.Unstructured, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
-	defer cancel()
+// makeFluxInstance creates a FluxInstance object from the provided file or command-line flags.
+// If a file is provided, it takes precedence over the flags.
+// It also returns the artifact URL to be used for downloading the Flux Operator manifests.
+func makeFluxInstance(ctx context.Context) (instance *fluxcdv1.FluxInstance, artifactURL string, err error) {
+	instance = &fluxcdv1.FluxInstance{}
+	artifactURL = installArgs.distributionArtifact
+	if filePath := installArgs.instanceFile; filePath != "" {
+		var data []byte
 
-	data, err := builder.ExtractFileFromArtifact(
-		ctx,
-		artifactURL,
-		"flux-operator/install.yaml",
-		authn.DefaultKeychain,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to pull distribution artifact: %w", err)
-	}
-
-	objects, err := ssautil.ReadObjects(bytes.NewReader(data))
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse flux-operator/install.yaml: %w", err)
-	}
-
-	if len(objects) == 0 {
-		return nil, fmt.Errorf("no Kubernetes objects found in flux-operator/install.yaml")
-	}
-
-	return objects, nil
-}
-
-// isInstalled checks if the Flux Operator is already installed in the cluster by checking
-// for the FluxInstance CRD. If the CRD is managed by Helm, it returns an error.
-func isInstalled(ctx context.Context) (bool, error) {
-	kubeClient, err := newKubeClient()
-	if err != nil {
-		return false, fmt.Errorf("unable to create kube client: %w", err)
-	}
-
-	crd := &apiextensionsv1.CustomResourceDefinition{}
-	err = kubeClient.Get(ctx, types.NamespacedName{
-		Name: "fluxinstances.fluxcd.controlplane.io",
-	}, crd)
-
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("unable to check if Flux Operator is installed: %w", err)
-	}
-
-	// Check if the CRD is managed by Helm
-	if managedBy, exists := crd.Labels["app.kubernetes.io/managed-by"]; exists && managedBy == "Helm" {
-		return true, fmt.Errorf("the Flux Operator installation is managed by Helm, cannot proceed with installation")
-	}
-
-	return true, nil
-}
-
-// applyOperatorManifests applies the Flux Operator manifests to the cluster and waits for them to be ready.
-// It sets consistent labels on all objects and ensures Deployment resources have matching selector and template labels.
-func applyOperatorManifests(ctx context.Context, objects []*unstructured.Unstructured) error {
-	operatorManager, err := newManager()
-	if err != nil {
-		return fmt.Errorf("unable to create operator manager: %w", err)
-	}
-
-	labels := map[string]string{
-		"app.kubernetes.io/name":     "flux-operator",
-		"app.kubernetes.io/instance": "flux-operator",
-	}
-
-	ssautil.SetCommonMetadata(objects, labels, nil)
-
-	// Iterate through objects and set label selectors to ensure
-	// that helm-controller can adopt the Flux Operator deployment
-	for _, obj := range objects {
-		if obj.GetKind() == "Deployment" {
-			// Set spec.selector.matchLabels
-			if err := unstructured.SetNestedStringMap(obj.Object, labels, "spec", "selector", "matchLabels"); err != nil {
-				return fmt.Errorf("failed to set deployment selector labels: %w", err)
+		// Check if the file path is a URL
+		if strings.HasPrefix(filePath, "https://") ||
+			strings.HasPrefix(filePath, "http://") ||
+			strings.HasPrefix(filePath, "oci://") {
+			// Fetch from URL
+			data, err = install.DownloadManifestFromURL(ctx, filePath, authn.DefaultKeychain)
+			if err != nil {
+				return nil, "", fmt.Errorf("failed to read response body: %w", err)
 			}
-
-			// Set spec.template.metadata.labels
-			if err := unstructured.SetNestedStringMap(obj.Object, labels, "spec", "template", "metadata", "labels"); err != nil {
-				return fmt.Errorf("failed to set deployment template labels: %w", err)
+		} else {
+			// Read from local file
+			data, err = os.ReadFile(filePath)
+			if err != nil {
+				return nil, "", fmt.Errorf("failed to read file: %w", err)
 			}
 		}
-	}
 
-	changeSet, err := operatorManager.ApplyAllStaged(ctx, objects, ssa.DefaultApplyOptions())
-	if err != nil {
-		return fmt.Errorf("failed to apply the operator manifests: %w", err)
-	}
-
-	for _, entry := range changeSet.Entries {
-		rootCmd.Println(`✔`, entry.String())
-	}
-
-	rootCmd.Println(`◎`, "Waiting for Flux Operator to be ready...")
-	return operatorManager.WaitForSetWithContext(ctx, changeSet.ToObjMetadataSet(), ssa.WaitOptions{
-		Interval: 5 * time.Second,
-		Timeout:  rootArgs.timeout,
-	})
-}
-
-// applySyncSecret creates and applies the sync credentials secret to the cluster.
-// It accepts the secret name and sync URL as parameters to support both flag-based
-// and file-based FluxInstance configurations.
-func applySyncSecret(ctx context.Context, secretName, syncURL string) error {
-	if syncURL == "" {
-		return fmt.Errorf("--instance-sync-creds requires sync URL to be set")
-	}
-
-	// Parse credentials
-	parts := strings.SplitN(installArgs.syncCreds, ":", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return fmt.Errorf("invalid credentials format, expected username:token")
-	}
-	username := parts[0]
-	password := parts[1]
-
-	var secret *corev1.Secret
-	var err error
-
-	// Determine source type and create appropriate secret
-	if strings.HasPrefix(syncURL, "oci://") {
-		// Extract server from OCI URL (strip oci:// prefix and take host part)
-		server := strings.TrimPrefix(syncURL, "oci://")
-		if idx := strings.Index(server, "/"); idx > 0 {
-			server = server[:idx]
+		// Unmarshal the FluxInstance
+		if err := yaml.Unmarshal(data, instance); err != nil {
+			return nil, "", fmt.Errorf("failed to unmarshal FluxInstance: %w", err)
 		}
-		secret, err = secrets.MakeRegistrySecret(
-			secretName,
-			defaultInstallNamespace,
-			server,
-			username,
-			password,
-		)
+
+		// Set namespace to flux-system
+		instance.Namespace = install.DefaultNamespace
+
+		// Use artifact URL from file if present
+		if instance.Spec.Distribution.Artifact != "" {
+			artifactURL = instance.Spec.Distribution.Artifact
+		}
+
+		// Use multitenant setting from file if present
+		if instance.Spec.Cluster != nil && instance.Spec.Cluster.Multitenant {
+			installArgs.clusterMultitenant = true
+		}
 	} else {
-		// Git source (HTTP/S or SSH)
-		secret, err = secrets.MakeBasicAuthSecret(
-			secretName,
-			defaultInstallNamespace,
-			username,
-			password,
-		)
-	}
-
-	if err != nil {
-		return fmt.Errorf("failed to create secret: %w", err)
-	}
-
-	rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)
-	if err != nil {
-		return fmt.Errorf("failed to convert secret to unstructured: %w", err)
-	}
-
-	secretManager, err := newManager()
-	if err != nil {
-		return fmt.Errorf("unable to create secret manager: %w", err)
-	}
-
-	changeSet, err := secretManager.ApplyAllStaged(ctx, []*unstructured.Unstructured{{Object: rawMap}}, ssa.DefaultApplyOptions())
-	if err != nil {
-		return fmt.Errorf("failed to apply secret: %w", err)
-	}
-
-	for _, entry := range changeSet.Entries {
-		rootCmd.Println(`✔`, entry.String())
-	}
-
-	return nil
-}
-
-// applyFluxInstance generates a FluxInstance from the install flags
-// and applies it to the cluster, waiting for it to be ready.
-// If a pre-loaded instance is provided, it is used instead of building from flags.
-func applyFluxInstance(ctx context.Context, preLoadedInstance *fluxcdv1.FluxInstance) error {
-	var instance *fluxcdv1.FluxInstance
-
-	if preLoadedInstance != nil {
-		// Use the pre-loaded instance
-		instance = preLoadedInstance
-	} else {
-		// Build instance from flags
+		// No file provided, build from flags
 		instance = &fluxcdv1.FluxInstance{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: fluxcdv1.GroupVersion.String(),
@@ -451,7 +341,7 @@ func applyFluxInstance(ctx context.Context, preLoadedInstance *fluxcdv1.FluxInst
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fluxcdv1.DefaultInstanceName,
-				Namespace: defaultInstallNamespace,
+				Namespace: install.DefaultNamespace,
 			},
 			Spec: fluxcdv1.FluxInstanceSpec{
 				Distribution: fluxcdv1.Distribution{
@@ -501,47 +391,57 @@ func applyFluxInstance(ctx context.Context, preLoadedInstance *fluxcdv1.FluxInst
 
 			// Set PullSecret if credentials were provided
 			if installArgs.syncCreds != "" {
-				sync.PullSecret = defaultInstallNamespace
+				sync.PullSecret = install.DefaultNamespace
 			}
 
 			instance.Spec.Sync = sync
 		}
 	}
 
-	// Convert to unstructured
-	rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(instance)
+	return instance, artifactURL, nil
+}
+
+// fetchOperatorManifests downloads the Flux Operator distribution artifact
+// and returns the list of Kubernetes objects from the install manifest.
+func fetchOperatorManifests(artifactURL string) ([]*unstructured.Unstructured, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	data, err := install.DownloadFileFromArtifact(
+		ctx,
+		artifactURL,
+		"flux-operator/install.yaml",
+		authn.DefaultKeychain,
+	)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("failed to pull distribution artifact: %w", err)
 	}
 
-	// Apply the FluxInstance
-	instanceManager, err := newManager()
+	objects, err := ssautil.ReadObjects(bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("unable to create instance manager: %w", err)
+		return nil, fmt.Errorf("unable to parse flux-operator/install.yaml: %w", err)
 	}
-	changeSet, err := instanceManager.ApplyAllStaged(ctx, []*unstructured.Unstructured{{Object: rawMap}}, ssa.DefaultApplyOptions())
-	if err != nil {
-		return fmt.Errorf("failed to apply the instance: %w", err)
+
+	if len(objects) == 0 {
+		return nil, fmt.Errorf("no Kubernetes objects found in flux-operator/install.yaml")
 	}
-	for _, entry := range changeSet.Entries {
+
+	return objects, nil
+}
+
+// printChangeSet prints the details of the applied changes from the ChangeSet.
+func printChangeSet(cs *ssa.ChangeSet) {
+	for _, entry := range cs.Entries {
 		rootCmd.Println(`✔`, entry.String())
 	}
-
-	rootCmd.Println(`◎`, "Waiting for Flux instance to be ready...")
-	_, err = waitForResourceReconciliation(ctx,
-		fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind),
-		fluxcdv1.DefaultInstanceName,
-		defaultInstallNamespace,
-		"", rootArgs.timeout)
-	return err
 }
 
 // printSyncInfo prints information about the sync status of the Flux instance
 // such as sync source URL and status of the last sync operation.
 func printSyncInfo(ctx context.Context) error {
 	reportName := types.NamespacedName{
-		Name:      "flux",
-		Namespace: defaultInstallNamespace,
+		Name:      fluxcdv1.DefaultInstanceName,
+		Namespace: install.DefaultNamespace,
 	}
 
 	kubeClient, err := newKubeClient()
@@ -568,8 +468,8 @@ func printSyncInfo(ctx context.Context) error {
 // printVersionInfo prints the version information of the Flux Operator.
 func printVersionInfo(ctx context.Context) error {
 	reportName := types.NamespacedName{
-		Name:      "flux",
-		Namespace: defaultInstallNamespace,
+		Name:      fluxcdv1.DefaultInstanceName,
+		Namespace: install.DefaultNamespace,
 	}
 
 	kubeClient, err := newKubeClient()
@@ -591,177 +491,3 @@ func printVersionInfo(ctx context.Context) error {
 	}
 	return nil
 }
-
-// instanceFromFile loads a FluxInstance from a local file or HTTPS URL.
-// GitHub, GitHub Gist, and GitLab URLs are automatically converted to raw content URLs.
-func instanceFromFile(ctx context.Context, filePath string) (*fluxcdv1.FluxInstance, error) {
-	var data []byte
-	var err error
-
-	// Check if the file path is a URL
-	if strings.HasPrefix(filePath, "https://") ||
-		strings.HasPrefix(filePath, "http://") ||
-		strings.HasPrefix(filePath, "oci://") {
-		// Fetch from URL
-		data, err = builder.FetchManifestFromURL(ctx, filePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read response body: %w", err)
-		}
-	} else {
-		// Read from local file
-		data, err = os.ReadFile(filePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read file: %w", err)
-		}
-	}
-
-	// Unmarshal the FluxInstance
-	instance := &fluxcdv1.FluxInstance{}
-	if err := yaml.Unmarshal(data, instance); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal FluxInstance: %w", err)
-	}
-
-	return instance, nil
-}
-
-// autoUpdateData holds the data for rendering the auto-update template.
-type autoUpdateData struct {
-	Namespace   string
-	ArtifactURL string
-	Multitenant bool
-}
-
-// applyAutoUpdate configures automatic updates of the Flux Operator from the distribution artifact.
-func applyAutoUpdate(ctx context.Context) error {
-	// Strip tag from artifact URL (e.g., "oci://registry/image:tag" -> "oci://registry/image")
-	artifactURL := installArgs.distributionArtifact
-	if idx := strings.LastIndex(artifactURL, ":"); idx > 6 {
-		artifactURL = artifactURL[:idx]
-	}
-
-	// Build template data
-	data := autoUpdateData{
-		Namespace:   defaultInstallNamespace,
-		ArtifactURL: artifactURL,
-		Multitenant: installArgs.clusterMultitenant,
-	}
-
-	// Execute template
-	tmpl, err := template.New("autoUpdate").Parse(autoUpdateTmpl)
-	if err != nil {
-		return fmt.Errorf("unable to parse auto-update template: %w", err)
-	}
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, data); err != nil {
-		return fmt.Errorf("unable to execute auto-update template: %w", err)
-	}
-	autoUpdateYAML := buf.String()
-
-	autoUpdateObjects, err := ssautil.ReadObjects(bytes.NewReader([]byte(autoUpdateYAML)))
-	if err != nil {
-		return fmt.Errorf("unable to parse auto-update manifest: %w", err)
-	}
-
-	autoUpdateManager, err := newManager()
-	if err != nil {
-		return fmt.Errorf("unable to create auto-update manager: %w", err)
-	}
-
-	changeSet, err := autoUpdateManager.ApplyAllStaged(ctx, autoUpdateObjects, ssa.DefaultApplyOptions())
-	if err != nil {
-		return fmt.Errorf("failed to apply auto-update ResourceSet: %w", err)
-	}
-
-	for _, entry := range changeSet.Entries {
-		rootCmd.Println(`✔`, entry.String())
-	}
-
-	rootCmd.Println(`◎`, "Waiting for ResourceSet to be ready...")
-	_, err = waitForResourceReconciliation(ctx,
-		fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind),
-		"flux-operator",
-		defaultInstallNamespace,
-		"", rootArgs.timeout)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-const autoUpdateTmpl = `
-apiVersion: fluxcd.controlplane.io/v1
-kind: ResourceSet
-metadata:
-  name: flux-operator
-  namespace: {{.Namespace}}
-  labels:
-    app.kubernetes.io/name: flux-operator
-    app.kubernetes.io/instance: flux-operator
-  annotations:
-    fluxcd.controlplane.io/reconcileTimeout: "5m"
-spec:
-  wait: true
-  inputs:
-    - url: {{.ArtifactURL}}
-      interval: "1h"
-  resources:
-    - apiVersion: source.toolkit.fluxcd.io/v1
-      kind: OCIRepository
-      metadata:
-        name: << inputs.provider.name >>
-        namespace: << inputs.provider.namespace >>
-      spec:
-        interval: << inputs.interval | quote >>
-        url: << inputs.url | quote >>
-        ref:
-          tag: latest
-    - apiVersion: kustomize.toolkit.fluxcd.io/v1
-      kind: Kustomization
-      metadata:
-        name: << inputs.provider.name >>
-        namespace: << inputs.provider.namespace >>
-      spec:
-        interval: 24h
-        retryInterval: 5m
-        timeout: 5m
-        wait: true
-        prune: true
-        force: true
-        deletionPolicy: Orphan
-        serviceAccountName: << inputs.provider.name >>
-        sourceRef:
-          kind: OCIRepository
-          name: << inputs.provider.name >>
-        path: ./flux-operator
-        commonMetadata:
-          labels:
-            app.kubernetes.io/name: flux-operator
-            app.kubernetes.io/instance: flux-operator
-        patches:
-          - patch: |-
-              - op: replace
-                path: "/spec/selector/matchLabels"
-                value:
-                  app.kubernetes.io/name: flux-operator
-                  app.kubernetes.io/instance: flux-operator
-              - op: replace
-                path: "/spec/template/metadata/labels"
-                value:
-                  app.kubernetes.io/name: flux-operator
-                  app.kubernetes.io/instance: flux-operator
-              - op: add
-                path: "/spec/template/spec/containers/0/env/-"
-                value:
-                  name: REPORTING_INTERVAL
-                  value: "30s"
-{{- if .Multitenant }}
-              - op: add
-                path: "/spec/template/spec/containers/0/env/-"
-                value:
-                  name: DEFAULT_SERVICE_ACCOUNT
-                  value: "flux-operator"
-{{- end }}
-            target:
-              kind: Deployment
-`

--- a/internal/builder/pull.go
+++ b/internal/builder/pull.go
@@ -4,20 +4,13 @@
 package builder
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"strings"
-	"time"
 
 	untar "github.com/fluxcd/pkg/tar"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 // PullArtifact downloads an artifact from an OCI repository and extracts the content
@@ -53,153 +46,4 @@ func PullArtifact(ctx context.Context, ociURL, dstDir string, keyChain authn.Key
 	}
 
 	return digest.String(), nil
-}
-
-// ExtractFileFromArtifact downloads an artifact from an OCI repository and
-// returns the content of a specific file from its first layer.
-// The operation is performed in-memory without writing to the filesystem.
-func ExtractFileFromArtifact(ctx context.Context, ociURL, filepath string, keyChain authn.Keychain) ([]byte, error) {
-	// Pull the OCI image/artifact from the repository.
-	img, err := crane.Pull(strings.TrimPrefix(ociURL, "oci://"), crane.WithContext(ctx), crane.WithAuthFromKeychain(keyChain))
-	if err != nil {
-		return nil, fmt.Errorf("pulling artifact %s failed: %w", ociURL, err)
-	}
-
-	// Get the layers of the image.
-	layers, err := img.Layers()
-	if err != nil {
-		return nil, fmt.Errorf("listing layers in artifact %s failed: %w", ociURL, err)
-	}
-
-	// Ensure there is at least one layer.
-	if len(layers) < 1 {
-		return nil, fmt.Errorf("no layers found in artifact %s", ociURL)
-	}
-
-	// Get the compressed blob of the first layer.
-	blob, err := layers[0].Compressed()
-	if err != nil {
-		return nil, fmt.Errorf("reading layer from artifact %s failed: %w", ociURL, err)
-	}
-	defer blob.Close()
-
-	// The layer is a gzipped tarball, so we create a gzip reader.
-	gzr, err := gzip.NewReader(blob)
-	if err != nil {
-		return nil, fmt.Errorf("decompressing layer from artifact %s failed: %w", ociURL, err)
-	}
-	defer gzr.Close()
-
-	// Create a tar reader to iterate through the files in the archive.
-	tr := tar.NewReader(gzr)
-
-	// Iterate through the files in the tar archive.
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			// End of tar archive reached.
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("reading tar archive from artifact %s failed: %w", ociURL, err)
-		}
-
-		// Check if the current file is the one we are looking for.
-		if header.Name == filepath {
-			// Read the file content into a byte slice.
-			content, err := io.ReadAll(tr)
-			if err != nil {
-				return nil, fmt.Errorf("reading file '%s' from artifact %s failed: %w", filepath, ociURL, err)
-			}
-			return content, nil
-		}
-	}
-
-	// If we get here, the file was not found in the archive.
-	return nil, fmt.Errorf("file '%s' not found in artifact %s", filepath, ociURL)
-}
-
-// FetchManifestFromURL downloads a YAML file from the given URL and returns its content.
-// It supports GitHub Gist, GitHub repository and GitLab project URLs, converting them to raw content URLs as needed.
-// It also supports OCI URLs in the format: oci://registry/repository:tag@digest#filepath
-func FetchManifestFromURL(ctx context.Context, rawURL string) ([]byte, error) {
-	parsedURL, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid URL: %w", err)
-	}
-
-	// Handle OCI URLs.
-	if parsedURL.Scheme == "oci" {
-		// Extract the filepath from the fragment.
-		filepath := parsedURL.Fragment
-		if filepath == "" {
-			return nil, fmt.Errorf("OCI URL must include a fragment with the file path, e.g., oci://registry/repository:tag@digest#filepath")
-		}
-
-		// Reconstruct the OCI URL without the fragment.
-		ociURL := fmt.Sprintf("oci://%s%s", parsedURL.Host, parsedURL.Path)
-		return ExtractFileFromArtifact(ctx, ociURL, filepath, authn.DefaultKeychain)
-	}
-
-	// Transform HTTP/S URL for specific providers to get raw content.
-	switch {
-	case parsedURL.Host == "gist.github.com":
-		// Gist URLs: https://gist.github.com/username/gist-id
-		// Raw URLs: https://gist.githubusercontent.com/username/gist-id/raw
-		parsedURL.Host = "gist.githubusercontent.com"
-		if !strings.HasSuffix(parsedURL.Path, "/raw") {
-			parsedURL.Path = parsedURL.Path + "/raw"
-		}
-		// If there's a fragment (e.g., #file-flux-instance-yaml), append it as a path component
-		if parsedURL.Fragment != "" && strings.HasPrefix(parsedURL.Fragment, "file-") {
-			// Convert fragment like "file-flux-instance-yaml" to "flux-instance.yaml"
-			filename := strings.TrimPrefix(parsedURL.Fragment, "file-")
-			filename = strings.ReplaceAll(filename, "-", ".")
-			parts := strings.Split(filename, ".")
-			if len(parts) > 1 {
-				// Reconstruct: everything before last dot, then dot, then extension
-				filename = strings.Join(parts[:len(parts)-1], "-") + "." + parts[len(parts)-1]
-			}
-			parsedURL.Path = parsedURL.Path + "/" + filename
-			parsedURL.Fragment = ""
-		}
-	case strings.Contains(parsedURL.Host, "github") && parsedURL.Query().Get("raw") != "true":
-		// For standard GitHub URLs, add 'raw=true' to get the raw file.
-		query := parsedURL.Query()
-		query.Set("raw", "true")
-		parsedURL.RawQuery = query.Encode()
-	case strings.Contains(parsedURL.Host, "gitlab") && strings.Contains(parsedURL.Path, "/-/blob/"):
-		// For GitLab URLs, replace '/-/blob/' with '/-/raw/'.
-		parsedURL.Path = strings.Replace(parsedURL.Path, "/-/blob/", "/-/raw/", 1)
-	}
-
-	// Create a new retryable HTTP request.
-	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request for %s: %w", rawURL, err)
-	}
-
-	// Use a retryable client to handle transient errors automatically.
-	client := retryablehttp.NewClient()
-	client.RetryMax = 3
-	client.RetryWaitMin = 2 * time.Second
-	client.RetryWaitMax = 5 * time.Second
-	client.Logger = nil
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download from %s: %w", rawURL, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to download from %s: server returned status %s", rawURL, resp.Status)
-	}
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body from %s: %w", rawURL, err)
-	}
-
-	return data, nil
 }

--- a/internal/install/autoupdate.go
+++ b/internal/install/autoupdate.go
@@ -1,0 +1,130 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package install
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/fluxcd/pkg/ssa"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+)
+
+// ApplyAutoUpdate configures automatic updates of the Flux Operator from the distribution artifact.
+func (in *Installer) ApplyAutoUpdate(ctx context.Context, multitenant bool) (*ssa.ChangeSet, error) {
+	// Strip tag from artifact URL (e.g., "oci://registry/image:tag" -> "oci://registry/image")
+	artifactURL := in.options.artifactURL
+	if idx := strings.LastIndex(artifactURL, ":"); idx > 6 {
+		artifactURL = artifactURL[:idx]
+	}
+
+	// Build template data
+	data := struct {
+		Namespace   string
+		ArtifactURL string
+		Multitenant bool
+	}{
+		Namespace:   in.options.namespace,
+		ArtifactURL: artifactURL,
+		Multitenant: multitenant,
+	}
+
+	// Execute template
+	tmpl, err := template.New("autoUpdate").Parse(autoUpdateTmpl)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse auto-update template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("unable to execute auto-update template: %w", err)
+	}
+	autoUpdateYAML := buf.String()
+
+	autoUpdateObjects, err := ssautil.ReadObjects(bytes.NewReader([]byte(autoUpdateYAML)))
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse auto-update manifest: %w", err)
+	}
+
+	return in.kubeClient.Manager.ApplyAllStaged(ctx, autoUpdateObjects, ssa.DefaultApplyOptions())
+}
+
+const autoUpdateTmpl = `
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: flux-operator
+  namespace: {{.Namespace}}
+  labels:
+    app.kubernetes.io/name: flux-operator
+    app.kubernetes.io/instance: flux-operator
+  annotations:
+    fluxcd.controlplane.io/reconcileTimeout: "5m"
+spec:
+  wait: true
+  inputs:
+    - url: {{.ArtifactURL}}
+      interval: "1h"
+  resources:
+    - apiVersion: source.toolkit.fluxcd.io/v1
+      kind: OCIRepository
+      metadata:
+        name: << inputs.provider.name >>
+        namespace: << inputs.provider.namespace >>
+      spec:
+        interval: << inputs.interval | quote >>
+        url: << inputs.url | quote >>
+        ref:
+          tag: latest
+    - apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: << inputs.provider.name >>
+        namespace: << inputs.provider.namespace >>
+      spec:
+        interval: 24h
+        retryInterval: 5m
+        timeout: 5m
+        wait: true
+        prune: true
+        force: true
+        deletionPolicy: Orphan
+        serviceAccountName: << inputs.provider.name >>
+        sourceRef:
+          kind: OCIRepository
+          name: << inputs.provider.name >>
+        path: ./flux-operator
+        commonMetadata:
+          labels:
+            app.kubernetes.io/name: flux-operator
+            app.kubernetes.io/instance: flux-operator
+        patches:
+          - patch: |-
+              - op: replace
+                path: "/spec/selector/matchLabels"
+                value:
+                  app.kubernetes.io/name: flux-operator
+                  app.kubernetes.io/instance: flux-operator
+              - op: replace
+                path: "/spec/template/metadata/labels"
+                value:
+                  app.kubernetes.io/name: flux-operator
+                  app.kubernetes.io/instance: flux-operator
+              - op: add
+                path: "/spec/template/spec/containers/0/env/-"
+                value:
+                  name: REPORTING_INTERVAL
+                  value: "30s"
+{{- if .Multitenant }}
+              - op: add
+                path: "/spec/template/spec/containers/0/env/-"
+                value:
+                  name: DEFAULT_SERVICE_ACCOUNT
+                  value: "flux-operator"
+{{- end }}
+            target:
+              kind: Deployment
+`

--- a/internal/install/client.go
+++ b/internal/install/client.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package install
+
+import (
+	"context"
+
+	"github.com/fluxcd/cli-utils/pkg/kstatus/polling"
+	"github.com/fluxcd/cli-utils/pkg/kstatus/polling/clusterreader"
+	"github.com/fluxcd/cli-utils/pkg/kstatus/polling/engine"
+	"github.com/fluxcd/pkg/apis/kustomize"
+	"github.com/fluxcd/pkg/runtime/cel"
+	fluxclient "github.com/fluxcd/pkg/runtime/client"
+	"github.com/fluxcd/pkg/runtime/statusreaders"
+	"github.com/fluxcd/pkg/ssa"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+// KubeClient embeds the controller-runtime client
+// and the server-side apply resource manager.
+type KubeClient struct {
+	client.Client
+
+	Config  *rest.Config
+	Manager *ssa.ResourceManager
+}
+
+// NewKubeClient creates a new server-side apply enabled Kubernetes client
+// using the provided rest.Config. The owner parameter is used to set
+// the server-side apply field manager for all applied resources.
+func NewKubeClient(ctx context.Context, cfg *rest.Config, owner string) (*KubeClient, error) {
+	restMapper, err := fluxclient.NewDynamicRESTMapper(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeClient, err := client.New(cfg, client.Options{Mapper: restMapper, Scheme: NewScheme()})
+	if err != nil {
+		return nil, err
+	}
+
+	kubePoller, err := NewStatusPoller(ctx, kubeClient, restMapper)
+	if err != nil {
+		return nil, err
+	}
+
+	manager := ssa.NewResourceManager(kubeClient, kubePoller, ssa.Owner{
+		Field: owner,
+		Group: fluxcdv1.GroupVersion.Group,
+	})
+
+	return &KubeClient{
+		Client:  kubeClient,
+		Config:  cfg,
+		Manager: manager,
+	}, nil
+}
+
+// NewScheme returns a new runtime.Scheme with all the
+// relevant types needed by the installer client.
+func NewScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(apiextensionsv1.AddToScheme(s))
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(rbacv1.AddToScheme(s))
+	utilruntime.Must(appsv1.AddToScheme(s))
+	utilruntime.Must(fluxcdv1.AddToScheme(s))
+	return s
+}
+
+// NewStatusPoller returns a polling.StatusPoller configured with
+// health checks for Flux Operator custom resources.
+func NewStatusPoller(ctx context.Context, reader client.Reader, mapper meta.RESTMapper) (*polling.StatusPoller, error) {
+	kinds := []string{fluxcdv1.FluxInstanceKind, fluxcdv1.ResourceSetKind, fluxcdv1.ResourceSetInputProviderKind}
+	healthChecks := make([]kustomize.CustomHealthCheck, 0, len(kinds))
+	for _, kind := range kinds {
+		healthChecks = append(healthChecks, kustomize.CustomHealthCheck{
+			APIVersion: fluxcdv1.GroupVersion.String(),
+			Kind:       kind,
+			HealthCheckExpressions: kustomize.HealthCheckExpressions{
+				Current: "status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True' && e.observedGeneration == metadata.generation)",
+			},
+		})
+	}
+
+	statusReaders, err := cel.PollerWithCustomHealthChecks(ctx, healthChecks)
+	if err != nil {
+		return nil, err
+	}
+
+	readers := make([]engine.StatusReader, 0, 1+len(statusReaders))
+	readers = append(readers, statusreaders.NewCustomJobStatusReader(mapper))
+	for _, sr := range statusReaders {
+		readers = append(readers, sr(mapper))
+	}
+
+	kubePoller := polling.NewStatusPoller(reader, mapper, polling.Options{
+		ClusterReaderFactory: engine.ClusterReaderFactoryFunc(clusterreader.NewDirectClusterReader),
+		CustomStatusReaders:  readers,
+	})
+
+	return kubePoller, nil
+}

--- a/internal/install/credentials.go
+++ b/internal/install/credentials.go
@@ -1,0 +1,71 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/pkg/runtime/secrets"
+	"github.com/fluxcd/pkg/ssa"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ApplyCredentials creates and applies the appropriate Kubernetes Secret
+// for the provided address using the credentials in the format "username:token".
+// It supports both Git (HTTP/S or SSH) and OCI registry sources.
+// The secret is created in the installer's namespace with the given secretName.
+func (in *Installer) ApplyCredentials(ctx context.Context, secretName, address string) (*ssa.ChangeSet, error) {
+	if address == "" {
+		return nil, fmt.Errorf("address is required to create credentials secret")
+	}
+
+	// Parse credentials
+	parts := strings.SplitN(in.options.credentials, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("invalid credentials format, expected username:token")
+	}
+	username := parts[0]
+	password := parts[1]
+
+	var secret *corev1.Secret
+	var err error
+
+	// Determine source type and create appropriate secret
+	if strings.HasPrefix(address, "oci://") {
+		// Extract server from OCI URL (strip oci:// prefix and take host part)
+		server := strings.TrimPrefix(address, "oci://")
+		if idx := strings.Index(server, "/"); idx > 0 {
+			server = server[:idx]
+		}
+		secret, err = secrets.MakeRegistrySecret(
+			secretName,
+			in.options.namespace,
+			server,
+			username,
+			password,
+		)
+	} else {
+		// Git source (HTTP/S or SSH)
+		secret, err = secrets.MakeBasicAuthSecret(
+			secretName,
+			in.options.namespace,
+			username,
+			password,
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to create secret: %w", err)
+	}
+
+	rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert secret to unstructured: %w", err)
+	}
+
+	return in.kubeClient.Manager.ApplyAllStaged(ctx, []*unstructured.Unstructured{{Object: rawMap}}, ssa.DefaultApplyOptions())
+}

--- a/internal/install/deploy.go
+++ b/internal/install/deploy.go
@@ -1,0 +1,70 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package install
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/fluxcd/pkg/ssa"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+// ApplyOperator applies the Flux Operator manifests to the cluster.
+// It sets consistent labels on all objects and ensures Deployment resources have matching selector and template labels.
+func (in *Installer) ApplyOperator(ctx context.Context, objects []*unstructured.Unstructured) (*ssa.ChangeSet, error) {
+	labels := map[string]string{
+		"app.kubernetes.io/name":     "flux-operator",
+		"app.kubernetes.io/instance": "flux-operator",
+	}
+	ssautil.SetCommonMetadata(objects, labels, nil)
+
+	// Iterate through objects and set label selectors to ensure
+	// that helm-controller can adopt the Flux Operator deployment
+	for _, obj := range objects {
+		if obj.GetKind() == "Deployment" {
+			// Set spec.selector.matchLabels
+			if err := unstructured.SetNestedStringMap(obj.Object, labels, "spec", "selector", "matchLabels"); err != nil {
+				return nil, fmt.Errorf("failed to set deployment selector labels: %w", err)
+			}
+
+			// Set spec.template.metadata.labels
+			if err := unstructured.SetNestedStringMap(obj.Object, labels, "spec", "template", "metadata", "labels"); err != nil {
+				return nil, fmt.Errorf("failed to set deployment template labels: %w", err)
+			}
+		}
+		if obj.GetKind() == "Service" {
+			// Set spec.selector
+			if err := unstructured.SetNestedStringMap(obj.Object, labels, "spec", "selector"); err != nil {
+				return nil, fmt.Errorf("failed to set service selector labels: %w", err)
+			}
+		}
+	}
+
+	return in.kubeClient.Manager.ApplyAllStaged(ctx, objects, ssa.DefaultApplyOptions())
+}
+
+// ApplyInstance applies the Flux instance manifests to the cluster.
+func (in *Installer) ApplyInstance(ctx context.Context, instance *fluxcdv1.FluxInstance) (*ssa.ChangeSet, error) {
+	// Convert to unstructured
+	rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(instance)
+	if err != nil {
+		return nil, err
+	}
+
+	return in.kubeClient.Manager.ApplyAllStaged(ctx, []*unstructured.Unstructured{{Object: rawMap}}, ssa.DefaultApplyOptions())
+}
+
+// WaitFor waits for all resources in the provided ChangeSet to be ready within the given timeout.
+func (in *Installer) WaitFor(ctx context.Context, cs *ssa.ChangeSet, timeout time.Duration) error {
+	return in.kubeClient.Manager.WaitForSetWithContext(ctx, cs.ToObjMetadataSet(), ssa.WaitOptions{
+		Interval: 5 * time.Second,
+		Timeout:  timeout,
+	})
+}

--- a/internal/install/download.go
+++ b/internal/install/download.go
@@ -1,0 +1,169 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package install
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// DownloadFileFromArtifact downloads an artifact from an OCI repository and
+// returns the content of a specific file from its first layer.
+// The operation is performed in-memory without writing to the filesystem.
+func DownloadFileFromArtifact(ctx context.Context, ociURL, filepath string, keyChain authn.Keychain) ([]byte, error) {
+	// Pull the OCI image/artifact from the repository.
+	img, err := crane.Pull(strings.TrimPrefix(ociURL, "oci://"), crane.WithContext(ctx), crane.WithAuthFromKeychain(keyChain))
+	if err != nil {
+		return nil, fmt.Errorf("pulling artifact %s failed: %w", ociURL, err)
+	}
+
+	// Get the layers of the image.
+	layers, err := img.Layers()
+	if err != nil {
+		return nil, fmt.Errorf("listing layers in artifact %s failed: %w", ociURL, err)
+	}
+
+	// Ensure there is at least one layer.
+	if len(layers) < 1 {
+		return nil, fmt.Errorf("no layers found in artifact %s", ociURL)
+	}
+
+	// Get the compressed blob of the first layer.
+	blob, err := layers[0].Compressed()
+	if err != nil {
+		return nil, fmt.Errorf("reading layer from artifact %s failed: %w", ociURL, err)
+	}
+	defer blob.Close()
+
+	// The layer is a gzipped tarball, so we create a gzip reader.
+	gzr, err := gzip.NewReader(blob)
+	if err != nil {
+		return nil, fmt.Errorf("decompressing layer from artifact %s failed: %w", ociURL, err)
+	}
+	defer gzr.Close()
+
+	// Create a tar reader to iterate through the files in the archive.
+	tr := tar.NewReader(gzr)
+
+	// Iterate through the files in the tar archive.
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			// End of tar archive reached.
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading tar archive from artifact %s failed: %w", ociURL, err)
+		}
+
+		// Check if the current file is the one we are looking for.
+		if header.Name == filepath {
+			// Read the file content into a byte slice.
+			content, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, fmt.Errorf("reading file '%s' from artifact %s failed: %w", filepath, ociURL, err)
+			}
+			return content, nil
+		}
+	}
+
+	// If we get here, the file was not found in the archive.
+	return nil, fmt.Errorf("file '%s' not found in artifact %s", filepath, ociURL)
+}
+
+// DownloadManifestFromURL downloads a YAML file from the given URL and returns its content.
+// It supports GitHub Gist, GitHub repository and GitLab project URLs, converting them to raw content URLs as needed.
+// It also supports OCI URLs in the format: oci://registry/repository:tag@digest#filepath
+func DownloadManifestFromURL(ctx context.Context, rawURL string, keyChain authn.Keychain) ([]byte, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	// Handle OCI URLs.
+	if parsedURL.Scheme == "oci" {
+		// Extract the filepath from the fragment.
+		filepath := parsedURL.Fragment
+		if filepath == "" {
+			return nil, fmt.Errorf("OCI URL must include a fragment with the file path, e.g., oci://registry/repository:tag@digest#filepath")
+		}
+
+		// Reconstruct the OCI URL without the fragment.
+		ociURL := fmt.Sprintf("oci://%s%s", parsedURL.Host, parsedURL.Path)
+		return DownloadFileFromArtifact(ctx, ociURL, filepath, keyChain)
+	}
+
+	// Transform HTTP/S URL for specific providers to get raw content.
+	switch {
+	case parsedURL.Host == "gist.github.com":
+		// Gist URLs: https://gist.github.com/username/gist-id
+		// Raw URLs: https://gist.githubusercontent.com/username/gist-id/raw
+		parsedURL.Host = "gist.githubusercontent.com"
+		if !strings.HasSuffix(parsedURL.Path, "/raw") {
+			parsedURL.Path = parsedURL.Path + "/raw"
+		}
+		// If there's a fragment (e.g., #file-flux-instance-yaml), append it as a path component
+		if parsedURL.Fragment != "" && strings.HasPrefix(parsedURL.Fragment, "file-") {
+			// Convert fragment like "file-flux-instance-yaml" to "flux-instance.yaml"
+			filename := strings.TrimPrefix(parsedURL.Fragment, "file-")
+			filename = strings.ReplaceAll(filename, "-", ".")
+			parts := strings.Split(filename, ".")
+			if len(parts) > 1 {
+				// Reconstruct: everything before last dot, then dot, then extension
+				filename = strings.Join(parts[:len(parts)-1], "-") + "." + parts[len(parts)-1]
+			}
+			parsedURL.Path = parsedURL.Path + "/" + filename
+			parsedURL.Fragment = ""
+		}
+	case strings.Contains(parsedURL.Host, "github") && parsedURL.Query().Get("raw") != "true":
+		// For standard GitHub URLs, add 'raw=true' to get the raw file.
+		query := parsedURL.Query()
+		query.Set("raw", "true")
+		parsedURL.RawQuery = query.Encode()
+	case strings.Contains(parsedURL.Host, "gitlab") && strings.Contains(parsedURL.Path, "/-/blob/"):
+		// For GitLab URLs, replace '/-/blob/' with '/-/raw/'.
+		parsedURL.Path = strings.Replace(parsedURL.Path, "/-/blob/", "/-/raw/", 1)
+	}
+
+	// Create a new retryable HTTP request.
+	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for %s: %w", rawURL, err)
+	}
+
+	// Use a retryable client to handle transient errors automatically.
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	client.RetryWaitMin = 2 * time.Second
+	client.RetryWaitMax = 5 * time.Second
+	client.Logger = nil
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download from %s: %w", rawURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download from %s: server returned status %s", rawURL, resp.Status)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body from %s: %w", rawURL, err)
+	}
+
+	return data, nil
+}

--- a/internal/install/events.go
+++ b/internal/install/events.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package install
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Event is a lighter representation of a Kubernetes event.
+type Event struct {
+	LastTimestamp  metav1.Time `json:"lastTimestamp"`
+	Type           string      `json:"type"`
+	Message        string      `json:"message"`
+	InvolvedObject string      `json:"involvedObject"`
+}
+
+// GetEvents retrieves events for a specific resource kind and name.
+func (in *Installer) GetEvents(ctx context.Context, kind, name string) ([]Event, error) {
+	el := &corev1.EventList{}
+
+	selectors := []fields.Selector{
+		fields.OneTermEqualSelector("involvedObject.kind", kind),
+		fields.OneTermEqualSelector("involvedObject.name", name),
+	}
+
+	listOpts := []client.ListOption{
+		client.Limit(100),
+		client.InNamespace(in.options.namespace),
+		client.MatchingFieldsSelector{
+			Selector: fields.AndSelectors(selectors...),
+		}}
+	err := in.kubeClient.List(ctx, el, listOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list events: %w", err)
+	}
+
+	sort.Sort(SortableEvents(el.Items))
+
+	events := make([]Event, 0, len(el.Items))
+	for _, event := range el.Items {
+		events = append(events, Event{
+			InvolvedObject: fmt.Sprintf("%s/%s/%s",
+				event.InvolvedObject.Kind,
+				in.options.namespace,
+				event.InvolvedObject.Name),
+			LastTimestamp: event.LastTimestamp,
+			Type:          event.Type,
+			Message:       event.Message,
+		})
+	}
+	return events, nil
+}
+
+// SortableEvents implements sort.Interface for []api.Event by time
+type SortableEvents []corev1.Event
+
+func (list SortableEvents) Len() int {
+	return len(list)
+}
+
+func (list SortableEvents) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+// Return the time that should be used for sorting, which can come from
+// various places in corev1.Event.
+func eventTime(event corev1.Event) time.Time {
+	if event.Series != nil {
+		return event.Series.LastObservedTime.Time
+	}
+	if !event.LastTimestamp.Time.IsZero() {
+		return event.LastTimestamp.Time
+	}
+	return event.EventTime.Time
+}
+
+func (list SortableEvents) Less(i, j int) bool {
+	return eventTime(list[i]).Before(eventTime(list[j]))
+}

--- a/internal/install/installer.go
+++ b/internal/install/installer.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package install
+
+import (
+	"context"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+)
+
+// Installer handles the installation of Flux Operator and Flux instance.
+type Installer struct {
+	kubeClient *KubeClient
+	options    *Options
+}
+
+// NewInstaller creates a new Installer with the provided Kubernetes config and options.
+// If no ArtifactURL, Owner, or Namespace is provided in the options, it uses the defaults.
+func NewInstaller(ctx context.Context, cfg *rest.Config, opts ...Option) (*Installer, error) {
+	// Apply default options
+	defaultOpts := []Option{
+		WithArtifactURL(DefaultArtifactURL),
+		WithOwner(DefaultOwner),
+		WithNamespace(DefaultNamespace),
+	}
+
+	// User options override defaults
+	allOpts := append(defaultOpts, opts...)
+
+	// Create and validate the final options
+	options, err := MakeOptions(allOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid options: %w", err)
+	}
+
+	// Create the Kubernetes client
+	kubeClient, err := NewKubeClient(ctx, cfg, options.Owner())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	return &Installer{
+		kubeClient: kubeClient,
+		options:    options,
+	}, nil
+}
+
+// IsInstalled checks if the Flux Operator installed in the cluster.
+// If the installation is managed by Helm, it returns an error.
+func (in *Installer) IsInstalled(ctx context.Context) (bool, error) {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	err := in.kubeClient.Get(ctx, types.NamespacedName{
+		Name: "fluxinstances.fluxcd.controlplane.io",
+	}, crd)
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("unable to check if Flux Operator is installed: %w", err)
+	}
+
+	// Check if the CRD is managed by Helm
+	if managedBy, exists := crd.Labels["app.kubernetes.io/managed-by"]; exists && managedBy == "Helm" {
+		return true, fmt.Errorf("the Flux Operator installation is managed by Helm, cannot proceed with installation")
+	}
+
+	return true, nil
+}

--- a/internal/install/options.go
+++ b/internal/install/options.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package install
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// DefaultArtifactURL is the default OCI artifact URL for Flux Operator manifests.
+	DefaultArtifactURL = "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
+
+	// DefaultOwner is the default field manager name for server-side apply operations.
+	DefaultOwner = "kubectl-flux-operator"
+
+	// DefaultNamespace is the default namespace for Flux Operator and Flux instance.
+	DefaultNamespace = "flux-system"
+)
+
+// Options holds the configuration for installing the Flux Operator and FluxInstance.
+// This is shared between the CLI and MCP server.
+type Options struct {
+	// artifactURL is the OCI artifact URL containing the Flux Operator manifests.
+	// Example: "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
+	artifactURL string
+
+	// credentials are the credentials for the sync source in the format "username:token".
+	// These are used to create a Kubernetes secret for authenticating to Git or OCI repositories.
+	credentials string
+
+	// owner is the field manager name used for server-side apply operations.
+	owner string
+
+	// namespace is the namespace where Flux Operator and Flux instance will be installed.
+	namespace string
+}
+
+// Option is a functional option for configuring the installer.
+type Option func(*Options)
+
+// WithArtifactURL sets the OCI artifact URL containing the Flux Operator manifests.
+func WithArtifactURL(url string) Option {
+	return func(o *Options) {
+		o.artifactURL = url
+	}
+}
+
+// WithCredentials sets the credentials for the sync source in the format "username:token".
+func WithCredentials(credentials string) Option {
+	return func(o *Options) {
+		o.credentials = credentials
+	}
+}
+
+// WithOwner sets the field manager name for server-side apply operations.
+func WithOwner(owner string) Option {
+	return func(o *Options) {
+		o.owner = owner
+	}
+}
+
+// WithNamespace sets the namespace where Flux Operator and Flux instance will be installed.
+func WithNamespace(namespace string) Option {
+	return func(o *Options) {
+		o.namespace = namespace
+	}
+}
+
+// MakeOptions creates a new Options instance with the provided functional options.
+func MakeOptions(opts ...Option) (*Options, error) {
+	o := &Options{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	if err := o.validate(); err != nil {
+		return nil, err
+	}
+
+	return o, nil
+}
+
+// validate checks if the options are valid and returns an error if not.
+func (o *Options) validate() error {
+	if !strings.HasPrefix(o.artifactURL, "oci://") {
+		return fmt.Errorf("artifact URL must start with 'oci://', got: %s", o.artifactURL)
+	}
+
+	if o.credentials != "" {
+		parts := strings.SplitN(o.credentials, ":", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("credentials must be in the format 'username:token'")
+		}
+	}
+
+	return nil
+}
+
+// ArtifactURL returns the OCI artifact URL.
+func (o *Options) ArtifactURL() string {
+	return o.artifactURL
+}
+
+// Credentials returns the sync credentials.
+func (o *Options) Credentials() string {
+	return o.credentials
+}
+
+// Owner returns the field manager name.
+func (o *Options) Owner() string {
+	return o.owner
+}
+
+// Namespace returns the installation namespace.
+func (o *Options) Namespace() string {
+	return o.namespace
+}


### PR DESCRIPTION
The `flux-operator install` command provides a quick way to bootstrap a Kubernetes cluster with the Flux Operator and a Flux instance.

This command performs the following steps:

1. Downloads the Flux Operator distribution artifact from `oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests`.
2. Installs the Flux Operator in the `flux-system` namespace and waits for it to become ready.
3. Installs the Flux instance in the `flux-system` namespace according to the provided configuration.
4. Configures the pull secret for the instance sync source if credentials are provided.
5. Configures Flux to bootstrap the cluster from a Git repository or OCI repository if a sync URL is provided.
6. Configures automatic updates of the Flux Operator from the distribution artifact.

This command is intended for development and testing purposes. On production environments, it is recommended to follow the [installation guide](https://fluxcd.control-plane.io/operator/install/).

- `flux-operator install`: Installs the Flux Operator and a Flux instance in the cluster.
    - `--instance-file, -f`: Path to FluxInstance YAML file (local file or HTTPS URL).
    - `--instance-distribution-version`: Flux distribution version.
    - `--instance-distribution-registry`: Container registry to pull Flux images from.
    - `--instance-distribution-artifact`: OCI artifact containing the Flux distribution manifests.
    - `--instance-components`: List of Flux components to install.
    - `--instance-components-extra`: Additional Flux components to install on top of the default set.
    - `--instance-cluster-type`: Cluster type (kubernetes, openshift, aws, azure, gcp).
    - `--instance-cluster-size`: Cluster size profile for vertical scaling (small, medium, large).
    - `--instance-cluster-domain`: Cluster domain used for generating the FQDN of services.
    - `--instance-cluster-multitenant`: Enable multitenant lockdown for Flux controllers.
    - `--instance-cluster-network-policy`: Restrict network access to the current namespace.
    - `--instance-sync-url`: URL of the source for cluster sync (Git repository URL or OCI repository address).
    - `--instance-sync-ref`: Source reference for cluster sync (Git ref name or OCI tag).
    - `--instance-sync-path`: Path to the manifests directory in the source.
    - `--instance-sync-creds`: Credentials for the source in the format `username:token`.
    - `--auto-update`: Enable automatic updates of the Flux Operator from the distribution artifact.

Example usage:

```sh
$ flux-operator install \
    --instance-distribution-version=2.7.x \
    --instance-components-extra=source-watcher \
    --instance-cluster-multitenant=true \
    --instance-sync-url=https://github.com/controlplaneio-fluxcd/distribution.git \
    --instance-sync-ref=refs/heads/main \
    --instance-sync-path=tests/v2.7/sources \
    --instance-sync-creds=git:${GITHUB_TOKEN}
```

Example output:

```console
◎ Downloading distribution artifact...
✔ Download completed
◎ Installing Flux Operator in flux-system namespace...
✔ CustomResourceDefinition/fluxinstances.fluxcd.controlplane.io created
✔ CustomResourceDefinition/fluxreports.fluxcd.controlplane.io created
✔ CustomResourceDefinition/resourcesetinputproviders.fluxcd.controlplane.io created
✔ CustomResourceDefinition/resourcesets.fluxcd.controlplane.io created
✔ Namespace/flux-system created
✔ ClusterRole/flux-operator-edit created
✔ ClusterRole/flux-operator-view created
✔ ClusterRoleBinding/flux-operator-cluster-admin created
✔ ServiceAccount/flux-system/flux-operator created
✔ Service/flux-system/flux-operator created
✔ Deployment/flux-system/flux-operator created
◎ Waiting for Flux Operator to be ready...
✔ Flux Operator has been installed successfully
◎ Configuring sync credentials...
✔ Secret/flux-system/flux-system created
◎ Installing the Flux instance...
✔ FluxInstance/flux-system/flux created
◎ Waiting for Flux instance to be ready...
✔ Flux has been installed successfully
✔ Syncing from: https://github.com/controlplaneio-fluxcd/distribution.git
✔ Applied revision: refs/heads/main@sha1:8342ed012f92c1c6bc7951f22855a967ab137885
◎ Configuring automatic updates...
✔ ResourceSet/flux-system/flux-operator created
◎ Waiting for ResourceSet to be ready...
✔ Flux Operator version: v0.32.0
✔ Flux Distribution version: v2.7.2
✔ Installation completed in 1m19s
```

