### PR TITLE
web: fix RBAC display on no permissions warning

### DIFF
--- a/internal/web/report.go
+++ b/internal/web/report.go
@@ -75,8 +75,14 @@ func (h *Handler) GetReport(ctx context.Context) (*unstructured.Unstructured, er
 	}
 
 	// Inject user info
+	impersonation := user.Permissions(ctx)
+	if len(impersonation.Groups) == 0 {
+		impersonation.Groups = nil
+	}
 	username, role := user.UsernameAndRole(ctx)
-	userInfo := make(map[string]any)
+	userInfo := map[string]any{
+		"impersonation": impersonation,
+	}
 	if username != "" {
 		userInfo["username"] = username
 	}

--- a/internal/web/user/user.go
+++ b/internal/web/user/user.go
@@ -101,7 +101,9 @@ func Permissions(ctx context.Context) Impersonation {
 	return imp
 }
 
-// UsernameAndRole returns the username and role for display purposes.
+// UsernameAndRole returns the username and role for UX purposes.
+// The information returned here is not meant for debugging RBAC.
+// For RBAC debugging purposes, display Permissions() instead.
 func UsernameAndRole(ctx context.Context) (string, string) {
 	s := LoadSession(ctx)
 	hn := os.Getenv("HOSTNAME")

--- a/web/src/components/dashboards/cluster/ClusterPage.jsx
+++ b/web/src/components/dashboards/cluster/ClusterPage.jsx
@@ -28,11 +28,11 @@ function NoNamespaceAccessWarning({ userInfo }) {
           <p class="mt-1 text-sm text-yellow-700 dark:text-yellow-300">
             You don't have access to any namespaces. Contact your administrator to grant your group the necessary permissions.
           </p>
-          {(userInfo?.username || userInfo?.role) && (
+          {(userInfo?.impersonation) && (userInfo?.impersonation.username || userInfo?.impersonation.groups) && (
             <p class="mt-2 text-xs text-yellow-600 dark:text-yellow-400 font-mono">
-              {userInfo.username && `User: ${userInfo.username}`}
-              {userInfo.username && userInfo.role && ' · '}
-              {userInfo.role && `Groups: ${userInfo.role}`}
+              {userInfo.impersonation.username && `User: ${userInfo.impersonation.username}`}
+              {userInfo.impersonation.username && userInfo.impersonation.groups && ' · '}
+              {userInfo.impersonation.groups && `Groups: ${userInfo.impersonation.groups.join(', ')}`}
             </p>
           )}
         </div>

--- a/web/src/components/dashboards/cluster/ClusterPage.test.jsx
+++ b/web/src/components/dashboards/cluster/ClusterPage.test.jsx
@@ -314,7 +314,7 @@ describe('ClusterPage', () => {
       const spec = {
         ...baseSpec,
         namespaces: [],
-        userInfo: { username: 'flux-user', role: 'cluster:view' }
+        userInfo: { impersonation: { username: 'flux-user', groups: ['cluster:view'] } }
       }
 
       render(<ClusterPage spec={spec} />)
@@ -327,7 +327,7 @@ describe('ClusterPage', () => {
       const spec = {
         ...baseSpec,
         namespaces: [],
-        userInfo: { username: 'flux-user' }
+        userInfo: { impersonation: { username: 'flux-user' } }
       }
 
       render(<ClusterPage spec={spec} />)
@@ -340,12 +340,12 @@ describe('ClusterPage', () => {
       const spec = {
         ...baseSpec,
         namespaces: [],
-        userInfo: { role: 'dev-team,ops-team' }
+        userInfo: { impersonation: { groups: ['dev-team', 'ops-team'] } }
       }
 
       render(<ClusterPage spec={spec} />)
 
-      expect(screen.getByText('Groups: dev-team,ops-team')).toBeInTheDocument()
+      expect(screen.getByText('Groups: dev-team, ops-team')).toBeInTheDocument()
       expect(screen.queryByText(/User:/)).not.toBeInTheDocument()
     })
 


### PR DESCRIPTION
While testing the configuration I posted on #597, I saw this:

<img width="1239" height="139" alt="incorrect" src="https://github.com/user-attachments/assets/b201a0ac-2d7d-46b5-a07e-7c709292906b" />

Which is incorrect. Should display the RBAC information, like this:

<img width="1239" height="139" alt="correct" src="https://github.com/user-attachments/assets/32889f83-274c-41e7-896d-5c1765bccdb0" />
