### PR TITLE
cli: add patch instance command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ disto/
 
 # Status Page config.
 web-config.yaml
+
+# CLI (normally how Claude Code builds it).
+/cli

--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -112,6 +112,17 @@ const (
 	FluxArtifactGeneratorKind = "ArtifactGenerator"
 )
 
+// Flux controller names.
+const (
+	FluxSourceController          = "source-controller"
+	FluxKustomizeController       = "kustomize-controller"
+	FluxHelmController            = "helm-controller"
+	FluxNotificationController    = "notification-controller"
+	FluxImageReflectorController  = "image-reflector-controller"
+	FluxImageAutomationController = "image-automation-controller"
+	FluxSourceWatcher             = "source-watcher"
+)
+
 // FluxKindInfo holds information about a Flux resource kind.
 type FluxKindInfo struct {
 	// Name is the singular name of the resource kind.
@@ -162,6 +173,19 @@ var FluxKinds = []FluxKindInfo{
 	{Name: FluxImageRepositoryKind, Plural: "imagerepositories", ShortName: "imgrepo", Reconcilable: true},
 	{Name: FluxImagePolicyKind, Plural: "imagepolicies", ShortName: "imgpol", Reconcilable: true},
 	{Name: FluxImageUpdateAutomationKind, Plural: "imageupdateautomations", ShortName: "imgauto", Reconcilable: true},
+}
+
+// ControllerCRDKinds maps each Flux controller to the CRD kinds it manages.
+// The kind names reference existing constants; use FluxGroupFor() to get the
+// API group and FindFluxKindInfo() to get the plural for each kind.
+var ControllerCRDKinds = map[string][]string{
+	FluxSourceController:          {FluxGitRepositoryKind, FluxOCIRepositoryKind, FluxBucketKind, FluxHelmRepositoryKind, FluxHelmChartKind, FluxExternalArtifactKind},
+	FluxKustomizeController:       {FluxKustomizationKind},
+	FluxHelmController:            {FluxHelmReleaseKind},
+	FluxNotificationController:    {FluxAlertKind, FluxAlertProviderKind, FluxReceiverKind},
+	FluxImageReflectorController:  {FluxImageRepositoryKind, FluxImagePolicyKind},
+	FluxImageAutomationController: {FluxImageUpdateAutomationKind},
+	FluxSourceWatcher:             {FluxArtifactGeneratorKind},
 }
 
 // FluxGroupFor returns the GroupKind for the given kind.

--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -27,7 +27,11 @@ type FluxInstanceSpec struct {
 	Distribution Distribution `json:"distribution"`
 
 	// Components is the list of controllers to install.
-	// Defaults to a commonly used subset.
+	// Defaults to the core Flux controllers:
+	//   - source-controller
+	//   - kustomize-controller
+	//   - helm-controller
+	//   - notification-controller
 	// +optional
 	Components []Component `json:"components,omitempty"`
 
@@ -367,10 +371,10 @@ func (in *FluxInstance) GetComponents() []string {
 	}
 	if len(components) == 0 {
 		components = []string{
-			"source-controller",
-			"kustomize-controller",
-			"helm-controller",
-			"notification-controller",
+			FluxSourceController,
+			FluxKustomizeController,
+			FluxHelmController,
+			FluxNotificationController,
 		}
 	}
 

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -45,7 +45,7 @@ docker run --rm -it --entrypoint=kubectl ghcr.io/controlplaneio-fluxcd/flux-oper
 ## Commands
 
 The Flux Operator CLI provides commands to manage the Flux Operator resources.
-Except for the `build` commands, all others require access to the Kubernetes cluster
+Except for the `build`, `diff` and `patch` commands, all others require access to the Kubernetes cluster
 and the Flux Operator to be installed.
 
 The CLI connects to the cluster using the `~.kube/config` file, similar to `kubectl`.
@@ -65,6 +65,37 @@ The following commands are available:
     - `-f, --file`: Path to the ResourceSet YAML manifest (required).
     - `--inputs-from`: Path to the ResourceSet inputs YAML manifest.
     - `--inputs-from-provider`: Path to the ResourceSetInputProvider static type YAML manifest.
+
+### Diff Commands
+
+The `flux-operator diff` commands are used to compare YAML files and generate patches.
+These commands do not require access to a Kubernetes cluster and can be run in any environment.
+
+The following commands are available:
+
+- `flux-operator diff yaml <source> <target>`: Compares two YAML files and produces a JSON patch (RFC 6902)
+  that can be applied to the source file to obtain the target file. The source and target can be
+  local file paths or remote URLs (including GitHub, GitLab, GitHub Gist and OCI URLs).
+  The comparison ignores metadata and status fields, focusing on the semantic content.
+    - `-o, --output`: Output format for the diff result (json-patch-yaml, json-patch). Default is json-patch-yaml.
+
+### Patch Commands
+
+The `flux-operator patch` commands are used to generate kustomize patches for Flux resources.
+These commands do not require access to a Kubernetes cluster and can be run in any environment.
+
+The following commands are available:
+
+- `flux-operator patch instance`: Generates kustomize patches for upgrading Flux controllers in a FluxInstance.
+  The command modifies the FluxInstance YAML manifest file in-place, appending patches to `.spec.kustomize.patches`.
+  For each controller, the command fetches the CRD schemas for both the current and target controller versions
+  from GitHub, computes a JSON patch for each changed CRD, and generates Deployment image patches pointing to
+  the target controller version. Previously generated patches (CRD and image) are automatically replaced on
+  subsequent runs.
+    - `-f, --filename`: Path to the FluxInstance YAML manifest (required, use `-` for stdin).
+    - `-v, --version`: Target Flux version (default `main`). Accepts: `main`, `v2.<minor>`, or `<minor>`.
+    - `-r, --registry`: Override the container registry for image patches (defaults to `.spec.distribution.registry`).
+    - `-c, --components`: Comma-separated list of controllers to patch (defaults to `.spec.components`).
 
 ### Get Commands
 

--- a/cmd/cli/patch.go
+++ b/cmd/cli/patch.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var patchCmd = &cobra.Command{
+	Use:   "patch",
+	Short: "Patch Flux Operator resources",
+}
+
+func init() {
+	rootCmd.AddCommand(patchCmd)
+}

--- a/cmd/cli/patch_instance.go
+++ b/cmd/cli/patch_instance.go
@@ -1,0 +1,894 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	ghauth "github.com/cli/go-gh/v2/pkg/auth"
+	"github.com/google/go-github/v81/github"
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+	"sigs.k8s.io/yaml"
+
+	"github.com/fluxcd/pkg/apis/kustomize"
+	"github.com/fluxcd/pkg/version"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+// fluxControllerBaseURL is the base URL for fetching controller CRD files.
+// It can be overridden in tests to point to a mock server.
+var fluxControllerBaseURL = "https://github.com/fluxcd"
+
+var patchInstanceCmd = &cobra.Command{
+	Use:   "instance",
+	Short: "Generate kustomize patches for upgrading Flux controllers in a FluxInstance",
+	Long: `The patch instance command automates the generation of kustomize patches needed
+to upgrade Flux controllers to a newer version. It modifies the FluxInstance YAML
+manifest file in-place, appending patches to .spec.kustomize.patches.
+
+The command performs the following steps:
+  1. Reads the FluxInstance YAML manifest and resolves the current Flux minor version
+     from .spec.distribution.version (supports exact versions like '2.7.0' and semver
+     constraints like '2.x' resolved via GitHub tags).
+  2. Resolves the target version from the --version flag ('main', 'v2.8', '8', etc.).
+  3. For each controller listed in --components (or .spec.components if not specified):
+     a. Fetches the CRD schemas for both the current and target controller versions
+        from the fluxcd GitHub repositories.
+     b. Computes a JSON patch (RFC 6902) for each CRD that changed between versions.
+        This includes schema additions, field removals, enum updates, and validation
+        rule changes. CRDs with no differences are skipped.
+     c. Generates a Deployment image patch pointing to the target controller version.
+  4. Appends all generated patches to .spec.kustomize.patches in the manifest file,
+     preserving the original YAML formatting (field order, quoting, indentation).
+     If the kustomize section or patches array does not exist, it is created.
+
+The controller version mapping is derived from the fluxcd/pkg/version package, which
+maps each Flux distribution minor version to the corresponding controller versions
+(e.g. Flux v2.7 maps to source-controller v1.7, helm-controller v1.4, etc.).
+
+When --version is set to 'main', the command targets the next unreleased version by
+fetching CRDs from the main branch. Image tags are set to 'rc-<sha>' using the first
+8 characters of each controller's main branch HEAD commit, with the registry fixed to
+ghcr.io/fluxcd.
+
+GitHub authentication is optional but recommended to avoid rate limits. The command
+uses credentials from the GH_TOKEN or GITHUB_TOKEN environment variables, or from
+credentials stored by 'gh auth login'.`,
+	Example: `  # Generate patches for upgrading to the latest development version (main branch)
+  flux-operator patch instance -f instance.yaml
+
+  # Generate patches for upgrading from the current version to Flux v2.8
+  flux-operator patch instance -f instance.yaml -v v2.8
+
+  # Same as above using the short minor version form
+  flux-operator patch instance -f instance.yaml -v 8
+
+  # Override the container registry for image patches
+  flux-operator patch instance -f instance.yaml -v 8 -r registry.example.com/fluxcd
+
+  # Patch only specific controllers
+  flux-operator patch instance -f instance.yaml -v 8 -c source-controller,helm-controller
+
+  # Pipe input from stdin (patches are printed to stdout)
+  cat instance.yaml | flux-operator patch instance -f - -v 8`,
+	Args: cobra.NoArgs,
+	RunE: patchInstanceCmdRun,
+}
+
+type patchInstanceFlags struct {
+	filename   string
+	version    string
+	registry   string
+	components []string
+}
+
+var patchInstanceArgs patchInstanceFlags
+
+func init() {
+	patchInstanceCmd.Flags().StringVarP(&patchInstanceArgs.filename, "filename", "f", "",
+		"Path to the FluxInstance YAML manifest.")
+	patchInstanceCmd.Flags().StringVarP(&patchInstanceArgs.version, "version", "v", "main",
+		"Target Flux version. Accepts: 'main', 'v2.<minor>', or <minor> integer.")
+	patchInstanceCmd.Flags().StringVarP(&patchInstanceArgs.registry, "registry", "r", "",
+		"Override the container registry for image patches (defaults to .spec.distribution.registry).")
+	patchInstanceCmd.Flags().StringSliceVarP(&patchInstanceArgs.components, "components", "c", nil,
+		"Comma-separated list of controllers to patch (defaults to .spec.components).")
+
+	patchCmd.AddCommand(patchInstanceCmd)
+}
+
+// patchTarget represents the resolved target version for patching.
+type patchTarget struct {
+	isMain    bool
+	fluxMinor int
+}
+
+func patchInstanceCmdRun(cmd *cobra.Command, args []string) error {
+	if patchInstanceArgs.filename == "" {
+		return fmt.Errorf("--filename is required")
+	}
+
+	// Read the input file (supports stdin via "-").
+	path := patchInstanceArgs.filename
+	if patchInstanceArgs.filename == "-" {
+		var err error
+		path, err = saveReaderToFile(os.Stdin)
+		if err != nil {
+			return err
+		}
+		defer os.Remove(path)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("invalid filename '%s', must point to an existing file", path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	// Parse the FluxInstance to extract version and component information.
+	var instance fluxcdv1.FluxInstance
+	if err := yaml.Unmarshal(data, &instance); err != nil {
+		return fmt.Errorf("parsing FluxInstance: %w", err)
+	}
+	setInstanceDefaults(&instance)
+	if instance.Spec.Distribution.Version == "" {
+		return fmt.Errorf(".spec.distribution.version is required")
+	}
+
+	// Resolve the current and target Flux minor versions.
+	ctx, cancel := context.WithTimeout(cmd.Context(), rootArgs.timeout)
+	defer cancel()
+
+	rootCmd.PrintErrln(`◎`, "Resolving current version from", instance.Spec.Distribution.Version)
+	fromMinor, err := resolveFromMinor(ctx, instance.Spec.Distribution.Version)
+	if err != nil {
+		return fmt.Errorf("resolving current version: %w", err)
+	}
+	target, err := resolveToTarget(patchInstanceArgs.version)
+	if err != nil {
+		return fmt.Errorf("resolving target version: %w", err)
+	}
+	if !target.isMain && target.fluxMinor <= fromMinor {
+		return fmt.Errorf("target minor version %d must be greater than current minor version %d",
+			target.fluxMinor, fromMinor)
+	}
+	targetLabel := "main"
+	if !target.isMain {
+		targetLabel = fmt.Sprintf("2.%d", target.fluxMinor)
+	}
+	rootCmd.PrintErrln(`✔`, fmt.Sprintf("Resolved version range: 2.%d -> %s", fromMinor, targetLabel))
+
+	// Determine which components to patch.
+	components := instance.GetComponents()
+	if len(patchInstanceArgs.components) > 0 {
+		components = patchInstanceArgs.components
+	}
+
+	// Remove previously generated patches (image and CRD) for the selected components.
+	if instance.Spec.Kustomize != nil {
+		var removed int
+		data, removed = removeGeneratedPatches(data, instance.Spec.Kustomize.Patches, components)
+		if removed > 0 {
+			rootCmd.PrintErrln(`✔`, fmt.Sprintf("Removed %d previously generated patches", removed))
+		}
+	}
+
+	// Compute image and CRD patches for each component.
+	registry := instance.Spec.Distribution.Registry
+	if patchInstanceArgs.registry != "" {
+		registry = patchInstanceArgs.registry
+	}
+	if token, _ := ghauth.TokenForHost("github.com"); token != "" {
+		rootCmd.PrintErrln(`✔`, "Using GitHub credentials for API requests")
+	} else {
+		rootCmd.PrintErrln(`◎`, "No GitHub credentials found, API requests may be rate-limited")
+		rootCmd.PrintErrln(`◎`, "Run 'gh auth login' or set GITHUB_TOKEN to authenticate")
+	}
+	rootCmd.PrintErrln(`◎`, fmt.Sprintf("Computing patches for %d components...", len(components)))
+	patches, err := computeAllPatches(ctx, components,
+		fromMinor, target, registry)
+	if err != nil {
+		return err
+	}
+	if len(patches) == 0 {
+		rootCmd.PrintErrln(`✔`, "No patches needed")
+		return nil
+	}
+
+	// Append patches to the YAML and write back.
+	out, err := appendPatchesToYAML(data, patches)
+	if err != nil {
+		return fmt.Errorf("appending patches: %w", err)
+	}
+	if err := writeOutput(out, path, len(patches)); err != nil {
+		return err
+	}
+
+	// Validate the patched instance by running 'build instance'.
+	if patchInstanceArgs.filename != "-" {
+		rootCmd.PrintErrln(`◎`, "Validating patched instance...")
+		if err := validatePatchedInstance(path); err != nil {
+			return err
+		}
+		rootCmd.PrintErrln(`✔`, "Validation passed")
+	}
+	return nil
+}
+
+// validatePatchedInstance runs 'build instance' on the patched file to
+// verify the generated patches produce valid Flux manifests.
+func validatePatchedInstance(path string) error {
+	saved := buildInstanceArgs.filename
+	defer func() { buildInstanceArgs.filename = saved }()
+	buildInstanceArgs.filename = path
+
+	// Suppress the build output by temporarily redirecting rootCmd.
+	origOut := rootCmd.OutOrStdout()
+	rootCmd.SetOut(io.Discard)
+	defer rootCmd.SetOut(origOut)
+
+	if err := buildInstanceCmdRun(rootCmd, nil); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+	return nil
+}
+
+// writeOutput writes the patched YAML to the original file or stdout.
+func writeOutput(out []byte, path string, patchCount int) error {
+	if patchInstanceArgs.filename == "-" {
+		rootCmd.Print(string(out))
+		return nil
+	}
+	if err := os.WriteFile(path, out, 0644); err != nil {
+		return fmt.Errorf("writing file: %w", err)
+	}
+	rootCmd.PrintErrln(`✔`, fmt.Sprintf("Appended %d patches to %s", patchCount, path))
+	return nil
+}
+
+// computeAllPatches generates image and CRD patches for all components.
+// Image patches are returned first, followed by CRD patches.
+func computeAllPatches(
+	ctx context.Context,
+	components []string,
+	fromMinor int,
+	target patchTarget,
+	registry string,
+) ([]kustomize.Patch, error) {
+	var imagePatches, crdPatches []kustomize.Patch
+
+	for _, component := range components {
+		rootCmd.PrintErrln(`◎`, fmt.Sprintf("Processing %s...", component))
+
+		// Image patch for this controller's Deployment.
+		imgPatch, err := computeImagePatch(ctx, component, target, registry)
+		if err != nil {
+			return nil, fmt.Errorf("computing image patch for %s: %w", component, err)
+		}
+		if imgPatch != nil {
+			imagePatches = append(imagePatches, *imgPatch)
+		}
+
+		// CRD patches for each CRD owned by this controller.
+		crdKinds, ok := fluxcdv1.ControllerCRDKinds[component]
+		if !ok {
+			rootCmd.PrintErrf("warning: no CRD mapping for component %q, skipping CRD patches\n", component)
+			continue
+		}
+		for _, kind := range crdKinds {
+			patch, err := computeCRDPatchForKind(ctx, component, kind, fromMinor, target)
+			if err != nil {
+				continue
+			}
+			if patch != nil {
+				crdPatches = append(crdPatches, *patch)
+			}
+		}
+	}
+
+	return append(imagePatches, crdPatches...), nil
+}
+
+// computeCRDPatchForKind resolves the CRD URLs for a given kind and
+// computes the diff patch. Returns nil if the CRD is unchanged.
+func computeCRDPatchForKind(
+	ctx context.Context,
+	controller string,
+	kind string,
+	fromMinor int,
+	target patchTarget,
+) (*kustomize.Patch, error) {
+	gk, err := fluxcdv1.FluxGroupFor(kind)
+	if err != nil {
+		return nil, fmt.Errorf("resolving group for kind %q: %w", kind, err)
+	}
+	kindInfo, err := fluxcdv1.FindFluxKindInfo(kind)
+	if err != nil {
+		return nil, fmt.Errorf("resolving kind info for %q: %w", kind, err)
+	}
+
+	crdName := kindInfo.Plural + "." + gk.Group
+	rootCmd.PrintErrln(`◎`, fmt.Sprintf("  Diffing CRD %s", crdName))
+
+	sourceURL, targetURL, err := buildCRDURLs(controller, gk.Group, kindInfo.Plural, fromMinor, target)
+	if err != nil {
+		return nil, fmt.Errorf("building CRD URLs for %s: %w", kind, err)
+	}
+
+	patch, err := computeCRDPatch(ctx, sourceURL, targetURL, gk.Group, kindInfo.Plural)
+	if err != nil {
+		rootCmd.PrintErrf("warning: computing CRD patch for %s: %v\n", crdName, err)
+		return nil, err
+	}
+	return patch, nil
+}
+
+// appendPatchesToYAML inserts kustomize patches into a YAML document
+// using raw string processing to preserve the original formatting.
+// It handles three cases:
+//   - No kustomize: key exists → adds kustomize.patches at end of spec block
+//   - kustomize: exists but no patches: → adds patches under kustomize
+//   - kustomize.patches: exists → appends items after existing patches
+func appendPatchesToYAML(data []byte, patches []kustomize.Patch) ([]byte, error) {
+	if len(patches) == 0 {
+		return data, nil
+	}
+
+	content := strings.TrimRight(string(data), "\n")
+	lines := strings.Split(content, "\n")
+	indent := detectIndentSize(lines)
+	patchesKeyIndent := indent * 2
+
+	// Marshal the patches array at zero indent.
+	patchesYAML, err := yaml.Marshal(patches)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling patches: %w", err)
+	}
+	fragment := strings.TrimRight(string(patchesYAML), "\n")
+
+	specIdx := findTopLevelKey(lines, "spec")
+	if specIdx < 0 {
+		return nil, fmt.Errorf("'spec' key not found in YAML")
+	}
+
+	kustomizeIdx := findChildKey(lines, specIdx, indent, "kustomize")
+
+	var insertIdx int
+	var insertText string
+
+	if kustomizeIdx < 0 {
+		// No kustomize: section, add it at end of spec block.
+		insertIdx = findBlockEnd(lines, specIdx, 0)
+		insertText = strings.Repeat(" ", indent) + "kustomize:\n" +
+			strings.Repeat(" ", patchesKeyIndent) + "patches:\n" +
+			prefixIndent(fragment, patchesKeyIndent)
+	} else {
+		patchesIdx := findChildKey(lines, kustomizeIdx, patchesKeyIndent, "patches")
+		if patchesIdx < 0 {
+			// kustomize: exists but no patches: key.
+			insertIdx = findBlockEnd(lines, kustomizeIdx, indent)
+			insertText = strings.Repeat(" ", patchesKeyIndent) + "patches:\n" +
+				prefixIndent(fragment, patchesKeyIndent)
+		} else {
+			// patches: exists, clear any inline value (e.g. "patches: []")
+			// and append items after the existing array.
+			patchesLine := lines[patchesIdx]
+			trimmed := strings.TrimSpace(patchesLine)
+			if trimmed != "patches:" {
+				lines[patchesIdx] = strings.Repeat(" ", countLeadingSpaces(patchesLine)) + "patches:"
+			}
+			itemIndent := detectArrayItemIndent(lines, patchesIdx, patchesKeyIndent)
+			insertIdx = findPatchesArrayEnd(lines, patchesIdx, itemIndent)
+			insertText = prefixIndent(fragment, itemIndent)
+		}
+	}
+
+	insertionLines := strings.Split(insertText, "\n")
+	result := make([]string, 0, len(lines)+len(insertionLines))
+	result = append(result, lines[:insertIdx]...)
+	result = append(result, insertionLines...)
+	result = append(result, lines[insertIdx:]...)
+
+	return []byte(strings.Join(result, "\n") + "\n"), nil
+}
+
+// detectIndentSize returns the indentation unit used in the YAML file
+// by looking at the first indented line.
+func detectIndentSize(lines []string) int {
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		spaces := countLeadingSpaces(line)
+		if spaces > 0 {
+			return spaces
+		}
+	}
+	return 2
+}
+
+// countLeadingSpaces returns the number of leading space characters.
+func countLeadingSpaces(line string) int {
+	return len(line) - len(strings.TrimLeft(line, " "))
+}
+
+// prefixIndent prepends a fixed number of spaces to each non-empty line.
+func prefixIndent(s string, spaces int) string {
+	prefix := strings.Repeat(" ", spaces)
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = prefix + line
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// findTopLevelKey returns the line index of a top-level YAML key (indent 0).
+func findTopLevelKey(lines []string, key string) int {
+	prefix := key + ":"
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if countLeadingSpaces(line) == 0 &&
+			(trimmed == prefix || strings.HasPrefix(trimmed, prefix+" ")) {
+			return i
+		}
+	}
+	return -1
+}
+
+// findChildKey finds a key at the expected indent level within a parent block.
+func findChildKey(lines []string, parentIdx int, childIndent int, key string) int {
+	prefix := key + ":"
+	for i := parentIdx + 1; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		spaces := countLeadingSpaces(line)
+		if spaces < childIndent {
+			break
+		}
+		if spaces == childIndent &&
+			(trimmed == prefix || strings.HasPrefix(trimmed, prefix+" ")) {
+			return i
+		}
+	}
+	return -1
+}
+
+// findBlockEnd returns the index of the first line after startIdx
+// that exits the block (indent <= parentIndent).
+func findBlockEnd(lines []string, startIdx int, parentIndent int) int {
+	for i := startIdx + 1; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if countLeadingSpaces(line) <= parentIndent {
+			return i
+		}
+	}
+	return len(lines)
+}
+
+// findPatchesArrayEnd returns the index of the first line after patchesIdx
+// that is no longer part of the patches array. Array items start with "- "
+// at the patchesIndent level; deeper lines are item content.
+// detectArrayItemIndent returns the indentation of the first array item
+// after the patches: key. Falls back to the provided default if no items exist.
+func detectArrayItemIndent(lines []string, patchesIdx int, fallback int) int {
+	for i := patchesIdx + 1; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "- ") {
+			return countLeadingSpaces(line)
+		}
+		break
+	}
+	return fallback
+}
+
+func findPatchesArrayEnd(lines []string, patchesIdx int, patchesIndent int) int {
+	for i := patchesIdx + 1; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		spaces := countLeadingSpaces(line)
+		if spaces < patchesIndent {
+			return i
+		}
+		if spaces == patchesIndent && !strings.HasPrefix(trimmed, "- ") {
+			return i
+		}
+	}
+	return len(lines)
+}
+
+// isGeneratedPatchForComponents returns true if the patch was generated by this
+// command for one of the given components. It checks Deployment image patches
+// by controller name and CRD patches by CRD name.
+func isGeneratedPatchForComponents(p kustomize.Patch, components []string) bool {
+	if p.Target == nil {
+		return false
+	}
+	if p.Target.Kind == "Deployment" &&
+		strings.Contains(p.Patch, "/spec/template/spec/containers/0/image") {
+		for _, c := range components {
+			if p.Target.Name == c {
+				return true
+			}
+		}
+		return false
+	}
+	if p.Target.Kind == "CustomResourceDefinition" {
+		for _, c := range components {
+			kinds, ok := fluxcdv1.ControllerCRDKinds[c]
+			if !ok {
+				continue
+			}
+			for _, kind := range kinds {
+				gk, err := fluxcdv1.FluxGroupFor(kind)
+				if err != nil {
+					continue
+				}
+				ki, err := fluxcdv1.FindFluxKindInfo(kind)
+				if err != nil {
+					continue
+				}
+				if p.Target.Name == ki.Plural+"."+gk.Group {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// removeGeneratedPatches removes previously generated image and CRD patches
+// for the given components from the raw YAML, preserving all other content and formatting.
+func removeGeneratedPatches(data []byte, patches []kustomize.Patch, components []string) ([]byte, int) {
+	if len(patches) == 0 {
+		return data, 0
+	}
+
+	content := strings.TrimRight(string(data), "\n")
+	lines := strings.Split(content, "\n")
+	indent := detectIndentSize(lines)
+	patchesKeyIndent := indent * 2
+
+	specIdx := findTopLevelKey(lines, "spec")
+	if specIdx < 0 {
+		return data, 0
+	}
+	kustomizeIdx := findChildKey(lines, specIdx, indent, "kustomize")
+	if kustomizeIdx < 0 {
+		return data, 0
+	}
+	patchesIdx := findChildKey(lines, kustomizeIdx, patchesKeyIndent, "patches")
+	if patchesIdx < 0 {
+		return data, 0
+	}
+
+	itemIndent := detectArrayItemIndent(lines, patchesIdx, patchesKeyIndent)
+	arrayEnd := findPatchesArrayEnd(lines, patchesIdx, itemIndent)
+
+	// Find all item start positions.
+	var itemStarts []int
+	for i := patchesIdx + 1; i < arrayEnd; i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if countLeadingSpaces(line) == itemIndent && strings.HasPrefix(trimmed, "- ") {
+			itemStarts = append(itemStarts, i)
+		}
+	}
+
+	if len(itemStarts) != len(patches) {
+		return data, 0
+	}
+
+	// Determine line ranges for generated patches.
+	type lineRange struct{ start, end int }
+	var toRemove []lineRange
+
+	for idx, patch := range patches {
+		if !isGeneratedPatchForComponents(patch, components) {
+			continue
+		}
+		start := itemStarts[idx]
+		scanEnd := arrayEnd
+		if idx+1 < len(itemStarts) {
+			scanEnd = itemStarts[idx+1]
+		}
+		// Tighten range to last content line (preserve trailing comments).
+		end := start + 1
+		for j := start + 1; j < scanEnd; j++ {
+			trimmed := strings.TrimSpace(lines[j])
+			if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+				end = j + 1
+			}
+		}
+		toRemove = append(toRemove, lineRange{start, end})
+	}
+
+	if len(toRemove) == 0 {
+		return data, 0
+	}
+
+	for i := len(toRemove) - 1; i >= 0; i-- {
+		r := toRemove[i]
+		lines = append(lines[:r.start], lines[r.end:]...)
+	}
+
+	return []byte(strings.Join(lines, "\n") + "\n"), len(toRemove)
+}
+
+// resolveFromMinor resolves the Flux minor version from a version expression.
+// It handles both exact semver versions (e.g., "2.7.5") and semver constraints
+// (e.g., "2.x", ">=2.7.0") by querying GitHub tags when needed.
+func resolveFromMinor(ctx context.Context, versionExpr string) (int, error) {
+	// Try parsing as an exact semver version first.
+	v, err := semver.NewVersion(versionExpr)
+	if err == nil {
+		return int(v.Minor()), nil
+	}
+
+	// Treat as a semver constraint and resolve via GitHub tags.
+	constraint, err := semver.NewConstraint(versionExpr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid version expression %q: not a valid semver or constraint", versionExpr)
+	}
+
+	ghClient := newGitHubClient(ctx)
+	tags, err := listFlux2Tags(ctx, ghClient)
+	if err != nil {
+		return 0, fmt.Errorf("listing flux2 tags: %w", err)
+	}
+
+	var matching []*semver.Version
+	for _, tag := range tags {
+		tv, err := semver.NewVersion(tag)
+		if err != nil {
+			continue
+		}
+		if constraint.Check(tv) {
+			matching = append(matching, tv)
+		}
+	}
+
+	if len(matching) == 0 {
+		return 0, fmt.Errorf("no flux2 tags match constraint %q", versionExpr)
+	}
+
+	sort.Sort(sort.Reverse(semver.Collection(matching)))
+	return int(matching[0].Minor()), nil
+}
+
+// resolveToTarget parses the version flag value into a patchTarget.
+// Accepted formats: "main", "v2.<minor>", "2.<minor>", "<minor>".
+func resolveToTarget(vFlag string) (patchTarget, error) {
+	if vFlag == "main" {
+		return patchTarget{isMain: true}, nil
+	}
+
+	s := strings.TrimPrefix(vFlag, "v")
+
+	if strings.Contains(s, ".") {
+		parts := strings.SplitN(s, ".", 2)
+		if parts[0] != "2" {
+			return patchTarget{}, fmt.Errorf("unsupported major version %q, only major version 2 is supported", parts[0])
+		}
+		minor, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return patchTarget{}, fmt.Errorf("invalid minor version %q: %w", parts[1], err)
+		}
+		return patchTarget{fluxMinor: minor}, nil
+	}
+
+	minor, err := strconv.Atoi(s)
+	if err != nil {
+		return patchTarget{}, fmt.Errorf("invalid version %q: expected 'main', 'v2.<minor>', or '<minor>'", vFlag)
+	}
+	return patchTarget{fluxMinor: minor}, nil
+}
+
+// buildCRDURLs constructs the source and target URLs for a CRD file
+// based on the controller name, version information, and target.
+func buildCRDURLs(
+	controller string,
+	group string,
+	plural string,
+	fromMinor int,
+	target patchTarget,
+) (string, string, error) {
+	major, err := version.RepoMajor(controller)
+	if err != nil {
+		return "", "", err
+	}
+
+	ctrlFromMinor, err := version.RepoMinorForFluxMinor(controller, fromMinor)
+	if err != nil {
+		return "", "", err
+	}
+
+	crdFile := fmt.Sprintf("%s_%s.yaml", group, plural)
+	fromRef := fmt.Sprintf("v%d.%d.0", major, ctrlFromMinor)
+	sourceURL := fmt.Sprintf("%s/%s/blob/%s/config/crd/bases/%s",
+		fluxControllerBaseURL, controller, fromRef, crdFile)
+
+	var targetURL string
+	if target.isMain {
+		targetURL = fmt.Sprintf("%s/%s/blob/main/config/crd/bases/%s",
+			fluxControllerBaseURL, controller, crdFile)
+	} else {
+		ctrlToMinor, err := version.RepoMinorForFluxMinor(controller, target.fluxMinor)
+		if err != nil {
+			return "", "", err
+		}
+		toRef := fmt.Sprintf("v%d.%d.0", major, ctrlToMinor)
+		targetURL = fmt.Sprintf("%s/%s/blob/%s/config/crd/bases/%s",
+			fluxControllerBaseURL, controller, toRef, crdFile)
+	}
+
+	return sourceURL, targetURL, nil
+}
+
+// computeCRDPatch diffs two CRD YAML files (given as URLs or local paths)
+// and returns a kustomize patch targeting the named CRD, or nil if unchanged.
+func computeCRDPatch(
+	ctx context.Context,
+	sourceURL string,
+	targetURL string,
+	group string,
+	plural string,
+) (*kustomize.Patch, error) {
+	diff, err := diffYAML(ctx, sourceURL, targetURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(diff) == 0 {
+		return nil, nil
+	}
+
+	patchYAML, err := yaml.Marshal(diff)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling CRD patch: %w", err)
+	}
+
+	return &kustomize.Patch{
+		Patch: string(patchYAML),
+		Target: &kustomize.Selector{
+			Kind: "CustomResourceDefinition",
+			Name: fmt.Sprintf("%s.%s", plural, group),
+		},
+	}, nil
+}
+
+// computeImagePatch generates a kustomize patch that sets the controller
+// Deployment image to the target version.
+func computeImagePatch(
+	ctx context.Context,
+	controller string,
+	target patchTarget,
+	registry string,
+) (*kustomize.Patch, error) {
+	var imageTag string
+	if target.isMain {
+		rootCmd.PrintErrln(`◎`, fmt.Sprintf("  Resolving main branch SHA for %s", controller))
+		sha, err := resolveMainBranchSHA(ctx, controller)
+		if err != nil {
+			return nil, fmt.Errorf("resolving main branch SHA for %s: %w", controller, err)
+		}
+		imageTag = fmt.Sprintf("rc-%s", sha[:8])
+		rootCmd.PrintErrln(`✔`, fmt.Sprintf("  Using image tag %s", imageTag))
+		registry = "ghcr.io/fluxcd"
+	} else {
+		major, err := version.RepoMajor(controller)
+		if err != nil {
+			return nil, err
+		}
+		ctrlToMinor, err := version.RepoMinorForFluxMinor(controller, target.fluxMinor)
+		if err != nil {
+			return nil, err
+		}
+		imageTag = fmt.Sprintf("v%d.%d.0", major, ctrlToMinor)
+	}
+
+	image := fmt.Sprintf("%s/%s:%s", registry, controller, imageTag)
+
+	ops := []map[string]any{
+		{
+			"op":    "replace",
+			"path":  "/spec/template/spec/containers/0/image",
+			"value": image,
+		},
+	}
+
+	patchYAML, err := yaml.Marshal(ops)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling image patch: %w", err)
+	}
+
+	return &kustomize.Patch{
+		Patch: string(patchYAML),
+		Target: &kustomize.Selector{
+			Kind: "Deployment",
+			Name: controller,
+		},
+	}, nil
+}
+
+// newGitHubClient creates a GitHub client with optional authentication.
+// It uses the go-gh auth package which supports GITHUB_TOKEN, GH_TOKEN
+// environment variables and credentials stored by 'gh auth login'.
+func newGitHubClient(ctx context.Context) *github.Client {
+	token, _ := ghauth.TokenForHost("github.com")
+	if token == "" {
+		return github.NewClient(nil)
+	}
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	return github.NewClient(oauth2.NewClient(ctx, ts))
+}
+
+// resolveMainBranchSHA returns the commit SHA of the main branch
+// for the given controller repository under the fluxcd GitHub org.
+// It is a variable so tests can override it.
+var resolveMainBranchSHA = func(ctx context.Context, controller string) (string, error) {
+	ghClient := newGitHubClient(ctx)
+	branch, _, err := ghClient.Repositories.GetBranch(ctx, "fluxcd", controller, "main", 0)
+	if err != nil {
+		return "", err
+	}
+	return branch.GetCommit().GetSHA(), nil
+}
+
+// listFlux2Tags fetches all tags from the fluxcd/flux2 GitHub repository.
+func listFlux2Tags(ctx context.Context, client *github.Client) ([]string, error) {
+	opts := &github.ListOptions{PerPage: 100}
+	var allTags []string
+
+	for {
+		tags, resp, err := client.Repositories.ListTags(ctx, "fluxcd", "flux2", opts)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, tag := range tags {
+			allTags = append(allTags, tag.GetName())
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return allTags, nil
+}

--- a/cmd/cli/patch_instance_test.go
+++ b/cmd/cli/patch_instance_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// requireEqualStrings compares two strings and fails the test with a
+// line-by-line diff showing exactly where they diverge. This avoids
+// the truncation that gomega's Equal matcher applies to long strings.
+func requireEqualStrings(t *testing.T, got, want string) {
+	t.Helper()
+	if got == want {
+		return
+	}
+	gotLines := strings.Split(got, "\n")
+	wantLines := strings.Split(want, "\n")
+	var b strings.Builder
+	maxLines := len(gotLines)
+	if len(wantLines) > maxLines {
+		maxLines = len(wantLines)
+	}
+	for i := range maxLines {
+		g, w := "", ""
+		if i < len(gotLines) {
+			g = gotLines[i]
+		}
+		if i < len(wantLines) {
+			w = wantLines[i]
+		}
+		if g != w {
+			fmt.Fprintf(&b, "line %d:\n  got:  %q\n  want: %q\n", i+1, g, w)
+		}
+	}
+	if len(gotLines) != len(wantLines) {
+		fmt.Fprintf(&b, "line count: got %d, want %d\n", len(gotLines), len(wantLines))
+	}
+	t.Fatalf("string mismatch:\n%s", b.String())
+}
+
+// TestPatchInstanceCmd patches a FluxInstance with all 7 controllers
+// from Flux v2.7 to v2.8, fetching real CRD data from GitHub.
+func TestPatchInstanceCmd(t *testing.T) {
+	g := NewWithT(t)
+
+	inputData, err := os.ReadFile("testdata/patch_instance/input.yaml")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "instance.yaml")
+	g.Expect(os.WriteFile(tmpFile, inputData, 0644)).To(Succeed())
+
+	output, err := executeCommand([]string{
+		"patch", "instance",
+		"-f", tmpFile,
+		"-v", "8",
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	goldenOutput, err := os.ReadFile("testdata/patch_instance/golden-v2.8-output.txt")
+	g.Expect(err).ToNot(HaveOccurred())
+	requireEqualStrings(t, output, fmt.Sprintf(string(goldenOutput), tmpFile))
+
+	result, err := os.ReadFile(tmpFile)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	golden, err := os.ReadFile("testdata/patch_instance/golden-v2.8.yaml")
+	g.Expect(err).ToNot(HaveOccurred())
+	requireEqualStrings(t, string(result), string(golden))
+}
+
+func TestPatchInstanceCmd_Mock(t *testing.T) {
+	g := NewWithT(t)
+
+	sourceData, err := os.ReadFile("testdata/patch_instance/crd-source.yaml")
+	g.Expect(err).ToNot(HaveOccurred())
+	targetData, err := os.ReadFile("testdata/patch_instance/crd-target.yaml")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/v1.7.0/"):
+			_, _ = w.Write(sourceData)
+		case strings.Contains(r.URL.Path, "/v1.8.0/"):
+			_, _ = w.Write(targetData)
+		case strings.Contains(r.URL.Path, "/main/"):
+			_, _ = w.Write(targetData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	tests := []struct {
+		name         string
+		input        string
+		goldenOutput string
+		goldenYAML   string
+		extraArgs    []string
+		stdin        bool
+	}{
+		{
+			name:         "no kustomize section",
+			input:        "input-no-kustomize.yaml",
+			goldenOutput: "golden-mock-output.txt",
+			goldenYAML:   "golden-no-kustomize.yaml",
+		},
+		{
+			name:         "existing user patches",
+			input:        "input-with-existing-patches.yaml",
+			goldenOutput: "golden-mock-output.txt",
+			goldenYAML:   "golden-with-existing-patches.yaml",
+		},
+		{
+			name:         "empty patches array",
+			input:        "input-with-empty-patches.yaml",
+			goldenOutput: "golden-mock-output.txt",
+			goldenYAML:   "golden-with-empty-patches.yaml",
+		},
+		{
+			name:         "deep indent patches",
+			input:        "input-with-deep-indent-patches.yaml",
+			goldenOutput: "golden-mock-output.txt",
+			goldenYAML:   "golden-with-deep-indent-patches.yaml",
+		},
+		{
+			name:         "stale generated patches replaced",
+			input:        "input-with-stale-patches.yaml",
+			goldenOutput: "golden-mock-output-with-removal.txt",
+			goldenYAML:   "golden-with-existing-patches.yaml",
+		},
+		{
+			name:         "idempotent re-run",
+			input:        "golden-with-existing-patches.yaml",
+			goldenOutput: "golden-mock-output-with-removal.txt",
+			goldenYAML:   "golden-with-existing-patches.yaml",
+		},
+		{
+			name:         "registry override",
+			input:        "input-no-kustomize.yaml",
+			goldenOutput: "golden-mock-output.txt",
+			goldenYAML:   "golden-registry-override.yaml",
+			extraArgs:    []string{"-r", "registry.example.com/fluxcd"},
+		},
+		{
+			name:         "components override",
+			input:        "input-no-kustomize.yaml",
+			goldenOutput: "golden-mock-output-components.txt",
+			goldenYAML:   "golden-components-override.yaml",
+			extraArgs:    []string{"-c", "notification-controller"},
+		},
+		{
+			name:         "scoped cleanup preserves other components",
+			input:        "input-with-mixed-patches.yaml",
+			goldenOutput: "golden-mock-output-mixed.txt",
+			goldenYAML:   "golden-mixed-patches.yaml",
+			extraArgs:    []string{"-c", "kustomize-controller"},
+		},
+		{
+			name:         "version main",
+			input:        "input-no-kustomize.yaml",
+			goldenOutput: "golden-mock-output-main.txt",
+			goldenYAML:   "golden-main.yaml",
+			extraArgs:    []string{"-v", "main"},
+		},
+		{
+			name:         "stdin input",
+			input:        "input-no-kustomize.yaml",
+			goldenOutput: "golden-mock-output-stdin.txt",
+			stdin:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			inputData, err := os.ReadFile(filepath.Join("testdata/patch_instance", tt.input))
+			g.Expect(err).ToNot(HaveOccurred())
+
+			fluxControllerBaseURL = ts.URL
+			resolveMainBranchSHA = func(_ context.Context, _ string) (string, error) {
+				return "abc1234567890def", nil
+			}
+
+			if tt.stdin {
+				// Replace os.Stdin with a file containing the input data.
+				stdinFile, err := os.CreateTemp(t.TempDir(), "stdin-*.yaml")
+				g.Expect(err).ToNot(HaveOccurred())
+				_, err = stdinFile.Write(inputData)
+				g.Expect(err).ToNot(HaveOccurred())
+				_, err = stdinFile.Seek(0, 0)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				origStdin := os.Stdin
+				os.Stdin = stdinFile
+				defer func() { os.Stdin = origStdin }()
+
+				args := append([]string{"patch", "instance", "-f", "-", "-v", "8"}, tt.extraArgs...)
+				output, err := executeCommand(args)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				goldenOutput, err := os.ReadFile(filepath.Join("testdata/patch_instance", tt.goldenOutput))
+				g.Expect(err).ToNot(HaveOccurred())
+				requireEqualStrings(t, output, string(goldenOutput))
+				return
+			}
+
+			tmpFile := filepath.Join(t.TempDir(), "instance.yaml")
+			g.Expect(os.WriteFile(tmpFile, inputData, 0644)).To(Succeed())
+
+			args := append([]string{"patch", "instance", "-f", tmpFile, "-v", "8"}, tt.extraArgs...)
+
+			output, err := executeCommand(args)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			goldenOutput, err := os.ReadFile(filepath.Join("testdata/patch_instance", tt.goldenOutput))
+			g.Expect(err).ToNot(HaveOccurred())
+			requireEqualStrings(t, output, fmt.Sprintf(string(goldenOutput), tmpFile))
+
+			result, err := os.ReadFile(tmpFile)
+			g.Expect(err).ToNot(HaveOccurred())
+			golden, err := os.ReadFile(filepath.Join("testdata/patch_instance", tt.goldenYAML))
+			g.Expect(err).ToNot(HaveOccurred())
+			requireEqualStrings(t, string(result), string(golden))
+		})
+	}
+}
+
+func TestPatchInstanceCmd_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		expectError string
+	}{
+		{
+			name:        "missing filename",
+			args:        []string{"patch", "instance"},
+			expectError: "--filename is required",
+		},
+		{
+			name:        "nonexistent file",
+			args:        []string{"patch", "instance", "-f", "nonexistent.yaml"},
+			expectError: "invalid filename",
+		},
+		{
+			name:        "invalid version flag",
+			args:        []string{"patch", "instance", "-f", "testdata/patch_instance/input.yaml", "-v", "invalid"},
+			expectError: "resolving target version",
+		},
+		{
+			name:        "downgrade rejected",
+			args:        []string{"patch", "instance", "-f", "testdata/patch_instance/input.yaml", "-v", "6"},
+			expectError: "target minor version 6 must be greater than current minor version 7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			_, err := executeCommand(tt.args)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tt.expectError))
+		})
+	}
+}

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -175,6 +175,10 @@ func resetCmdArgs() {
 	// Diff commands
 	diffYAMLArgs = diffYAMLFlags{output: "json-patch-yaml"}
 
+	// Patch commands
+	patchInstanceArgs = patchInstanceFlags{version: "main", components: nil}
+	fluxControllerBaseURL = "https://github.com/fluxcd"
+
 	// Distro commands
 	distroKeygenSigArgs = distroKeygenSigFlags{}
 	distroSignManifestsArgs = distroSignManifestsFlags{}

--- a/cmd/cli/testdata/patch_instance/crd-source.yaml
+++ b/cmd/cli/testdata/patch_instance/crd-source.yaml
@@ -1,0 +1,949 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: gitrepositories.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: GitRepository
+    listKind: GitRepositoryList
+    plural: gitrepositories
+    shortNames:
+    - gitrepo
+    singular: gitrepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              GitRepositorySpec specifies the required configuration to produce an
+              Artifact for a Git repository.
+            properties:
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              include:
+                description: |-
+                  Include specifies a list of GitRepository resources which Artifacts
+                  should be included in the Artifact produced for this GitRepository.
+                items:
+                  description: |-
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: |-
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
+                      type: string
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              interval:
+                description: |-
+                  Interval at which the GitRepository URL is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              provider:
+                description: |-
+                  Provider used for authentication, can be 'azure', 'github', 'generic'.
+                  When not specified, defaults to 'generic'.
+                enum:
+                - generic
+                - azure
+                - github
+                type: string
+              proxySecretRef:
+                description: |-
+                  ProxySecretRef specifies the Secret containing the proxy configuration
+                  to use while communicating with the Git server.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              recurseSubmodules:
+                description: |-
+                  RecurseSubmodules enables the initialization of all submodules within
+                  the GitRepository as cloned from the URL, using their default settings.
+                type: boolean
+              ref:
+                description: |-
+                  Reference specifies the Git reference to resolve and monitor for
+                  changes, defaults to the 'master' branch.
+                properties:
+                  branch:
+                    description: Branch to check out, defaults to 'master' if no other
+                      field is defined.
+                    type: string
+                  commit:
+                    description: |-
+                      Commit SHA to check out, takes precedence over all reference fields.
+
+                      This can be combined with Branch to shallow clone the branch, in which
+                      the commit is expected to exist.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                    type: string
+                  semver:
+                    description: SemVer tag expression to check out, takes precedence
+                      over Tag.
+                    type: string
+                  tag:
+                    description: Tag to check out, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials for
+                  the GitRepository.
+                  For HTTPS repositories the Secret must contain 'username' and 'password'
+                  fields for basic auth or 'bearerToken' field for token auth.
+                  For SSH repositories the Secret must contain 'identity'
+                  and 'known_hosts' fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+                  authenticate to the GitRepository. This field is only supported for 'azure' provider.
+                type: string
+              sparseCheckout:
+                description: |-
+                  SparseCheckout specifies a list of directories to checkout when cloning
+                  the repository. If specified, only these directories are included in the
+                  Artifact produced for this GitRepository.
+                items:
+                  type: string
+                type: array
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  GitRepository.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for Git operations like cloning, defaults to
+                  60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: URL specifies the Git repository URL, it can be an HTTP/S
+                  or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: |-
+                  Verification specifies the configuration to verify the Git commit
+                  signature(s).
+                properties:
+                  mode:
+                    default: HEAD
+                    description: |-
+                      Mode specifies which Git object(s) should be verified.
+
+                      The variants "head" and "HEAD" both imply the same thing, i.e. verify
+                      the commit that the HEAD of the Git repository points to. The variant
+                      "head" solely exists to ensure backwards compatibility.
+                    enum:
+                    - head
+                    - HEAD
+                    - Tag
+                    - TagAndHEAD
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Secret containing the public keys of trusted Git
+                      authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+            x-kubernetes-validations:
+            - message: serviceAccountName can only be set when provider is 'azure'
+              rule: '!has(self.serviceAccountName) || (has(self.provider) && self.provider
+                == ''azure'')'
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus records the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful GitRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - digest
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              includedArtifacts:
+                description: |-
+                  IncludedArtifacts contains a list of the last successfully included
+                  Artifacts as instructed by GitRepositorySpec.Include.
+                items:
+                  description: Artifact represents the output of a Source reconciliation.
+                  properties:
+                    digest:
+                      description: Digest is the digest of the file in the form of
+                        '<algorithm>:<checksum>'.
+                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                      type: string
+                    lastUpdateTime:
+                      description: |-
+                        LastUpdateTime is the timestamp corresponding to the last update of the
+                        Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI
+                        annotations.
+                      type: object
+                    path:
+                      description: |-
+                        Path is the relative file path of the Artifact. It can be used to locate
+                        the file in the root of the Artifact storage on the local file system of
+                        the controller managing the Source.
+                      type: string
+                    revision:
+                      description: |-
+                        Revision is a human-readable identifier traceable in the origin source
+                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: |-
+                        URL is the HTTP address of the Artifact as exposed by the controller
+                        managing the Source. It can be used to retrieve the Artifact for
+                        consumption, e.g. by another controller applying the Artifact contents.
+                      type: string
+                  required:
+                  - digest
+                  - lastUpdateTime
+                  - path
+                  - revision
+                  - url
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the GitRepository
+                  object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              observedInclude:
+                description: |-
+                  ObservedInclude is the observed list of GitRepository resources used to
+                  produce the current Artifact.
+                items:
+                  description: |-
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: |-
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
+                      type: string
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              observedRecurseSubmodules:
+                description: |-
+                  ObservedRecurseSubmodules is the observed resource submodules
+                  configuration used to produce the current Artifact.
+                type: boolean
+              observedSparseCheckout:
+                description: |-
+                  ObservedSparseCheckout is the observed list of directories used to
+                  produce the current Artifact.
+                items:
+                  type: string
+                type: array
+              sourceVerificationMode:
+                description: |-
+                  SourceVerificationMode is the last used verification mode indicating
+                  which Git object(s) have been verified.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta2 GitRepository is deprecated, upgrade to v1
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              GitRepositorySpec specifies the required configuration to produce an
+              Artifact for a Git repository.
+            properties:
+              accessFrom:
+                description: |-
+                  AccessFrom specifies an Access Control List for allowing cross-namespace
+                  references to this object.
+                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              gitImplementation:
+                default: go-git
+                description: |-
+                  GitImplementation specifies which Git client library implementation to
+                  use. Defaults to 'go-git', valid values are ('go-git', 'libgit2').
+                  Deprecated: gitImplementation is deprecated now that 'go-git' is the
+                  only supported implementation.
+                enum:
+                - go-git
+                - libgit2
+                type: string
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              include:
+                description: |-
+                  Include specifies a list of GitRepository resources which Artifacts
+                  should be included in the Artifact produced for this GitRepository.
+                items:
+                  description: |-
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: |-
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
+                      type: string
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              interval:
+                description: Interval at which to check the GitRepository for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              recurseSubmodules:
+                description: |-
+                  RecurseSubmodules enables the initialization of all submodules within
+                  the GitRepository as cloned from the URL, using their default settings.
+                type: boolean
+              ref:
+                description: |-
+                  Reference specifies the Git reference to resolve and monitor for
+                  changes, defaults to the 'master' branch.
+                properties:
+                  branch:
+                    description: Branch to check out, defaults to 'master' if no other
+                      field is defined.
+                    type: string
+                  commit:
+                    description: |-
+                      Commit SHA to check out, takes precedence over all reference fields.
+
+                      This can be combined with Branch to shallow clone the branch, in which
+                      the commit is expected to exist.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                    type: string
+                  semver:
+                    description: SemVer tag expression to check out, takes precedence
+                      over Tag.
+                    type: string
+                  tag:
+                    description: Tag to check out, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials for
+                  the GitRepository.
+                  For HTTPS repositories the Secret must contain 'username' and 'password'
+                  fields for basic auth or 'bearerToken' field for token auth.
+                  For SSH repositories the Secret must contain 'identity'
+                  and 'known_hosts' fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  GitRepository.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for Git operations like cloning, defaults to
+                  60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: URL specifies the Git repository URL, it can be an HTTP/S
+                  or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: |-
+                  Verification specifies the configuration to verify the Git commit
+                  signature(s).
+                properties:
+                  mode:
+                    description: Mode specifies what Git object should be verified,
+                      currently ('head').
+                    enum:
+                    - head
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Secret containing the public keys of trusted Git
+                      authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - mode
+                - secretRef
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus records the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful GitRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - digest
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              contentConfigChecksum:
+                description: |-
+                  ContentConfigChecksum is a checksum of all the configurations related to
+                  the content of the source artifact:
+                   - .spec.ignore
+                   - .spec.recurseSubmodules
+                   - .spec.included and the checksum of the included artifacts
+                  observed in .status.observedGeneration version of the object. This can
+                  be used to determine if the content of the included repository has
+                  changed.
+                  It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
+
+                  Deprecated: Replaced with explicit fields for observed artifact content
+                  config in the status.
+                type: string
+              includedArtifacts:
+                description: |-
+                  IncludedArtifacts contains a list of the last successfully included
+                  Artifacts as instructed by GitRepositorySpec.Include.
+                items:
+                  description: Artifact represents the output of a Source reconciliation.
+                  properties:
+                    digest:
+                      description: Digest is the digest of the file in the form of
+                        '<algorithm>:<checksum>'.
+                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                      type: string
+                    lastUpdateTime:
+                      description: |-
+                        LastUpdateTime is the timestamp corresponding to the last update of the
+                        Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI
+                        annotations.
+                      type: object
+                    path:
+                      description: |-
+                        Path is the relative file path of the Artifact. It can be used to locate
+                        the file in the root of the Artifact storage on the local file system of
+                        the controller managing the Source.
+                      type: string
+                    revision:
+                      description: |-
+                        Revision is a human-readable identifier traceable in the origin source
+                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: |-
+                        URL is the HTTP address of the Artifact as exposed by the controller
+                        managing the Source. It can be used to retrieve the Artifact for
+                        consumption, e.g. by another controller applying the Artifact contents.
+                      type: string
+                  required:
+                  - digest
+                  - lastUpdateTime
+                  - path
+                  - revision
+                  - url
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the GitRepository
+                  object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              observedInclude:
+                description: |-
+                  ObservedInclude is the observed list of GitRepository resources used to
+                  to produce the current Artifact.
+                items:
+                  description: |-
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: |-
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
+                      type: string
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              observedRecurseSubmodules:
+                description: |-
+                  ObservedRecurseSubmodules is the observed resource submodules
+                  configuration used to produce the current Artifact.
+                type: boolean
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  GitRepositoryStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/cmd/cli/testdata/patch_instance/crd-target.yaml
+++ b/cmd/cli/testdata/patch_instance/crd-target.yaml
@@ -1,0 +1,482 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: gitrepositories.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: GitRepository
+    listKind: GitRepositoryList
+    plural: gitrepositories
+    shortNames:
+    - gitrepo
+    singular: gitrepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              GitRepositorySpec specifies the required configuration to produce an
+              Artifact for a Git repository.
+            properties:
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              include:
+                description: |-
+                  Include specifies a list of GitRepository resources which Artifacts
+                  should be included in the Artifact produced for this GitRepository.
+                items:
+                  description: |-
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: |-
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
+                      type: string
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              interval:
+                description: |-
+                  Interval at which the GitRepository URL is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              provider:
+                description: |-
+                  Provider used for authentication, can be 'azure', 'github', 'generic'.
+                  When not specified, defaults to 'generic'.
+                enum:
+                - generic
+                - azure
+                - github
+                type: string
+              proxySecretRef:
+                description: |-
+                  ProxySecretRef specifies the Secret containing the proxy configuration
+                  to use while communicating with the Git server.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              recurseSubmodules:
+                description: |-
+                  RecurseSubmodules enables the initialization of all submodules within
+                  the GitRepository as cloned from the URL, using their default settings.
+                type: boolean
+              ref:
+                description: |-
+                  Reference specifies the Git reference to resolve and monitor for
+                  changes, defaults to the 'master' branch.
+                properties:
+                  branch:
+                    description: Branch to check out, defaults to 'master' if no other
+                      field is defined.
+                    type: string
+                  commit:
+                    description: |-
+                      Commit SHA to check out, takes precedence over all reference fields.
+
+                      This can be combined with Branch to shallow clone the branch, in which
+                      the commit is expected to exist.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                    type: string
+                  semver:
+                    description: SemVer tag expression to check out, takes precedence
+                      over Tag.
+                    type: string
+                  tag:
+                    description: Tag to check out, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials for
+                  the GitRepository.
+                  For HTTPS repositories the Secret must contain 'username' and 'password'
+                  fields for basic auth or 'bearerToken' field for token auth.
+                  For SSH repositories the Secret must contain 'identity'
+                  and 'known_hosts' fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+                  authenticate to the GitRepository. This field is only supported for 'azure' provider.
+                type: string
+              sparseCheckout:
+                description: |-
+                  SparseCheckout specifies a list of directories to checkout when cloning
+                  the repository. If specified, only these directories are included in the
+                  Artifact produced for this GitRepository.
+                items:
+                  type: string
+                type: array
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  GitRepository.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for Git operations like cloning, defaults to
+                  60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: URL specifies the Git repository URL, it can be an HTTP/S
+                  or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: |-
+                  Verification specifies the configuration to verify the Git commit
+                  signature(s).
+                properties:
+                  mode:
+                    default: HEAD
+                    description: |-
+                      Mode specifies which Git object(s) should be verified.
+
+                      The variants "head" and "HEAD" both imply the same thing, i.e. verify
+                      the commit that the HEAD of the Git repository points to. The variant
+                      "head" solely exists to ensure backwards compatibility.
+                    enum:
+                    - head
+                    - HEAD
+                    - Tag
+                    - TagAndHEAD
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Secret containing the public keys of trusted Git
+                      authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+            x-kubernetes-validations:
+            - message: serviceAccountName can only be set when provider is 'azure'
+              rule: '!has(self.serviceAccountName) || (has(self.provider) && self.provider
+                == ''azure'')'
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus records the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful GitRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - digest
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              includedArtifacts:
+                description: |-
+                  IncludedArtifacts contains a list of the last successfully included
+                  Artifacts as instructed by GitRepositorySpec.Include.
+                items:
+                  description: Artifact represents the output of a Source reconciliation.
+                  properties:
+                    digest:
+                      description: Digest is the digest of the file in the form of
+                        '<algorithm>:<checksum>'.
+                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                      type: string
+                    lastUpdateTime:
+                      description: |-
+                        LastUpdateTime is the timestamp corresponding to the last update of the
+                        Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI
+                        annotations.
+                      type: object
+                    path:
+                      description: |-
+                        Path is the relative file path of the Artifact. It can be used to locate
+                        the file in the root of the Artifact storage on the local file system of
+                        the controller managing the Source.
+                      type: string
+                    revision:
+                      description: |-
+                        Revision is a human-readable identifier traceable in the origin source
+                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: |-
+                        URL is the HTTP address of the Artifact as exposed by the controller
+                        managing the Source. It can be used to retrieve the Artifact for
+                        consumption, e.g. by another controller applying the Artifact contents.
+                      type: string
+                  required:
+                  - digest
+                  - lastUpdateTime
+                  - path
+                  - revision
+                  - url
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the GitRepository
+                  object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              observedInclude:
+                description: |-
+                  ObservedInclude is the observed list of GitRepository resources used to
+                  produce the current Artifact.
+                items:
+                  description: |-
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: |-
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
+                      type: string
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              observedRecurseSubmodules:
+                description: |-
+                  ObservedRecurseSubmodules is the observed resource submodules
+                  configuration used to produce the current Artifact.
+                type: boolean
+              observedSparseCheckout:
+                description: |-
+                  ObservedSparseCheckout is the observed list of directories used to
+                  produce the current Artifact.
+                items:
+                  type: string
+                type: array
+              sourceVerificationMode:
+                description: |-
+                  SourceVerificationMode is the last used verification mode indicating
+                  which Git object(s) have been verified.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cmd/cli/testdata/patch_instance/golden-components-override.yaml
+++ b/cmd/cli/testdata/patch_instance/golden-components-override.yaml
@@ -1,0 +1,38 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/notification-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: notification-controller
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: alerts.notification.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: providers.notification.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: receivers.notification.toolkit.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/golden-main.yaml
+++ b/cmd/cli/testdata/patch_instance/golden-main.yaml
@@ -1,0 +1,26 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/kustomize-controller:rc-abc12345
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: kustomizations.kustomize.toolkit.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/golden-mixed-patches.yaml
+++ b/cmd/cli/testdata/patch_instance/golden-mixed-patches.yaml
@@ -1,0 +1,42 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+    - notification-controller
+  kustomize:
+    patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/notification-controller:v1.7.1
+      target:
+        kind: Deployment
+        name: notification-controller
+    - patch: |
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/stale
+          value:
+            type: string
+      target:
+        kind: CustomResourceDefinition
+        name: alerts.notification.toolkit.fluxcd.io
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/kustomize-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: kustomizations.kustomize.toolkit.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/golden-mock-output-components.txt
+++ b/cmd/cli/testdata/patch_instance/golden-mock-output-components.txt
@@ -1,0 +1,11 @@
+◎ Resolving current version from 2.7.0
+✔ Resolved version range: 2.7 -> 2.8
+✔ Using GitHub credentials for API requests
+◎ Computing patches for 1 components...
+◎ Processing notification-controller...
+◎   Diffing CRD alerts.notification.toolkit.fluxcd.io
+◎   Diffing CRD providers.notification.toolkit.fluxcd.io
+◎   Diffing CRD receivers.notification.toolkit.fluxcd.io
+✔ Appended 4 patches to %s
+◎ Validating patched instance...
+✔ Validation passed

