### PR TITLE
Fix ResourceSet docs using incorrect "ResourceSetInputsProvider"

### DIFF
--- a/docs/api/v1/resourceset.md
+++ b/docs/api/v1/resourceset.md
@@ -164,7 +164,7 @@ Example of inputs generated from GitHub Pull Requests:
 spec:
   inputsFrom:
     - apiVersion: fluxcd.controlplane.io/v1
-      kind: ResourceSetInputsProvider
+      kind: ResourceSetInputProvider
       name: podinfo-pull-requests
 ```
 
@@ -175,7 +175,7 @@ Example of inputs generated from multiple `ResourceSetInputProvider` objects via
 spec:
   inputsFrom:
     - apiVersion: fluxcd.controlplane.io/v1
-      kind: ResourceSetInputsProvider
+      kind: ResourceSetInputProvider
       selector:
         matchLabels:
           app: podinfo


### PR DESCRIPTION
PR https://github.com/controlplaneio-fluxcd/distribution/pull/269 was in a wrong place, so this is the correct place.

> Using the .kind from the docs verbatim causes this:
>ResourceSet/flux-system/test-rset dry-run failed (Invalid): ResourceSet.fluxcd.controlplane.io "test-rset" is invalid: [spec.inputsFrom[0].kind: Unsupported value: "ResourceSetInputsProvider": supported values: "ResourceSetInputProvider", : Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]