### PR TITLE
web: track the user who suspended a resource

### DIFF
--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -33,6 +33,7 @@ var (
 	ForceAnnotation                  = fmt.Sprintf("%s/force", GroupVersion.Group)
 	RevisionAnnotation               = fmt.Sprintf("%s/revision", GroupVersion.Group)
 	CopyFromAnnotation               = fmt.Sprintf("%s/copyFrom", GroupVersion.Group)
+	SuspendedByAnnotation            = fmt.Sprintf("%s/suspendedBy", GroupVersion.Group)
 )
 
 // FluxObject is the interface that all Flux objects must implement.

--- a/internal/web/action_test.go
+++ b/internal/web/action_test.go
@@ -298,6 +298,7 @@ func TestActionHandler_Suspend_Success(t *testing.T) {
 	var updated fluxcdv1.ResourceSet
 	g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(resourceSet), &updated)).To(Succeed())
 	g.Expect(updated.Annotations).To(HaveKeyWithValue(fluxcdv1.ReconcileAnnotation, fluxcdv1.DisabledValue))
+	g.Expect(updated.Annotations).To(HaveKey(fluxcdv1.SuspendedByAnnotation))
 }
 
 func TestActionHandler_Resume_Success(t *testing.T) {
@@ -309,7 +310,8 @@ func TestActionHandler_Resume_Success(t *testing.T) {
 			Name:      "test-action-resume",
 			Namespace: "default",
 			Annotations: map[string]string{
-				fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue,
+				fluxcdv1.ReconcileAnnotation:   fluxcdv1.DisabledValue,
+				fluxcdv1.SuspendedByAnnotation: "test-user",
 			},
 		},
 		Spec: fluxcdv1.ResourceSetSpec{},
@@ -351,6 +353,7 @@ func TestActionHandler_Resume_Success(t *testing.T) {
 	g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(resourceSet), &updated)).To(Succeed())
 	g.Expect(updated.Annotations).To(HaveKeyWithValue(fluxcdv1.ReconcileAnnotation, fluxcdv1.EnabledValue))
 	g.Expect(updated.Annotations).To(HaveKey("reconcile.fluxcd.io/requestedAt"))
+	g.Expect(updated.Annotations).NotTo(HaveKey(fluxcdv1.SuspendedByAnnotation))
 }
 
 func TestActionHandler_ResourceNotFound(t *testing.T) {

--- a/web/src/components/dashboards/resource/ReconcilerPanel.jsx
+++ b/web/src/components/dashboards/resource/ReconcilerPanel.jsx
@@ -260,15 +260,25 @@ export function ReconcilerPanel({ kind, name, namespace, resourceData }) {
             )}
           </div>
 
-          {/* Right column: Last action message */}
-          {message && (
+          {/* Right column: Suspended by and Last action message */}
+          {(message || (status === 'Suspended' && resourceData?.metadata?.annotations?.['fluxcd.controlplane.io/suspendedBy'])) && (
             <div class="space-y-2 border-gray-200 dark:border-gray-700 border-t pt-4 md:border-t-0 md:border-l md:pt-0 md:pl-6">
-              <div class="text-sm text-gray-500 dark:text-gray-400">
-                Last action <span class="text-gray-900 dark:text-white">{lastReconciled ? new Date(lastReconciled).toLocaleString().replace(',', '') : '-'}</span>
-              </div>
-              <div class="text-sm text-gray-700 dark:text-gray-300">
-                <pre class="whitespace-pre-wrap break-all font-sans">{message}</pre>
-              </div>
+              {/* Suspended by - shown when status is Suspended and annotation exists */}
+              {status === 'Suspended' && resourceData?.metadata?.annotations?.['fluxcd.controlplane.io/suspendedBy'] && (
+                <div class="text-sm text-gray-500 dark:text-gray-400">
+                  Suspended by <span class="text-gray-900 dark:text-white">{resourceData.metadata.annotations['fluxcd.controlplane.io/suspendedBy']}</span>
+                </div>
+              )}
+              {message && (
+                <>
+                  <div class="text-sm text-gray-500 dark:text-gray-400">
+                    Last action <span class="text-gray-900 dark:text-white">{lastReconciled ? new Date(lastReconciled).toLocaleString().replace(',', '') : '-'}</span>
+                  </div>
+                  <div class="text-sm text-gray-700 dark:text-gray-300">
+                    <pre class="whitespace-pre-wrap break-all font-sans">{message}</pre>
+                  </div>
+                </>
+              )}
             </div>
           )}
         </div>

--- a/web/src/components/dashboards/resource/ReconcilerPanel.test.jsx
+++ b/web/src/components/dashboards/resource/ReconcilerPanel.test.jsx
@@ -1023,4 +1023,94 @@ describe('ReconcilerPanel component', () => {
       expect(screen.queryByText('Last action')).not.toBeInTheDocument()
     })
   })
