### PR TITLE
Ensure the `set_kubeconfig_context` tool persists changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,24 +124,19 @@ To run the MCP Server using stdio, add the following configuration to your AI as
   "mcpServers": {
     "flux-operator-mcp": {
       "command": "/path/to/bin/flux-operator-mcp",
-      "args": ["serve"],
-      "env": {
-        "KUBECONFIG": "/path/to/.kube/config"
-      }
+      "args": ["serve"]
     }
   }
 }
 ```
 
-Replace `/path/to/bin/flux-operator-mcp` with the absolute path to the binary
-and `/path/to/.kube/config` with the absolute path to your kubeconfig file.
+Replace `/path/to/bin/flux-operator-mcp` with the absolute path to the binary.
 
 After rebuilding the MCP Server binary, you need to restart the AI assistant app to test the new build.
 
 To run the MCP Server using SSE, use the following command:
 
 ```shell
-export KUBECONFIG=$HOME/.kube/config
 ./bin/flux-operator-mcp serve --transport sse --port 8080
 ```
 

--- a/cmd/mcp/README.md
+++ b/cmd/mcp/README.md
@@ -30,16 +30,13 @@ Add the following configuration to your AI assistant's MCP settings:
     "args":[
       "serve",
       "--read-only=false"
-    ],
-    "env":{
-      "KUBECONFIG":"/path/to/.kube/config"
-    }
+    ]
   }
 }
 ```
 
