### PR TITLE
web: use browser locale for time formatting

### DIFF
--- a/web/src/utils/time.js
+++ b/web/src/utils/time.js
@@ -11,8 +11,8 @@
  * - Less than 1 minute: "just now"
  * - Less than 60 minutes: "5m ago"
  * - Less than 24 hours: "3h ago"
- * - Older (same year): "Jan 15, 02:30 PM"
- * - Older (different year): "Jan 15, 2024, 02:30 PM"
+ * - Older (same year): "Jan 15, 02:30 PM" (en-US) or "15 Jan, 14:30" (de-DE)
+ * - Older (different year): "Jan 15, 2024, 02:30 PM" (en-US) or "15 Jan 2024, 14:30" (de-DE)
  */
 export const formatTimestamp = (timestamp) => {
   const date = new Date(timestamp)
@@ -35,22 +35,22 @@ export const formatTimestamp = (timestamp) => {
   if (includeYear) {
     options.year = 'numeric'
   }
-  return date.toLocaleString('en-US', options)
+  return date.toLocaleString(undefined, options)
 }
 
 /**
  * Format a date into an absolute time string (HH:MM:SS format).
  *
  * @param {Date|null} date - The date to format
- * @returns {string} Formatted time string (e.g., "02:30:45 PM") or "Never" if date is null
+ * @returns {string} Formatted time string (e.g., "02:30:45 PM" or "14:30:45") or "Never" if date is null
  *
  * Examples:
- * - Valid date: "02:30:45 PM"
+ * - Valid date: "02:30:45 PM" (en-US) or "14:30:45" (de-DE)
  * - Null/undefined: "Never"
  */
 export const formatTime = (date) => {
   if (!date) return 'Never'
-  return new Intl.DateTimeFormat('en-US', {
+  return new Intl.DateTimeFormat(undefined, {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',

--- a/web/src/utils/time.test.js
+++ b/web/src/utils/time.test.js
@@ -23,17 +23,19 @@ describe('formatTimestamp', () => {
 
   it('should return absolute date for timestamps older than 24 hours', () => {
     const date = new Date(now.getTime() - 25 * 60 * 60 * 1000) // 25 hours ago
-    // Mock Date.toLocaleString to ensure consistent output across environments
-    const mockToLocaleString = vi.fn(() => 'Jan 15, 02:30 PM');
-    date.toLocaleString = mockToLocaleString;
-    expect(formatTimestamp(date)).toMatch(/\w{3} \d{1,2}, \d{2}:\d{2} (AM|PM)/)
+    const result = formatTimestamp(date)
+    // Should not be a relative time string
+    expect(result).not.toMatch(/ago$/)
+    expect(result).not.toBe('just now')
+    // Should contain some date/time content
+    expect(result.length).toBeGreaterThan(0)
   })
 
   it('should include year for timestamps from a different year', () => {
     const lastYear = now.getFullYear() - 1
     const date = new Date(lastYear, 0, 15, 14, 30) // Jan 15 of last year
     // Should include the year in the output
-    expect(formatTimestamp(date)).toMatch(/\w{3} \d{1,2}, \d{4}, \d{2}:\d{2} (AM|PM)/)
+    expect(formatTimestamp(date)).toContain(String(lastYear))
   })
 })
 
@@ -43,12 +45,10 @@ describe('formatTime', () => {
     expect(formatTime(undefined)).toBe('Never')
   })
 
-  it('should format a Date object into HH:MM:SS AM/PM format', () => {
+  it('should format a Date object into a time string with hours, minutes, and seconds', () => {
     const date = new Date('2025-11-16T14:30:45Z') // 2:30:45 PM UTC
-    // Adjust for local timezone if necessary, or use a fixed locale for testing
-    // For simplicity, we'll test against a known output for a specific locale/timezone
-    // This might need adjustment based on the test runner's environment
-    const expectedTimeRegex = /\d{2}:\d{2}:\d{2} (AM|PM)/
-    expect(formatTime(date)).toMatch(expectedTimeRegex)
+    const result = formatTime(date)
+    // Should contain time components (works for both 12h and 24h locales)
+    expect(result).toMatch(/\d{1,2}:\d{2}:\d{2}/)
   })
 })


### PR DESCRIPTION
Replace hardcoded 'en-US' locale with the browser's default locale so that users in 24-hour format countries see times                                                                                                      like "15 Jan 2026, 14:30" instead of "Jan 15, 2026, 02:30 PM". 

Fix: #692