### PR TITLE
web: implement `Delete` action for Pods

### DIFF
--- a/api/v1/webconfig_types.go
+++ b/api/v1/webconfig_types.go
@@ -35,6 +35,10 @@ const (
 	// UserActionRestart is the restart user action for workloads
 	// (Deployments, StatefulSets, DaemonSets).
 	UserActionRestart = "restart"
+
+	// UserActionDelete is the delete user action for Pods owned
+	// by workloads managed by Flux.
+	UserActionDelete = "delete"
 )
 
 var (
@@ -51,6 +55,7 @@ var (
 		UserActionResume,
 		UserActionDownload,
 		UserActionRestart,
+		UserActionDelete,
 	}
 )
 

--- a/config/default/rbac.yaml
+++ b/config/default/rbac.yaml
@@ -75,6 +75,7 @@ rules:
       - get
       - list
       - watch
+  # Allow actions: reconcile, suspend/resume and download for Flux resources.
   - apiGroups:
       - fluxcd.controlplane.io
       - source.toolkit.fluxcd.io
@@ -90,3 +91,29 @@ rules:
       - suspend
       - resume
       - download
+  # Allow action: rollout restart for Deployments, StatefulSets and DaemonSets managed by Flux.
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs:
+      - patch
+      - restart
+  # Allow action: create Job from CronJobs managed by Flux.
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - create
+      - restart
+  # Allow action: delete Pods owned by workloads managed by Flux.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete

