### PR TITLE
operator: Add ExternalService ResourceSetInputProvider

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -360,6 +360,7 @@ func main() {
 			StatusManager: controllerName,
 			EventRecorder: mgr.GetEventRecorderFor(controllerName),
 			TokenCache:    tokenCache,
+			Version:       VERSION,
 		}).SetupWithManager(mgr,
 			controller.ResourceSetInputProviderReconcilerOptions{
 				RateLimiter: runtimeCtrl.GetRateLimiter(rateLimiterOptions),

--- a/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
@@ -60,9 +60,9 @@ spec:
                   - a PEM-encoded CA certificate (`ca.crt`)
                   - a PEM-encoded client certificate (`tls.crt`) and private key (`tls.key`)
 
-                  When connecting to a Git or OCI provider that uses self-signed certificates, the CA certificate
-                  must be set in the Secret under the 'ca.crt' key to establish the trust relationship.
-                  When connecting to an OCI provider that supports client certificates (mTLS), the client certificate
+                  When connecting to a Git, OCI, or ExternalService provider that uses self-signed certificates,
+                  the CA certificate must be set in the Secret under the 'ca.crt' key to establish the trust relationship.
+                  When connecting to a provider that supports client certificates (mTLS), the client certificate
                   and private key must be set in the Secret under the 'tls.crt' and 'tls.key' keys, respectively.
                 properties:
                   name:
@@ -133,6 +133,11 @@ spec:
                       Supported only for tags at the moment.
                     type: string
                 type: object
+              insecure:
+                description: |-
+                  Insecure allows connecting to an ExternalService provider over
+                  plain HTTP without TLS. When not set, the URL must use HTTPS.
+                type: boolean
               schedule:
                 description: Schedule defines the schedules for the input provider
                   to run.
@@ -160,13 +165,16 @@ spec:
                 type: array
               secretRef:
                 description: |-
-                  SecretRef specifies the Kubernetes Secret containing the basic-auth credentials
+                  SecretRef specifies the Kubernetes Secret containing the credentials
                   to access the input provider.
                   When connecting to a Git provider, the secret must contain the keys
                   'username' and 'password', and the password should be a personal access token
                   that grants read-only access to the repository.
                   When connecting to an OCI provider, the secret must contain a Kubernetes
                   Image Pull Secret, as if created by `kubectl create secret docker-registry`.
+                  When connecting to an ExternalService provider, the secret must contain either
+                  a 'token' key for bearer token authentication, or 'username' and 'password'
+                  keys for basic authentication.
                 properties:
                   name:
                     description: Name of the referent.
@@ -215,6 +223,7 @@ spec:
                 - ACRArtifactTag
                 - ECRArtifactTag
                 - GARArtifactTag
+                - ExternalService
                 type: string
               url:
                 description: |-
@@ -240,6 +249,14 @@ spec:
             - message: spec.url must start with 'oci://' when spec.type is an OCI
                 provider
               rule: '!self.type.endsWith(''ArtifactTag'') || self.url.startsWith(''oci'')'
+            - message: spec.url must start with 'http://' or 'https://' when spec.type
+                is 'ExternalService'
+              rule: self.type != 'ExternalService' || self.url.startsWith('http')
+            - message: spec.insecure can only be set when spec.type is 'ExternalService'
+              rule: '!has(self.insecure) || !self.insecure || self.type == ''ExternalService'''
+            - message: spec.url must use 'https://' unless spec.insecure is true
+              rule: self.type != 'ExternalService' || !self.url.startsWith('http://')
+                || (has(self.insecure) && self.insecure)
             - message: cannot specify spec.serviceAccountName when spec.type is not
                 one of AzureDevOps* or *ArtifactTag
               rule: '!has(self.serviceAccountName) || self.type.startsWith(''AzureDevOps'')

--- a/internal/controller/resourcesetinputprovider_controller_externalservice_test.go
+++ b/internal/controller/resourcesetinputprovider_controller_externalservice_test.go
@@ -1,0 +1,785 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/runtime/conditions"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestResourceSetInputProviderReconciler_ExternalService_LifeCycle(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Create a mock HTTP server that returns inputs.
+	inputsResponse := externalServiceResponse{
+		Inputs: []map[string]any{
+			{"id": "1", "tenant": "tenant1", "version": "2.0.0-rc.1"},
+			{"id": "2", "tenant": "tenant2", "version": "1.9.0"},
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(inputsResponse)
+	}))
+	defer server.Close()
+
+	objDef := fmt.Sprintf(`
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: test-external-service
+  namespace: "%[1]s"
+spec:
+  type: ExternalService
+  url: %[2]s
+  insecure: true
+`, ns.Name, server.URL)
+
+	obj := &fluxcdv1.ResourceSetInputProvider{}
+	err = yaml.Unmarshal([]byte(objDef), obj)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	err = testEnv.Create(ctx, obj)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Initialize the ResourceSetInputProvider.
+	r, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(r.Requeue).To(BeTrue())
+
+	// Reconcile and verify exported inputs.
+	r, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	result := &fluxcdv1.ResourceSetInputProvider{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(conditions.IsReady(result)).To(BeTrue())
+	g.Expect(result.Status.ExportedInputs).To(HaveLen(2))
+	g.Expect(result.Status.LastExportedRevision).To(HavePrefix("sha256:"))
+	g.Expect(result.Status.LastExportedRevision).To(HaveLen(71))
+
+	// Verify input values.
+	b, err := yaml.Marshal(result.Status.ExportedInputs[0])
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(b)).To(MatchYAML(`
+id: "1"
+tenant: tenant1
+version: 2.0.0-rc.1
+`))
+
+	b, err = yaml.Marshal(result.Status.ExportedInputs[1])
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(b)).To(MatchYAML(`
+id: "2"
+tenant: tenant2
+version: "1.9.0"
+`))
+
+	lastRevision := result.Status.LastExportedRevision
+
+	// Reconcile again with same data — revision should not change.
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	result = &fluxcdv1.ResourceSetInputProvider{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Status.LastExportedRevision).To(Equal(lastRevision))
+
+	// Update mock server response — revision should change.
+	inputsResponse = externalServiceResponse{
+		Inputs: []map[string]any{
+			{"id": "1", "tenant": "tenant1", "version": "2.0.0"},
+		},
+	}
+
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	result = &fluxcdv1.ResourceSetInputProvider{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Status.ExportedInputs).To(HaveLen(1))
+	g.Expect(result.Status.LastExportedRevision).NotTo(Equal(lastRevision))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_DefaultValues(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(externalServiceResponse{
+			Inputs: []map[string]any{
+				{"id": "1", "tenant": "tenant1"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	objDef := fmt.Sprintf(`
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: test-es-defaults
+  namespace: "%[1]s"
+spec:
+  type: ExternalService
+  url: %[2]s
+  insecure: true
+  defaultValues:
+    env: "production"
+    region: "us-east-1"
+`, ns.Name, server.URL)
+
+	obj := &fluxcdv1.ResourceSetInputProvider{}
+	err = yaml.Unmarshal([]byte(objDef), obj)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = testEnv.Create(ctx, obj)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Initialize.
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Reconcile.
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	result := &fluxcdv1.ResourceSetInputProvider{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(conditions.IsReady(result)).To(BeTrue())
+	g.Expect(result.Status.ExportedInputs).To(HaveLen(1))
+
+	// Verify default values are merged.
+	b, err := yaml.Marshal(result.Status.ExportedInputs[0])
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(b)).To(MatchYAML(`
+id: "1"
+tenant: tenant1
+env: production
+region: us-east-1
+`))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_BearerToken(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Create a mock server that validates bearer token.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer my-secret-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(externalServiceResponse{
+			Inputs: []map[string]any{
+				{"id": "1", "feature": "cert-manager"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	// Create the auth secret with a bearer token.
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bearer-secret",
+			Namespace: ns.Name,
+		},
+		Data: map[string][]byte{
+			"token": []byte("my-secret-token"),
+		},
+	}
+	err = testEnv.Create(ctx, secret)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	objDef := fmt.Sprintf(`
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: test-es-bearer
+  namespace: "%[1]s"
+spec:
+  type: ExternalService
+  url: %[2]s
+  insecure: true
+  secretRef:
+    name: bearer-secret
+`, ns.Name, server.URL)
+
+	obj := &fluxcdv1.ResourceSetInputProvider{}
+	err = yaml.Unmarshal([]byte(objDef), obj)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = testEnv.Create(ctx, obj)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Initialize.
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Reconcile.
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	result := &fluxcdv1.ResourceSetInputProvider{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(conditions.IsReady(result)).To(BeTrue())
+	g.Expect(result.Status.ExportedInputs).To(HaveLen(1))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_BasicAuth(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Create a mock server that validates basic auth.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "admin" || password != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(externalServiceResponse{
+			Inputs: []map[string]any{
+				{"id": "1", "feature": "cert-manager"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	// Create the auth secret with basic auth.
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "basic-auth-secret",
+			Namespace: ns.Name,
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("secret"),
+		},
+	}
+	err = testEnv.Create(ctx, secret)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	objDef := fmt.Sprintf(`
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: test-es-basic
+  namespace: "%[1]s"
+spec:
+  type: ExternalService
+  url: %[2]s
+  insecure: true
+  secretRef:
+    name: basic-auth-secret
+`, ns.Name, server.URL)
+
+	obj := &fluxcdv1.ResourceSetInputProvider{}
+	err = yaml.Unmarshal([]byte(objDef), obj)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = testEnv.Create(ctx, obj)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Initialize.
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Reconcile.
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	result := &fluxcdv1.ResourceSetInputProvider{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(conditions.IsReady(result)).To(BeTrue())
+	g.Expect(result.Status.ExportedInputs).To(HaveLen(1))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_FilterLimit(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Return 5 inputs.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(externalServiceResponse{
+			Inputs: []map[string]any{
+				{"id": "1", "name": "a"},
+				{"id": "2", "name": "b"},
+				{"id": "3", "name": "c"},
+				{"id": "4", "name": "d"},
+				{"id": "5", "name": "e"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	objDef := fmt.Sprintf(`
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: test-es-limit
+  namespace: "%[1]s"
+spec:
+  type: ExternalService
+  url: %[2]s
+  insecure: true
+  filter:
+    limit: 2
+`, ns.Name, server.URL)
+
+	obj := &fluxcdv1.ResourceSetInputProvider{}
+	err = yaml.Unmarshal([]byte(objDef), obj)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = testEnv.Create(ctx, obj)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Initialize.
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Reconcile.
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	result := &fluxcdv1.ResourceSetInputProvider{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(conditions.IsReady(result)).To(BeTrue())
+	// Should be limited to 2 despite 5 being returned.
+	g.Expect(result.Status.ExportedInputs).To(HaveLen(2))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_PayloadTooLarge(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// Create a mock server that returns a response larger than 900Ki.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"inputs": [`))
+		// Write a payload larger than maxExternalServicePayloadSize.
+		largeValue := strings.Repeat("x", 1024)
+		for i := 0; i < 1000; i++ {
+			if i > 0 {
+				_, _ = w.Write([]byte(","))
+			}
+			_, _ = fmt.Fprintf(w, `{"id": "%d", "data": "%s"}`, i, largeValue)
+		}
+		_, _ = w.Write([]byte(`]}`))
+	}))
+	defer server.Close()
+
+	obj := &fluxcdv1.ResourceSetInputProvider{
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type: fluxcdv1.InputProviderExternalService,
+			URL:  server.URL,
+		},
+	}
+
+	_, err := reconciler.callExternalServiceProvider(ctx, obj, nil, nil, nil)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("maximum allowed size"))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_MissingID(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(externalServiceResponse{
+			Inputs: []map[string]any{
+				{"tenant": "tenant1", "version": "1.0.0"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	obj := &fluxcdv1.ResourceSetInputProvider{
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type: fluxcdv1.InputProviderExternalService,
+			URL:  server.URL,
+		},
+	}
+
+	_, err := reconciler.callExternalServiceProvider(ctx, obj, nil, nil, nil)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("missing the required 'id' field"))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_DuplicateID(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(externalServiceResponse{
+			Inputs: []map[string]any{
+				{"id": "1", "tenant": "tenant1"},
+				{"id": "1", "tenant": "tenant2"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	obj := &fluxcdv1.ResourceSetInputProvider{
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type: fluxcdv1.InputProviderExternalService,
+			URL:  server.URL,
+		},
+	}
+
+	_, err := reconciler.callExternalServiceProvider(ctx, obj, nil, nil, nil)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("duplicate 'id' value '1'"))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_InvalidJSON(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`not valid json`))
+	}))
+	defer server.Close()
+
+	obj := &fluxcdv1.ResourceSetInputProvider{
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type: fluxcdv1.InputProviderExternalService,
+			URL:  server.URL,
+		},
+	}
+
+	_, err := reconciler.callExternalServiceProvider(ctx, obj, nil, nil, nil)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to parse JSON response"))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_HTTPError(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	obj := &fluxcdv1.ResourceSetInputProvider{
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type: fluxcdv1.InputProviderExternalService,
+			URL:  server.URL,
+		},
+	}
+
+	_, err := reconciler.callExternalServiceProvider(ctx, obj, nil, nil, nil)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("returned HTTP 500"))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_MissingInputsField(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [{"id": "1"}]}`))
+	}))
+	defer server.Close()
+
+	obj := &fluxcdv1.ResourceSetInputProvider{
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type: fluxcdv1.InputProviderExternalService,
+			URL:  server.URL,
+		},
+	}
+
+	_, err := reconciler.callExternalServiceProvider(ctx, obj, nil, nil, nil)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("does not contain an 'inputs' field"))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_NestedValues(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Return inputs with nested/complex values (arrays, objects).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(externalServiceResponse{
+			Inputs: []map[string]any{
+				{
+					"id":      "1",
+					"tenant":  "tenant1",
+					"version": "2.0.0",
+					"featureFlags": []string{
+						"feature1",
+						"feature2",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	objDef := fmt.Sprintf(`
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: test-es-nested
+  namespace: "%[1]s"
+spec:
+  type: ExternalService
+  url: %[2]s
+  insecure: true
+`, ns.Name, server.URL)
+
+	obj := &fluxcdv1.ResourceSetInputProvider{}
+	err = yaml.Unmarshal([]byte(objDef), obj)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = testEnv.Create(ctx, obj)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Initialize.
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Reconcile.
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	result := &fluxcdv1.ResourceSetInputProvider{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(conditions.IsReady(result)).To(BeTrue())
+	g.Expect(result.Status.ExportedInputs).To(HaveLen(1))
+
+	b, err := yaml.Marshal(result.Status.ExportedInputs[0])
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(b)).To(MatchYAML(`
+id: "1"
+tenant: tenant1
+version: "2.0.0"
+featureFlags:
+  - feature1
+  - feature2
+`))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_NonStringID(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Return numeric ID — should be rejected.
+		_, _ = w.Write([]byte(`{"inputs": [{"id": 123, "name": "test"}]}`))
+	}))
+	defer server.Close()
+
+	obj := &fluxcdv1.ResourceSetInputProvider{
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type: fluxcdv1.InputProviderExternalService,
+			URL:  server.URL,
+		},
+	}
+
+	_, err := reconciler.callExternalServiceProvider(ctx, obj, nil, nil, nil)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("non-string 'id' field"))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_UserAgent(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	reconciler.Version = "1.2.3-test"
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var capturedUserAgent string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUserAgent = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(externalServiceResponse{
+			Inputs: []map[string]any{
+				{"id": "1", "name": "test"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	obj := &fluxcdv1.ResourceSetInputProvider{
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type: fluxcdv1.InputProviderExternalService,
+			URL:  server.URL,
+		},
+	}
+
+	_, err := reconciler.callExternalServiceProvider(ctx, obj, nil, nil, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(capturedUserAgent).To(Equal("flux-operator/1.2.3-test"))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_InvalidURL(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	obj := &fluxcdv1.ResourceSetInputProvider{
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type: fluxcdv1.InputProviderExternalService,
+			URL:  "oci://registry.example.com/repo",
+		},
+	}
+
+	r, err := reconciler.reconcile(ctx, obj, nil)
+	g.Expect(r).To(Equal(reconcile.Result{}))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(conditions.IsReady(obj)).To(BeFalse())
+	g.Expect(conditions.IsStalled(obj)).To(BeTrue())
+	g.Expect(conditions.GetReason(obj, meta.ReadyCondition)).To(Equal(fluxcdv1.ReasonInvalidSpec))
+	g.Expect(conditions.GetMessage(obj, meta.StalledCondition)).To(ContainSubstring("spec.url must start with"))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_HTTPWithoutInsecure(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	obj := &fluxcdv1.ResourceSetInputProvider{
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type: fluxcdv1.InputProviderExternalService,
+			URL:  "http://example.com/api",
+		},
+	}
+
+	r, err := reconciler.reconcile(ctx, obj, nil)
+	g.Expect(r).To(Equal(reconcile.Result{}))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(conditions.IsReady(obj)).To(BeFalse())
+	g.Expect(conditions.IsStalled(obj)).To(BeTrue())
+	g.Expect(conditions.GetReason(obj, meta.ReadyCondition)).To(Equal(fluxcdv1.ReasonInvalidSpec))
+	g.Expect(conditions.GetMessage(obj, meta.StalledCondition)).To(ContainSubstring("spec.insecure is true"))
+}
+
+func TestResourceSetInputProviderReconciler_ExternalService_InsecureOnNonExternalService(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetInputProviderReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	obj := &fluxcdv1.ResourceSetInputProvider{
+		Spec: fluxcdv1.ResourceSetInputProviderSpec{
+			Type:     fluxcdv1.InputProviderGitHubBranch,
+			URL:      "https://github.com/example/repo",
+			Insecure: true,
+		},
+	}
+
+	r, err := reconciler.reconcile(ctx, obj, nil)
+	g.Expect(r).To(Equal(reconcile.Result{}))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(conditions.IsReady(obj)).To(BeFalse())
+	g.Expect(conditions.IsStalled(obj)).To(BeTrue())
+	g.Expect(conditions.GetReason(obj, meta.ReadyCondition)).To(Equal(fluxcdv1.ReasonInvalidSpec))
+	g.Expect(conditions.GetMessage(obj, meta.StalledCondition)).To(ContainSubstring("spec.insecure can only be set"))
+}


### PR DESCRIPTION
This PR adds support for ExternalService as a new ResourceSetInputProvider.spec.type, so Flux Operator can fetch dynamic ResourceSet inputs from third-party orchestrator APIs over HTTP/S.

Closes #150  

#### Implemented with these constraints in mind: 

-  reject payloads that don't fit into etcd (900Ki max)
- protect against OOM by not loading the whole response into memory if it's over the limit
- the expected format is an array, each element with a unique id
- trim the array based on .spec.filter.limit that has 100 as the default

I am attaching an e2e kind testing script, with its log outputs. 

[e2d-logs.txt](https://github.com/user-attachments/files/25524513/e2d-logs.txt)
[externalservice-e2e.sh](https://github.com/user-attachments/files/25524518/externalservice-e2e.sh)

