### PR TITLE
web: add user profile page with identity information

### DIFF
--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -17,6 +17,7 @@ import { EventList } from './components/search/EventList'
 import { ResourceList } from './components/search/ResourceList'
 import { ResourcePage } from './components/dashboards/resource/ResourcePage'
 import { FavoritesPage } from './components/favorites/FavoritesPage'
+import { ProfilePage } from './components/user/ProfilePage'
 import { NotFoundPage } from './components/layout/NotFoundPage'
 import { FluxOperatorIcon } from './components/layout/Icons'
 
@@ -310,6 +311,7 @@ function AppContent({ spec, namespace }) {
         <Route path="/events" component={EventList} />
         <Route path="/resources" component={ResourceList} />
         <Route path="/resource/:kind/:namespace/:name" component={ResourcePage} />
+        <Route path="/user/profile" component={ProfilePage} />
         <Route default component={NotFoundPage} />
       </Router>
     </div>

--- a/web/src/components/layout/UserMenu.jsx
+++ b/web/src/components/layout/UserMenu.jsx
@@ -18,7 +18,7 @@ export const userMenuOpen = signal(false)
  *
  * Features:
  * - User icon button that toggles a dropdown menu
- * - Displays username and role information
+ * - Displays username
  * - Theme toggle control
  * - Link to provide feedback
  * - Clear local storage action (with confirmation)
@@ -154,16 +154,8 @@ export function UserMenu() {
                 class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate"
                 title={reportData.value?.spec?.userInfo?.username || ''}
               >
-                {reportData.value?.spec?.userInfo?.username || '<no username>'}
+                {reportData.value?.spec?.userInfo?.username || 'unknown'}
               </span>
-              {reportData.value?.spec?.userInfo?.role && (
-                <span
-                  class="text-xs text-gray-500 dark:text-gray-400 truncate"
-                  title={reportData.value?.spec?.userInfo?.role}
-                >
-                  {reportData.value?.spec?.userInfo?.role}
-                </span>
-              )}
             </div>
             {/* Mobile close button */}
             <button
@@ -179,6 +171,18 @@ export function UserMenu() {
 
           {/* Separator */}
           <div class="my-1 border-t border-gray-200 dark:border-gray-700" />
+
+          {/* Profile link */}
+          <a
+            href="/user/profile"
+            class="px-4 py-2 flex items-center gap-3 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            onClick={() => userMenuOpen.value = false}
+          >
+            <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+            </svg>
+            <span>Profile</span>
+          </a>
 
           {/* Theme toggle */}
           <button

--- a/web/src/components/layout/UserMenu.test.jsx
+++ b/web/src/components/layout/UserMenu.test.jsx
@@ -24,8 +24,7 @@ describe('UserMenu', () => {
     reportData.value = {
       spec: {
         userInfo: {
-          username: '@flux-user',
-          role: 'cluster:view'
+          username: '@flux-user'
         }
       }
     }
@@ -93,7 +92,6 @@ describe('UserMenu', () => {
       render(<UserMenu />)
 
       expect(screen.getByText('@flux-user')).toBeInTheDocument()
-      expect(screen.getByText('cluster:view')).toBeInTheDocument()
     })
 
     it('should render mobile close button', () => {

--- a/web/src/components/user/ProfilePage.jsx
+++ b/web/src/components/user/ProfilePage.jsx
@@ -1,0 +1,205 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useMemo } from 'preact/hooks'
+import { useState } from 'preact/hooks'
+import { reportData } from '../../app'
+import { usePageMeta } from '../../utils/meta'
+import { formatTime } from '../../utils/time'
+import { usePrismTheme } from '../dashboards/common/yaml'
+import { DashboardPanel, TabButton } from '../dashboards/common/panel'
+import { KubernetesIcon, OpenIDIcon } from '../layout/Icons'
+import { favorites } from '../../utils/favorites'
+import { navHistory } from '../../utils/navHistory'
+import Prism from 'prismjs'
+import 'prismjs/components/prism-json'
+
+/**
+ * ProfilePage component - User profile page displaying identity information
+ *
+ * Features:
+ * - Header with user icon, username, and role
+ * - Identity panel with tabs (Overview, Kubernetes, SSO)
+ * - Local Storage section with favorites/history counts and clear data button
+ */
+export function ProfilePage() {
+  usePageMeta('Profile', 'User profile and identity information')
+  usePrismTheme()
+
+  const userInfo = reportData.value?.spec?.userInfo
+
+  // Tab state for Identity panel
+  const [activeTab, setActiveTab] = useState('overview')
+
+  // Check if features are enabled
+  const hasImpersonation = !!userInfo?.impersonation
+  const hasProvider = !!userInfo?.provider
+
+  // Highlight impersonation JSON with Prism
+  const highlightedImpersonation = useMemo(() => {
+    if (!userInfo?.impersonation) return null
+    const jsonStr = JSON.stringify(userInfo.impersonation, null, 2)
+    return Prism.highlight(jsonStr, Prism.languages.json, 'json')
+  }, [userInfo?.impersonation])
+
+  // Highlight provider JSON with Prism
+  const highlightedProvider = useMemo(() => {
+    if (!userInfo?.provider) return null
+    const jsonStr = JSON.stringify(userInfo.provider, null, 2)
+    return Prism.highlight(jsonStr, Prism.languages.json, 'json')
+  }, [userInfo?.provider])
+
+  // Calculate local storage size
+  const storageSize = useMemo(() => {
+    try {
+      const favoritesSize = (localStorage.getItem('favorites') || '').length * 2 // UTF-16
+      const navHistorySize = (localStorage.getItem('nav-history') || '').length * 2
+      const totalBytes = favoritesSize + navHistorySize
+      if (totalBytes < 1024) return `${totalBytes} B`
+      if (totalBytes < 1024 * 1024) return `${(totalBytes / 1024).toFixed(1)} KB`
+      return `${(totalBytes / (1024 * 1024)).toFixed(1)} MB`
+    } catch {
+      return '0 B'
+    }
+  }, [favorites.value, navHistory.value])
+
+  return (
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow w-full">
+      <div class="space-y-6">
+        {/* Header Card */}
+        <div class="card bg-blue-50 dark:bg-opacity-20 border-2 border-flux-blue">
+          <div class="flex items-center gap-4">
+            {/* User icon in circle */}
+            <div class="w-16 h-16 rounded-full flex items-center justify-center flex-shrink-0 bg-flux-blue/10 dark:bg-flux-blue/20">
+              <svg class="w-8 h-8 text-flux-blue dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+              </svg>
+            </div>
+            <div class="flex flex-col min-w-0 flex-1">
+              <span class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                Profile
+              </span>
+              <h1 class="text-xl font-semibold text-gray-900 dark:text-white truncate">
+                {userInfo?.username || 'unknown'}
+              </h1>
+            </div>
+            {/* Session Started - only show when provider has iat claim */}
+            {userInfo?.provider?.iat && (
+              <div class="hidden md:block text-right flex-shrink-0">
+                <div class="text-sm text-gray-600 dark:text-gray-400">Session Started</div>
+                <div class="text-lg font-semibold text-gray-900 dark:text-white">{formatTime(new Date(userInfo.provider.iat * 1000))}</div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Identity Panel with Tabs */}
+        <DashboardPanel title="Identity" id="identity-panel">
+          {/* Tab Navigation */}
+          <div class="border-b border-gray-200 dark:border-gray-700 mb-4">
+            <nav class="flex space-x-4">
+              <TabButton active={activeTab === 'overview'} onClick={() => setActiveTab('overview')}>
+                Overview
+              </TabButton>
+              {hasImpersonation && (
+                <TabButton active={activeTab === 'kubernetes'} onClick={() => setActiveTab('kubernetes')}>
+                  Kubernetes
+                </TabButton>
+              )}
+              {hasProvider && (
+                <TabButton active={activeTab === 'sso'} onClick={() => setActiveTab('sso')}>
+                  SSO
+                </TabButton>
+              )}
+            </nav>
+          </div>
+
+          {/* Tab Content */}
+          {activeTab === 'overview' && (
+            <div class="space-y-4">
+              {/* Kubernetes RBAC status */}
+              <div class="text-sm">
+                <span class="text-gray-500 dark:text-gray-400">Kubernetes RBAC</span>
+                <span class={`ml-1 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                  hasImpersonation
+                    ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                    : 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400'
+                }`}>
+                  {hasImpersonation ? 'Enabled' : 'Disabled'}
+                </span>
+              </div>
+
+              {/* Single Sign-On status */}
+              <div class="text-sm">
+                <span class="text-gray-500 dark:text-gray-400">Single Sign-On</span>
+                <span class={`ml-1 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                  hasProvider
+                    ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                    : 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400'
+                }`}>
+                  {hasProvider ? 'Enabled' : 'Disabled'}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'kubernetes' && hasImpersonation && (
+            <div>
+              <div class="flex items-center gap-2 mb-3">
+                <KubernetesIcon className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Impersonation config</span>
+              </div>
+              <pre class="p-3 bg-gray-50 dark:bg-gray-900 rounded-md overflow-x-auto language-json" style="font-size: 12px; line-height: 1.5;">
+                <code class="language-json" style="font-size: 12px;" dangerouslySetInnerHTML={{ __html: highlightedImpersonation }} />
+              </pre>
+            </div>
+          )}
+
+          {activeTab === 'sso' && hasProvider && (
+            <div>
+              <div class="flex items-center gap-2 mb-3">
+                <OpenIDIcon className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Provider claims</span>
+              </div>
+              <pre class="p-3 bg-gray-50 dark:bg-gray-900 rounded-md overflow-x-auto language-json" style="font-size: 12px; line-height: 1.5;">
+                <code class="language-json" style="font-size: 12px;" dangerouslySetInnerHTML={{ __html: highlightedProvider }} />
+              </pre>
+            </div>
+          )}
+        </DashboardPanel>
+
+        {/* Local Storage Panel */}
+        <DashboardPanel title="Local Storage" id="storage-panel">
+          {/* Tab Navigation */}
+          <div class="border-b border-gray-200 dark:border-gray-700 mb-4">
+            <nav class="flex space-x-4">
+              <TabButton active={true} onClick={() => {}}>
+                Overview
+              </TabButton>
+            </nav>
+          </div>
+
+          {/* Overview Content */}
+          <div class="space-y-4">
+            <div class="text-sm">
+              <span class="text-gray-500 dark:text-gray-400">Favorites</span>
+              <span class="ml-1 text-gray-900 dark:text-white">
+                {favorites.value.length} {favorites.value.length === 1 ? 'item' : 'items'}
+              </span>
+            </div>
+            <div class="text-sm">
+              <span class="text-gray-500 dark:text-gray-400">Navigation History</span>
+              <span class="ml-1 text-gray-900 dark:text-white">
+                {navHistory.value.length} {navHistory.value.length === 1 ? 'item' : 'items'}
+              </span>
+            </div>
+            <div class="text-sm">
+              <span class="text-gray-500 dark:text-gray-400">Storage Size</span>
+              <span class="ml-1 text-gray-900 dark:text-white">{storageSize}</span>
+            </div>
+          </div>
+        </DashboardPanel>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/user/ProfilePage.test.jsx
+++ b/web/src/components/user/ProfilePage.test.jsx
@@ -1,0 +1,387 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { ProfilePage } from './ProfilePage'
+import { reportData } from '../../app'
+import { favorites } from '../../utils/favorites'
+import { navHistory } from '../../utils/navHistory'
+
+// Mock the favorites module
+vi.mock('../../utils/favorites', async () => {
+  const { signal } = await import('@preact/signals')
+  return {
+    favorites: signal([])
+  }
+})
+
+// Mock the navHistory module
+vi.mock('../../utils/navHistory', async () => {
+  const { signal } = await import('@preact/signals')
+  return {
+    navHistory: signal([])
+  }
+})
+
+describe('ProfilePage', () => {
+  beforeEach(() => {
+    // Reset mocks
+    vi.clearAllMocks()
+
+    // Reset favorites and navHistory signals
+    favorites.value = []
+    navHistory.value = []
+
+    // Set mock user info in reportData
+    reportData.value = {
+      spec: {
+        userInfo: {
+          username: 'test-user'
+        }
+      }
+    }
+  })
+
+  describe('Header Section', () => {
+    it('should render username', () => {
+      render(<ProfilePage />)
+
+      expect(screen.getByText('test-user')).toBeInTheDocument()
+    })
+
+    it('should display Profile label', () => {
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Profile')).toBeInTheDocument()
+    })
+
+    it('should show fallback when no username', () => {
+      reportData.value = {
+        spec: {
+          userInfo: {}
+        }
+      }
+
+      render(<ProfilePage />)
+
+      expect(screen.getByText('unknown')).toBeInTheDocument()
+    })
+
+  })
+
+  describe('Identity Panel', () => {
+    it('should render Identity panel title', () => {
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Identity')).toBeInTheDocument()
+    })
+
+    it('should show Overview tabs by default', () => {
+      render(<ProfilePage />)
+
+      // There are two Overview tabs (Identity and Local Storage panels)
+      const overviewTabs = screen.getAllByText('Overview')
+      expect(overviewTabs.length).toBe(2)
+    })
+
+    it('should show Kubernetes RBAC as Disabled when no impersonation', () => {
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Kubernetes RBAC')).toBeInTheDocument()
+      // Both impersonation and SSO are disabled, so there are two Disabled badges
+      const disabledBadges = screen.getAllByText('Disabled')
+      expect(disabledBadges.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('should show Single Sign-On as Disabled when no provider', () => {
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Single Sign-On')).toBeInTheDocument()
+      // There are two Disabled badges (impersonation and SSO)
+      const disabledBadges = screen.getAllByText('Disabled')
+      expect(disabledBadges.length).toBe(2)
+    })
+
+    it('should show Kubernetes RBAC as Enabled when impersonation exists', () => {
+      reportData.value = {
+        spec: {
+          userInfo: {
+            username: 'test-user',
+            impersonation: {
+              username: 'user@example.com',
+              groups: ['fluxcd:maintainers']
+            }
+          }
+        }
+      }
+
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Kubernetes RBAC')).toBeInTheDocument()
+      expect(screen.getByText('Enabled')).toBeInTheDocument()
+    })
+
+    it('should show Single Sign-On as Enabled when provider exists', () => {
+      reportData.value = {
+        spec: {
+          userInfo: {
+            username: 'test-user',
+            provider: {
+              iss: 'https://accounts.example.com',
+              sub: '1234567890'
+            }
+          }
+        }
+      }
+
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Single Sign-On')).toBeInTheDocument()
+      expect(screen.getByText('Enabled')).toBeInTheDocument()
+    })
+  })
+
+  describe('Identity Panel - Kubernetes Tab', () => {
+    it('should show Kubernetes tab when impersonation exists', () => {
+      reportData.value = {
+        spec: {
+          userInfo: {
+            username: 'test-user',
+            impersonation: {
+              username: 'user@example.com',
+              groups: ['fluxcd:maintainers', 'fluxcd:developers']
+            }
+          }
+        }
+      }
+
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Kubernetes')).toBeInTheDocument()
+    })
+
+    it('should not show Kubernetes tab when impersonation is missing', () => {
+      reportData.value = {
+        spec: {
+          userInfo: {
+            username: 'test-user'
+          }
+        }
+      }
+
+      render(<ProfilePage />)
+
+      expect(screen.queryByText('Kubernetes')).not.toBeInTheDocument()
+    })
+
+    it('should show impersonation JSON when Kubernetes tab is clicked', () => {
+      reportData.value = {
+        spec: {
+          userInfo: {
+            username: 'test-user',
+            impersonation: {
+              username: 'user@example.com',
+              groups: ['fluxcd:maintainers', 'fluxcd:developers']
+            }
+          }
+        }
+      }
+
+      render(<ProfilePage />)
+
+      // Click Kubernetes tab
+      fireEvent.click(screen.getByText('Kubernetes'))
+
+      // Check that the JSON is rendered (content will be syntax highlighted)
+      expect(screen.getByText(/user@example\.com/)).toBeInTheDocument()
+      expect(screen.getByText(/fluxcd:maintainers/)).toBeInTheDocument()
+    })
+
+    it('should show impersonation groups in JSON when username is missing', () => {
+      reportData.value = {
+        spec: {
+          userInfo: {
+            username: 'test-user',
+            impersonation: {
+              groups: ['fluxcd:maintainers']
+            }
+          }
+        }
+      }
+
+      render(<ProfilePage />)
+
+      // Click Kubernetes tab
+      fireEvent.click(screen.getByText('Kubernetes'))
+
+      // The JSON should still show the groups
+      expect(screen.getByText(/fluxcd:maintainers/)).toBeInTheDocument()
+    })
+  })
+
+  describe('Identity Panel - SSO Tab', () => {
+    it('should show SSO tab when provider exists', () => {
+      reportData.value = {
+        spec: {
+          userInfo: {
+            username: 'test-user',
+            provider: {
+              iss: 'https://accounts.example.com',
+              sub: '1234567890',
+              email: 'user@example.com'
+            }
+          }
+        }
+      }
+
+      render(<ProfilePage />)
+
+      expect(screen.getByText('SSO')).toBeInTheDocument()
+    })
+
+    it('should not show SSO tab when provider is missing', () => {
+      reportData.value = {
+        spec: {
+          userInfo: {
+            username: 'test-user'
+          }
+        }
+      }
+
+      render(<ProfilePage />)
+
+      expect(screen.queryByText('SSO')).not.toBeInTheDocument()
+    })
+
+    it('should show provider JSON when SSO tab is clicked', () => {
+      reportData.value = {
+        spec: {
+          userInfo: {
+            username: 'test-user',
+            provider: {
+              iss: 'https://accounts.example.com',
+              sub: '1234567890',
+              email: 'user@example.com'
+            }
+          }
+        }
+      }
+
+      render(<ProfilePage />)
+
+      // Click SSO tab
+      fireEvent.click(screen.getByText('SSO'))
+
+      // Check that the JSON is rendered (content will be syntax highlighted)
+      expect(screen.getByText(/accounts\.example\.com/)).toBeInTheDocument()
+    })
+  })
+
+  describe('Local Storage Section', () => {
+    it('should display favorites count', () => {
+      favorites.value = [
+        { kind: 'FluxInstance', namespace: 'flux-system', name: 'flux' },
+        { kind: 'Kustomization', namespace: 'default', name: 'app' }
+      ]
+
+      render(<ProfilePage />)
+
+      expect(screen.getByText('2 items')).toBeInTheDocument()
+    })
+
+    it('should display singular "item" for one favorite', () => {
+      favorites.value = [
+        { kind: 'FluxInstance', namespace: 'flux-system', name: 'flux' }
+      ]
+
+      render(<ProfilePage />)
+
+      expect(screen.getByText('1 item')).toBeInTheDocument()
+    })
+
+    it('should display navigation history count', () => {
+      navHistory.value = [
+        { kind: 'FluxInstance', namespace: 'flux-system', name: 'flux' },
+        { kind: 'Kustomization', namespace: 'default', name: 'app' },
+        { kind: 'HelmRelease', namespace: 'default', name: 'nginx' }
+      ]
+
+      render(<ProfilePage />)
+
+      expect(screen.getByText('3 items')).toBeInTheDocument()
+    })
+
+    it('should display 0 items when no favorites or history', () => {
+      favorites.value = []
+      navHistory.value = []
+
+      render(<ProfilePage />)
+
+      const zeroItems = screen.getAllByText('0 items')
+      expect(zeroItems.length).toBe(2) // One for favorites, one for history
+    })
+
+    it('should show Local Storage section header', () => {
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Local Storage')).toBeInTheDocument()
+    })
+
+    it('should show Favorites label', () => {
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Favorites')).toBeInTheDocument()
+    })
+
+    it('should show Navigation History label', () => {
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Navigation History')).toBeInTheDocument()
+    })
+  })
+
+  describe('Complete User Info', () => {
+    it('should render all sections when all data is present', () => {
+      reportData.value = {
+        spec: {
+          userInfo: {
+            username: 'Flux User',
+            impersonation: {
+              username: 'user@example.com',
+              groups: ['fluxcd:maintainers']
+            },
+            provider: {
+              iss: 'https://accounts.example.com',
+              sub: '1234567890',
+              email: 'user@example.com'
+            }
+          }
+        }
+      }
+
+      favorites.value = [{ kind: 'FluxInstance', namespace: 'flux-system', name: 'flux' }]
+      navHistory.value = [{ kind: 'Kustomization', namespace: 'default', name: 'app' }]
+
+      render(<ProfilePage />)
+
+      // Header section
+      expect(screen.getByText('Profile')).toBeInTheDocument()
+      expect(screen.getByText('Flux User')).toBeInTheDocument()
+
+      // Identity panel with tabs
+      expect(screen.getByText('Identity')).toBeInTheDocument()
+      expect(screen.getAllByText('Overview').length).toBe(2) // Identity and Local Storage panels
+      expect(screen.getByText('Kubernetes')).toBeInTheDocument()
+      expect(screen.getByText('SSO')).toBeInTheDocument()
+
+      // Overview tab shows both as Enabled
+      const enabledBadges = screen.getAllByText('Enabled')
+      expect(enabledBadges.length).toBe(2)
+
+      // Local Storage section
+      expect(screen.getByText('Local Storage')).toBeInTheDocument()
+      expect(screen.getAllByText('1 item').length).toBe(2) // favorites and history
+    })
+  })
+})

--- a/web/src/mock/report.js
+++ b/web/src/mock/report.js
@@ -243,8 +243,24 @@ export const mockReport = {
       'registry'
     ],
     userInfo: {
-      username: 'flux-user',
-      role: 'cluster:view'
+      username: 'Flux User',
+      impersonation: {
+        username: "user@example.com",
+        groups: [
+          "fluxcd:maintainers"
+        ]
+      },
+      provider: {
+        "iss":   "https://accounts.example.com",
+        "sub":   "1234567890",
+        "iat":   Math.floor(Date.now() / 1000),
+        "email": "user@example.com",
+        "name":  "Flux User",
+        "groups": [
+          "fluxcd/maintainers",
+          "fluxcd/developers"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Closes: #607

  Add ProfilePage component at /user/profile displaying:                                                                                                           
  - User identity with session start time from provider IAT claim                                                                                                  
  - Identity panel with Overview, Kubernetes RBAC, and SSO tabs                                                                                                    
  - Local Storage panel showing favorites/history counts and size 
 
The Kubernetes tab shows the RBAC impersonation configuration: username and/or groups.

The SSO tab shows the OIDC provider claims as JSON, useful for debugging permission mapping issues.

---

<img width="1692" height="1642" alt="Opera Snapshot_2026-01-20_193236_status-preview staging flux-d2 control-plane-demos com" src="https://github.com/user-attachments/assets/fdef8eea-ca44-458b-84a7-29fa1bff0d86" />