+
+  describe('Suspended by', () => {
+    it('should display "Suspended by" when status is Suspended and annotation exists', () => {
+      const suspendedData = {
+        ...mockResourceData,
+        metadata: {
+          ...mockResourceData.metadata,
+          annotations: {
+            ...mockResourceData.metadata.annotations,
+            'fluxcd.controlplane.io/suspendedBy': 'test-user@example.com'
+          }
+        },
+        status: {
+          ...mockResourceData.status,
+          reconcilerRef: {
+            ...mockResourceData.status.reconcilerRef,
+            status: 'Suspended'
+          }
+        }
+      }
+
+      render(
+        <ReconcilerPanel
+          kind="FluxInstance"
+          name="flux"
+          namespace="flux-system"
+          resourceData={suspendedData}
+        />
+      )
+
+      expect(screen.getByText('Suspended by')).toBeInTheDocument()
+      expect(screen.getByText('test-user@example.com')).toBeInTheDocument()
+    })
+
+    it('should NOT display "Suspended by" when status is not Suspended', () => {
+      const readyDataWithAnnotation = {
+        ...mockResourceData,
+        metadata: {
+          ...mockResourceData.metadata,
+          annotations: {
+            ...mockResourceData.metadata.annotations,
+            'fluxcd.controlplane.io/suspendedBy': 'test-user@example.com'
+          }
+        },
+        status: {
+          ...mockResourceData.status,
+          reconcilerRef: {
+            ...mockResourceData.status.reconcilerRef,
+            status: 'Ready'
+          }
+        }
+      }
+
+      render(
+        <ReconcilerPanel
+          kind="FluxInstance"
+          name="flux"
+          namespace="flux-system"
+          resourceData={readyDataWithAnnotation}
+        />
+      )
+
+      expect(screen.queryByText('Suspended by')).not.toBeInTheDocument()
+    })
+
+    it('should NOT display "Suspended by" when annotation does not exist', () => {
+      const suspendedNoAnnotation = {
+        ...mockResourceData,
+        status: {
+          ...mockResourceData.status,
+          reconcilerRef: {
+            ...mockResourceData.status.reconcilerRef,
+            status: 'Suspended'
+          }
+        }
+      }
+
+      render(
+        <ReconcilerPanel
+          kind="FluxInstance"
+          name="flux"
+          namespace="flux-system"
+          resourceData={suspendedNoAnnotation}
+        />
+      )
+
+      expect(screen.getByText('Suspended')).toBeInTheDocument()
+      expect(screen.queryByText('Suspended by')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/web/src/mock/resource.js
+++ b/web/src/mock/resource.js
@@ -3770,7 +3770,10 @@ export const mockResourcesArray =
     "kind": "Bucket",
     "metadata": {
       "name": "preview-configs",
-      "namespace": "flux-system"
+      "namespace": "flux-system",
+      "annotations": {
+        "fluxcd.controlplane.io/suspendedBy": "John Doe"
+      }
     },
     "spec": {
       "bucketName": "preview-configs",


### PR DESCRIPTION
Closes: #612

Track who suspended a resource by adding the `fluxcd.controlplane.io/suspendedBy: <username>` annotation. On resume, the  annotation is removed. The Web UI displays the `Suspended by: <username>` in the reconciler section of the resource dashboard.

---

<img width="921" height="526" alt="Screenshot 2026-01-21 at 10 50 37" src="https://github.com/user-attachments/assets/7a5313ec-9c5c-4cfc-8868-814744e09284" />
