### PR TITLE
web: improve history timeline view

### DIFF
--- a/web/src/components/dashboards/resource/HistoryTimeline.jsx
+++ b/web/src/components/dashboards/resource/HistoryTimeline.jsx
@@ -124,8 +124,8 @@ export function HistoryTimeline({ history, kind }) {
               <div class={`flex-1 ${!isLast ? 'pb-6' : 'pb-0'}`}>
                 {/* Time range */}
                 <div class="text-sm text-gray-900 dark:text-white mb-1">
-                  {firstTime === lastTime ? (
-                    <span>{formatTimestamp(firstTime)}</span>
+                  {isHelmRelease || firstTime === lastTime ? (
+                    <span>{formatTimestamp(lastTime)}</span>
                   ) : (
                     <span>
                       {formatTimestamp(firstTime)} → {formatTimestamp(lastTime)}

--- a/web/src/utils/time.js
+++ b/web/src/utils/time.js
@@ -11,7 +11,8 @@
  * - Less than 1 minute: "just now"
  * - Less than 60 minutes: "5m ago"
  * - Less than 24 hours: "3h ago"
- * - Older: "Jan 15, 02:30 PM"
+ * - Older (same year): "Jan 15, 02:30 PM"
+ * - Older (different year): "Jan 15, 2024, 02:30 PM"
  */
 export const formatTimestamp = (timestamp) => {
   const date = new Date(timestamp)
@@ -22,12 +23,19 @@ export const formatTimestamp = (timestamp) => {
   if (diffMins < 1) return 'just now'
   if (diffMins < 60) return `${diffMins}m ago`
   if (diffMins < 1440) return `${Math.floor(diffMins / 60)}h ago`
-  return date.toLocaleString('en-US', {
+
+  // Include year if date is from a different year
+  const includeYear = date.getFullYear() !== now.getFullYear()
+  const options = {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',
     minute: '2-digit'
-  })
+  }
+  if (includeYear) {
+    options.year = 'numeric'
+  }
+  return date.toLocaleString('en-US', options)
 }
 
 /**

--- a/web/src/utils/time.test.js
+++ b/web/src/utils/time.test.js
@@ -28,6 +28,13 @@ describe('formatTimestamp', () => {
     date.toLocaleString = mockToLocaleString;
     expect(formatTimestamp(date)).toMatch(/\w{3} \d{1,2}, \d{2}:\d{2} (AM|PM)/)
   })
+
+  it('should include year for timestamps from a different year', () => {
+    const lastYear = now.getFullYear() - 1
+    const date = new Date(lastYear, 0, 15, 14, 30) // Jan 15 of last year
+    // Should include the year in the output
+    expect(formatTimestamp(date)).toMatch(/\w{3} \d{1,2}, \d{4}, \d{2}:\d{2} (AM|PM)/)
+  })
 })
 
 describe('formatTime', () => {


### PR DESCRIPTION
Reconciler History UX improvements:
- Include the year when the date is from a different year than the current year
- Show only the last deployed timestamp for HelmRelease