--- a/cmd/cli/testdata/patch_instance/golden-mock-output-main.txt
+++ b/cmd/cli/testdata/patch_instance/golden-mock-output-main.txt
@@ -1,0 +1,11 @@
+◎ Resolving current version from 2.7.0
+✔ Resolved version range: 2.7 -> main
+✔ Using GitHub credentials for API requests
+◎ Computing patches for 1 components...
+◎ Processing kustomize-controller...
+◎   Resolving main branch SHA for kustomize-controller
+✔   Using image tag rc-abc12345
+◎   Diffing CRD kustomizations.kustomize.toolkit.fluxcd.io
+✔ Appended 2 patches to %s
+◎ Validating patched instance...
+✔ Validation passed

--- a/cmd/cli/testdata/patch_instance/golden-mock-output-mixed.txt
+++ b/cmd/cli/testdata/patch_instance/golden-mock-output-mixed.txt
@@ -1,0 +1,10 @@
+◎ Resolving current version from 2.7.0
+✔ Resolved version range: 2.7 -> 2.8
+✔ Removed 2 previously generated patches
+✔ Using GitHub credentials for API requests
+◎ Computing patches for 1 components...
+◎ Processing kustomize-controller...
+◎   Diffing CRD kustomizations.kustomize.toolkit.fluxcd.io
+✔ Appended 2 patches to %s
+◎ Validating patched instance...
+✔ Validation passed

