### PR TITLE
operator: Wait for owned resources managed by ResourceSets

### DIFF
--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -19,6 +19,8 @@ const (
 
 	ReconciliationDisabledReason  = "ReconciliationDisabled"
 	ReconciliationDisabledMessage = "Reconciliation is disabled"
+
+	HealthCheckExpr = "status.conditions.filter(c, c.type == 'Ready').all(c, c.status == 'True' && c.observedGeneration == metadata.generation)"
 )
 
 var (

--- a/internal/install/client.go
+++ b/internal/install/client.go
@@ -89,7 +89,7 @@ func NewStatusPoller(ctx context.Context, reader client.Reader, mapper meta.REST
 			APIVersion: fluxcdv1.GroupVersion.String(),
 			Kind:       kind,
 			HealthCheckExpressions: kustomize.HealthCheckExpressions{
-				Current: "status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True' && e.observedGeneration == metadata.generation)",
+				Current: fluxcdv1.HealthCheckExpr,
 			},
 		})
 	}


### PR DESCRIPTION
This PR makes the ResourceSet wait logic aware of Flux Operator owned kinds. For `dependsOn`, the `readyExpr` is no longer needed, also when a ResourceSet generates input providers, it knows how to wait for them to reconcile. 