### PR TITLE
web: implement `Run Job` action for CronJobs

### DIFF
--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -35,6 +35,7 @@ var (
 	CopyFromAnnotation               = fmt.Sprintf("%s/copyFrom", GroupVersion.Group)
 	ConvertKubeConfigFromAnnotation  = fmt.Sprintf("%s/convertKubeConfigFrom", GroupVersion.Group)
 	SuspendedByAnnotation            = fmt.Sprintf("%s/suspendedBy", GroupVersion.Group)
+	CreatedByAnnotation              = fmt.Sprintf("%s/createdBy", GroupVersion.Group)
 )
 
 // FluxObject is the interface that all Flux objects must implement.

--- a/docs/web/web-user-management.md
+++ b/docs/web/web-user-management.md
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
       - restart
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - create
+      - restart
 ```
 
 Note that the `patch` verb is not enough to allow a user to perform actions in the Web UI.
@@ -250,4 +258,4 @@ The `download` verb allows users to download artifacts from Flux source resource
 (Bucket, GitRepository, OCIRepository, HelmChart, and ExternalArtifact).
 
 The `restart` verb allows users to trigger a rollout restart on workloads
-(Deployment, StatefulSet, and DaemonSet).
+(Deployment, StatefulSet, and DaemonSet) and to create Jobs from CronJobs.

--- a/internal/web/suite_test.go
+++ b/internal/web/suite_test.go
@@ -64,6 +64,11 @@ func setupActionRBAC(ctx context.Context, c client.Client) error {
 				Resources: []string{"*"},
 				Verbs:     []string{"reconcile", "suspend", "resume", "download"},
 			},
+			{
+				APIGroups: []string{"batch"},
+				Resources: []string{"cronjobs", "jobs"},
+				Verbs:     []string{"get", "list", "create", "restart"},
+			},
 		},
 	}
 	if err := c.Create(ctx, clusterRole); err != nil {

--- a/internal/web/workload_action.go
+++ b/internal/web/workload_action.go
@@ -11,12 +11,14 @@ import (
 	"slices"
 	"time"
 
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
@@ -47,9 +49,10 @@ type workloadKindInfo struct {
 
 // supportedWorkloadKinds maps workload kinds to their API group and supported actions.
 var supportedWorkloadKinds = map[string]workloadKindInfo{
-	"Deployment":  {group: "apps", plural: "deployments", actions: []string{fluxcdv1.UserActionRestart}},
-	"StatefulSet": {group: "apps", plural: "statefulsets", actions: []string{fluxcdv1.UserActionRestart}},
-	"DaemonSet":   {group: "apps", plural: "daemonsets", actions: []string{fluxcdv1.UserActionRestart}},
+	workloadKindDeployment:  {group: "apps", plural: "deployments", actions: []string{fluxcdv1.UserActionRestart}},
+	workloadKindStatefulSet: {group: "apps", plural: "statefulsets", actions: []string{fluxcdv1.UserActionRestart}},
+	workloadKindDaemonSet:   {group: "apps", plural: "daemonsets", actions: []string{fluxcdv1.UserActionRestart}},
+	workloadKindCronJob:     {group: "batch", plural: "cronjobs", actions: []string{fluxcdv1.UserActionRestart}},
 }
 
 // WorkloadActionHandler handles POST /api/v1/workload/action requests to perform actions on workloads.
@@ -81,7 +84,7 @@ func (h *Handler) WorkloadActionHandler(w http.ResponseWriter, req *http.Request
 	// Validate workload kind.
 	kindInfo, ok := supportedWorkloadKinds[actionReq.Kind]
 	if !ok {
-		http.Error(w, fmt.Sprintf("Unsupported workload kind: %s. Supported kinds: Deployment, StatefulSet, DaemonSet", actionReq.Kind), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("Unsupported workload kind: %s", actionReq.Kind), http.StatusBadRequest)
 		return
 	}
 
@@ -111,7 +114,7 @@ func (h *Handler) WorkloadActionHandler(w http.ResponseWriter, req *http.Request
 	var workload *unstructured.Unstructured
 	if h.isAuditEnabled(actionReq.Action) {
 		workload = &unstructured.Unstructured{}
-		workload.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: actionReq.Kind})
+		workload.SetGroupVersionKind(schema.GroupVersionKind{Group: kindInfo.group, Version: "v1", Kind: actionReq.Kind})
 		if err := h.kubeClient.GetClient(ctx).Get(ctx, client.ObjectKey{
 			Namespace: actionReq.Namespace, Name: actionReq.Name,
 		}, workload); err != nil {
@@ -126,8 +129,13 @@ func (h *Handler) WorkloadActionHandler(w http.ResponseWriter, req *http.Request
 
 	switch actionReq.Action {
 	case fluxcdv1.UserActionRestart:
-		actionErr = h.restartWorkload(ctx, actionReq.Kind, actionReq.Namespace, actionReq.Name)
-		message = fmt.Sprintf("Rollout restart triggered for %s/%s", actionReq.Namespace, actionReq.Name)
+		if actionReq.Kind == workloadKindCronJob {
+			actionErr = h.runJob(ctx, actionReq.Namespace, actionReq.Name)
+			message = fmt.Sprintf("Job created from CronJob %s/%s", actionReq.Namespace, actionReq.Name)
+		} else {
+			actionErr = h.restartWorkload(ctx, actionReq.Kind, actionReq.Namespace, actionReq.Name)
+			message = fmt.Sprintf("Rollout restart triggered for %s/%s", actionReq.Namespace, actionReq.Name)
+		}
 	default:
 		http.Error(w, fmt.Sprintf("Unknown action: %s", actionReq.Action), http.StatusBadRequest)
 		return
@@ -223,6 +231,63 @@ func (h *Handler) restartWorkload(ctx context.Context, kind, namespace, name str
 		client.ForceOwnership, client.FieldOwner(kubeclient.FieldOwner))
 	if err != nil {
 		return fmt.Errorf("failed to patch workload: %w", err)
+	}
+
+	return nil
+}
+
+// runJob creates a new Job from a CronJob's jobTemplate spec.
+// The Job is created with an owner reference to the CronJob so that
+// its pods show up under the CronJob in the UI. The CreatedBy annotation
+// is set on both the Job and its pods to differentiate manually
+// triggered jobs from those created by the CronJob schedule.
+func (h *Handler) runJob(ctx context.Context, namespace, name string) error {
+	kubeClient := h.kubeClient.GetClient(ctx)
+
+	// Fetch the CronJob to get its jobTemplate spec.
+	var cronJob batchv1.CronJob
+	if err := kubeClient.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, &cronJob); err != nil {
+		return err
+	}
+
+	// Get the username for the CreatedBy annotation.
+	username := user.Username(ctx)
+
+	// Build the Job from the CronJob's jobTemplate.
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: name + "-",
+			Namespace:    namespace,
+			Annotations: map[string]string{
+				fluxcdv1.CreatedByAnnotation: username,
+			},
+		},
+		Spec: *cronJob.Spec.JobTemplate.Spec.DeepCopy(),
+	}
+
+	// Set the CronJob as the controller owner of the Job so that
+	// its pods show up under the CronJob in the UI.
+	if err := controllerutil.SetControllerReference(&cronJob, job, h.kubeClient.GetScheme()); err != nil {
+		return fmt.Errorf("failed to set controller reference to job from cronjob %s/%s: %w", namespace, name, err)
+	}
+
+	// Copy labels from the CronJob's jobTemplate.
+	job.Labels = make(map[string]string)
+	for k, v := range cronJob.Spec.JobTemplate.Labels {
+		job.Labels[k] = v
+	}
+
+	// Set the CreatedBy annotation on the pod template.
+	if job.Spec.Template.Annotations == nil {
+		job.Spec.Template.Annotations = make(map[string]string)
+	}
+	job.Spec.Template.Annotations[fluxcdv1.CreatedByAnnotation] = username
+
+	if err := kubeClient.Create(ctx, job); err != nil {
+		return fmt.Errorf("failed to create job from cronjob %s/%s: %w", namespace, name, err)
 	}
 
 	return nil

--- a/web/src/components/dashboards/resource/GraphTabContent.jsx
+++ b/web/src/components/dashboards/resource/GraphTabContent.jsx
@@ -519,6 +519,8 @@ export function GraphTabContent({ resourceData, namespace, onNavigate, setActive
       return
     }
 
+    let cancelled = false
+
     const fetchWorkloadStatuses = async () => {
       try {
         // Build workloads array with resolved namespaces
@@ -547,13 +549,14 @@ export function GraphTabContent({ resourceData, namespace, onNavigate, setActive
             statusMessage: workload.statusMessage
           }
         })
-        setWorkloadStatuses(newStatuses)
+        if (!cancelled) setWorkloadStatuses(newStatuses)
       } catch (err) {
         console.error('Failed to fetch workload statuses:', err)
       }
     }
 
     fetchWorkloadStatuses()
+    return () => { cancelled = true }
   }, [isActive, resourceData, namespace, graphData.inventory.workloads])
 
   const { upstream, sources, helmChart, reconciler, inventory } = graphData

--- a/web/src/mock/action.js
+++ b/web/src/mock/action.js
@@ -12,7 +12,7 @@ export const mockAction = (body) => {
 // Mock workload action response for POST /api/v1/workload/action
 export const mockWorkloadAction = (body) => {
   const actionMessages = {
-    restart: 'Rollout restart triggered'
+    restart: body.kind === 'CronJob' ? 'Job created' : 'Rollout restart triggered'
   }
   const message = actionMessages[body.action] || `${body.action} triggered`
   return {

--- a/web/src/mock/workload.js
+++ b/web/src/mock/workload.js
@@ -299,9 +299,10 @@ const mockWorkloads = {
     pods: [
       {
         name: 'garbage-collection-28945678-xk9j2',
-        status: 'Succeeded',
-        statusMessage: 'Completed at 2026-02-02 10:30:00 UTC',
-        createdAt: getTimestamp(0, 1, 30) // 1 hour 30 minutes ago
+        status: 'Running',
+        statusMessage: 'Started at 2026-02-06 10:30:00 UTC',
+        createdAt: getTimestamp(0, 0, 0, 10), // 10 seconds ago (recent, in progress)
+        createdBy: 'admin@example.com'
       }
     ]
   },


### PR DESCRIPTION
This PR adds the "Run Job" to the workloads action bar. This action is guarded by the `restart` RBAC verb on CronJobs and requires `create` for Jobs.

The UI highlights the newly created job pods for a short period of time and disables the `Run Job` button while the rollout is initiated. The job pods created via the UI display the user that triggered them. The jobs created in the UI have their owner set to the CronJob, so they are subject to garbage collection in the same way as the jobs atomically created by the CronJob controller.

Closes: #658

https://github.com/user-attachments/assets/e70de4b3-e579-4ac1-8916-6e56ec47f9d5

