### PR TITLE
web: enable audit for download actions

### DIFF
--- a/internal/web/artifact_download.go
+++ b/internal/web/artifact_download.go
@@ -177,6 +177,9 @@ func (h *Handler) DownloadHandler(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", artifactResp.ContentLength))
 	}
 
+	// Send audit event for the download action.
+	h.sendAuditEvent(ctx, fluxcdv1.UserActionDownload, resource, nil)
+
 	w.WriteHeader(http.StatusOK)
 
 	// Use chunked writing with flush to keep connection alive through proxies.

--- a/internal/web/audit.go
+++ b/internal/web/audit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -34,14 +35,18 @@ func (h *Handler) isAuditEnabled(action string) bool {
 }
 
 // sendAuditEvent sends an audit event for a user action if auditing is enabled.
-// If reconcilerRef is non-empty (format: "Kind/namespace/name"), the audit event
-// is associated with the managing Flux resource instead of obj.
-func (h *Handler) sendAuditEvent(ctx context.Context, action string, obj client.Object, reconcilerRef string) {
+// If workload is non-nil, the audit event is associated with the managing Flux
+// resource (extracted from the workload's labels) instead of obj.
+func (h *Handler) sendAuditEvent(ctx context.Context, action string, obj client.Object, workload *unstructured.Unstructured) {
 	if !h.isAuditEnabled(action) {
 		return
 	}
 
-	// Build the subject string before potentially fetching the reconciler ref.
+	// Use the privileged kube client to ensure we can fetch the workload reconciler
+	// and the Flux instance to discover the notification-controller endpoint.
+	kubeClient := h.kubeClient.GetClient(ctx, kubeclient.WithPrivileges())
+
+	// Build the subject string before potentially fetching the workload reconciler.
 	subject := fmt.Sprintf("%s/%s/%s",
 		obj.GetObjectKind().GroupVersionKind().Kind,
 		obj.GetNamespace(),
@@ -51,23 +56,25 @@ func (h *Handler) sendAuditEvent(ctx context.Context, action string, obj client.
 	// This should always succeed since the audit event is only sent for authenticated users.
 	perms := user.Permissions(ctx)
 
-	// If reconcilerRef is provided, fetch the Flux resource and use it instead.
+	// If workload is provided, extract the reconciler ref and fetch the Flux resource.
 	// If the fetch fails, skip the audit event entirely and log the error.
-	if reconcilerRef != "" {
-		fluxObj, err := h.fetchReconcilerRef(ctx, reconcilerRef)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "skipping audit event, failed to fetch reconciler ref",
-				"reconcilerRef", reconcilerRef,
-				"subject", subject,
-				"action", action,
-				"user", perms.Username,
-			)
-			return
-		}
+	if workload != nil {
+		if reconcilerRef := getReconcilerRef(workload); reconcilerRef != "" {
+			fluxObj, err := h.fetchReconcilerRef(ctx, kubeClient, reconcilerRef)
+			if err != nil {
+				log.FromContext(ctx).Error(err, "skipping audit event, failed to fetch reconciler ref",
+					"reconcilerRef", reconcilerRef,
+					"subject", subject,
+					"action", action,
+					"user", perms.Username,
+				)
+				return
+			}
 
-		// Swap the object with the Flux resource managing it,
-		// so the event is associated with the Flux resource instead of the workload.
-		obj = fluxObj
+			// Swap the object with the Flux resource managing it,
+			// so the event is associated with the Flux resource instead of the workload.
+			obj = fluxObj
+		}
 	}
 
 	token := fmt.Sprintf("%s/%s", obj.GetObjectKind().GroupVersionKind().Group, eventv1.MetaTokenKey)
@@ -78,12 +85,11 @@ func (h *Handler) sendAuditEvent(ctx context.Context, action string, obj client.
 		token:                       uuid.NewString(), // Forces unique events (this is an audit feature).
 	}
 
-	// Send the event using the privileged kube client for the notifier so it can
-	// fetch the FluxInstance and discover the notification-controller address.
-	kubeClient := h.kubeClient.GetClient(ctx, kubeclient.WithPrivileges())
-	notifier.
-		New(ctx, h.eventRecorder,
-			h.kubeClient.GetScheme(), notifier.WithClient(kubeClient)).
+	if workload != nil {
+		annotations[eventv1.Group+"/subject"] = subject
+	}
+
+	notifier.New(ctx, h.eventRecorder, h.kubeClient.GetScheme(), notifier.WithClient(kubeClient)).
 		AnnotatedEventf(obj, annotations, corev1.EventTypeNormal, auditEventReason,
 			"User '%s' performed action '%s' for '%s' on the web UI",
 			perms.Username,
@@ -93,8 +99,8 @@ func (h *Handler) sendAuditEvent(ctx context.Context, action string, obj client.
 }
 
 // fetchReconcilerRef parses a reconciler ref string (Kind/namespace/name)
-// and fetches the corresponding Flux resource.
-func (h *Handler) fetchReconcilerRef(ctx context.Context, ref string) (client.Object, error) {
+// and fetches the corresponding Flux resource using the provided client.
+func (h *Handler) fetchReconcilerRef(ctx context.Context, kubeClient client.Client, ref string) (client.Object, error) {
 	parts := strings.Split(ref, "/")
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("invalid reconciler ref: %s", ref)
@@ -108,7 +114,7 @@ func (h *Handler) fetchReconcilerRef(ctx context.Context, ref string) (client.Ob
 
 	obj := &metav1.PartialObjectMetadata{}
 	obj.SetGroupVersionKind(*gvk)
-	if err := h.kubeClient.GetClient(ctx).Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
+	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
 		return nil, fmt.Errorf("unable to fetch reconciler %s/%s/%s: %w", kind, namespace, name, err)
 	}
 

--- a/internal/web/resource_action.go
+++ b/internal/web/resource_action.go
@@ -156,7 +156,7 @@ func (h *Handler) ActionHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Send audit event.
-	h.sendAuditEvent(req.Context(), actionReq.Action, obj, "")
+	h.sendAuditEvent(req.Context(), actionReq.Action, obj, nil)
 
 	// Return success response
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Move all the audit related code to `audit.go` and enable auditing for the artifact download action. Now all actions are properly audited, for actions like "Rollout Restart" the audit contains in metadata the subject e.g. `Deployment/apps/podinfo`.