--- a/cmd/cli/testdata/patch_instance/golden-mock-output-stdin.txt
+++ b/cmd/cli/testdata/patch_instance/golden-mock-output-stdin.txt
@@ -1,0 +1,32 @@
+◎ Resolving current version from 2.7.0
+✔ Resolved version range: 2.7 -> 2.8
+✔ Using GitHub credentials for API requests
+◎ Computing patches for 1 components...
+◎ Processing kustomize-controller...
+◎   Diffing CRD kustomizations.kustomize.toolkit.fluxcd.io
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/kustomize-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: kustomizations.kustomize.toolkit.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/golden-mock-output-with-removal.txt
+++ b/cmd/cli/testdata/patch_instance/golden-mock-output-with-removal.txt
@@ -1,0 +1,10 @@
+◎ Resolving current version from 2.7.0
+✔ Resolved version range: 2.7 -> 2.8
+✔ Removed 2 previously generated patches
+✔ Using GitHub credentials for API requests
+◎ Computing patches for 1 components...
+◎ Processing kustomize-controller...
+◎   Diffing CRD kustomizations.kustomize.toolkit.fluxcd.io
+✔ Appended 2 patches to %s
+◎ Validating patched instance...
+✔ Validation passed

--- a/cmd/cli/testdata/patch_instance/golden-mock-output.txt
+++ b/cmd/cli/testdata/patch_instance/golden-mock-output.txt
@@ -1,0 +1,9 @@
+◎ Resolving current version from 2.7.0
+✔ Resolved version range: 2.7 -> 2.8
+✔ Using GitHub credentials for API requests
+◎ Computing patches for 1 components...
+◎ Processing kustomize-controller...
+◎   Diffing CRD kustomizations.kustomize.toolkit.fluxcd.io
+✔ Appended 2 patches to %s
+◎ Validating patched instance...
+✔ Validation passed