--- a/docs/web/web-user-management.md
+++ b/docs/web/web-user-management.md
@@ -247,6 +247,12 @@ rules:
     verbs:
       - create
       - restart
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
 ```
 
 Note that the `patch` verb is not enough to allow a user to perform actions in the Web UI.
@@ -259,3 +265,6 @@ The `download` verb allows users to download artifacts from Flux source resource
 
 The `restart` verb allows users to trigger a rollout restart on workloads
 (Deployment, StatefulSet, and DaemonSet) and to create Jobs from CronJobs.
+
+The `delete` verb on pods allows users to delete individual pods,
+which will be recreated by their controller.

--- a/internal/web/audit.go
+++ b/internal/web/audit.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -118,5 +119,66 @@ func (h *Handler) fetchReconcilerRef(ctx context.Context, kubeClient client.Clie
 		return nil, fmt.Errorf("unable to fetch reconciler %s/%s/%s: %w", kind, namespace, name, err)
 	}
 
+	return obj, nil
+}
+
+// getPodOwnerWorkload resolves a pod's owner workload using the privileged client for audit purposes.
+// It walks the owner chain: Pod -> ReplicaSet/Job -> Deployment/StatefulSet/DaemonSet/CronJob.
+func (h *Handler) getPodOwnerWorkload(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error) {
+	kubeClient := h.kubeClient.GetClient(ctx, kubeclient.WithPrivileges())
+
+	// Fetch the pod.
+	pod := &unstructured.Unstructured{}
+	pod.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: workloadKindPod})
+	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, pod); err != nil {
+		return nil, fmt.Errorf("failed to get pod %s/%s: %w", namespace, name, err)
+	}
+
+	// Find the controller owner of the pod.
+	owner := getControllerOwner(pod)
+	if owner == nil {
+		return nil, fmt.Errorf("pod %s/%s has no controller owner", namespace, name)
+	}
+
+	// If the owner is a top-level workload, fetch and return it.
+	switch owner.Kind {
+	case workloadKindDeployment, workloadKindStatefulSet, workloadKindDaemonSet, workloadKindCronJob:
+		return fetchOwner(ctx, kubeClient, owner, namespace)
+	}
+
+	// The owner is an intermediate resource (ReplicaSet, Job); fetch it and walk up.
+	intermediate := &unstructured.Unstructured{}
+	ownerGV, _ := schema.ParseGroupVersion(owner.APIVersion)
+	intermediate.SetGroupVersionKind(ownerGV.WithKind(owner.Kind))
+	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: owner.Name}, intermediate); err != nil {
+		return nil, fmt.Errorf("failed to get %s %s/%s: %w", owner.Kind, namespace, owner.Name, err)
+	}
+
+	topOwner := getControllerOwner(intermediate)
+	if topOwner == nil {
+		return nil, fmt.Errorf("%s %s/%s has no controller owner", owner.Kind, namespace, owner.Name)
+	}
+
+	return fetchOwner(ctx, kubeClient, topOwner, namespace)
+}
+
+// getControllerOwner returns the controller ownerReference from an unstructured object, or nil.
+func getControllerOwner(obj *unstructured.Unstructured) *metav1.OwnerReference {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			return &ref
+		}
+	}
+	return nil
+}
+
+// fetchOwner fetches an unstructured object based on an ownerReference.
+func fetchOwner(ctx context.Context, kubeClient client.Client, ref *metav1.OwnerReference, namespace string) (*unstructured.Unstructured, error) {
+	obj := &unstructured.Unstructured{}
+	gv, _ := schema.ParseGroupVersion(ref.APIVersion)
+	obj.SetGroupVersionKind(gv.WithKind(ref.Kind))
+	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, obj); err != nil {
+		return nil, fmt.Errorf("failed to get %s %s/%s: %w", ref.Kind, namespace, ref.Name, err)
+	}
 	return obj, nil
 }

--- a/internal/web/config/user_actions_validation_test.go
+++ b/internal/web/config/user_actions_validation_test.go
@@ -96,6 +96,7 @@ func TestAllUserActions(t *testing.T) {
 		fluxcdv1.UserActionResume,
 		fluxcdv1.UserActionDownload,
 		fluxcdv1.UserActionRestart,
+		fluxcdv1.UserActionDelete,
 	))
-	g.Expect(fluxcdv1.AllUserActions).To(HaveLen(5))
+	g.Expect(fluxcdv1.AllUserActions).To(HaveLen(6))
 }

--- a/web/src/components/dashboards/resource/WorkloadDeleteAction.jsx
+++ b/web/src/components/dashboards/resource/WorkloadDeleteAction.jsx
@@ -1,0 +1,97 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useEffect } from 'preact/hooks'
+import { useAction } from '../../../utils/useAction'
+
+/**
+ * WorkloadDeleteAction - Delete button for individual pods
+ *
+ * @param {Object} props
+ * @param {string} props.namespace - Pod namespace
+ * @param {string} props.name - Pod name
+ * @param {boolean} props.isPendingDeletion - Whether this pod is awaiting deletion (spinner persists until pod disappears)
+ * @param {Function} props.onActionStart - Callback when action starts (for faster polling)
+ * @param {Function} props.onActionComplete - Callback to refetch workload data after action
+ * @param {Function} props.onPodDeleteStart - Callback to mark pod as pending deletion
+ * @param {Function} props.onPodDeleteFailed - Callback to unmark pod on error
+ */
+export function WorkloadDeleteAction({ namespace, name, isPendingDeletion, onActionStart, onActionComplete, onPodDeleteStart, onPodDeleteFailed }) {
+  const { error, performAction, clearError } = useAction({
+    onActionStart,
+    onActionComplete
+  })
+
+  // When an error occurs, remove the pod from pending deletions
+  // so the spinner stops and the error message is visible.
+  useEffect(() => {
+    if (error && onPodDeleteFailed) {
+      onPodDeleteFailed(name)
+    }
+  }, [error, name, onPodDeleteFailed])
+
+  const isDeleting = isPendingDeletion && !error
+
+  const handleDelete = (e) => {
+    e.stopPropagation()
+    if (!window.confirm(`Are you sure you want to delete the pod ${namespace}/${name}?`)) {
+      return
+    }
+    if (onPodDeleteStart) {
+      onPodDeleteStart(name)
+    }
+    performAction({
+      endpoint: '/api/v1/workload/action',
+      body: {
+        kind: 'Pod',
+        namespace,
+        name,
+        action: 'delete'
+      },
+      loadingId: 'delete',
+      mockPath: '../mock/action',
+      mockExport: 'mockWorkloadAction'
+    })
+  }
+
+  return (
+    <>
+      <button
+        onClick={handleDelete}
+        disabled={isDeleting}
+        class={`inline-flex items-center p-1 rounded transition-colors focus:outline-none ${
+          isDeleting
+            ? 'text-gray-300 cursor-not-allowed dark:text-gray-600'
+            : 'text-gray-400 hover:text-red-500 dark:text-gray-500 dark:hover:text-red-400'
+        }`}
+        data-testid="delete-pod-button"
+        title={`Delete pod ${name}`}
+      >
+        {isDeleting ? (
+          <svg class="animate-spin h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" data-testid="delete-pod-spinner">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+        ) : (
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+        )}
+      </button>
+      {error && (
+        <div class="w-full mt-1 p-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-xs text-red-800 dark:text-red-200 flex items-center justify-between gap-2" data-testid="delete-pod-error">
+          <span>{error}</span>
+          <button
+            onClick={(e) => { e.stopPropagation(); clearError() }}
+            class="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-200 p-0.5"
+            aria-label="Dismiss error"
+          >
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      )}
+    </>
+  )
+}

--- a/web/src/components/dashboards/resource/WorkloadDeleteAction.test.jsx
+++ b/web/src/components/dashboards/resource/WorkloadDeleteAction.test.jsx
@@ -1,0 +1,153 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/preact'
+import userEvent from '@testing-library/user-event'
+import { WorkloadDeleteAction } from './WorkloadDeleteAction'
+
+// Mock the fetchWithMock function
+vi.mock('../../../utils/fetch', () => ({
+  fetchWithMock: vi.fn()
+}))
+
+import { fetchWithMock } from '../../../utils/fetch'
+
+describe('WorkloadDeleteAction component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fetchWithMock.mockResolvedValue({ success: true, message: 'Pod deleted' })
+  })
+
+  const defaultProps = {
+    namespace: 'default',
+    name: 'my-pod-abc123',
+    isPendingDeletion: false,
+    onActionStart: vi.fn(),
+    onActionComplete: vi.fn(),
+    onPodDeleteStart: vi.fn(),
+    onPodDeleteFailed: vi.fn()
+  }
+
+  it('should render delete button with trash icon', () => {
+    render(<WorkloadDeleteAction {...defaultProps} />)
+
+    const button = screen.getByTestId('delete-pod-button')
+    expect(button).toBeInTheDocument()
+    expect(button.querySelector('svg')).toBeInTheDocument()
+    expect(button.title).toBe('Delete pod my-pod-abc123')
+  })
+
+  it('should show confirmation dialog on click', async () => {
+    const user = userEvent.setup()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<WorkloadDeleteAction {...defaultProps} />)
+
+    await user.click(screen.getByTestId('delete-pod-button'))
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Are you sure you want to delete the pod default/my-pod-abc123?'
+    )
+    confirmSpy.mockRestore()
+  })
+
+  it('should not call API if confirm is cancelled', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<WorkloadDeleteAction {...defaultProps} />)
+
+    await user.click(screen.getByTestId('delete-pod-button'))
+
+    expect(fetchWithMock).not.toHaveBeenCalled()
+    expect(defaultProps.onActionStart).not.toHaveBeenCalled()
+    expect(defaultProps.onPodDeleteStart).not.toHaveBeenCalled()
+
+    window.confirm.mockRestore()
+  })
+
+  it('should call API with correct payload and notify parent after confirm', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<WorkloadDeleteAction {...defaultProps} />)
+
+    await user.click(screen.getByTestId('delete-pod-button'))
+
+    expect(defaultProps.onPodDeleteStart).toHaveBeenCalledWith('my-pod-abc123')
+
+    await waitFor(() => {
+      expect(fetchWithMock).toHaveBeenCalledWith({
+        endpoint: '/api/v1/workload/action',
+        mockPath: '../mock/action',
+        mockExport: 'mockWorkloadAction',
+        method: 'POST',
+        body: {
+          kind: 'Pod',
+          namespace: 'default',
+          name: 'my-pod-abc123',
+          action: 'delete'
+        }
+      })
+    })
+
+    window.confirm.mockRestore()
+  })
+
+  it('should show spinner and disable button when isPendingDeletion is true', () => {
+    render(<WorkloadDeleteAction {...defaultProps} isPendingDeletion={true} />)
+
+    expect(screen.getByTestId('delete-pod-spinner')).toBeInTheDocument()
+
+    const button = screen.getByTestId('delete-pod-button')
+    expect(button.disabled).toBe(true)
+  })
+
+  it('should not show spinner when isPendingDeletion is false', () => {
+    render(<WorkloadDeleteAction {...defaultProps} isPendingDeletion={false} />)
+
+    expect(screen.queryByTestId('delete-pod-spinner')).not.toBeInTheDocument()
+
+    const button = screen.getByTestId('delete-pod-button')
+    expect(button.disabled).toBe(false)
+  })
+
+  it('should show error message on failure and notify parent', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    fetchWithMock.mockRejectedValue(new Error('Permission denied'))
+
+    render(<WorkloadDeleteAction {...defaultProps} isPendingDeletion={false} />)
+
+    await user.click(screen.getByTestId('delete-pod-button'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-pod-error')).toBeInTheDocument()
+      expect(screen.getByText('Permission denied')).toBeInTheDocument()
+    })
+
+    // Should notify parent to remove from pending deletions
+    await waitFor(() => {
+      expect(defaultProps.onPodDeleteFailed).toHaveBeenCalledWith('my-pod-abc123')
+    })
+
+    window.confirm.mockRestore()
+  })
+
+  it('should call onActionStart and onActionComplete callbacks', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<WorkloadDeleteAction {...defaultProps} />)
+
+    await user.click(screen.getByTestId('delete-pod-button'))
+
+    await waitFor(() => {
+      expect(defaultProps.onActionStart).toHaveBeenCalled()
+      expect(defaultProps.onActionComplete).toHaveBeenCalled()
+    })
+
+    window.confirm.mockRestore()
+  })
+})

--- a/web/src/mock/action.js
+++ b/web/src/mock/action.js
@@ -12,7 +12,8 @@ export const mockAction = (body) => {
 // Mock workload action response for POST /api/v1/workload/action
 export const mockWorkloadAction = (body) => {
   const actionMessages = {
-    restart: body.kind === 'CronJob' ? 'Job created' : 'Rollout restart triggered'
+    restart: body.kind === 'CronJob' ? 'Job created' : 'Rollout restart triggered',
+    delete: 'Pod deleted'
   }
   const message = actionMessages[body.action] || `${body.action} triggered`
   return {

--- a/web/src/mock/workload.js
+++ b/web/src/mock/workload.js
@@ -26,6 +26,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/source-controller:v1.7.4@sha256:16f21ac1795528df80ddef51ccbb14a57b78ea26e66dc8551636ef9a3cec71b3'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'source-controller-5f76f5c549-wz2gk',
@@ -45,6 +46,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/kustomize-controller:v1.7.3@sha256:e8ca82d66dafdd8ef77e0917f4adec53478075130ac61264dc0f91eb0f8cb6ce'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'kustomize-controller-5fc57fb9cc-bhl8q',
@@ -64,6 +66,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/helm-controller:v1.4.4@sha256:5eae73909e1471c0cd01bb23d87c9d4219a4f645134a23629c8708c72635398d'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'helm-controller-bf4685d7f-nxqsj',
@@ -82,6 +85,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/notification-controller:v1.7.5@sha256:ba723a55f7c7c7feedd50bb5db0ff2dd9a3b0ae85b50f61a0457184025b38c54'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'notification-controller-58cfb55954-fcf6l',
@@ -102,6 +106,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/image-automation-controller:v1.0.4@sha256:f9383dccb80ec65e274648941af623ce74084d25026e14389111c14b630efece'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'image-automation-controller-5c5fc5487b-w4458',
@@ -126,6 +131,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/image-reflector-controller:v1.0.4@sha256:0bdc30aea2b7cdfea02d0f6d53c06b9df0ea1c6516b85ed523792e222329c039'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'image-reflector-controller-547c8dbffc-2gjhj',
@@ -144,6 +150,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/source-watcher:v2.0.3@sha256:9cd46c3c958dcfcd8a3c857fa09989f9df5d8396eae165f219cbb472343371a9'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'source-watcher-85bcf4bd57-vfbs6',
@@ -162,6 +169,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/controlplaneio-fluxcd/flux-operator:v0.34.0'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'flux-operator-67cdfc557d-h656w',
@@ -182,6 +190,7 @@ const mockWorkloads = {
     containerImages: [
       'quay.io/jetstack/cert-manager-controller:v1.19.1'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'cert-manager-6b7bcdbb84-cclfj',
@@ -200,6 +209,7 @@ const mockWorkloads = {
     containerImages: [
       'quay.io/jetstack/cert-manager-cainjector:v1.19.1'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'cert-manager-cainjector-d74c65ddb-6v869',
@@ -218,6 +228,7 @@ const mockWorkloads = {
     containerImages: [
       'quay.io/jetstack/cert-manager-webhook:v1.19.1'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'cert-manager-webhook-6bf5dfc659-w95d9',
@@ -238,6 +249,7 @@ const mockWorkloads = {
     containerImages: [
       'registry.k8s.io/metrics-server/metrics-server:v0.8.0'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'metrics-server-57b56685f4-59gn2',
@@ -256,6 +268,7 @@ const mockWorkloads = {
     containerImages: [
       'tailscale/k8s-operator:v1.90.8'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'operator-84ddf77c66-gjsxz',
@@ -275,6 +288,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/project-zot/zot:v2.1.11'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'zot-registry-0',
@@ -296,6 +310,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/flux-cli:v2.6.1'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'garbage-collection-28945678-xk9j2',
@@ -315,6 +330,7 @@ const mockWorkloads = {
     containerImages: [
       'prom/prometheus:v3.3.0'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'prometheus-backup-28945600-abc12',
@@ -333,6 +349,7 @@ const mockWorkloads = {
     containerImages: [
       'quay.io/jetstack/cert-manager-ctl:v1.19.1'
     ],
+    canDeletePods: true,
     pods: [
       {
         name: 'cert-renewal-check-28945500-def34',


### PR DESCRIPTION
This PR adds a `delete` action for Pods owned by workloads managed by Flux. This action is guarded by RBAC and is traced by the Flux Operator audit.

Closes: #666 

---

https://github.com/user-attachments/assets/711ce4b1-da67-4074-bb5a-857a820c1efb

---

<img width="548" height="342" alt="Screenshot 2026-02-07 at 12 06 02" src="https://github.com/user-attachments/assets/bd9255ff-1c14-4de7-b963-cd9d29ad30f1" />

