### PR TITLE
mcp: Add `ArtifactGenerator` API docs to `search_flux_docs` tool

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,13 +13,16 @@ Flux consists of the following Kubernetes controllers and custom resource defini
     - **FluxInstance**: Manages the Flux controllers installation and configuration
     - **FluxReport**: Reflects the state of a Flux installation
     - **ResourceSet**: Manages groups of Kubernetes resources based on input matrices
-    - **ResourceSetInputProvider**: Fetches input values from external services (GitHub, GitLab)
+    - **ResourceSetInputProvider**: Fetches input values from external services (GitHub, GitLab, AzureDevOps, OCI registries)
 - Source Controller
     - **GitRepository**: Points to a Git repository containing Kubernetes manifests or Helm charts
     - **OCIRepository**: Points to a container registry containing OCI artifacts (manifests or Helm charts)
     - **Bucket**: Points to an S3-compatible bucket containing manifests
     - **HelmRepository**: Points to a Helm chart repository
     - **HelmChart**: References a chart from a HelmRepository or a GitRepository
+    - **ExternalArtifact**: Represents a 3rd-party source controller artifact that Flux can consume
+- Source Watcher
+    - **ArtifactGenerator**: Composes and decomposes sources into new artifacts for Flux consumption
 - Kustomize Controller
     - **Kustomization**: Builds and applies Kubernetes manifests from sources
 - Helm Controller
@@ -38,14 +41,12 @@ For a deep understanding of the Flux CRDs, call the `search_flux_docs` tool for 
 ## General rules
 
 - When asked about the Flux installation status, call the `get_flux_instance` tool.
-- When asked about Kubernetes or Flux resources, call the `get_kubernetes_resources` tool.
+- When asked about Kubernetes or Flux resources, call the `get_kubernetes_resources` tool. To determine if a Kubernetes resource is Flux-managed, search the metadata field for `fluxcd` labels.
 - Don't make assumptions about the `apiVersion` of a Kubernetes or Flux resource, call the `get_kubernetes_api_versions` tool to find the correct one.
 - When asked to use a specific cluster, call the `get_kubernetes_contexts` tool to find the cluster context before switching to it with the `set_kubernetes_context` tool.
 - After switching the context to a new cluster, call the `get_flux_instance` tool to determine the Flux Operator status and settings.
-- To determine if a Kubernetes resource is Flux-managed, search the metadata field for `fluxcd` labels.
-- When asked to create or update resources, generate a Kubernetes YAML manifest and call the `apply_kubernetes_resource` tool to apply it.
-- Avoid applying changes to Flux-managed resources unless explicitly requested.
-- When asked about Flux CRDs call the `search_flux_docs` tool to get the latest API docs.
+- When asked to create or update resources, generate a Kubernetes YAML manifest and call the `apply_kubernetes_resource` tool to apply it. Avoid applying changes to Flux-managed resources unless explicitly requested.
+- When asked to install Flux use the `install_flux_instance` tool.
 
 ## Kubernetes logs analysis
 

--- a/cmd/mcp/toolbox/library_index.go
+++ b/cmd/mcp/toolbox/library_index.go
@@ -22,7 +22,7 @@ var docsMetadata = []DocumentMetadata{
 		},
 	},
 	{
-		URL:   "https://raw.githubusercontent.com/fluxcd/source-controller/refs/heads/main/docs/spec/v1beta2/ocirepositories.md",
+		URL:   "https://raw.githubusercontent.com/fluxcd/source-controller/refs/heads/main/docs/spec/v1/ocirepositories.md",
 		Group: fluxcdv1.FluxSourceGroup,
 		Kind:  fluxcdv1.FluxOCIRepositoryKind,
 		Keywords: []string{
@@ -55,6 +55,15 @@ var docsMetadata = []DocumentMetadata{
 			"source-controller", "s3", "storage", "minio", "blob", "endpoint",
 			"region", "insecure", "managed-identity", "sas", "token", "certificate",
 			"proxy", "authentication", "provider", "aws", "azure", "gcp",
+		},
+	},
+	{
+		URL:   "https://raw.githubusercontent.com/fluxcd/source-watcher/refs/heads/main/docs/spec/v1beta1/artifactgenerators.md",
+		Group: fluxcdv1.FluxSourceExtensionsGroup,
+		Kind:  fluxcdv1.FluxArtifactGeneratorKind,
+		Keywords: []string{
+			"source-watcher", "artifact", "generator", "external", "composition", "decomposition", "multiple",
+			"copy", "alias", "originrevision", "exclude", "extension",
 		},
 	},
 	{
@@ -108,7 +117,7 @@ var docsMetadata = []DocumentMetadata{
 		},
 	},
 	{
-		URL:   "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/refs/heads/main/docs/spec/v1beta2/imagerepositories.md",
+		URL:   "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/refs/heads/main/docs/spec/v1/imagerepositories.md",
 		Group: fluxcdv1.FluxImageGroup,
 		Kind:  fluxcdv1.FluxImageRepositoryKind,
 		Keywords: []string{
@@ -117,7 +126,7 @@ var docsMetadata = []DocumentMetadata{
 		},
 	},
 	{
-		URL:   "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/refs/heads/main/docs/spec/v1beta2/imagepolicies.md",
+		URL:   "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/refs/heads/main/docs/spec/v1/imagepolicies.md",
 		Group: fluxcdv1.FluxImageGroup,
 		Kind:  fluxcdv1.FluxImagePolicyKind,
 		Keywords: []string{
@@ -126,7 +135,7 @@ var docsMetadata = []DocumentMetadata{
 		},
 	},
 	{
-		URL:   "https://raw.githubusercontent.com/fluxcd/image-automation-controller/refs/heads/main/docs/spec/v1beta2/imageupdateautomations.md",
+		URL:   "https://raw.githubusercontent.com/fluxcd/image-automation-controller/refs/heads/main/docs/spec/v1/imageupdateautomations.md",
 		Group: fluxcdv1.FluxImageGroup,
 		Kind:  fluxcdv1.FluxImageUpdateAutomationKind,
 		Keywords: []string{


### PR DESCRIPTION
Add `ArtifactGenerator` docs and update the Flux API docs to latest for the  `search_flux_docs` tool.