### PR TITLE
olm: Extend compatibility to OpenShift v4.20

### DIFF
--- a/config/olm/bundle/metadata/annotations.yaml
+++ b/config/olm/bundle/metadata/annotations.yaml
@@ -14,5 +14,5 @@ annotations:
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
-  # OpenShift specific annotations
-  com.redhat.openshift.versions: "v4.12-v4.19"
+  # OpenShift version compatibility.
+  com.redhat.openshift.versions: "v4.12-v4.20"


### PR DESCRIPTION
OpenShift v4.20 passed Flux Enterprise end-to-end tests.