--- a/cmd/cli/testdata/patch_instance/golden-no-kustomize.yaml
+++ b/cmd/cli/testdata/patch_instance/golden-no-kustomize.yaml
@@ -1,0 +1,26 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/kustomize-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: kustomizations.kustomize.toolkit.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/golden-registry-override.yaml
+++ b/cmd/cli/testdata/patch_instance/golden-registry-override.yaml
@@ -1,0 +1,26 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: registry.example.com/fluxcd/kustomize-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: kustomizations.kustomize.toolkit.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/golden-v2.8-output.txt
+++ b/cmd/cli/testdata/patch_instance/golden-v2.8-output.txt
@@ -1,0 +1,29 @@
+◎ Resolving current version from 2.7.0
+✔ Resolved version range: 2.7 -> 2.8
+✔ Using GitHub credentials for API requests
+◎ Computing patches for 7 components...
+◎ Processing source-controller...
+◎   Diffing CRD gitrepositories.source.toolkit.fluxcd.io
+◎   Diffing CRD ocirepositories.source.toolkit.fluxcd.io
+◎   Diffing CRD buckets.source.toolkit.fluxcd.io
+◎   Diffing CRD helmrepositories.source.toolkit.fluxcd.io
+◎   Diffing CRD helmcharts.source.toolkit.fluxcd.io
+◎   Diffing CRD externalartifacts.source.toolkit.fluxcd.io
+◎ Processing kustomize-controller...
+◎   Diffing CRD kustomizations.kustomize.toolkit.fluxcd.io
+◎ Processing helm-controller...
+◎   Diffing CRD helmreleases.helm.toolkit.fluxcd.io
+◎ Processing notification-controller...
+◎   Diffing CRD alerts.notification.toolkit.fluxcd.io
+◎   Diffing CRD providers.notification.toolkit.fluxcd.io
+◎   Diffing CRD receivers.notification.toolkit.fluxcd.io
+◎ Processing image-reflector-controller...
+◎   Diffing CRD imagerepositories.image.toolkit.fluxcd.io
+◎   Diffing CRD imagepolicies.image.toolkit.fluxcd.io
+◎ Processing image-automation-controller...
+◎   Diffing CRD imageupdateautomations.image.toolkit.fluxcd.io
+◎ Processing source-watcher...
+◎   Diffing CRD artifactgenerators.source.extensions.fluxcd.io
+✔ Appended 18 patches to %s
+◎ Validating patched instance...
+✔ Validation passed

