### PR TITLE
docs: add `flux-operator` CLI to install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 The Flux Operator is a Kubernetes CRD controller that manages
 the lifecycle of CNCF [Flux CD](https://fluxcd.io) and the [ControlPlane enterprise distribution](https://github.com/controlplaneio-fluxcd/distribution).
 The operator extends Flux with self-service capabilities, deployment windows,
-and preview environments for GitHub, GitLab and Azure DevOps pull requests testing.
+and preview environments for GitHub, GitLab, Gitea and Azure DevOps pull requests testing.
 
 ---
 

--- a/docs/guides/operator/operator-install.md
+++ b/docs/guides/operator/operator-install.md
@@ -11,7 +11,8 @@ statically compiled as a single binary with no external dependencies.
 
 ## Install methods
 
-The Flux Operator can be installed with Helm, Terraform, Operator Lifecycle Manager (OLM), or kubectl.
+The Flux Operator can be installed with Helm, Terraform, Operator Lifecycle Manager (OLM),
+the `flux-operator` CLI, or `kubectl`.
 It is recommended to install the operator in a dedicated namespace, such as `flux-system`.
 
 ### Helm
@@ -92,6 +93,24 @@ The Flux Operator is also available in the OpenShift and OKD
     Flux Operator supports various environment variables to customize its behavior on OpenShift.
     Please see the operator [configuration guide](operator-config.md#environment-variables) for more details.
 
+### Flux Operator CLI
+
+The Flux Operator can be installed using the
+[flux-operator CLI](https://fluxoperator.dev/docs/guides/cli/),
+which bootstraps a Kubernetes cluster with the Flux Operator and a Flux instance.
+
+Install the CLI with Homebrew:
+
+```shell
+brew install controlplaneio-fluxcd/tap/flux-operator
+```
+
+Install the Flux Operator and a Flux instance from a configuration file:
+
+```shell
+flux-operator install -f flux-instance.yaml
+```
+
 ### Kubectl
 
 The Flux Operator can be installed with `kubectl` by
@@ -101,9 +120,25 @@ applying the Kubernetes manifests published on the releases page:
 kubectl apply -f https://github.com/controlplaneio-fluxcd/flux-operator/releases/latest/download/install.yaml
 ```
 
+!!! warning "Development and testing"
+
+    This method is intended for development and testing purposes. On production environments,
+    it is recommended to use [Helm](#helm) or [Terraform](#terraform).
+
 ## Uninstall
 
-Before uninstalling the Flux Operator, make sure to delete the `FluxInstance` resources with:
+The recommended way to uninstall the Flux Operator and Flux instance is using the
+[flux-operator CLI](https://fluxoperator.dev/docs/guides/cli/):
+
+```shell
+flux-operator -n flux-system uninstall --keep-namespace
+```
+
+The `uninstall` command safely removes the Flux Operator and Flux controllers
+without affecting the Kubernetes objects or Helm releases reconciled by Flux.
+It is safe to re-install the Flux Operator later to resume managing the existing resources.
+
+Alternatively, you can uninstall manually by first deleting the `FluxInstance` resources:
 
 ```shell
 kubectl -n flux-system delete fluxinstances --all
@@ -111,13 +146,7 @@ kubectl -n flux-system delete fluxinstances --all
 
 The operator will uninstall Flux from the cluster without affecting the Flux-managed workloads.
 
-Verify that the Flux controllers have been removed:
-
-```shell
-kubectl -n flux-system get deployments
-```
-
-Uninstall the Flux Operator with your preferred method, e.g. Helm:
+Then uninstall the Flux Operator with your preferred method, e.g. Helm:
 
 ```shell
 helm -n flux-system uninstall flux-operator

--- a/docs/guides/resourcesets/rset-introduction.md
+++ b/docs/guides/resourcesets/rset-introduction.md
@@ -27,11 +27,11 @@ To get started with ResourceSets see the [Using ResourceSets for Application Def
 ### Self-service environments
 
 A main goal of the Flux Operator is to enable self-service environments. In order to achieve this,
-the ResourceSet controller integrates with services such as GitHub and GitLab to automate
-the lifecycle of applications based on external events and state changes.
+the ResourceSet controller integrates with services such as GitHub, GitLab, Gitea, Forgejo and Azure DevOps
+to automate the lifecycle of applications based on external events and state changes.
 
-One such use-case is deploying app code and/or config changes made in a GitHub Pull Request
-or GitLab Merge Request to an ephemeral environment for testing and validation.
+One such use-case is deploying app code and/or config changes made in a change request
+to an ephemeral environment for testing and validation.
 The Flux Operator has the ability to create, update and delete application instances on-demand
 based on the ResourceSet definitions and Pull/Merge Requests state.
 


### PR DESCRIPTION
Add `flux-operator install` as one of the options to deploy the operator. Also highlight  `flux-operator uninstall` as the preferred way to remove the operator and Flux from a cluster, no other tool can do this correctly, especially when using ResourceSets.