-Replace `/path/to/.kube/config` with the absolute path to your kubeconfig file,
-you can find it with: `echo $HOME/.kube/config`.
+The kubeconfig file location can be overridden with the `$KUBECONFIG`
+environment variable, or the `--kubeconfig` flag.
 
 Copy the AI rules from
 [instructions.md](https://raw.githubusercontent.com/controlplaneio-fluxcd/distribution/refs/heads/main/docs/mcp/instructions.md)

--- a/cmd/mcp/toolbox/apply_manifest.go
+++ b/cmd/mcp/toolbox/apply_manifest.go
@@ -43,7 +43,7 @@ func (m *Manager) HandleApplyKubernetesManifest(ctx context.Context, request *mc
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/apply_manifest_test.go
+++ b/cmd/mcp/toolbox/apply_manifest_test.go
@@ -20,9 +20,11 @@ func TestManager_HandleApplyKubernetesManifest(t *testing.T) {
 	configFile := "testdata/kubeconfig.yaml"
 	t.Setenv("KUBECONFIG", configFile)
 
+	flags := cli.NewConfigFlags(false)
+
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
-		flags:      cli.NewConfigFlags(false),
+		kubeconfig: k8s.NewKubeConfig(flags),
+		flags:      flags,
 		timeout:    time.Second,
 	}
 

--- a/cmd/mcp/toolbox/delete_resource.go
+++ b/cmd/mcp/toolbox/delete_resource.go
@@ -51,7 +51,7 @@ func (m *Manager) HandleDeleteKubernetesResource(ctx context.Context, request *m
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/delete_resource_test.go
+++ b/cmd/mcp/toolbox/delete_resource_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleDeleteKubernetesResource(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/get_apis.go
+++ b/cmd/mcp/toolbox/get_apis.go
@@ -33,7 +33,7 @@ func (m *Manager) HandleGetAPIVersions(ctx context.Context, request *mcp.CallToo
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/get_apis_test.go
+++ b/cmd/mcp/toolbox/get_apis_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleGetAPIVersions(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/get_contexts.go
+++ b/cmd/mcp/toolbox/get_contexts.go
@@ -24,12 +24,12 @@ func init() {
 
 // HandleGetKubeconfigContexts is the handler function for the get_kubeconfig_contexts tool.
 func (m *Manager) HandleGetKubeconfigContexts(ctx context.Context, request *mcp.CallToolRequest, input struct{}) (*mcp.CallToolResult, any, error) {
-	err := m.kubeconfig.Load()
+	contexts, err := m.kubeconfig.Contexts()
 	if err != nil {
-		return NewToolResultErrorFromErr("Failed to read kubeconfig", err)
+		return NewToolResultErrorFromErr("Failed to list contexts", err)
 	}
 
-	data, err := yaml.Marshal(m.kubeconfig.Contexts())
+	data, err := yaml.Marshal(contexts)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed marshalling data", err)
 	}

--- a/cmd/mcp/toolbox/get_contexts_test.go
+++ b/cmd/mcp/toolbox/get_contexts_test.go
@@ -23,7 +23,7 @@ func TestManager_HandleGetKubeconfigContexts(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 	}
 

--- a/cmd/mcp/toolbox/get_instance.go
+++ b/cmd/mcp/toolbox/get_instance.go
@@ -35,7 +35,7 @@ func (m *Manager) HandleGetFluxInstance(ctx context.Context, request *mcp.CallTo
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/get_instance_test.go
+++ b/cmd/mcp/toolbox/get_instance_test.go
@@ -20,7 +20,7 @@ func TestManager_HandleGetFluxInstance(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/get_logs.go
+++ b/cmd/mcp/toolbox/get_logs.go
@@ -56,7 +56,7 @@ func (m *Manager) HandleGetKubernetesLogs(ctx context.Context, request *mcp.Call
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/get_logs_test.go
+++ b/cmd/mcp/toolbox/get_logs_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleGetKubernetesLogs(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/get_metrics.go
+++ b/cmd/mcp/toolbox/get_metrics.go
@@ -50,7 +50,7 @@ func (m *Manager) HandleGetKubernetesMetrics(ctx context.Context, request *mcp.C
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/get_metrics_test.go
+++ b/cmd/mcp/toolbox/get_metrics_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleGetKubernetesMetrics(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/get_resource.go
+++ b/cmd/mcp/toolbox/get_resource.go
@@ -53,7 +53,7 @@ func (m *Manager) HandleGetKubernetesResources(ctx context.Context, request *mcp
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/get_resource_test.go
+++ b/cmd/mcp/toolbox/get_resource_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleGetKubernetesResources(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/install_instance_test.go
+++ b/cmd/mcp/toolbox/install_instance_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleInstallFluxInstance(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/manager.go
+++ b/cmd/mcp/toolbox/manager.go
@@ -40,7 +40,7 @@ type Manager struct {
 // with the provided configuration and settings.
 func NewManager(flags *cli.ConfigFlags, timeout time.Duration, maskSecrets bool, readOnly bool) *Manager {
 	m := &Manager{
-		kubeconfig:  k8s.NewKubeConfig(),
+		kubeconfig:  k8s.NewKubeConfig(flags),
 		flags:       flags,
 		timeout:     timeout,
 		maskSecrets: maskSecrets,

--- a/cmd/mcp/toolbox/reconcile_helmrelease.go
+++ b/cmd/mcp/toolbox/reconcile_helmrelease.go
@@ -53,7 +53,7 @@ func (m *Manager) HandleReconcileHelmRelease(ctx context.Context, request *mcp.C
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/reconcile_helmrelease_test.go
+++ b/cmd/mcp/toolbox/reconcile_helmrelease_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleReconcileHelmRelease(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/reconcile_kustomization.go
+++ b/cmd/mcp/toolbox/reconcile_kustomization.go
@@ -53,7 +53,7 @@ func (m *Manager) HandleReconcileKustomization(ctx context.Context, request *mcp
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/reconcile_kustomization_test.go
+++ b/cmd/mcp/toolbox/reconcile_kustomization_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleReconcileKustomization(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/reconcile_resourceset.go
+++ b/cmd/mcp/toolbox/reconcile_resourceset.go
@@ -50,7 +50,7 @@ func (m *Manager) HandleReconcileResourceSet(ctx context.Context, request *mcp.C
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/reconcile_resourceset_test.go
+++ b/cmd/mcp/toolbox/reconcile_resourceset_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleReconcileResourceSet(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/reconcile_source.go
+++ b/cmd/mcp/toolbox/reconcile_source.go
@@ -55,7 +55,7 @@ func (m *Manager) HandleReconcileSource(ctx context.Context, request *mcp.CallTo
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/reconcile_source_test.go
+++ b/cmd/mcp/toolbox/reconcile_source_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleReconcileSource(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/resume_reconciliation.go
+++ b/cmd/mcp/toolbox/resume_reconciliation.go
@@ -55,7 +55,7 @@ func (m *Manager) HandleResumeReconciliation(ctx context.Context, request *mcp.C
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/resume_reconciliation_test.go
+++ b/cmd/mcp/toolbox/resume_reconciliation_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleResumeReconciliation(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/cmd/mcp/toolbox/set_context.go
+++ b/cmd/mcp/toolbox/set_context.go
@@ -33,12 +33,7 @@ func (m *Manager) HandleSetKubeconfigContext(ctx context.Context, request *mcp.C
 		return NewToolResultError("name is required")
 	}
 
-	err := m.kubeconfig.Load()
-	if err != nil {
-		return NewToolResultErrorFromErr("error reading kubeconfig contexts", err)
-	}
-
-	err = m.kubeconfig.SetCurrentContext(input.Name)
+	err := m.kubeconfig.SetCurrentContext(input.Name)
 	if err != nil {
 		return NewToolResultErrorFromErr("error setting kubeconfig context", err)
 	}

--- a/cmd/mcp/toolbox/set_context_test.go
+++ b/cmd/mcp/toolbox/set_context_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleSetKubeconfigContext(t *testing.T) {
 
 	flags := cli.NewConfigFlags(false)
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      flags,
 	}
 

--- a/cmd/mcp/toolbox/suspend_reconciliation.go
+++ b/cmd/mcp/toolbox/suspend_reconciliation.go
@@ -55,7 +55,7 @@ func (m *Manager) HandleSuspendReconciliation(ctx context.Context, request *mcp.
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
-	kubeClient, err := k8s.NewClient(ctx, m.flags)
+	kubeClient, err := k8s.NewClient(ctx, m.flags, m.kubeconfig.CurrentContextName)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to create Kubernetes client", err)
 	}

--- a/cmd/mcp/toolbox/suspend_reconciliation_test.go
+++ b/cmd/mcp/toolbox/suspend_reconciliation_test.go
@@ -21,7 +21,7 @@ func TestManager_HandleSuspendReconciliation(t *testing.T) {
 	t.Setenv("KUBECONFIG", configFile)
 
 	m := &Manager{
-		kubeconfig: k8s.NewKubeConfig(),
+		kubeconfig: k8s.NewKubeConfig(cli.NewConfigFlags(false)),
 		flags:      cli.NewConfigFlags(false),
 		timeout:    time.Second,
 	}

--- a/docs/mcp/mcp-install.md
+++ b/docs/mcp/mcp-install.md
@@ -67,17 +67,13 @@ Add the following configuration to your AI assistant's settings to enable the Fl
  "mcpServers": {
    "flux-operator-mcp": {
      "command": "/path/to/flux-operator-mcp",
-     "args": ["serve"],
-     "env": {
-       "KUBECONFIG": "/path/to/.kube/config"
-     }
+     "args": ["serve"]
    }
  }
 }
 ```
 
-Replace `/path/to/flux-operator-mcp` with the actual path to the binary
-and `/path/to/.kube/config` with the path to your kubeconfig file.
+Replace `/path/to/flux-operator-mcp` with the actual path to the binary.
 
 To determine the correct paths for the binary and kubeconfig, you can use the following commands:
 
@@ -96,10 +92,7 @@ Add the following configuration to your VS Code settings:
    "servers": {
      "flux-operator-mcp": {
        "command": "/path/to/flux-operator-mcp",
-       "args": ["serve"],
-       "env": {
-         "KUBECONFIG": "/path/to/.kube/config"
-       }
+       "args": ["serve"]
      }
    }
  },
@@ -107,8 +100,7 @@ Add the following configuration to your VS Code settings:
 }
 ```
 
-Replace `/path/to/flux-operator-mcp` with the actual path to the binary
-and `/path/to/.kube/config` with the path to your kubeconfig file.
+Replace `/path/to/flux-operator-mcp` with the actual path to the binary.
 
 When using GitHub Copilot Chat, enable Agent mode to access the Flux MCP tools.
 


### PR DESCRIPTION
This also uses kubectl's internal loading logic across the board, as opposed to requiring $KUBECONFIG to be set.

It's intended to be backwards-compatible, as $KUBECONFIG will still be respected if set. I tested it with both out and in cluster installations. I saw $KUBECONFIG being referenced directly in `cmd/cli/main.go` but decided this PR was already changing a lot of files. It would also be feasible to return the merged `contexts` from the configs as-is, but decided to keep that backwards-compatible as well.