--- a/cmd/cli/testdata/patch_instance/golden-v2.8.yaml
+++ b/cmd/cli/testdata/patch_instance/golden-v2.8.yaml
@@ -1,0 +1,361 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - source-controller
+    - kustomize-controller
+    - helm-controller
+    - notification-controller
+    - image-reflector-controller
+    - image-automation-controller
+    - source-watcher
+  kustomize:
+    patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/source-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: source-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/kustomize-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/helm-controller:v1.5.0
+      target:
+        kind: Deployment
+        name: helm-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/notification-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: notification-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/image-reflector-controller:v1.1.0
+      target:
+        kind: Deployment
+        name: image-reflector-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/image-automation-controller:v1.1.0
+      target:
+        kind: Deployment
+        name: image-automation-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/source-watcher:v2.1.0
+      target:
+        kind: Deployment
+        name: source-watcher
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: gitrepositories.source.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: ocirepositories.source.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: buckets.source.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: helmrepositories.source.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/x-kubernetes-validations
+          value:
+          - message: spec.verify is only supported when spec.sourceRef.kind is 'HelmRepository'
+            rule: '!has(self.verify) || self.sourceRef.kind == ''HelmRepository'''
+      target:
+        kind: CustomResourceDefinition
+        name: helmcharts.source.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: kustomizations.kustomize.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/healthCheckExprs
+          value:
+            description: |-
+              HealthCheckExprs is a list of healthcheck expressions for evaluating the
+              health of custom resources using Common Expression Language (CEL).
+              The expressions are evaluated only when the specific Helm action
+              taking place has wait enabled, i.e. DisableWait is false, and the
+              'poller' WaitStrategy is used.
+            items:
+              description: CustomHealthCheck defines the health check for custom resources.
+              properties:
+                apiVersion:
+                  description: APIVersion of the custom resource under evaluation.
+                  type: string
+                current:
+                  description: |-
+                    Current is the CEL expression that determines if the status
+                    of the custom resource has reached the desired state.
+                  type: string
+                failed:
+                  description: |-
+                    Failed is the CEL expression that determines if the status
+                    of the custom resource has failed to reach the desired state.
+                  type: string
+                inProgress:
+                  description: |-
+                    InProgress is the CEL expression that determines if the status
+                    of the custom resource has not yet reached the desired state.
+                  type: string
+                kind:
+                  description: Kind of the custom resource under evaluation.
+                  type: string
+              required:
+              - apiVersion
+              - current
+              - kind
+              type: object
+            type: array
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/install/properties/serverSideApply
+          value:
+            description: |-
+              ServerSideApply enables server-side apply for resources during install.
+              Defaults to true (or false when UseHelm3Defaults feature gate is enabled).
+            type: boolean
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/rollback/properties/recreate/description
+          value: |-
+            Recreate performs pod restarts for any managed workloads.
+
+            Deprecated: This behavior was deprecated in Helm 3:
+              - Deprecation: https://github.com/helm/helm/pull/6463
+              - Removal: https://github.com/helm/helm/pull/31023
+            After helm-controller was upgraded to the Helm 4 SDK,
+            this field is no longer functional and will print a
+            warning if set to true. It will also be removed in a
+            future release.
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/rollback/properties/serverSideApply
+          value:
+            description: |-
+              ServerSideApply enables server-side apply for resources during rollback.
+              Can be "enabled", "disabled", or "auto".
+              When "auto", server-side apply usage will be based on the release's previous usage.
+              Defaults to "auto".
+            enum:
+            - enabled
+            - disabled
+            - auto
+            type: string
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/upgrade/properties/serverSideApply
+          value:
+            description: |-
+              ServerSideApply enables server-side apply for resources during upgrade.
+              Can be "enabled", "disabled", or "auto".
+              When "auto", server-side apply usage will be based on the release's previous usage.
+              Defaults to "auto".
+            enum:
+            - enabled
+            - disabled
+            - auto
+            type: string
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/waitStrategy
+          value:
+            description: |-
+              WaitStrategy defines Helm's wait strategy for waiting for applied
+              resources to become ready.
+            properties:
+              name:
+                description: |-
+                  Name is Helm's wait strategy for waiting for applied resources to
+                  become ready. One of 'poller' or 'legacy'. The 'poller' strategy uses
+                  kstatus to poll resource statuses, while the 'legacy' strategy uses
+                  Helm v3's waiting logic.
+                  Defaults to 'poller', or to 'legacy' when UseHelm3Defaults feature
+                  gate is enabled.
+                enum:
+                - poller
+                - legacy
+                type: string
+            required:
+            - name
+            type: object
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/history/items/properties/action
+          value:
+            description: Action is the action that resulted in this snapshot being created.
+            type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/history/items/properties/apiVersion/description
+          value: |-
+            APIVersion is the API version of the Snapshot.
+            When the calculation method of the Digest field is changed, this
+            field will be used to distinguish between the old and new methods.
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/inventory
+          value:
+            description: |-
+              Inventory contains the list of Kubernetes resource object references
+              that have been applied for this release.
+            properties:
+              entries:
+                description: Entries of Kubernetes resource object references.
+                items:
+                  description: ResourceRef contains the information necessary to locate a
+                    resource within a cluster.
+                  properties:
+                    id:
+                      description: |-
+                        ID is the string representation of the Kubernetes resource object's metadata,
+                        in the format '<namespace>_<name>_<group>_<kind>'.
+                      type: string
+                    v:
+                      description: Version is the API version of the Kubernetes resource object's
+                        kind.
+                      type: string
+                  required:
+                  - id
+                  - v
+                  type: object
+                type: array
+            required:
+            - entries
+            type: object
+      target:
+        kind: CustomResourceDefinition
+        name: helmreleases.helm.toolkit.fluxcd.io
+    - patch: |
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-
+          value: ArtifactGenerator
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-
+          value: ExternalArtifact
+        - op: add
+          path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-
+          value: ArtifactGenerator
+        - op: add
+          path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-
+          value: ExternalArtifact
+      target:
+        kind: CustomResourceDefinition
+        name: alerts.notification.toolkit.fluxcd.io
+    - patch: |
+        - op: replace
+          path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/type/enum
+          value:
+          - slack
+          - discord
+          - msteams
+          - rocket
+          - generic
+          - generic-hmac
+          - github
+          - gitlab
+          - gitea
+          - giteapullrequestcomment
+          - bitbucketserver
+          - bitbucket
+          - azuredevops
+          - googlechat
+          - googlepubsub
+          - webex
+          - sentry
+          - azureeventhub
+          - telegram
+          - lark
+          - matrix
+          - opsgenie
+          - alertmanager
+          - grafana
+          - githubdispatch
+          - githubpullrequestcomment
+          - gitlabmergerequestcomment
+          - pagerduty
+          - datadog
+          - nats
+          - zulip
+          - otel
+      target:
+        kind: CustomResourceDefinition
+        name: providers.notification.toolkit.fluxcd.io
+    - patch: |
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/resources/items/properties/kind/enum/-
+          value: ArtifactGenerator
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/resources/items/properties/kind/enum/-
+          value: ExternalArtifact
+        - op: add
+          path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/resources/items/properties/kind/enum/-
+          value: ArtifactGenerator
+        - op: add
+          path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/resources/items/properties/kind/enum/-
+          value: ExternalArtifact
+      target:
+        kind: CustomResourceDefinition
+        name: receivers.notification.toolkit.fluxcd.io
+    - patch: |
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/artifacts/items/properties/copy/items/properties/strategy
+          value:
+            description: |-
+              Strategy specifies the copy strategy to use.
+              'Overwrite' will overwrite existing files in the destination.
+              'Merge' is for merging YAML files using Helm values merge strategy.
+              'Extract' is for extracting the contents of tarball archives (.tar.gz, .tgz)
+              When using glob patterns, non-tarball files are silently skipped. For single file sources,
+              the file must be a tarball or an error is returned. Directories are not supported.
+              If not specified, defaults to 'Overwrite'.
+            enum:
+            - Overwrite
+            - Merge
+            - Extract
+            type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/sources/items/properties/kind/enum
+          value:
+          - Bucket
+          - GitRepository
+          - OCIRepository
+          - HelmChart
+          - ExternalArtifact
+      target:
+        kind: CustomResourceDefinition
+        name: artifactgenerators.source.extensions.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/golden-with-deep-indent-patches.yaml
+++ b/cmd/cli/testdata/patch_instance/golden-with-deep-indent-patches.yaml
@@ -1,0 +1,33 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches:
+      - target:
+          kind: Deployment
+          name: kustomize-controller
+        patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --log-level=debug
+      - patch: |
+          - op: replace
+            path: /spec/template/spec/containers/0/image
+            value: ghcr.io/fluxcd/kustomize-controller:v1.8.0
+        target:
+          kind: Deployment
+          name: kustomize-controller
+      - patch: |
+          - op: remove
+            path: /spec/versions/1
+        target:
+          kind: CustomResourceDefinition
+          name: kustomizations.kustomize.toolkit.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/golden-with-empty-patches.yaml
+++ b/cmd/cli/testdata/patch_instance/golden-with-empty-patches.yaml
@@ -1,0 +1,26 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/kustomize-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: kustomizations.kustomize.toolkit.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/golden-with-existing-patches.yaml
+++ b/cmd/cli/testdata/patch_instance/golden-with-existing-patches.yaml
@@ -1,0 +1,33 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches:
+    - patch: |
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --log-level=debug
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/kustomize-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: kustomizations.kustomize.toolkit.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/input-no-kustomize.yaml
+++ b/cmd/cli/testdata/patch_instance/input-no-kustomize.yaml
@@ -1,0 +1,11 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller

