### PR TITLE
operator: Fix instance deletion race conditions in tests

### DIFF
--- a/internal/controller/fluxreport_controller_test.go
+++ b/internal/controller/fluxreport_controller_test.go
@@ -167,6 +167,9 @@ func TestFluxReportReconciler_Reconcile(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(emptyReport.Spec.Distribution.Status).To(Equal("Not Installed"))
 	g.Expect(emptyReport.Spec.Distribution.Entitlement).To(Equal("Issued by " + entitlement.DefaultVendor))
+
+	// Wait for CRDs to be fully deleted to prevent race conditions with subsequent tests.
+	waitForFluxCRDsDeletion(ctx, g)
 }
 
 func TestFluxReportReconciler_CustomSyncName(t *testing.T) {
@@ -263,6 +266,9 @@ func TestFluxReportReconciler_CustomSyncName(t *testing.T) {
 		NamespacedName: client.ObjectKeyFromObject(instance),
 	})
 	g.Expect(err).ToNot(HaveOccurred())
+
+	// Wait for CRDs to be fully deleted to prevent race conditions with subsequent tests.
+	waitForFluxCRDsDeletion(ctx, g)
 }
 
 func getFluxReportReconciler() *FluxReportReconciler {


### PR DESCRIPTION
Fix for flaky tests observed in GitHub runners:

```
  --- FAIL: TestFluxInstanceReconciler_Downgrade (61.14s)                                                                                                          
  fluxinstance_controller_test.go:598:                                                                                                                             
  Unexpected error:                                                                                                                                                
  <*errors.errorString | 0xc0032d8ec0>:                                                                                                                            
  timeout waiting for: [CustomResourceDefinition/providers.notification.toolkit.fluxcd.io status: 'NotFound']                                                      
  {                                                                                                                                                                
  s: "timeout waiting for: [CustomResourceDefinition/providers.notification.toolkit.fluxcd.io status: 'NotFound']",                                                
  }   
```