### PR TITLE
web: strict validation for RBAC impersonation

### DIFF
--- a/internal/web/auth/claims.go
+++ b/internal/web/auth/claims.go
@@ -135,6 +135,11 @@ func newClaimsProcessor(conf *config.ConfigSpec) (claimsProcessorFunc, error) {
 			imp.Groups = []string{}
 		}
 
+		// Sanitize and validate the extracted impersonation.
+		if err := imp.SanitizeAndValidate(); err != nil {
+			return nil, fmt.Errorf("impersonation validation failed: %w", err)
+		}
+
 		return &user.Details{
 			Profile:       profile,
 			Impersonation: imp,

--- a/internal/web/config/authentication_types.go
+++ b/internal/web/config/authentication_types.go
@@ -12,6 +12,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fluxcd/pkg/runtime/cel"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
 )
 
 const (
@@ -139,9 +141,11 @@ func (a *AnonymousAuthenticationSpec) Configured() bool { return a != nil }
 
 // Validate validates the AnonymousAuthenticationSpec configuration.
 func (a *AnonymousAuthenticationSpec) Validate() error {
-	if a.Username == "" && len(a.Groups) == 0 {
-		return fmt.Errorf("at least one of 'username' or 'groups' must be set for Anonymous authentication")
+	imp := (user.Impersonation)(*a)
+	if err := imp.SanitizeAndValidate(); err != nil {
+		return fmt.Errorf("invalid anonymous authentication impersonation: %w", err)
 	}
+	*a = (AnonymousAuthenticationSpec)(imp)
 	return nil
 }
 

--- a/internal/web/user/user.go
+++ b/internal/web/user/user.go
@@ -28,6 +28,27 @@ type Impersonation struct {
 	Groups   []string `json:"groups"`
 }
 
+// SanitizeAndValidate sanitizes and validates the user impersonation details.
+func (imp *Impersonation) SanitizeAndValidate() error {
+	imp.Username = strings.TrimSpace(imp.Username)
+	for i, g := range imp.Groups {
+		imp.Groups[i] = strings.TrimSpace(g)
+	}
+	if imp.Groups == nil {
+		imp.Groups = []string{}
+	}
+	slices.Sort(imp.Groups)
+	if imp.Username == "" && len(imp.Groups) == 0 {
+		return fmt.Errorf("at least one of 'username' or 'groups' must be set for user impersonation")
+	}
+	for i, g := range imp.Groups {
+		if g == "" {
+			return fmt.Errorf("group[%d] is an empty string", i)
+		}
+	}
+	return nil
+}
+
 // session holds the user session information during the life of a request.
 type session struct {
 	Details


### PR DESCRIPTION
Sanitize and validate the user and groups used for Kubernetes RBAC impersonation after evaluating the CEL expressions for extracting the info from OIDC claims.

Also make this validation consistent with Anonymous authentication.