### PR TITLE
ci: Set `GITHUB_TOKEN` to avoid rate limits in tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,8 @@ jobs:
         run: make web-test
       - name: Run controller tests
         run: make test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check if working tree is dirty
         run: |
           if [[ $(git diff --stat) != '' ]]; then
@@ -75,6 +77,8 @@ jobs:
         run: make web-ci-install web-build
       - name: Run controller e2e tests
         run: make test-e2e
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check if working tree is dirty
         run: |
           if [[ $(git diff --stat) != '' ]]; then


### PR DESCRIPTION
Fix for:

```
could not list pull requests: GET https://api.github.com/repos/fluxcd-testing/pr-testing/pulls?per_page=100&state=open: 403 API rate limit exceeded for 104.209.5.145. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 22m47s]",
```