### PR TITLE
web: conditionally display the sync link in the cluster dashboard 

### DIFF
--- a/web/src/components/dashboards/cluster/ClusterPage.jsx
+++ b/web/src/components/dashboards/cluster/ClusterPage.jsx
@@ -77,7 +77,7 @@ export function ClusterPage({ spec, namespace }) {
           )}
 
           {spec.sync && (
-            <SyncPanel sync={spec.sync} namespace={namespace} />
+            <SyncPanel sync={spec.sync} namespace={namespace} namespaces={spec.namespaces} />
           )}
 
           {spec.components && spec.components.length > 0 && (

--- a/web/src/components/dashboards/cluster/SyncPanel.jsx
+++ b/web/src/components/dashboards/cluster/SyncPanel.jsx
@@ -9,8 +9,9 @@ import { useSignal } from '@preact/signals'
  * @param {Object} props
  * @param {Object} props.sync - Cluster sync information
  * @param {string} props.namespace - Report namespace
+ * @param {string[]} [props.namespaces] - List of namespaces the user has access to
  */
-export function SyncPanel({ sync, namespace }) {
+export function SyncPanel({ sync, namespace, namespaces }) {
 
   // Extract name from sync.id (e.g., "kustomization/flux-system" -> "flux-system")
   const syncName = sync.id ? sync.id.split('/').pop() : ''
@@ -85,15 +86,17 @@ export function SyncPanel({ sync, namespace }) {
       {isExpanded.value && (
         <div class="px-6 py-4 space-y-2">
           <div class="flex flex-col gap-2 text-sm text-gray-900 dark:text-white break-all">
-            <a
-              href={`/resource/${encodeURIComponent('Kustomization')}/${encodeURIComponent(namespace)}/${encodeURIComponent(syncName)}`}
-              class="flex items-start gap-2 text-flux-blue dark:text-blue-400 hover:underline text-left"
-            >
-              <svg class="w-5 h-5 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-              </svg>
-              <span class="break-all">Kustomization/{namespace}/{syncName}</span>
-            </a>
+            {namespaces?.includes(namespace) && (
+              <a
+                href={`/resource/${encodeURIComponent('Kustomization')}/${encodeURIComponent(namespace)}/${encodeURIComponent(syncName)}`}
+                class="flex items-start gap-2 text-flux-blue dark:text-blue-400 hover:underline text-left"
+              >
+                <svg class="w-5 h-5 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+                <span class="break-all">Kustomization/{namespace}/{syncName}</span>
+              </a>
+            )}
             <div class="flex items-start gap-2">
               {(sync.source?.startsWith('http') || sync.source?.startsWith('ssh')) ? (
                 <svg class="w-5 h-5 flex-shrink-0 mt-0.5 text-blue-600 dark:text-blue-400" fill="currentColor" viewBox="0 0 24 24">

--- a/web/src/components/dashboards/cluster/SyncPanel.test.jsx
+++ b/web/src/components/dashboards/cluster/SyncPanel.test.jsx
@@ -28,7 +28,8 @@ describe('SyncPanel', () => {
       status: 'Applied revision: v2.4.0',
       ready: true
     },
-    namespace: 'flux-system'
+    namespace: 'flux-system',
+    namespaces: ['flux-system']
   }
 
   describe('Basic Rendering', () => {
@@ -314,6 +315,44 @@ describe('SyncPanel', () => {
 
       // "failing" badge should be present
       expect(screen.getByText('failing')).toBeInTheDocument()
+    })
+  })
+
+  describe('Kustomization Link Visibility', () => {
+    it('should show Kustomization link when namespace is in namespaces list', () => {
+      const props = {
+        ...baseProps,
+        namespaces: ['flux-system', 'default']
+      }
+      render(<SyncPanel {...props} />)
+      expect(screen.getByText('Kustomization/flux-system/flux-cluster')).toBeInTheDocument()
+    })
+
+    it('should hide Kustomization link when namespace is not in namespaces list', () => {
+      const props = {
+        ...baseProps,
+        namespaces: ['default', 'monitoring']
+      }
+      render(<SyncPanel {...props} />)
+      expect(screen.queryByText('Kustomization/flux-system/flux-cluster')).not.toBeInTheDocument()
+    })
+
+    it('should hide Kustomization link when namespaces is undefined', () => {
+      const props = {
+        ...baseProps,
+        namespaces: undefined
+      }
+      render(<SyncPanel {...props} />)
+      expect(screen.queryByText('Kustomization/flux-system/flux-cluster')).not.toBeInTheDocument()
+    })
+
+    it('should hide Kustomization link when namespaces is empty', () => {
+      const props = {
+        ...baseProps,
+        namespaces: []
+      }
+      render(<SyncPanel {...props} />)
+      expect(screen.queryByText('Kustomization/flux-system/flux-cluster')).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
Fix: #609

Hide the link to the root Kustomization on multi-tenant cluster when the user does not have access to the namespace where the Kustomization resides. For these users, showing the link would always result in an access denied error when clicked, so this is just a UX improvment not a security feature.