--- a/cmd/cli/testdata/patch_instance/input-with-deep-indent-patches.yaml
+++ b/cmd/cli/testdata/patch_instance/input-with-deep-indent-patches.yaml
@@ -1,0 +1,20 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches:
+      - target:
+          kind: Deployment
+          name: kustomize-controller
+        patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --log-level=debug

--- a/cmd/cli/testdata/patch_instance/input-with-empty-patches.yaml
+++ b/cmd/cli/testdata/patch_instance/input-with-empty-patches.yaml
@@ -1,0 +1,13 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches: []

--- a/cmd/cli/testdata/patch_instance/input-with-existing-patches.yaml
+++ b/cmd/cli/testdata/patch_instance/input-with-existing-patches.yaml
@@ -1,0 +1,20 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches:
+    - patch: |
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --log-level=debug
+      target:
+        kind: Deployment
+        name: kustomize-controller

--- a/cmd/cli/testdata/patch_instance/input-with-mixed-patches.yaml
+++ b/cmd/cli/testdata/patch_instance/input-with-mixed-patches.yaml
@@ -1,0 +1,44 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+    - notification-controller
+  kustomize:
+    patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/notification-controller:v1.7.1
+      target:
+        kind: Deployment
+        name: notification-controller
+    - patch: |
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/stale
+          value:
+            type: string
+      target:
+        kind: CustomResourceDefinition
+        name: alerts.notification.toolkit.fluxcd.io
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/kustomize-controller:v1.8.0-rc.1
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/stale
+          value:
+            type: string
+      target:
+        kind: CustomResourceDefinition
+        name: kustomizations.kustomize.toolkit.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/input-with-stale-patches.yaml
+++ b/cmd/cli/testdata/patch_instance/input-with-stale-patches.yaml
@@ -1,0 +1,35 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - kustomize-controller
+  kustomize:
+    patches:
+    - patch: |
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --log-level=debug
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/kustomize-controller:v1.8.0-rc.1
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/stale
+          value:
+            type: string
+      target:
+        kind: CustomResourceDefinition
+        name: kustomizations.kustomize.toolkit.fluxcd.io

