### PR TITLE
fix(cli): correct typo in create sops command

### DIFF
--- a/cmd/cli/create_secret_sops.go
+++ b/cmd/cli/create_secret_sops.go
@@ -192,6 +192,6 @@ func createSecretSOPSCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	rootCmd.Println(`✔`, fmt.Sprintf("Secret %s/%s applied succefuly", secret.GetNamespace(), secret.GetName()))
+	rootCmd.Println(`✔`, fmt.Sprintf("Secret %s/%s applied successfully", secret.GetNamespace(), secret.GetName()))
 	return nil
 }


### PR DESCRIPTION
Hi!

Thanks for your work on the awesome flux-operator project!

I found a small typo in the output text of the `flux-operator create secret sops` command.

BR, Pascal