### PR TITLE
cli: Add JSON support to `flux-operator export` commands

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -98,7 +98,7 @@ Arguments:
 
 ### Export Commands
 
-The `flux-operator export` commands are used to export the Flux Operator resources in YAML format.
+The `flux-operator export` commands are used to export the Flux Operator resources in YAML or JSON format.
 The exported resources can be used for backup, migration, or inspection purposes.
 
 The following commands are available:
@@ -109,6 +109,7 @@ The following commands are available:
 Arguments:
 
 - `-n, --namespace`: Specifies the namespace scope of the command.
+- `-o, --output`: Specifies the output format (yaml, json). Default is yaml.
 
 ### Reconcile Commands
 

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -168,6 +168,10 @@ func resetCmdArgs() {
 	createSecretRegistryArgs = createSecretRegistryFlags{}
 	createSecretSOPSArgs = createSecretSOPSFlags{}
 
+	// Export commands
+	exportReportArgs = exportReportFlags{output: "yaml"}
+	exportResourceArgs = exportResourceFlags{output: "yaml"}
+
 	// Distro commands
 	distroKeygenSigArgs = distroKeygenSigFlags{}
 	distroSignManifestsArgs = distroSignManifestsFlags{}


### PR DESCRIPTION
Add `flux-operator export -o, --output`: Specifies the output format (yaml, json). Default is yaml.