### PR TITLE
web: implement download action for source artifacts

### DIFF
--- a/api/v1/webconfig_types.go
+++ b/api/v1/webconfig_types.go
@@ -28,6 +28,9 @@ const (
 
 	// UserActionResume is the resume user action.
 	UserActionResume = "resume"
+
+	// UserActionDownload is the download user action.
+	UserActionDownload = "download"
 )
 
 var (
@@ -42,6 +45,7 @@ var (
 		UserActionReconcile,
 		UserActionSuspend,
 		UserActionResume,
+		UserActionDownload,
 	}
 )
 

--- a/config/default/rbac.yaml
+++ b/config/default/rbac.yaml
@@ -89,3 +89,4 @@ rules:
       - reconcile
       - suspend
       - resume
+      - download

--- a/docs/web/web-user-management.md
+++ b/docs/web/web-user-management.md
@@ -229,9 +229,13 @@ rules:
       - reconcile
       - suspend
       - resume
+      - download
 ```
 
 Note that the `patch` verb is not enough to allow a user to perform actions in the Web UI.
-The user also needs the `reconcile`, `suspend`, and `resume` verbs
+The user also needs the `reconcile`, `suspend`, `resume`, and `download` verbs
 for the respective resources. These verbs are specially defined in Flux Operator
 to assign action permissions.
+
+The `download` verb allows users to download artifacts from Flux source resources
+(Bucket, GitRepository, OCIRepository, HelmChart, and ExternalArtifact).

--- a/internal/web/config/user_actions_validation_test.go
+++ b/internal/web/config/user_actions_validation_test.go
@@ -90,6 +90,11 @@ func TestAllUserActions(t *testing.T) {
 	g := NewWithT(t)
 
 	// Verify AllUserActions contains the expected actions
-	g.Expect(fluxcdv1.AllUserActions).To(ConsistOf(fluxcdv1.UserActionReconcile, fluxcdv1.UserActionSuspend, fluxcdv1.UserActionResume))
-	g.Expect(fluxcdv1.AllUserActions).To(HaveLen(3))
+	g.Expect(fluxcdv1.AllUserActions).To(ConsistOf(
+		fluxcdv1.UserActionReconcile,
+		fluxcdv1.UserActionSuspend,
+		fluxcdv1.UserActionResume,
+		fluxcdv1.UserActionDownload,
+	))
+	g.Expect(fluxcdv1.AllUserActions).To(HaveLen(4))
 }

--- a/internal/web/download.go
+++ b/internal/web/download.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package web
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"slices"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
+)
+
+// DownloadableKinds lists the Flux source kinds that have downloadable artifacts.
+var DownloadableKinds = []string{
+	fluxcdv1.FluxBucketKind,
+	fluxcdv1.FluxGitRepositoryKind,
+	fluxcdv1.FluxOCIRepositoryKind,
+	fluxcdv1.FluxHelmChartKind,
+	fluxcdv1.FluxExternalArtifactKind,
+}
+
+// isDownloadableKind checks if the given kind supports artifact downloads.
+func isDownloadableKind(kind string) bool {
+	return slices.Contains(DownloadableKinds, kind)
+}
+
+// artifactHTTPClient is a dedicated HTTP client for fetching artifacts from source-controller.
+// The timeout is set to 59 seconds, just under the web server's 60 second write timeout.
+var artifactHTTPClient = &http.Client{
+	Timeout: 59 * time.Second,
+	Transport: &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	},
+}
+
+// DownloadHandler handles GET /api/v1/download requests to download artifacts from Flux sources.
+func (h *Handler) DownloadHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Check if actions are enabled.
+	if !h.conf.UserActionsEnabled() {
+		http.Error(w, "User actions are disabled", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse query parameters.
+	kind := req.URL.Query().Get("kind")
+	namespace := req.URL.Query().Get("namespace")
+	name := req.URL.Query().Get("name")
+
+	// Validate required fields.
+	if kind == "" || namespace == "" || name == "" {
+		http.Error(w, "Missing required query parameters: kind, namespace, name", http.StatusBadRequest)
+		return
+	}
+
+	// Find the FluxKindInfo for validation.
+	kindInfo, err := fluxcdv1.FindFluxKindInfo(kind)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Unknown resource kind: %s", kind), http.StatusBadRequest)
+		return
+	}
+
+	// Check if the kind supports downloads.
+	if !isDownloadableKind(kindInfo.Name) {
+		http.Error(w, fmt.Sprintf("Resource kind %s does not support artifact downloads", kindInfo.Name), http.StatusBadRequest)
+		return
+	}
+
+	// Get the preferred GVK for the kind.
+	gvk, err := h.preferredFluxGVK(req.Context(), kindInfo.Name)
+	if err != nil {
+		log.FromContext(req.Context()).Error(err, "failed to get GVK for kind", "kind", kindInfo.Name)
+		http.Error(w, fmt.Sprintf("Unable to get resource type for kind %s", kindInfo.Name), http.StatusInternalServerError)
+		return
+	}
+
+	ctx := req.Context()
+
+	// Check custom RBAC for download action.
+	if allowed, err := h.kubeClient.CanActOnResource(ctx,
+		fluxcdv1.UserActionDownload, gvk.Group, kindInfo.Plural, namespace, name); err != nil {
+		log.FromContext(req.Context()).Error(err, "failed to check custom RBAC for download",
+			"kind", kind, "name", name, "namespace", namespace)
+		http.Error(w, "Unable to verify permissions", http.StatusInternalServerError)
+		return
+	} else if !allowed {
+		perms := user.Permissions(req.Context())
+		http.Error(w, fmt.Sprintf("Permission denied. User %s does not have access to download %s/%s/%s",
+			perms.Username, kind, namespace, name), http.StatusForbidden)
+		return
+	}
+
+	// Fetch the resource.
+	kubeClient := h.kubeClient.GetClient(ctx)
+	resource := &unstructured.Unstructured{}
+	resource.SetGroupVersionKind(*gvk)
+	resource.SetName(name)
+	resource.SetNamespace(namespace)
+
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+	if err := kubeClient.Get(ctx, key, resource); err != nil {
+		log.FromContext(ctx).Error(err, "failed to fetch resource",
+			"kind", kind, "name", name, "namespace", namespace)
+		http.Error(w, fmt.Sprintf("Resource %s/%s not found", namespace, name), http.StatusNotFound)
+		return
+	}
+
+	// Extract the artifact URL from status.artifact.url.
+	artifactURL, found, err := unstructured.NestedString(resource.Object, "status", "artifact", "url")
+	if err != nil || !found || artifactURL == "" {
+		http.Error(w, fmt.Sprintf("Artifact not available for %s/%s", namespace, name), http.StatusNotFound)
+		return
+	}
+
+	// Fetch the artifact from the source-controller.
+	artifactReq, err := http.NewRequestWithContext(ctx, http.MethodGet, artifactURL, nil)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to create artifact request",
+			"kind", kind, "name", name, "namespace", namespace, "url", artifactURL)
+		http.Error(w, "Failed to download artifact from source", http.StatusBadGateway)
+		return
+	}
+
+	artifactResp, err := artifactHTTPClient.Do(artifactReq)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to fetch artifact",
+			"kind", kind, "name", name, "namespace", namespace, "url", artifactURL)
+		http.Error(w, "Failed to download artifact from source", http.StatusBadGateway)
+		return
+	}
+	defer artifactResp.Body.Close()
+
+	if artifactResp.StatusCode != http.StatusOK {
+		log.FromContext(ctx).Error(nil, "artifact fetch returned non-OK status",
+			"kind", kind, "name", name, "namespace", namespace, "url", artifactURL, "status", artifactResp.StatusCode)
+		http.Error(w, "Failed to download artifact from source", http.StatusBadGateway)
+		return
+	}
+
+	// Enforce maximum artifact size of 50MB.
+	const maxArtifactSize int64 = 50 * 1024 * 1024
+	if artifactResp.ContentLength > maxArtifactSize {
+		log.FromContext(ctx).Error(nil, "artifact size exceeds maximum allowed",
+			"kind", kind, "name", name, "namespace", namespace,
+			"size", artifactResp.ContentLength, "maxSize", maxArtifactSize)
+		http.Error(w, fmt.Sprintf("Artifact size %d bytes exceeds maximum allowed size of 50MB", artifactResp.ContentLength), http.StatusBadRequest)
+		return
+	}
+
+	// Set response headers for cross-browser compatible downloads.
+	filename := fmt.Sprintf("%s-%s-%s.tar.gz", kind, namespace, name)
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+
+	// Content-Length allows browser to show download progress.
+	if artifactResp.ContentLength > 0 {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", artifactResp.ContentLength))
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	// Use chunked writing with flush to keep connection alive through proxies.
+	// Track total bytes to enforce size limit even when Content-Length is missing or incorrect.
+	flusher, canFlush := w.(http.Flusher)
+	buf := make([]byte, 32*1024) // 32KB chunks
+	var totalBytes int64
+	for {
+		n, err := artifactResp.Body.Read(buf)
+		if n > 0 {
+			totalBytes += int64(n)
+			if totalBytes > maxArtifactSize {
+				log.FromContext(ctx).Error(nil, "artifact exceeded maximum size during streaming",
+					"kind", kind, "name", name, "namespace", namespace,
+					"bytesRead", totalBytes, "maxSize", maxArtifactSize)
+				return // Abort streaming, response will be truncated
+			}
+			if _, wErr := w.Write(buf[:n]); wErr != nil {
+				return // Connection closed by client
+			}
+			if canFlush {
+				flusher.Flush()
+			}
+		}
+		if err != nil {
+			if err != io.EOF {
+				log.FromContext(ctx).Error(err, "failed to stream artifact to client",
+					"kind", kind, "name", name, "namespace", namespace)
+			}
+			break
+		}
+	}
+}

--- a/internal/web/download_test.go
+++ b/internal/web/download_test.go
@@ -1,0 +1,323 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
+)
+
+func TestDownloadHandler_MethodNotAllowed(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	// Test with POST method (should fail)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/download?kind=GitRepository&namespace=default&name=test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.DownloadHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
+	g.Expect(rec.Body.String()).To(ContainSubstring("Method not allowed"))
+}
+
+func TestDownloadHandler_MissingParameters(t *testing.T) {
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	testCases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "missing kind",
+			query: "namespace=default&name=test",
+		},
+		{
+			name:  "missing namespace",
+			query: "kind=GitRepository&name=test",
+		},
+		{
+			name:  "missing name",
+			query: "kind=GitRepository&namespace=default",
+		},
+		{
+			name:  "all missing",
+			query: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/download?"+tc.query, nil)
+			rec := httptest.NewRecorder()
+
+			handler.DownloadHandler(rec, req)
+
+			g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
+			g.Expect(rec.Body.String()).To(ContainSubstring("Missing required query parameters"))
+		})
+	}
+}
+
+func TestDownloadHandler_UnknownKind(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/download?kind=UnknownKind&namespace=default&name=test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.DownloadHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
+	g.Expect(rec.Body.String()).To(ContainSubstring("Unknown resource kind"))
+}
+
+func TestDownloadHandler_NonDownloadableKind(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	// Kustomization is a valid Flux kind but doesn't support downloads
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/download?kind=Kustomization&namespace=default&name=test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.DownloadHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
+	g.Expect(rec.Body.String()).To(ContainSubstring("does not support artifact downloads"))
+}
+
+func TestDownloadHandler_ActionsDisabled_NoAuth(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test with no authentication configured
+	handler := &Handler{
+		conf: &fluxcdv1.WebConfigSpec{
+			UserActions: &fluxcdv1.UserActionsSpec{},
+		},
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/download?kind=GitRepository&namespace=default&name=test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.DownloadHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
+	g.Expect(rec.Body.String()).To(ContainSubstring("User actions are disabled"))
+}
+
+func TestDownloadHandler_UnprivilegedUser_Forbidden(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create RBAC for the test user but NOT for the "download" action
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-download-no-permission",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{fluxcdv1.GroupVersion.Group},
+				Resources: []string{"resourcesets"},
+				Verbs:     []string{"get", "list"}, // No "download" permission
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, clusterRole)).To(Succeed())
+	defer testClient.Delete(ctx, clusterRole)
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-download-no-permission-binding",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     clusterRole.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "User",
+				Name: "unprivileged-download-user",
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, clusterRoleBinding)).To(Succeed())
+	defer testClient.Delete(ctx, clusterRoleBinding)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	// Create an unprivileged user session (no download RBAC permissions)
+	imp := user.Impersonation{
+		Username: "unprivileged-download-user",
+		Groups:   []string{"system:authenticated"},
+	}
+	userClient, err := kubeClient.GetUserClientFromCache(imp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	userCtx := user.StoreSession(ctx, user.Details{
+		Profile:       user.Profile{Name: "Unprivileged User"},
+		Impersonation: imp,
+	}, userClient)
+
+	// Request for a ResourceSet - will fail at RBAC check
+	// Using ResourceSet because FluxOperator CRDs are installed in test env
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/download?kind=ResourceSet&namespace=default&name=test", nil)
+	req = req.WithContext(userCtx)
+	rec := httptest.NewRecorder()
+
+	handler.DownloadHandler(rec, req)
+
+	// ResourceSet is not a downloadable kind, so it should fail at kind validation
+	g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
+	g.Expect(rec.Body.String()).To(ContainSubstring("does not support artifact downloads"))
+}
+
+func TestDownloadHandler_GVKLookupFailsWhenCRDNotInstalled(t *testing.T) {
+	g := NewWithT(t)
+
+	// This test verifies that when Flux CRDs are not installed,
+	// the handler returns 500 Internal Server Error for GVK lookup failure.
+	// In a real cluster with Flux installed, this would proceed to RBAC checks.
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	// Request for a GitRepository - will fail at GVK lookup because CRD is not installed
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/download?kind=GitRepository&namespace=default&name=test", nil)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handler.DownloadHandler(rec, req)
+
+	// Should return 500 because the GitRepository CRD is not installed in test environment
+	g.Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+	g.Expect(rec.Body.String()).To(ContainSubstring("Unable to get resource type"))
+}
+
+func TestIsDownloadableKind(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test downloadable kinds
+	g.Expect(isDownloadableKind(fluxcdv1.FluxGitRepositoryKind)).To(BeTrue())
+	g.Expect(isDownloadableKind(fluxcdv1.FluxBucketKind)).To(BeTrue())
+	g.Expect(isDownloadableKind(fluxcdv1.FluxOCIRepositoryKind)).To(BeTrue())
+	g.Expect(isDownloadableKind(fluxcdv1.FluxHelmChartKind)).To(BeTrue())
+	g.Expect(isDownloadableKind(fluxcdv1.FluxExternalArtifactKind)).To(BeTrue())
+
+	// Test non-downloadable kinds
+	g.Expect(isDownloadableKind(fluxcdv1.FluxKustomizationKind)).To(BeFalse())
+	g.Expect(isDownloadableKind(fluxcdv1.FluxHelmReleaseKind)).To(BeFalse())
+	g.Expect(isDownloadableKind(fluxcdv1.FluxAlertKind)).To(BeFalse())
+	g.Expect(isDownloadableKind("UnknownKind")).To(BeFalse())
+}
+
+func TestDownloadHandler_DownloadableKindsValidation(t *testing.T) {
+	downloadableKinds := []string{
+		fluxcdv1.FluxBucketKind,
+		fluxcdv1.FluxGitRepositoryKind,
+		fluxcdv1.FluxOCIRepositoryKind,
+		fluxcdv1.FluxHelmChartKind,
+	}
+
+	nonDownloadableKinds := []string{
+		fluxcdv1.FluxKustomizationKind,
+		fluxcdv1.FluxHelmReleaseKind,
+		fluxcdv1.FluxAlertKind,
+		fluxcdv1.FluxAlertProviderKind,
+		"ResourceSet",
+	}
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	// Test that downloadable kinds pass the kind validation
+	for _, kind := range downloadableKinds {
+		t.Run("downloadable_"+kind, func(t *testing.T) {
+			g := NewWithT(t)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/download?kind="+kind+"&namespace=default&name=test", nil)
+			req = req.WithContext(ctx)
+			rec := httptest.NewRecorder()
+
+			handler.DownloadHandler(rec, req)
+
+			// Should get past kind validation (not 400 for invalid kind)
+			// Will fail with 404 (not found) or 403 (no permission) or 500 (no CRD installed)
+			g.Expect(rec.Body.String()).NotTo(ContainSubstring("does not support artifact downloads"))
+		})
+	}
+
+	// Test that non-downloadable kinds are rejected
+	for _, kind := range nonDownloadableKinds {
+		t.Run("non_downloadable_"+kind, func(t *testing.T) {
+			g := NewWithT(t)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/download?kind="+kind+"&namespace=default&name=test", nil)
+			req = req.WithContext(ctx)
+			rec := httptest.NewRecorder()
+
+			handler.DownloadHandler(rec, req)
+
+			// Should fail with 400 for non-downloadable kind
+			g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
+			g.Expect(rec.Body.String()).To(ContainSubstring("does not support artifact downloads"))
+		})
+	}
+}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -61,6 +61,7 @@ func NewHandler(ctx context.Context, conf *fluxcdv1.WebConfigSpec, spaHandler ht
 
 	// Handle API.
 	mux.HandleFunc("POST /api/v1/action", h.ActionHandler)
+	mux.HandleFunc("GET /api/v1/download", h.DownloadHandler)
 	mux.HandleFunc("GET /api/v1/events", h.EventsHandler)
 	mux.HandleFunc("POST /api/v1/favorites", h.FavoritesHandler)
 	mux.HandleFunc("GET /api/v1/report", h.ReportHandler)

--- a/internal/web/middlewares.go
+++ b/internal/web/middlewares.go
@@ -36,6 +36,12 @@ func (w *gzipResponseWriter) Flush() {
 // GzipMiddleware adds gzip compression to responses.
 func GzipMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Skip gzip for download endpoint to avoid double compression of Flux artifacts
+		if r.URL.Path == "/api/v1/download" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		// Check if client accepts gzip compression
 		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
 			next.ServeHTTP(w, r)

--- a/internal/web/suite_test.go
+++ b/internal/web/suite_test.go
@@ -59,7 +59,7 @@ func setupActionRBAC(ctx context.Context, c client.Client) error {
 			{
 				APIGroups: []string{fluxcdv1.GroupVersion.Group},
 				Resources: []string{"*"},
-				Verbs:     []string{"reconcile", "suspend", "resume"},
+				Verbs:     []string{"reconcile", "suspend", "resume", "download"},
 			},
 		},
 	}

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -59,6 +59,7 @@ export default [
         global: 'readonly',
         window: 'readonly',
         document: 'readonly',
+        Blob: 'readonly',
       },
     },
     rules: {


### PR DESCRIPTION
 Implement the download action for source artifacts guarded by RBAC using the `download` virtual verb.

Closes: #578

<img width="829" height="541" alt="Screenshot 2026-01-31 at 17 23 59" src="https://github.com/user-attachments/assets/e10280cc-0bc5-44a4-be8f-41dc73063fa0" />
