### PR TITLE
feat(cli): add command to generate Flux Web config secret

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -257,6 +257,15 @@ The following commands are available:
   - `--tls-crt-file`: Path to TLS client certificate file.
   - `--tls-key-file`: Path to TLS client private key file.
   - `--ca-crt-file`: Path to CA certificate file (optional).
+- `flux-operator create secret web-config`: Create a Kubernetes Secret containing Flux Web UI configuration.
+  - `--base-url`: The external URL for the Flux Web UI (required).
+  - `--provider`: Authentication provider (defaults to OIDC).
+  - `--issuer-url`: OIDC issuer URL (required when provider is OIDC).
+  - `--client-id`: OIDC client ID (required when provider is OIDC).
+  - `--client-secret`: OIDC client secret.
+  - `--client-secret-stdin`: Read the client secret from stdin.
+  - `--client-secret-rnd`: Generate a random client secret.
+
 
 Arguments:
 

--- a/cmd/cli/create_secret_web_config.go
+++ b/cmd/cli/create_secret_web_config.go
@@ -1,0 +1,257 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/fluxcd/pkg/runtime/secrets"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type webConfigFlags struct {
+	baseURL           string
+	provider          string
+	issuerURL         string
+	clientID          string
+	clientSecret      string
+	clientSecretRnd   bool
+	clientSecretStdin bool
+	export            bool
+}
+
+type webConfig struct {
+	APIVersion string        `json:"apiVersion"`
+	Kind       string        `json:"kind"`
+	Spec       webConfigSpec `json:"spec"`
+}
+
+type webConfigSpec struct {
+	BaseURL        string        `json:"baseURL"`
+	Authentication webConfigAuth `json:"authentication"`
+}
+
+type webConfigAuth struct {
+	Type   string          `json:"type"`
+	OAuth2 webConfigOAuth2 `json:"oauth2"`
+}
+
+type webConfigOAuth2 struct {
+	Provider     string `json:"provider"`
+	ClientID     string `json:"clientID"`
+	ClientSecret string `json:"clientSecret"`
+	IssuerURL    string `json:"issuerURL"`
+}
+
+var createSecretWebConfigCmd = &cobra.Command{
+	Use:   "web-config [name]",
+	Short: "Create a Kubernetes secret with Flux Web configuration",
+	Long: `The create secret web-config command generates a Kubernetes secret containing
+the configuration for Flux Web authentication.
+
+The secret contains a config.yaml file with OAuth2 authentication settings
+that can be mounted into the Flux Web deployment.`,
+	Example: `  # Create a web-config secret with OIDC authentication
+  flux-operator create secret web-config flux-web-config \
+    --namespace=flux-system \
+    --base-url=https://flux.example.com \
+    --provider=OIDC \
+    --issuer-url=https://dex.example.com \
+    --client-id=my-client-id \
+    --client-secret=my-client-secret
+
+  # Generate a random client secret
+  flux-operator create secret web-config flux-web-config \
+    --namespace=flux-system \
+    --base-url=https://flux.example.com \
+    --provider=OIDC \
+    --issuer-url=https://dex.example.com \
+    --client-id=my-client-id \
+    --client-secret-rnd
+
+  # Read client secret from stdin
+  echo "my-secret" | flux-operator create secret web-config flux-web-config \
+    --namespace=flux-system \
+    --base-url=https://flux.example.com \
+    --provider=OIDC \
+    --issuer-url=https://dex.example.com \
+    --client-id=my-client-id \
+    --client-secret-stdin`,
+	RunE: createSecretWebConfigCmdRun,
+}
+
+var webConfigArgs webConfigFlags
+
+func init() {
+	createSecretCmd.AddCommand(createSecretWebConfigCmd)
+
+	createSecretWebConfigCmd.Flags().StringVar(&webConfigArgs.baseURL, "base-url", "",
+		"base URL where Flux Web is accessible (required)")
+	createSecretWebConfigCmd.Flags().StringVar(&webConfigArgs.provider, "provider", "OIDC",
+		"OAuth2 provider type (e.g., OIDC, GitHub, Google)")
+	createSecretWebConfigCmd.Flags().StringVar(&webConfigArgs.issuerURL, "issuer-url", "",
+		"OIDC issuer URL (required for OIDC provider)")
+	createSecretWebConfigCmd.Flags().StringVar(&webConfigArgs.clientID, "client-id", "",
+		"OAuth2 client ID (required)")
+	createSecretWebConfigCmd.Flags().StringVar(&webConfigArgs.clientSecret, "client-secret", "",
+		"OAuth2 client secret")
+	createSecretWebConfigCmd.Flags().BoolVar(&webConfigArgs.clientSecretRnd, "client-secret-rnd", false,
+		"generate a random client secret")
+	createSecretWebConfigCmd.Flags().BoolVar(&webConfigArgs.clientSecretStdin, "client-secret-stdin", false,
+		"read client secret from stdin")
+	createSecretWebConfigCmd.Flags().BoolVar(&webConfigArgs.export, "export", false,
+		"export resource in YAML format to stdout")
+
+	_ = createSecretWebConfigCmd.MarkFlagRequired("base-url")
+	_ = createSecretWebConfigCmd.MarkFlagRequired("client-id")
+}
+
+func createSecretWebConfigCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("secret name is required")
+	}
+	secretName := args[0]
+
+	if err := validateWebConfigFlags(); err != nil {
+		return err
+	}
+
+	clientSecret, err := getClientSecret()
+	if err != nil {
+		return fmt.Errorf("failed to get client secret: %w", err)
+	}
+
+	config := webConfig{
+		APIVersion: "web.fluxcd.controlplane.io/v1",
+		Kind:       "Config",
+		Spec: webConfigSpec{
+			BaseURL: webConfigArgs.baseURL,
+			Authentication: webConfigAuth{
+				Type: "OAuth2",
+				OAuth2: webConfigOAuth2{
+					Provider:     webConfigArgs.provider,
+					ClientID:     webConfigArgs.clientID,
+					ClientSecret: clientSecret,
+					IssuerURL:    webConfigArgs.issuerURL,
+				},
+			},
+		},
+	}
+
+	configYAML, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal web config: %w", err)
+	}
+
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: *kubeconfigArgs.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			"config.yaml": string(configYAML),
+		},
+	}
+
+	if webConfigArgs.export {
+		return printSecret(secret)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client error: %w", err)
+	}
+
+	err = secrets.Apply(
+		ctx,
+		kubeClient,
+		secret,
+		secrets.WithForce(),
+	)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, fmt.Sprintf("Secret %s/%s applied successfully", secret.GetNamespace(), secret.GetName()))
+	return nil
+}
+
+func validateWebConfigFlags() error {
+	if webConfigArgs.provider == "OIDC" && webConfigArgs.issuerURL == "" {
+		return fmt.Errorf("--issuer-url is required when using OIDC provider")
+	}
+
+	secretMethods := 0
+	if webConfigArgs.clientSecret != "" {
+		secretMethods++
+	}
+	if webConfigArgs.clientSecretRnd {
+		secretMethods++
+	}
+	if webConfigArgs.clientSecretStdin {
+		secretMethods++
+	}
+
+	if secretMethods == 0 {
+		return fmt.Errorf("one of --client-secret, --client-secret-rnd, or --client-secret-stdin must be specified")
+	}
+	if secretMethods > 1 {
+		return fmt.Errorf("only one of --client-secret, --client-secret-rnd, or --client-secret-stdin can be specified")
+	}
+
+	return nil
+}
+
+func getClientSecret() (string, error) {
+	if webConfigArgs.clientSecret != "" {
+		return webConfigArgs.clientSecret, nil
+	}
+
+	if webConfigArgs.clientSecretRnd {
+		return generateRandomSecret(32)
+	}
+
+	if webConfigArgs.clientSecretStdin {
+		var secret string
+		_, err := fmt.Scan(&secret)
+		if err != nil {
+			return "", fmt.Errorf("unable to read secret from stdin: %w", err)
+		}
+
+		secretStr := secret
+		secretStr = strings.TrimSpace(secretStr)
+
+		if secretStr == "" {
+			return "", fmt.Errorf("client secret read from stdin is empty")
+		}
+		return secretStr, nil
+	}
+
+	return "", fmt.Errorf("no client secret method specified")
+}
+
+func generateRandomSecret(length int) (string, error) {
+	bytes := make([]byte, length)
+
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("failed to generate random secret: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(bytes), nil
+}

--- a/cmd/cli/create_secret_web_config_test.go
+++ b/cmd/cli/create_secret_web_config_test.go
@@ -1,0 +1,252 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCreateSecretWebConfig(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantErr    bool
+		assertFunc func(t *testing.T, output string)
+	}{
+		{
+			name: "create web-config secret with all flags",
+			args: []string{
+				"create", "secret", "web-config", "test-secret",
+				"--namespace=test-namespace",
+				"--base-url=https://flux.example.com",
+				"--provider=OIDC",
+				"--issuer-url=https://dex.example.com",
+				"--client-id=test-client-id",
+				"--client-secret=test-client-secret",
+				"--export",
+			},
+			wantErr: false,
+			assertFunc: func(t *testing.T, output string) {
+				if !strings.Contains(output, "kind: Secret") {
+					t.Error("output should contain 'kind: Secret'")
+				}
+				if !strings.Contains(output, "name: test-secret") {
+					t.Error("output should contain secret name")
+				}
+				if !strings.Contains(output, "config.yaml") {
+					t.Error("output should contain config.yaml key")
+				}
+				if !strings.Contains(output, "baseURL: https://flux.example.com") {
+					t.Error("output should contain base URL")
+				}
+			},
+		},
+		{
+			name: "fail without base-url",
+			args: []string{
+				"create", "secret", "web-config", "test-secret",
+				"--client-id=test-client-id",
+				"--client-secret=test-secret",
+			},
+			wantErr: true,
+		},
+		{
+			name: "fail without client-id",
+			args: []string{
+				"create", "secret", "web-config", "test-secret",
+				"--base-url=https://flux.example.com",
+				"--client-secret=test-secret",
+			},
+			wantErr: true,
+		},
+		{
+			name: "generate random secret",
+			args: []string{
+				"create", "secret", "web-config", "test-secret",
+				"--namespace=test-namespace",
+				"--base-url=https://flux.example.com",
+				"--provider=OIDC",
+				"--issuer-url=https://dex.example.com",
+				"--client-id=test-client-id",
+				"--client-secret-rnd",
+				"--export",
+			},
+			wantErr: false,
+			assertFunc: func(t *testing.T, output string) {
+				if !strings.Contains(output, "clientSecret:") {
+					t.Error("output should contain clientSecret field")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset global flags between tests
+			webConfigArgs = webConfigFlags{}
+
+			output, err := executeCommand(tt.args)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("expected error: %v, got: %v", tt.wantErr, err)
+			}
+
+			if tt.assertFunc != nil && !tt.wantErr {
+				tt.assertFunc(t, output)
+			}
+		})
+	}
+}
+
+func TestGenerateRandomSecret(t *testing.T) {
+	secret, err := generateRandomSecret(32)
+	if err != nil {
+		t.Fatalf("failed to generate random secret: %v", err)
+	}
+
+	if secret == "" {
+		t.Error("generated secret is empty")
+	}
+
+	if strings.ContainsAny(secret, " \n\t") {
+		t.Error("generated secret contains whitespace")
+	}
+
+	secret2, err := generateRandomSecret(32)
+	if err != nil {
+		t.Fatalf("failed to generate second random secret: %v", err)
+	}
+
+	if secret == secret2 {
+		t.Error("two random secrets are identical (very unlikely)")
+	}
+}
+
+func TestValidateWebConfigFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   webConfigFlags
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid OIDC configuration",
+			flags: webConfigFlags{
+				baseURL:      "https://flux.example.com",
+				provider:     "OIDC",
+				issuerURL:    "https://dex.example.com",
+				clientID:     "test-client",
+				clientSecret: "test-secret",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OIDC without issuer URL",
+			flags: webConfigFlags{
+				baseURL:      "https://flux.example.com",
+				provider:     "OIDC",
+				clientID:     "test-client",
+				clientSecret: "test-secret",
+			},
+			wantErr: true,
+			errMsg:  "issuer-url is required",
+		},
+		{
+			name: "no secret method",
+			flags: webConfigFlags{
+				baseURL:   "https://flux.example.com",
+				provider:  "OIDC",
+				issuerURL: "https://dex.example.com",
+				clientID:  "test-client",
+			},
+			wantErr: true,
+			errMsg:  "one of --client-secret",
+		},
+		{
+			name: "multiple secret methods",
+			flags: webConfigFlags{
+				baseURL:         "https://flux.example.com",
+				provider:        "OIDC",
+				issuerURL:       "https://dex.example.com",
+				clientID:        "test-client",
+				clientSecret:    "test-secret",
+				clientSecretRnd: true,
+			},
+			wantErr: true,
+			errMsg:  "only one of",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set global flags
+			webConfigArgs = tt.flags
+
+			err := validateWebConfigFlags()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateWebConfigFlags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("error message = %v, should contain %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestGetClientSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		flags     webConfigFlags
+		wantErr   bool
+		checkFunc func(t *testing.T, secret string)
+	}{
+		{
+			name: "direct secret",
+			flags: webConfigFlags{
+				clientSecret: "my-direct-secret",
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, secret string) {
+				if secret != "my-direct-secret" {
+					t.Errorf("expected 'my-direct-secret', got '%s'", secret)
+				}
+			},
+		},
+		{
+			name: "random secret",
+			flags: webConfigFlags{
+				clientSecretRnd: true,
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, secret string) {
+				if len(secret) == 0 {
+					t.Error("random secret is empty")
+				}
+				if len(secret) < 40 {
+					t.Errorf("random secret too short: %d chars", len(secret))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webConfigArgs = tt.flags
+
+			secret, err := getClientSecret()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getClientSecret() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr && tt.checkFunc != nil {
+				tt.checkFunc(t, secret)
+			}
+		})
+	}
+}

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -167,6 +167,7 @@ func resetCmdArgs() {
 	createSecretSSHArgs = createSecretSSHFlags{}
 	createSecretRegistryArgs = createSecretRegistryFlags{}
 	createSecretSOPSArgs = createSecretSOPSFlags{}
+	webConfigArgs = webConfigFlags{}
 
 	// Export commands
 	exportReportArgs = exportReportFlags{output: "yaml"}


### PR DESCRIPTION
# Add `create secret web-config` command

## 📖 Overview

This PR introduces the `create secret web-config` command to the CLI. This command simplifies the process of generating a Kubernetes `Secret` containing the `config.yaml` required for **Flux Web** authentication.

Previously, users had to manually construct the YAML for the internal `Config` object and wrap it in a Secret; this command automates that workflow, supporting OAuth2/OIDC configurations out of the box.

## ✨ Key Changes

### CLI Enhancements

* **New Command**: Added `flux-operator create secret web-config [name]`.
* **Flag Support**:
* `--base-url`: The external URL for the Flux Web UI.
* `--provider`: Authentication provider (defaults to `OIDC`).
* `--issuer-url`, `--client-id`: Standard OIDC configuration.
* **Secret Handling**: Support for `--client-secret`, `--client-secret-stdin`, and `--client-secret-rnd` for secure secret generation.
* `--export`: Outputs the Secret YAML to stdout instead of applying it to the cluster.



### Technical Improvements

* **Test Coverage**: Added `cmd/cli/create_secret_web_config_test.go` to validate various flag combinations and output formats.
* **Test Isolation**: Updated `cmd/cli/suite_test.go` to ensure global flags are reset between test runs, preventing side effects.

---

## 🛠 Usage Example

### Command

```bash
flux-operator create secret web-config flux-web-config \
  --namespace=flux-system \
  --base-url=https://flux.example.com/ \
  --provider=OIDC \
  --issuer-url=https://dex.example.com/ \
  --client-id=client-id-example \
  --client-secret=client-secret-example \
  --export

```

### Generated Output

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: flux-web-config
  namespace: flux-system
type: Opaque
stringData:
  config.yaml: |
    apiVersion: web.fluxcd.controlplane.io/v1
    kind: Config
    spec:
      baseURL: https://flux.example.com/
      authentication:
        type: OAuth2
        oauth2:
          provider: OIDC
          clientID: client-id-example
          clientSecret: client-secret-example
          issuerURL: https://dex.example.com/

```

---

## ✅ Checklist

* [x] Unit tests added/updated.
* [x] Command follows existing CLI naming conventions.
* [x] Sensitive input (client secrets) handled via stdin/randomization options.
* [x] `go fmt` and `go vet` passed.

closes: #552