### PR TITLE
web: extend workload views with CronJob support

### DIFF
--- a/web/src/components/dashboards/resource/GraphTabContent.jsx
+++ b/web/src/components/dashboards/resource/GraphTabContent.jsx
@@ -156,21 +156,18 @@ function getStatusBorderClass(status) {
 }
 
 /**
- * Format workload status message for display in the graph
- * For ready workloads, extracts just the "Replicas: X" part if present
+ * Format workload status message for display in the graph.
+ * For Idle CronJobs, returns "Idle" as the display message.
  * @param {string} status - Workload status
- * @param {string} message - Full status message
+ * @param {string} message - Status message
  * @returns {string|null} Formatted message or null
  */
 export function formatWorkloadGraphMessage(status, message) {
   if (!message) return null
 
-  // For ready workloads, extract just the replicas part
-  if (status === 'Current' || status === 'Ready') {
-    const replicasMatch = message.match(/Replicas:\s*.+/)
-    if (replicasMatch) {
-      return replicasMatch[0]
-    }
+  // For idle CronJobs, show "Idle" as the status message
+  if (status === 'Idle') {
+    return 'Idle'
   }
 
   return message
@@ -179,13 +176,14 @@ export function formatWorkloadGraphMessage(status, message) {
 /**
  * Get dot color class for workload status
  * Uses same color scheme as getWorkloadStatusBadgeClass from utils/status
- * @param {string} status - Workload status (Current, Ready, Failed, InProgress, Progressing, Terminating)
+ * @param {string} status - Workload status (Current, Ready, Idle, Failed, InProgress, Progressing, Terminating, Suspended)
  * @returns {string} Tailwind CSS classes for the dot
  */
 export function getWorkloadDotClass(status) {
   switch (status) {
   case 'Current':
   case 'Ready':
+  case 'Idle':
     return 'bg-green-500 dark:bg-green-400'
   case 'Failed':
     return 'bg-red-500 dark:bg-red-400'
@@ -193,6 +191,7 @@ export function getWorkloadDotClass(status) {
   case 'Progressing':
     return 'bg-blue-500 dark:bg-blue-400'
   case 'Terminating':
+  case 'Suspended':
     return 'bg-yellow-500 dark:bg-yellow-400'
   default:
     return 'bg-gray-400 dark:bg-gray-500'

--- a/web/src/components/dashboards/resource/GraphTabContent.test.jsx
+++ b/web/src/components/dashboards/resource/GraphTabContent.test.jsx
@@ -1360,6 +1360,10 @@ describe('getWorkloadDotClass function', () => {
     expect(getWorkloadDotClass('Ready')).toBe('bg-green-500 dark:bg-green-400')
   })
 
+  it('should return green class for Idle status', () => {
+    expect(getWorkloadDotClass('Idle')).toBe('bg-green-500 dark:bg-green-400')
+  })
+
   it('should return red class for Failed status', () => {
     expect(getWorkloadDotClass('Failed')).toBe('bg-red-500 dark:bg-red-400')
   })
@@ -1374,6 +1378,10 @@ describe('getWorkloadDotClass function', () => {
 
   it('should return yellow class for Terminating status', () => {
     expect(getWorkloadDotClass('Terminating')).toBe('bg-yellow-500 dark:bg-yellow-400')
+  })
+
+  it('should return yellow class for Suspended status', () => {
+    expect(getWorkloadDotClass('Suspended')).toBe('bg-yellow-500 dark:bg-yellow-400')
   })
 
   it('should return gray class for unknown status', () => {
@@ -1394,39 +1402,28 @@ describe('formatWorkloadGraphMessage function', () => {
     expect(formatWorkloadGraphMessage('Current', undefined)).toBeNull()
   })
 
-  it('should extract Replicas part for Current status', () => {
-    const message = 'Deployment is available. Replicas: 3/3'
-    expect(formatWorkloadGraphMessage('Current', message)).toBe('Replicas: 3/3')
+  it('should pass through Replicas message for Current status', () => {
+    expect(formatWorkloadGraphMessage('Current', 'Replicas: 3')).toBe('Replicas: 3')
   })
 
-  it('should extract Replicas part for Ready status', () => {
-    const message = 'StatefulSet is ready. Replicas: 2/2'
-    expect(formatWorkloadGraphMessage('Ready', message)).toBe('Replicas: 2/2')
+  it('should pass through Replicas message for Ready status', () => {
+    expect(formatWorkloadGraphMessage('Ready', 'Replicas: 2')).toBe('Replicas: 2')
   })
 
-  it('should extract Replicas with different formats', () => {
-    const message = 'Some text. Replicas: 2 of 3 ready'
-    expect(formatWorkloadGraphMessage('Current', message)).toBe('Replicas: 2 of 3 ready')
+  it('should return Idle for Idle status regardless of message', () => {
+    expect(formatWorkloadGraphMessage('Idle', '0 */6 * * *')).toBe('Idle')
   })
 
-  it('should return full message when no Replicas part for ready status', () => {
-    const message = 'Deployment is available'
-    expect(formatWorkloadGraphMessage('Current', message)).toBe('Deployment is available')
-  })
-
-  it('should return full message for Failed status even with Replicas', () => {
-    const message = 'Deployment failed. Replicas: 1/3'
-    expect(formatWorkloadGraphMessage('Failed', message)).toBe('Deployment failed. Replicas: 1/3')
+  it('should return full message for Failed status', () => {
+    expect(formatWorkloadGraphMessage('Failed', 'Job failed: BackoffLimitExceeded')).toBe('Job failed: BackoffLimitExceeded')
   })
 
   it('should return full message for InProgress status', () => {
-    const message = 'Deployment progressing. Replicas: 2/3'
-    expect(formatWorkloadGraphMessage('InProgress', message)).toBe('Deployment progressing. Replicas: 2/3')
+    expect(formatWorkloadGraphMessage('InProgress', 'Deployment progressing')).toBe('Deployment progressing')
   })
 
   it('should return full message for Terminating status', () => {
-    const message = 'Pod is terminating'
-    expect(formatWorkloadGraphMessage('Terminating', message)).toBe('Pod is terminating')
+    expect(formatWorkloadGraphMessage('Terminating', 'Pod is terminating')).toBe('Pod is terminating')
   })
 })
 

--- a/web/src/components/dashboards/resource/WorkloadsTabContent.jsx
+++ b/web/src/components/dashboards/resource/WorkloadsTabContent.jsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from 'preact/hooks'
 import { fetchWithMock } from '../../../utils/fetch'
 import { formatTimestamp } from '../../../utils/time'
 import { getWorkloadStatusBadgeClass, formatWorkloadStatus } from '../../../utils/status'
+import { formatScheduleMessage } from '../../../utils/cron'
 import { FluxOperatorIcon } from '../../layout/Icons'
 
 /**
@@ -130,7 +131,7 @@ export function WorkloadsTabContent({ workloadItems, namespace }) {
                   {/* Line 3: StatusMessage */}
                   {workload && workload.statusMessage && (
                     <div class="text-sm text-gray-700 dark:text-gray-300 mt-1 break-all">
-                      {workload.statusMessage}
+                      {formatScheduleMessage(workload.statusMessage)}
                     </div>
                   )}
                 </div>
@@ -190,7 +191,9 @@ export function WorkloadsTabContent({ workloadItems, namespace }) {
 
                 {/* No Pods */}
                 {(!workload.pods || workload.pods.length === 0) && (
-                  <p class="text-xs text-gray-500 dark:text-gray-400">No pods found</p>
+                  <p class="text-xs text-gray-500 dark:text-gray-400">
+                    {item.kind === 'CronJob' ? 'No recent jobs' : 'No pods found'}
+                  </p>
                 )}
               </div>
             )}

--- a/web/src/components/dashboards/resource/WorkloadsTabContent.test.jsx
+++ b/web/src/components/dashboards/resource/WorkloadsTabContent.test.jsx
@@ -393,6 +393,51 @@ describe('WorkloadsTabContent component', () => {
     })
   })
 
+  it('should show "No recent jobs" for CronJob with no pods', async () => {
+    const cronJobWorkload = {
+      kind: 'CronJob',
+      name: 'backup',
+      namespace: 'default',
+      status: 'Idle',
+      statusMessage: '0 */6 * * *',
+      containerImages: ['busybox:1.36'],
+      pods: []
+    }
+
+    fetchWithMock.mockImplementation(() =>
+      Promise.resolve({ workloads: [cronJobWorkload] })
+    )
+    const user = userEvent.setup()
+
+    const cronJobItem = [{
+      kind: 'CronJob',
+      name: 'backup',
+      namespace: 'default'
+    }]
+
+    render(
+      <WorkloadsTabContent
+        workloadItems={cronJobItem}
+        namespace="default"
+      />
+    )
+
+    await waitFor(() => {
+      const textContent = document.body.textContent
+      expect(textContent).toContain('default/backup')
+    })
+
+    // Expand the workload
+    const workloadButtons = screen.getAllByRole('button')
+    const backupButton = workloadButtons.find(btn => btn.textContent.includes('backup'))
+    await user.click(backupButton)
+
+    // Should show "No recent jobs" for CronJob
+    await waitFor(() => {
+      expect(screen.getByText('No recent jobs')).toBeInTheDocument()
+    })
+  })
+
   it('should refetch workload data when workloadItems change', async () => {
     const { rerender } = render(
       <WorkloadsTabContent

--- a/web/src/mock/workload.js
+++ b/web/src/mock/workload.js
@@ -12,6 +12,7 @@ const getTimestamp = (daysAgo, hoursAgo = 0, minutesAgo = 0) => {
 }
 
 // Mock workload data
+// Pod statuses use Kubernetes pod phases: Pending, Running, Succeeded, Failed, Unknown
 const mockWorkloads = {
   // Flux controllers in flux-system namespace
   'Deployment/flux-system/source-controller': {
@@ -19,15 +20,15 @@ const mockWorkloads = {
     name: 'source-controller',
     namespace: 'flux-system',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'ghcr.io/fluxcd/source-controller:v1.7.4@sha256:16f21ac1795528df80ddef51ccbb14a57b78ea26e66dc8551636ef9a3cec71b3'
     ],
     pods: [
       {
         name: 'source-controller-5f76f5c549-wz2gk',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(7, 2, 15) // 7 days, 2 hours, 15 minutes ago
       }
     ]
@@ -37,15 +38,15 @@ const mockWorkloads = {
     name: 'kustomize-controller',
     namespace: 'flux-system',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'ghcr.io/fluxcd/kustomize-controller:v1.7.3@sha256:e8ca82d66dafdd8ef77e0917f4adec53478075130ac61264dc0f91eb0f8cb6ce'
     ],
     pods: [
       {
         name: 'kustomize-controller-5fc57fb9cc-bhl8q',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(7, 2, 20)
       }
     ]
@@ -55,15 +56,15 @@ const mockWorkloads = {
     name: 'helm-controller',
     namespace: 'flux-system',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'ghcr.io/fluxcd/helm-controller:v1.4.4@sha256:5eae73909e1471c0cd01bb23d87c9d4219a4f645134a23629c8708c72635398d'
     ],
     pods: [
       {
         name: 'helm-controller-bf4685d7f-nxqsj',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(7, 2, 25)
       }
     ]
@@ -73,15 +74,15 @@ const mockWorkloads = {
     name: 'notification-controller',
     namespace: 'flux-system',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'ghcr.io/fluxcd/notification-controller:v1.7.5@sha256:ba723a55f7c7c7feedd50bb5db0ff2dd9a3b0ae85b50f61a0457184025b38c54'
     ],
     pods: [
       {
         name: 'notification-controller-58cfb55954-fcf6l',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(7, 2, 30)
       }
     ]
@@ -98,14 +99,14 @@ const mockWorkloads = {
     pods: [
       {
         name: 'image-automation-controller-5c5fc5487b-w4458',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(5, 8, 45)
       },
       {
         name: 'image-automation-controller-dfcfc789b-9dtqk',
-        status: 'InProgress',
-        statusMessage: 'Pod is in the Pending phase. Reason: ImagePullBackOff',
+        status: 'Pending',
+        statusMessage: 'Waiting: ImagePullBackOff',
         timestamp: getTimestamp(0, 0, 5) // Recent pod with issue
       }
     ]
@@ -115,15 +116,15 @@ const mockWorkloads = {
     name: 'image-reflector-controller',
     namespace: 'flux-system',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'ghcr.io/fluxcd/image-reflector-controller:v1.0.4@sha256:0bdc30aea2b7cdfea02d0f6d53c06b9df0ea1c6516b85ed523792e222329c039'
     ],
     pods: [
       {
         name: 'image-reflector-controller-547c8dbffc-2gjhj',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(7, 3, 10)
       }
     ]
@@ -133,15 +134,15 @@ const mockWorkloads = {
     name: 'source-watcher',
     namespace: 'flux-system',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'ghcr.io/fluxcd/source-watcher:v2.0.3@sha256:9cd46c3c958dcfcd8a3c857fa09989f9df5d8396eae165f219cbb472343371a9'
     ],
     pods: [
       {
         name: 'source-watcher-85bcf4bd57-vfbs6',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(7, 3, 20)
       }
     ]
@@ -151,15 +152,15 @@ const mockWorkloads = {
     name: 'flux-operator',
     namespace: 'flux-system',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'ghcr.io/controlplaneio-fluxcd/flux-operator:v0.34.0'
     ],
     pods: [
       {
         name: 'flux-operator-67cdfc557d-h656w',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(7, 3, 30)
       }
     ]
@@ -171,15 +172,15 @@ const mockWorkloads = {
     name: 'cert-manager',
     namespace: 'cert-manager',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'quay.io/jetstack/cert-manager-controller:v1.19.1'
     ],
     pods: [
       {
         name: 'cert-manager-6b7bcdbb84-cclfj',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(10, 4, 15)
       }
     ]
@@ -189,15 +190,15 @@ const mockWorkloads = {
     name: 'cert-manager-cainjector',
     namespace: 'cert-manager',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'quay.io/jetstack/cert-manager-cainjector:v1.19.1'
     ],
     pods: [
       {
         name: 'cert-manager-cainjector-d74c65ddb-6v869',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(10, 4, 20)
       }
     ]
@@ -207,15 +208,15 @@ const mockWorkloads = {
     name: 'cert-manager-webhook',
     namespace: 'cert-manager',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'quay.io/jetstack/cert-manager-webhook:v1.19.1'
     ],
     pods: [
       {
         name: 'cert-manager-webhook-6bf5dfc659-w95d9',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(10, 4, 25)
       }
     ]
@@ -227,15 +228,15 @@ const mockWorkloads = {
     name: 'metrics-server',
     namespace: 'monitoring',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'registry.k8s.io/metrics-server/metrics-server:v0.8.0'
     ],
     pods: [
       {
         name: 'metrics-server-57b56685f4-59gn2',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(14, 6, 30)
       }
     ]
@@ -245,15 +246,15 @@ const mockWorkloads = {
     name: 'operator',
     namespace: 'tailscale',
     status: 'Current',
-    statusMessage: 'Deployment is available. Replicas: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'tailscale/k8s-operator:v1.90.8'
     ],
     pods: [
       {
         name: 'operator-84ddf77c66-gjsxz',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(12, 8, 45)
       }
     ]
@@ -263,16 +264,72 @@ const mockWorkloads = {
     name: 'zot-registry',
     namespace: 'registry',
     status: 'Current',
-    statusMessage: 'Partition rollout complete. updated: 1',
+    statusMessage: 'Replicas: 1',
     containerImages: [
       'ghcr.io/project-zot/zot:v2.1.11'
     ],
     pods: [
       {
         name: 'zot-registry-0',
-        status: 'Current',
-        statusMessage: 'Pod is Ready',
+        status: 'Running',
+        statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
         timestamp: getTimestamp(15, 10, 0)
+      }
+    ]
+  },
+
+  // CronJob examples
+  'CronJob/flux-system/garbage-collection': {
+    kind: 'CronJob',
+    name: 'garbage-collection',
+    namespace: 'flux-system',
+    status: 'Idle',
+    statusMessage: '0 */6 * * *',
+    containerImages: [
+      'ghcr.io/fluxcd/flux-cli:v2.6.1'
+    ],
+    pods: [
+      {
+        name: 'garbage-collection-28945678-xk9j2',
+        status: 'Succeeded',
+        statusMessage: 'Completed at 2026-02-02 10:30:00 UTC',
+        timestamp: getTimestamp(0, 1, 30) // 1 hour 30 minutes ago
+      }
+    ]
+  },
+  'CronJob/monitoring/prometheus-backup': {
+    kind: 'CronJob',
+    name: 'prometheus-backup',
+    namespace: 'monitoring',
+    status: 'Idle',
+    statusMessage: '0 0 * * *',
+    containerImages: [
+      'prom/prometheus:v3.3.0'
+    ],
+    pods: [
+      {
+        name: 'prometheus-backup-28945600-abc12',
+        status: 'Succeeded',
+        statusMessage: 'Completed at 2026-02-02 06:00:00 UTC',
+        timestamp: getTimestamp(0, 6, 0) // 6 hours ago
+      }
+    ]
+  },
+  'CronJob/cert-manager/cert-renewal-check': {
+    kind: 'CronJob',
+    name: 'cert-renewal-check',
+    namespace: 'cert-manager',
+    status: 'Failed',
+    statusMessage: 'Job failed: BackoffLimitExceeded',
+    containerImages: [
+      'quay.io/jetstack/cert-manager-ctl:v1.19.1'
+    ],
+    pods: [
+      {
+        name: 'cert-renewal-check-28945500-def34',
+        status: 'Failed',
+        statusMessage: 'Reason: Error',
+        timestamp: getTimestamp(0, 12, 0) // 12 hours ago
       }
     ]
   }

--- a/web/src/utils/constants.js
+++ b/web/src/utils/constants.js
@@ -155,6 +155,7 @@ export const resourceStatuses = ['Ready', 'Failed', 'Progressing', 'Suspended', 
 
 // Kubernetes workload kinds
 export const workloadKinds = [
+  'CronJob',
   'DaemonSet',
   'Deployment',
   'StatefulSet'

--- a/web/src/utils/cron.js
+++ b/web/src/utils/cron.js
@@ -1,0 +1,102 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+/**
+ * Convert a cron expression to human-readable format.
+ * Handles common cron patterns; falls back to raw expression for complex ones.
+ * @param {string} cron - Cron expression (5 fields: minute hour day month weekday)
+ * @returns {string} Human-readable description
+ */
+export function formatCronExpression(cron) {
+  if (!cron || typeof cron !== 'string') return cron
+
+  const parts = cron.trim().split(/\s+/)
+  if (parts.length !== 5) return cron
+
+  const [minute, hour, day, month, weekday] = parts
+
+  // Every minute
+  if (minute === '*' && hour === '*' && day === '*' && month === '*' && weekday === '*') {
+    return 'Every minute'
+  }
+
+  // Every N minutes
+  if (minute.startsWith('*/') && hour === '*' && day === '*' && month === '*' && weekday === '*') {
+    const interval = parseInt(minute.slice(2), 10)
+    if (interval === 1) return 'Every minute'
+    return `Every ${interval} minutes`
+  }
+
+  // Every hour at specific minute
+  if (!minute.includes('*') && !minute.includes('/') && hour === '*' && day === '*' && month === '*' && weekday === '*') {
+    const min = parseInt(minute, 10)
+    if (min === 0) return 'Every hour'
+    return `Every hour at minute ${min}`
+  }
+
+  // Every N hours
+  if (minute === '0' && hour.startsWith('*/') && day === '*' && month === '*' && weekday === '*') {
+    const interval = parseInt(hour.slice(2), 10)
+    if (interval === 1) return 'Every hour'
+    return `Every ${interval} hours`
+  }
+
+  // Daily at specific time
+  if (!minute.includes('*') && !hour.includes('*') && day === '*' && month === '*' && weekday === '*') {
+    const h = parseInt(hour, 10)
+    const m = parseInt(minute, 10)
+    const time = `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`
+    return `Daily at ${time}`
+  }
+
+  // Weekly on specific day
+  if (!minute.includes('*') && !hour.includes('*') && day === '*' && month === '*' && !weekday.includes('*')) {
+    const h = parseInt(hour, 10)
+    const m = parseInt(minute, 10)
+    const time = `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`
+    const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    const dayNum = parseInt(weekday, 10)
+    const dayName = dayNames[dayNum] || weekday
+    return `Weekly on ${dayName} at ${time}`
+  }
+
+  // Monthly on specific day
+  if (!minute.includes('*') && !hour.includes('*') && !day.includes('*') && month === '*' && weekday === '*') {
+    const h = parseInt(hour, 10)
+    const m = parseInt(minute, 10)
+    const d = parseInt(day, 10)
+    const time = `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`
+    const suffix = d === 1 ? 'st' : d === 2 ? 'nd' : d === 3 ? 'rd' : 'th'
+    return `Monthly on the ${d}${suffix} at ${time}`
+  }
+
+  // Fall back to raw expression for complex patterns
+  return cron
+}
+
+// Regex to validate cron field: digits, *, /, -, or comma
+const cronFieldPattern = /^[\d*/,-]+$/
+
+/**
+ * Check if a string looks like a cron expression.
+ * @param {string} str - String to check
+ * @returns {boolean} True if it looks like a cron expression
+ */
+function isCronExpression(str) {
+  const parts = str.trim().split(/\s+/)
+  if (parts.length !== 5) return false
+  return parts.every(part => cronFieldPattern.test(part))
+}
+
+/**
+ * Format a cron schedule message for display.
+ * Converts cron expression to human-readable format with "Schedule: " prefix.
+ * @param {string} message - Cron expression or status message
+ * @returns {string} Human-readable schedule or original message
+ */
+export function formatScheduleMessage(message) {
+  if (!message || typeof message !== 'string') return message
+  if (!isCronExpression(message)) return message
+
+  return `Schedule: ${formatCronExpression(message)}`
+}

--- a/web/src/utils/cron.test.js
+++ b/web/src/utils/cron.test.js
@@ -1,0 +1,178 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect } from 'vitest'
+import { formatCronExpression, formatScheduleMessage } from './cron'
+
+describe('formatCronExpression', () => {
+  describe('invalid inputs', () => {
+    it('should return null for null input', () => {
+      expect(formatCronExpression(null)).toBeNull()
+    })
+
+    it('should return undefined for undefined input', () => {
+      expect(formatCronExpression(undefined)).toBeUndefined()
+    })
+
+    it('should return non-string inputs as-is', () => {
+      expect(formatCronExpression(123)).toBe(123)
+    })
+
+    it('should return invalid cron expressions as-is', () => {
+      expect(formatCronExpression('invalid')).toBe('invalid')
+      expect(formatCronExpression('* * *')).toBe('* * *')
+      expect(formatCronExpression('* * * * * *')).toBe('* * * * * *')
+    })
+  })
+
+  describe('every minute patterns', () => {
+    it('should format "* * * * *" as "Every minute"', () => {
+      expect(formatCronExpression('* * * * *')).toBe('Every minute')
+    })
+
+    it('should format "*/1 * * * *" as "Every minute"', () => {
+      expect(formatCronExpression('*/1 * * * *')).toBe('Every minute')
+    })
+  })
+
+  describe('every N minutes patterns', () => {
+    it('should format "*/5 * * * *" as "Every 5 minutes"', () => {
+      expect(formatCronExpression('*/5 * * * *')).toBe('Every 5 minutes')
+    })
+
+    it('should format "*/15 * * * *" as "Every 15 minutes"', () => {
+      expect(formatCronExpression('*/15 * * * *')).toBe('Every 15 minutes')
+    })
+
+    it('should format "*/30 * * * *" as "Every 30 minutes"', () => {
+      expect(formatCronExpression('*/30 * * * *')).toBe('Every 30 minutes')
+    })
+  })
+
+  describe('hourly patterns', () => {
+    it('should format "0 * * * *" as "Every hour"', () => {
+      expect(formatCronExpression('0 * * * *')).toBe('Every hour')
+    })
+
+    it('should format "30 * * * *" as "Every hour at minute 30"', () => {
+      expect(formatCronExpression('30 * * * *')).toBe('Every hour at minute 30')
+    })
+
+    it('should format "0 */1 * * *" as "Every hour"', () => {
+      expect(formatCronExpression('0 */1 * * *')).toBe('Every hour')
+    })
+
+    it('should format "0 */2 * * *" as "Every 2 hours"', () => {
+      expect(formatCronExpression('0 */2 * * *')).toBe('Every 2 hours')
+    })
+
+    it('should format "0 */6 * * *" as "Every 6 hours"', () => {
+      expect(formatCronExpression('0 */6 * * *')).toBe('Every 6 hours')
+    })
+  })
+
+  describe('daily patterns', () => {
+    it('should format "0 0 * * *" as "Daily at 00:00"', () => {
+      expect(formatCronExpression('0 0 * * *')).toBe('Daily at 00:00')
+    })
+
+    it('should format "30 9 * * *" as "Daily at 09:30"', () => {
+      expect(formatCronExpression('30 9 * * *')).toBe('Daily at 09:30')
+    })
+
+    it('should format "0 14 * * *" as "Daily at 14:00"', () => {
+      expect(formatCronExpression('0 14 * * *')).toBe('Daily at 14:00')
+    })
+  })
+
+  describe('weekly patterns', () => {
+    it('should format "0 0 * * 0" as "Weekly on Sunday at 00:00"', () => {
+      expect(formatCronExpression('0 0 * * 0')).toBe('Weekly on Sunday at 00:00')
+    })
+
+    it('should format "0 9 * * 1" as "Weekly on Monday at 09:00"', () => {
+      expect(formatCronExpression('0 9 * * 1')).toBe('Weekly on Monday at 09:00')
+    })
+
+    it('should format "30 17 * * 5" as "Weekly on Friday at 17:30"', () => {
+      expect(formatCronExpression('30 17 * * 5')).toBe('Weekly on Friday at 17:30')
+    })
+  })
+
+  describe('monthly patterns', () => {
+    it('should format "0 0 1 * *" as "Monthly on the 1st at 00:00"', () => {
+      expect(formatCronExpression('0 0 1 * *')).toBe('Monthly on the 1st at 00:00')
+    })
+
+    it('should format "0 0 2 * *" as "Monthly on the 2nd at 00:00"', () => {
+      expect(formatCronExpression('0 0 2 * *')).toBe('Monthly on the 2nd at 00:00')
+    })
+
+    it('should format "0 0 3 * *" as "Monthly on the 3rd at 00:00"', () => {
+      expect(formatCronExpression('0 0 3 * *')).toBe('Monthly on the 3rd at 00:00')
+    })
+
+    it('should format "0 0 15 * *" as "Monthly on the 15th at 00:00"', () => {
+      expect(formatCronExpression('0 0 15 * *')).toBe('Monthly on the 15th at 00:00')
+    })
+  })
+
+  describe('complex patterns (fallback)', () => {
+    it('should return complex expressions as-is', () => {
+      // Patterns with specific month (not *) fall through all checks
+      expect(formatCronExpression('0 0 1 1 *')).toBe('0 0 1 1 *')
+      expect(formatCronExpression('0 0 * 6 *')).toBe('0 0 * 6 *')
+      // Pattern with both day-of-month and weekday
+      expect(formatCronExpression('0 0 15 * 1')).toBe('0 0 15 * 1')
+    })
+  })
+
+  describe('weekday ranges', () => {
+    it('should format weekday ranges as weekly (using first day)', () => {
+      // Note: ranges like 1-5 are parsed as the first number
+      expect(formatCronExpression('0 0 * * 1-5')).toBe('Weekly on Monday at 00:00')
+    })
+  })
+
+  describe('whitespace handling', () => {
+    it('should handle extra whitespace', () => {
+      expect(formatCronExpression('  */5  *  *  *  *  ')).toBe('Every 5 minutes')
+    })
+  })
+})
+
+describe('formatScheduleMessage', () => {
+  describe('invalid inputs', () => {
+    it('should return null for null input', () => {
+      expect(formatScheduleMessage(null)).toBeNull()
+    })
+
+    it('should return undefined for undefined input', () => {
+      expect(formatScheduleMessage(undefined)).toBeUndefined()
+    })
+
+    it('should return non-schedule messages as-is', () => {
+      expect(formatScheduleMessage('Some other message')).toBe('Some other message')
+      expect(formatScheduleMessage('Ready')).toBe('Ready')
+    })
+  })
+
+  describe('cron expression formatting', () => {
+    it('should format "*/5 * * * *" with Schedule prefix', () => {
+      expect(formatScheduleMessage('*/5 * * * *')).toBe('Schedule: Every 5 minutes')
+    })
+
+    it('should format "0 * * * *" with Schedule prefix', () => {
+      expect(formatScheduleMessage('0 * * * *')).toBe('Schedule: Every hour')
+    })
+
+    it('should format "0 0 * * *" with Schedule prefix', () => {
+      expect(formatScheduleMessage('0 0 * * *')).toBe('Schedule: Daily at 00:00')
+    })
+
+    it('should keep complex schedules with Schedule prefix', () => {
+      // Specific month patterns keep the raw cron
+      expect(formatScheduleMessage('0 0 1 1 *')).toBe('Schedule: 0 0 1 1 *')
+    })
+  })
+})

--- a/web/src/utils/status.js
+++ b/web/src/utils/status.js
@@ -33,22 +33,33 @@ export function getStatusBadgeClass(status) {
 
 /**
  * Get badge class for Kubernetes workload statuses.
- * Accepts both backend values (Current, InProgress) and display values (Ready, Progressing).
- * @param {string} status - Status value (Current/Ready, Failed, InProgress/Progressing, Terminating)
+ * Accepts workload-level statuses (Current, InProgress, Ready, Progressing) and
+ * Kubernetes pod phases (Pending, Running, Succeeded, Failed).
+ * @param {string} status - Status value
  * @returns {string} Tailwind CSS classes for the badge
  */
 export function getWorkloadStatusBadgeClass(status) {
   switch (status) {
+  // Workload-level statuses
   case 'Current':
   case 'Ready':
+  case 'Idle':
     return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-  case 'Failed':
-    return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
   case 'InProgress':
   case 'Progressing':
     return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400'
   case 'Terminating':
+  case 'Suspended':
     return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400'
+  // Kubernetes pod phases
+  case 'Pending':
+    return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400'
+  case 'Running':
+    return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400'
+  case 'Succeeded':
+    return 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400'
+  case 'Failed':
+    return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
   default:
     return 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400'
   }


### PR DESCRIPTION
Changes:
- Add CronJob support to the Workload API, Graph view and Workloads list view
- Display CronJob-specific statuses: `Idle`, `Suspended`, `Progressing`
- Refactor the pod status reporting to use the pod phase which is more accurate than kstatus
- List pods from CronJob's owned Jobs using field indexer for efficient lookups

---

<img width="664" height="546" alt="Screenshot 2026-02-02 at 18 12 56" src="https://github.com/user-attachments/assets/a6e52b58-a87d-4792-b1d2-d4d4fcbdae0b" />
