### PR TITLE
cmd: add command to generate Flux Web-auth secret

### DIFF
--- a/cmd/cli/create_secret_webauth.go
+++ b/cmd/cli/create_secret_webauth.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/fluxcd/pkg/runtime/secrets"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var createSecretWebAuthCmd = &cobra.Command{
+	Use:   "web-auth [name]",
+	Short: "Create a Kubernetes Secret containing web UI authentication credentials",
+	Example: `  # Create or update a secret with OAuth2 client credentials
+  flux-operator create secret web-auth flux-web-auth \
+    --namespace=flux-system \
+    --client-id=flux-web \
+    --client-secret=$client_secret
+
+  # Create a secret with random client secret
+  flux-operator create secret web-auth flux-web-client \
+    --client-id=flux-web \
+    --client-secret-rnd
+
+  # Create a secret with client secret from stdin
+  echo $client_secret | flux-operator create secret web-auth flux-web-client \
+    --client-id=flux-web \
+    --client-secret-stdin
+
+  # Generate a web-auth secret and export it to YAML file
+  flux-operator create secret web-auth flux-web-client \
+    --client-id=flux-web \
+    --client-secret-rnd \
+    --export > flux-web-auth.yaml
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: CreateSecretWebAuthCmdRun,
+}
+
+type createSecretWebAuthFlags struct {
+	clientID          string
+	clientSecret      string
+	clientSecretStdin bool
+	clientSecretRnd   bool
+
+	annotations []string
+	labels      []string
+	immutable   bool
+	export      bool
+}
+
+var createSecretWebAuthArgs createSecretWebAuthFlags
+
+func init() {
+	createSecretWebAuthCmd.Flags().StringVar(&createSecretWebAuthArgs.clientID, "client-id", "", "set the client ID for OAuth2 authentication (required)")
+	createSecretWebAuthCmd.Flags().StringVar(&createSecretWebAuthArgs.clientSecret, "client-secret", "", "set the client secret for OAuth2 authentication (required)")
+	createSecretWebAuthCmd.Flags().BoolVar(&createSecretWebAuthArgs.clientSecretStdin, "client-secret-stdin", false, "read the client secret from standard input")
+	createSecretWebAuthCmd.Flags().BoolVar(&createSecretWebAuthArgs.clientSecretRnd, "client-secret-rnd", false, "generate a random client secret")
+	createSecretWebAuthCmd.Flags().StringSliceVar(&createSecretWebAuthArgs.annotations, "annotation", nil, "set annotations on the resource (can specify multiple annotations with commas: annotation1=value1,annotation2=value2)")
+	createSecretWebAuthCmd.Flags().StringSliceVar(&createSecretWebAuthArgs.labels, "label", nil, "set labels on the resource (can specify multiple labels with commas: label1=value1,label2=value2)")
+	createSecretWebAuthCmd.Flags().BoolVar(&createSecretWebAuthArgs.immutable, "immutable", false, "set the immutable flag on the Secret")
+	createSecretWebAuthCmd.Flags().BoolVar(&createSecretWebAuthArgs.export, "export", false, "export resource in YAML format to stdout")
+	createSecretCmd.AddCommand(createSecretWebAuthCmd)
+}
+
+func CreateSecretWebAuthCmdRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("a single name must be specified")
+	}
+	name := args[0]
+
+	if createSecretWebAuthArgs.clientID == "" {
+		return fmt.Errorf("--client-id is required")
+	}
+	clientSecret := createSecretWebAuthArgs.clientSecret
+
+	secretSources := 0
+	if createSecretWebAuthArgs.clientSecret != "" {
+		secretSources++
+	}
+	if createSecretWebAuthArgs.clientSecretStdin {
+		secretSources++
+	}
+	if createSecretWebAuthArgs.clientSecretRnd {
+		secretSources++
+	}
+	if secretSources == 0 {
+		return fmt.Errorf("one of --client-secret, --client-secret-stdin, or --client-secret-rnd must be specified")
+	}
+	if secretSources > 1 {
+		return fmt.Errorf("only one of --client-secret, --client-secret-stdin, or --client-secret-rnd can be specified")
+	}
+
+	if createSecretWebAuthArgs.clientSecretStdin {
+		var input string
+		_, err := fmt.Scan(&input)
+		if err != nil {
+			return fmt.Errorf("unable to read client secret from stdin: %w", err)
+		}
+		clientSecret = input
+	}
+	if createSecretWebAuthArgs.clientSecretRnd {
+		randomBytes := make([]byte, 32)
+		if _, err := rand.Read(randomBytes); err != nil {
+			return fmt.Errorf("unable to generate random client secret: %w", err)
+		}
+		clientSecret = base64.RawURLEncoding.EncodeToString(randomBytes)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: *kubeconfigArgs.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			"client-id":     createSecretWebAuthArgs.clientID,
+			"client-secret": clientSecret,
+		},
+	}
+	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+
+	if err := setSecretMetadata(
+		secret,
+		createSecretWebAuthArgs.annotations,
+		createSecretWebAuthArgs.labels,
+	); err != nil {
+		return fmt.Errorf("unable to set metadata on secret: %w", err)
+	}
+
+	if createSecretWebAuthArgs.export {
+		return printSecret(secret)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client: %w", err)
+	}
+	err = secrets.Apply(
+		ctx,
+		kubeClient,
+		secret,
+		secrets.WithForce(),
+		secrets.WithImmutable(createSecretWebAuthArgs.immutable),
+	)
+	if err != nil {
+		return err
+	}
+
+	rootCmd.Println(`✔`, fmt.Sprintf("Secret %s/%s applied successfully", secret.GetNamespace(), secret.GetName()))
+	return nil
+}

--- a/cmd/cli/create_secret_webauth_test.go
+++ b/cmd/cli/create_secret_webauth_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
+)
+
+func TestCreateSecretWebAuthCmd(t *testing.T) {
+	gt := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(context.Background(), "test-web-auth")
+	gt.Expect(err).ToNot(HaveOccurred())
+
+	tests := []struct {
+		name         string
+		args         []string
+		expectError  bool
+		expectExport bool
+	}{
+		{
+			name:        "create web-auth secret with client-secret",
+			args:        []string{"create", "secret", "web-auth", "test-secret", "--client-id=test-client", "--client-secret=test-secret-value"},
+			expectError: false,
+		},
+		{
+			name:        "create web-auth secret with random client-secret",
+			args:        []string{"create", "secret", "web-auth", "test-secret-rnd", "--client-id=test-client", "--client-secret-rnd"},
+			expectError: false,
+		},
+		{
+			name:         "create web-auth secret with export",
+			args:         []string{"create", "secret", "web-auth", "test-secret", "--client-id=test-client", "--client-secret=test-secret-value", "--export"},
+			expectError:  false,
+			expectExport: true,
+		},
+		{
+			name:         "create web-auth secret with random and export",
+			args:         []string{"create", "secret", "web-auth", "test-secret", "--client-id=test-client", "--client-secret-rnd", "--export"},
+			expectError:  false,
+			expectExport: true,
+		},
+		{
+			name: "create web-auth secret with annotations and labels",
+			// FIX 1: flag is now registered as "--label" (singular) in init(),
+			// consistent with "--annotation". Test arg updated to match.
+			args:        []string{"create", "secret", "web-auth", "test-secret", "--client-id=test-client", "--client-secret=test-secret-value", "--annotation=test.io/annotation=value", "--label=test.io/label=value"},
+			expectError: false,
+		},
+		{
+			name:        "create immutable web-auth secret",
+			args:        []string{"create", "secret", "web-auth", "test-secret", "--client-id=test-client", "--client-secret=test-secret-value", "--immutable"},
+			expectError: false,
+		},
+		{
+			name: "missing client-id",
+			// FIX 2: removed expectExport: true — never evaluated when expectError is true,
+			// misleading to readers and can mask real intent of the test case.
+			args:        []string{"create", "secret", "web-auth", "test-secret", "--client-secret=test-secret-value", "--export"},
+			expectError: true,
+		},
+		{
+			name:        "missing client-secret source",
+			args:        []string{"create", "secret", "web-auth", "test-secret", "--client-id=test-client", "--export"},
+			expectError: true,
+		},
+		{
+			name:        "multiple client-secret sources",
+			args:        []string{"create", "secret", "web-auth", "test-secret", "--client-id=test-client", "--client-secret=test", "--client-secret-rnd", "--export"},
+			expectError: true,
+		},
+		{
+			name:        "missing secret name",
+			args:        []string{"create", "secret", "web-auth", "--client-id=test-client", "--client-secret=test-secret-value"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			g := NewWithT(t)
+
+			kubeconfigArgs.Namespace = &ns.Name
+			output, err := executeCommand(tt.args)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if tt.expectExport {
+				obj := &unstructured.Unstructured{}
+				err = yaml.Unmarshal([]byte(output), &obj.Object)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				g.Expect(obj.GetAPIVersion()).To(Equal("v1"))
+				g.Expect(obj.GetKind()).To(Equal("Secret"))
+				g.Expect(obj.GetName()).To(Equal("test-secret"))
+				g.Expect(obj.GetNamespace()).To(Equal(ns.Name))
+
+				secretType, found, err := unstructured.NestedString(obj.Object, "type")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(secretType).To(Equal(string(corev1.SecretTypeOpaque)))
+
+				stringData, found, err := unstructured.NestedStringMap(obj.Object, "stringData")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(stringData).To(HaveKey("client-id"))
+				g.Expect(stringData).To(HaveKey("client-secret"))
+				g.Expect(stringData["client-id"]).To(Equal("test-client"))
+
+				if tt.name == "create web-auth secret with random and export" {
+					g.Expect(stringData["client-secret"]).ToNot(BeEmpty())
+					g.Expect(len(stringData["client-secret"])).To(BeNumerically(">=", 32))
+				}
+
+				// Verify clean export — creationTimestamp should not be present.
+				_, found, err = unstructured.NestedString(obj.Object, "metadata", "creationTimestamp")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(found).To(BeFalse())
+
+			} else {
+				secretName := "test-secret"
+				if tt.name == "create web-auth secret with random client-secret" {
+					secretName = "test-secret-rnd"
+				}
+
+				secret := &corev1.Secret{}
+				secretKey := types.NamespacedName{Name: secretName, Namespace: ns.Name}
+				err = testClient.Get(ctx, secretKey, secret)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				g.Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+				g.Expect(secret.Data).To(HaveKey("client-id"))
+				g.Expect(secret.Data).To(HaveKey("client-secret"))
+				g.Expect(string(secret.Data["client-id"])).To(Equal("test-client"))
+
+				if tt.name == "create web-auth secret with client-secret" {
+					g.Expect(string(secret.Data["client-secret"])).To(Equal("test-secret-value"))
+				}
+
+				if tt.name == "create web-auth secret with random client-secret" {
+					g.Expect(string(secret.Data["client-secret"])).ToNot(BeEmpty())
+					g.Expect(len(secret.Data["client-secret"])).To(BeNumerically(">=", 32))
+				}
+
+				if tt.name == "create web-auth secret with annotations and labels" {
+					g.Expect(secret.Annotations).To(HaveKeyWithValue("test.io/annotation", "value"))
+					g.Expect(secret.Labels).To(HaveKeyWithValue("test.io/label", "value"))
+				}
+
+				if tt.name == "create immutable web-auth secret" {
+					g.Expect(secret.Immutable).ToNot(BeNil())
+					g.Expect(*secret.Immutable).To(BeTrue())
+				}
+
+				defer func() {
+					_ = testClient.Delete(context.Background(), secret)
+				}()
+			}
+		})
+	}
+}

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -166,6 +166,7 @@ func resetCmdArgs() {
 	createSecretSSHArgs = createSecretSSHFlags{}
 	createSecretRegistryArgs = createSecretRegistryFlags{}
 	createSecretSOPSArgs = createSecretSOPSFlags{}
+	createSecretWebAuthArgs = createSecretWebAuthFlags{}
 	webConfigArgs = webConfigFlags{}
 
 	// Export commands


### PR DESCRIPTION
## Summary

This PR adds a new `create secret web-auth` CLI command for generating Kubernetes Secrets containing OAuth2 web UI authentication credentials.

The implementation follows the existing `create secret basicauth` command pattern.
The generated Secret contains:

* `client-id`
* `client-secret`

Fixes: #551
Closes: #559

## Features

The client secret can be provided using:

* `--client-secret`
* `--client-secret-stdin`
* `--client-secret-rnd` (secure random generation)

Only one secret source can be specified at a time.

The command also supports:

* annotations and labels
* immutable secrets
* YAML export (`--export`)
* server-side apply via `secrets.Apply`

## Example

```bash
flux-operator create secret web-auth flux-web-client \
  --client-id=flux-web \
  --client-secret-rnd
```
