### PR TITLE
operator: fix  forced CRD migration on Flux minor upgrade

### DIFF
--- a/internal/builder/semver_test.go
+++ b/internal/builder/semver_test.go
@@ -38,6 +38,80 @@ func TestMatchVersion(t *testing.T) {
 	}
 }
 
+func TestIsMinorUpgrade(t *testing.T) {
+	tests := []struct {
+		name        string
+		fromVer     string
+		toVer       string
+		expected    bool
+		expectError bool
+	}{
+		{
+			name:     "minor upgrade",
+			fromVer:  "v2.3.0",
+			toVer:    "v2.4.0",
+			expected: true,
+		},
+		{
+			name:     "minor upgrade with digest",
+			fromVer:  "v2.3.0@sha256:abc123",
+			toVer:    "v2.4.0@sha256:def456",
+			expected: true,
+		},
+		{
+			name:     "patch upgrade",
+			fromVer:  "v2.3.0",
+			toVer:    "v2.3.1",
+			expected: false,
+		},
+		{
+			name:     "same version",
+			fromVer:  "v2.3.0",
+			toVer:    "v2.3.0",
+			expected: false,
+		},
+		{
+			name:     "major upgrade",
+			fromVer:  "v2.3.0",
+			toVer:    "v3.0.0",
+			expected: false,
+		},
+		{
+			name:     "empty from version",
+			fromVer:  "",
+			toVer:    "v2.4.0",
+			expected: false,
+		},
+		{
+			name:        "invalid from version",
+			fromVer:     "invalid",
+			toVer:       "v2.4.0",
+			expectError: true,
+		},
+		{
+			name:        "invalid to version",
+			fromVer:     "v2.3.0",
+			toVer:       "invalid",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			minor, err := IsMinorUpgrade(tt.fromVer, tt.toVer)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(minor).To(BeFalse())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(minor).To(Equal(tt.expected))
+			}
+		})
+	}
+}
+
 func TestExtractVersionDigest(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -582,7 +582,7 @@ func (r *FluxInstanceReconciler) apply(ctx context.Context,
 	// Migrate all custom resources if the Flux CRDs storage version has changed.
 	if obj.GetMigrateResources() {
 		// Force migration if this is a minor upgrade.
-		if minor, err := builder.IsMinorUpgrade(obj.Status.LastAppliedRevision, buildResult.Revision); err != nil && minor {
+		if minor, err := builder.IsMinorUpgrade(obj.Status.LastAppliedRevision, buildResult.Revision); err == nil && minor {
 			force = true
 		}
 		if err := r.migrateResources(ctx, client.MatchingLabels{"app.kubernetes.io/part-of": obj.Name}, force); err != nil {


### PR DESCRIPTION
This PR fixes an inverted condition in FluxInstance reconciliation that
prevented forced CRD migration during Flux minor version upgrades.

In `FluxInstanceReconciler.reconcile()` (internal/controller/fluxinstance_controller.go:585),
the code intended to force migration on minor upgrades checked
`err != nil && minor`. However, `builder.IsMinorUpgrade()` never returns
`(true, error)`, making this branch unreachable dead code.

As a result, forced migration was silently skipped on every Flux minor
upgrade, contradicting the comment and expected upgrade semantics.

The condition is corrected to `err == nil && minor`, restoring the
intended behavior: if a minor upgrade is successfully detected, CRD
migration is forced.

This is a minimal, one-character fix (`!=` → `==`) that restores
correctness without changing behavior in error cases.