### PR TITLE
operator: fix resourceset copyfrom not normalizing

### DIFF
--- a/internal/controller/resourceset_controller.go
+++ b/internal/controller/resourceset_controller.go
@@ -476,10 +476,6 @@ func (r *ResourceSetReconciler) apply(ctx context.Context,
 	})
 	resourceManager.SetOwnerLabels(objects, obj.GetName(), obj.GetNamespace())
 
-	if err := normalize.UnstructuredList(objects); err != nil {
-		return "", err
-	}
-
 	if cm := obj.Spec.CommonMetadata; cm != nil {
 		ssautil.SetCommonMetadata(objects, cm.Labels, cm.Annotations)
 	}
@@ -489,6 +485,10 @@ func (r *ResourceSetReconciler) apply(ctx context.Context,
 	}
 
 	if err := r.convertKubeConfigResources(ctx, kubeClient, objects); err != nil {
+		return "", err
+	}
+
+	if err := normalize.UnstructuredList(objects); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Fixes: #700

The problem is writing with `stringData` instead of `data`. SSA normalization handles that, but was being called before the copy features.

The test in this PR fails without the fix.

I'm adding a test also for ConfigMap just in case, but the bug was only for Secret. There's no write-only field in ConfigMap.