--- a/cmd/cli/testdata/patch_instance/input.yaml
+++ b/cmd/cli/testdata/patch_instance/input.yaml
@@ -1,0 +1,17 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.7.0"
+    registry: "ghcr.io/fluxcd"
+  components:
+    - source-controller
+    - kustomize-controller
+    - helm-controller
+    - notification-controller
+    - image-reflector-controller
+    - image-automation-controller
+    - source-watcher

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -157,7 +157,11 @@ spec:
               components:
                 description: |-
                   Components is the list of controllers to install.
-                  Defaults to a commonly used subset.
+                  Defaults to the core Flux controllers:
+                    - source-controller
+                    - kustomize-controller
+                    - helm-controller
+                    - notification-controller
                 items:
                   description: Component is the name of a controller to install.
                   enum:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/marketplacemetering v1.35.6
+	github.com/cli/go-gh/v2 v2.13.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/fluxcd/cli-utils v0.37.1-flux.1
 	github.com/fluxcd/pkg/apis/event v0.24.0
@@ -19,7 +20,7 @@ require (
 	github.com/fluxcd/pkg/runtime v0.100.0
 	github.com/fluxcd/pkg/ssa v0.68.0
 	github.com/fluxcd/pkg/tar v0.17.0
-	github.com/fluxcd/pkg/version v0.12.0
+	github.com/fluxcd/pkg/version v0.14.0
 	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/logr v1.4.3
 	github.com/go-task/slim-sprig/v3 v3.0.0
@@ -92,6 +93,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
+	github.com/cli/safeexec v1.0.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.18.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,10 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.3 h1:9liNh8t+u26xl5ddmWLmsOsdNLwkdRTg5AG+JnTiM80=
 github.com/chai2010/gettext-go v1.0.3/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
+github.com/cli/go-gh/v2 v2.13.0 h1:jEHZu/VPVoIJkciK3pzZd3rbT8J90swsK5Ui4ewH1ys=
+github.com/cli/go-gh/v2 v2.13.0/go.mod h1:Us/NbQ8VNM0fdaILgoXSz6PKkV5PWaEzkJdc9vR2geM=
+github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=
+github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/containerd/stargz-snapshotter/estargz v0.18.1 h1:cy2/lpgBXDA3cDKSyEfNOFMA/c10O1axL69EU7iirO8=
 github.com/containerd/stargz-snapshotter/estargz v0.18.1/go.mod h1:ALIEqa7B6oVDsrF37GkGN20SuvG/pIMm7FwP7ZmRb0Q=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
@@ -139,8 +143,8 @@ github.com/fluxcd/pkg/ssh v0.24.0 h1:hrPlxs0hhXf32DRqs68VbsXs0XfQMphyRVIk0rYYJa4
 github.com/fluxcd/pkg/ssh v0.24.0/go.mod h1:xWammEqalrpurpcMiixJRXtynRQtBEoqheyU5F/vWrg=
 github.com/fluxcd/pkg/tar v0.17.0 h1:uNxbFXy8ly8C7fJ8D7w3rjTNJFrb4Hp1aY/30XkfvxY=
 github.com/fluxcd/pkg/tar v0.17.0/go.mod h1:b1xyIRYDD0ket4SV5u0UXYv+ZdN/O/HmIO5jZQdHQls=
-github.com/fluxcd/pkg/version v0.12.0 h1:MGbdbNf2D5wazMqAkNPn+Lh5j+oY0gxQJFTGyet5Hfc=
-github.com/fluxcd/pkg/version v0.12.0/go.mod h1:YHdg/78kzf+kCqS+SqSOiUxum5AjxlixiqwpX6AUZB8=
+github.com/fluxcd/pkg/version v0.14.0 h1:T3llSc8sUnsuFrW5ng2ePSfXwGXUKv0YG9QXf0ErhWw=
+github.com/fluxcd/pkg/version v0.14.0/go.mod h1:YHdg/78kzf+kCqS+SqSOiUxum5AjxlixiqwpX6AUZB8=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=


### PR DESCRIPTION
## Summary

Adds a new `flux-operator patch instance` command that generates kustomize patches for upgrading Flux controllers between versions.

Given a `FluxInstance` YAML file and a target version, the command:
1. Resolves the current and target Flux minor versions
2. Fetches every CRD schema from both versions (from GitHub)
3. Computes RFC 6902 JSON Patches for each CRD diff
4. Generates image replacement patches for each Deployment
5. Appends all patches to `.spec.kustomize.patches` in-place, preserving existing YAML formatting

### Example

```bash
flux-operator patch instance -f instance.yaml -v 8
```

This patches a v2.7 instance for upgrade to v2.8, writing the result back to `instance.yaml`.

<details>
<summary>Full diff for v2.7 → v2.8 (all controllers)</summary>

```diff
--- instance.yaml
+++ instance.yaml (patched)
@@ -15,3 +15,347 @@
     - image-reflector-controller
     - image-automation-controller
     - source-watcher
+  kustomize:
+    patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/source-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: source-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/kustomize-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: kustomize-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/helm-controller:v1.5.0
+      target:
+        kind: Deployment
+        name: helm-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/notification-controller:v1.8.0
+      target:
+        kind: Deployment
+        name: notification-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/image-reflector-controller:v1.1.0
+      target:
+        kind: Deployment
+        name: image-reflector-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/image-automation-controller:v1.1.0
+      target:
+        kind: Deployment
+        name: image-automation-controller
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: ghcr.io/fluxcd/source-watcher:v2.1.0
+      target:
+        kind: Deployment
+        name: source-watcher
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: gitrepositories.source.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: ocirepositories.source.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: buckets.source.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: helmrepositories.source.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/x-kubernetes-validations
+          value:
+          - message: spec.verify is only supported when spec.sourceRef.kind is 'HelmRepository'
+            rule: '!has(self.verify) || self.sourceRef.kind == ''HelmRepository'''
+      target:
+        kind: CustomResourceDefinition
+        name: helmcharts.source.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+      target:
+        kind: CustomResourceDefinition
+        name: kustomizations.kustomize.toolkit.fluxcd.io
+    - patch: |
+        - op: remove
+          path: /spec/versions/1
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/healthCheckExprs
+          value:
+            description: |-
+              HealthCheckExprs is a list of healthcheck expressions for evaluating the
+              health of custom resources using Common Expression Language (CEL).
+              The expressions are evaluated only when the specific Helm action
+              taking place has wait enabled, i.e. DisableWait is false, and the
+              'poller' WaitStrategy is used.
+            items:
+              description: CustomHealthCheck defines the health check for custom resources.
+              properties:
+                apiVersion:
+                  description: APIVersion of the custom resource under evaluation.
+                  type: string
+                current:
+                  description: |-
+                    Current is the CEL expression that determines if the status
+                    of the custom resource has reached the desired state.
+                  type: string
+                failed:
+                  description: |-
+                    Failed is the CEL expression that determines if the status
+                    of the custom resource has failed to reach the desired state.
+                  type: string
+                inProgress:
+                  description: |-
+                    InProgress is the CEL expression that determines if the status
+                    of the custom resource has not yet reached the desired state.
+                  type: string
+                kind:
+                  description: Kind of the custom resource under evaluation.
+                  type: string
+              required:
+              - apiVersion
+              - current
+              - kind
+              type: object
+            type: array
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/install/properties/serverSideApply
+          value:
+            description: |-
+              ServerSideApply enables server-side apply for resources during install.
+              Defaults to true (or false when UseHelm3Defaults feature gate is enabled).
+            type: boolean
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/rollback/properties/recreate/description
+          value: |-
+            Recreate performs pod restarts for any managed workloads.
+
+            Deprecated: This behavior was deprecated in Helm 3:
+              - Deprecation: https://github.com/helm/helm/pull/6463
+              - Removal: https://github.com/helm/helm/pull/31023
+            After helm-controller was upgraded to the Helm 4 SDK,
+            this field is no longer functional and will print a
+            warning if set to true. It will also be removed in a
+            future release.
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/rollback/properties/serverSideApply
+          value:
+            description: |-
+              ServerSideApply enables server-side apply for resources during rollback.
+              Can be "enabled", "disabled", or "auto".
+              When "auto", server-side apply usage will be based on the release's previous usage.
+              Defaults to "auto".
+            enum:
+            - enabled
+            - disabled
+            - auto
+            type: string
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/upgrade/properties/serverSideApply
+          value:
+            description: |-
+              ServerSideApply enables server-side apply for resources during upgrade.
+              Can be "enabled", "disabled", or "auto".
+              When "auto", server-side apply usage will be based on the release's previous usage.
+              Defaults to "auto".
+            enum:
+            - enabled
+            - disabled
+            - auto
+            type: string
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/waitStrategy
+          value:
+            description: |-
+              WaitStrategy defines Helm's wait strategy for waiting for applied
+              resources to become ready.
+            properties:
+              name:
+                description: |-
+                  Name is Helm's wait strategy for waiting for applied resources to
+                  become ready. One of 'poller' or 'legacy'. The 'poller' strategy uses
+                  kstatus to poll resource statuses, while the 'legacy' strategy uses
+                  Helm v3's waiting logic.
+                  Defaults to 'poller', or to 'legacy' when UseHelm3Defaults feature
+                  gate is enabled.
+                enum:
+                - poller
+                - legacy
+                type: string
+            required:
+            - name
+            type: object
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/history/items/properties/action
+          value:
+            description: Action is the action that resulted in this snapshot being created.
+            type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/history/items/properties/apiVersion/description
+          value: |-
+            APIVersion is the API version of the Snapshot.
+            When the calculation method of the Digest field is changed, this
+            field will be used to distinguish between the old and new methods.
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/inventory
+          value:
+            description: |-
+              Inventory contains the list of Kubernetes resource object references
+              that have been applied for this release.
+            properties:
+              entries:
+                description: Entries of Kubernetes resource object references.
+                items:
+                  description: ResourceRef contains the information necessary to locate a
+                    resource within a cluster.
+                  properties:
+                    id:
+                      description: |-
+                        ID is the string representation of the Kubernetes resource object's metadata,
+                        in the format '<namespace>_<name>_<group>_<kind>'.
+                      type: string
+                    v:
+                      description: Version is the API version of the Kubernetes resource object's
+                        kind.
+                      type: string
+                  required:
+                  - id
+                  - v
+                  type: object
+                type: array
+            required:
+            - entries
+            type: object
+      target:
+        kind: CustomResourceDefinition
+        name: helmreleases.helm.toolkit.fluxcd.io
+    - patch: |
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-
+          value: ArtifactGenerator
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-
+          value: ExternalArtifact
+        - op: add
+          path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-
+          value: ArtifactGenerator
+        - op: add
+          path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-
+          value: ExternalArtifact
+      target:
+        kind: CustomResourceDefinition
+        name: alerts.notification.toolkit.fluxcd.io
+    - patch: |
+        - op: replace
+          path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/type/enum
+          value:
+          - slack
+          - discord
+          - msteams
+          - rocket
+          - generic
+          - generic-hmac
+          - github
+          - gitlab
+          - gitea
+          - giteapullrequestcomment
+          - bitbucketserver
+          - bitbucket
+          - azuredevops
+          - googlechat
+          - googlepubsub
+          - webex
+          - sentry
+          - azureeventhub
+          - telegram
+          - lark
+          - matrix
+          - opsgenie
+          - alertmanager
+          - grafana
+          - githubdispatch
+          - githubpullrequestcomment
+          - gitlabmergerequestcomment
+          - pagerduty
+          - datadog
+          - nats
+          - zulip
+          - otel
+      target:
+        kind: CustomResourceDefinition
+        name: providers.notification.toolkit.fluxcd.io
+    - patch: |
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/resources/items/properties/kind/enum/-
+          value: ArtifactGenerator
+        - op: add
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/resources/items/properties/kind/enum/-
+          value: ExternalArtifact
+        - op: add
+          path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/resources/items/properties/kind/enum/-
+          value: ArtifactGenerator
+        - op: add
+          path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/resources/items/properties/kind/enum/-
+          value: ExternalArtifact
+      target:
+        kind: CustomResourceDefinition
+        name: receivers.notification.toolkit.fluxcd.io
+    - patch: |
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/artifacts/items/properties/copy/items/properties/strategy
+          value:
+            description: |-
+              Strategy specifies the copy strategy to use.
+              'Overwrite' will overwrite existing files in the destination.
+              'Merge' is for merging YAML files using Helm values merge strategy.
+              'Extract' is for extracting the contents of tarball archives (.tar.gz, .tgz)
+              When using glob patterns, non-tarball files are silently skipped. For single file sources,
+              the file must be a tarball or an error is returned. Directories are not supported.
+              If not specified, defaults to 'Overwrite'.
+            enum:
+            - Overwrite
+            - Merge
+            - Extract
+            type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/sources/items/properties/kind/enum
+          value:
+          - Bucket
+          - GitRepository
+          - OCIRepository
+          - HelmChart
+          - ExternalArtifact
+      target:
+        kind: CustomResourceDefinition
+        name: artifactgenerators.source.extensions.fluxcd.io
```

</details>