### PR TITLE
web: Introduce workload dashboard and log viewer

### DIFF
--- a/api/v1/webconfig_types.go
+++ b/api/v1/webconfig_types.go
@@ -49,6 +49,13 @@ const (
 	// pods of a workload. Should not be added to the userActions map.
 	UserActionDeletePods = "deletePods"
 
+	// UserActionViewLogs is the view-logs user action for pods of workloads
+	// managed by Flux. Like UserActionDeletePods, this constant is not a
+	// custom RBAC verb: it only signals to the frontend that the user is
+	// allowed to read pod logs (the native "get" verb on the "pods/log"
+	// subresource). It must not be added to the userActions map.
+	UserActionViewLogs = "logs"
+
 	// UserActionsAccessImpersonated configures GitOps actions to be performed
 	// by impersonating the user's Kubernetes RBAC identity. This is the default
 	// and requires the user to hold both the custom per-action verb and the

--- a/config/default/rbac.yaml
+++ b/config/default/rbac.yaml
@@ -117,3 +117,10 @@ rules:
       - pods
     verbs:
       - delete
+  # Allow action: view logs of Pods owned by workloads managed by Flux.
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get

--- a/docs/web/web-actions.md
+++ b/docs/web/web-actions.md
@@ -139,6 +139,10 @@ previous container instance (useful for troubleshooting crash loops), and
 expand to fullscreen. Each log entry is rendered on its own separated row, and
 newly arrived entries are briefly highlighted while following.
 
+On the workload dashboard the action is available per pod in the Pods list, and
+from the action bar as a "View logs" dropdown listing all the pods of the
+workload. Selecting a pod opens the viewer for that pod.
+
 Unlike the GitOps and workload mutation actions, viewing logs is a read-only
 operation. The logs are always read using the authenticated user's identity,
 so a user can only view the logs of pods they are explicitly authorized to read.

--- a/docs/web/web-actions.md
+++ b/docs/web/web-actions.md
@@ -139,6 +139,8 @@ entries containing it, e.g. `!debug`), a level filter to show only entries of a
 chosen severity, a control to choose how many lines to
 fetch, and toggles to follow the logs (polling for new entries, enabled by
 default), switch between formatted and raw output, and expand to fullscreen.
+On small screens the viewer opens full-screen with the toolbar laid out in a
+compact grid, and the fullscreen toggle is hidden.
 
 When following, each poll requests only the entries newer than the last one
 already shown and appends them, so the lines you are reading stay put instead of
@@ -166,9 +168,17 @@ separator rule (faint blue for info, escalating through amber for warnings and
 red for errors), and the footer summarizes the per-level counts, which doubles
 as the color legend. ANSI color escape codes in the logs are stripped.
 
-On the workload dashboard the action is available per pod in the Pods list, and
-from the action bar as a "View logs" dropdown listing all the pods of the
-workload. Selecting a pod opens the viewer for that pod.
+On the workload dashboard the action is available per pod in the Pods list (opening
+the viewer on that pod), and from the action bar as a "View logs" button that opens
+the viewer on the merged "All pods" view; the viewer's own pod selector then narrows
+it to a single pod.
+
+The viewer keeps the page URL pointed at the pod currently shown (`?logs=<pod>`, or
+`?logs=*` for the merged "All pods" view), updating it both when the viewer is
+opened and whenever the pod is changed with the viewer's own selector. The link can
+be copied or bookmarked and, when reopened, loads the workload dashboard with the
+logs viewer already showing that pod's logs (subject to the same authorization).
+Closing the viewer removes the parameter.
 
 Unlike the GitOps and workload mutation actions, viewing logs is a read-only
 operation. The logs are always read using the authenticated user's identity,

--- a/docs/web/web-actions.md
+++ b/docs/web/web-actions.md
@@ -131,14 +131,15 @@ is performed.
 ### View Logs
 
 The View Logs action opens a viewer that displays the logs of a pod container.
-The viewer provides a container selector (including init containers), a
-free-text filter to show only entries containing a given substring (prefix the
-text with `!` to instead hide entries containing it, e.g. `!debug`), a control
-to choose how many lines to fetch, and toggles to follow the logs (polling for
-new entries, enabled by default), show or hide timestamps, switch to the
-previous container instance (useful for troubleshooting crash loops), and
-expand to fullscreen. Each log entry is rendered on its own separated row, and
-newly arrived entries are briefly highlighted while following.
+The viewer provides a container selector (including init containers; containers
+that have restarted also expose a "(previous)" entry for the prior instance's
+logs, useful for troubleshooting crash loops), a free-text filter to show only
+entries containing a given substring (prefix the text with `!` to instead hide
+entries containing it, e.g. `!debug`), a control to choose how many lines to
+fetch, and toggles to follow the logs (polling for new entries, enabled by
+default) and expand to fullscreen. Each log entry is rendered on its own row,
+with its timestamp shown as a pill on the row separator; the latest timestamp
+pill is briefly highlighted when new entries arrive while following.
 
 On the workload dashboard the action is available per pod in the Pods list, and
 from the action bar as a "View logs" dropdown listing all the pods of the

--- a/docs/web/web-actions.md
+++ b/docs/web/web-actions.md
@@ -132,7 +132,8 @@ is performed.
 
 The View Logs action opens a viewer that displays the logs of a pod container.
 The viewer provides a container selector (including init containers), a
-free-text filter to show only entries containing a given substring, a control
+free-text filter to show only entries containing a given substring (prefix the
+text with `!` to instead hide entries containing it, e.g. `!debug`), a control
 to choose how many lines to fetch, and toggles to follow the logs (polling for
 new entries, enabled by default), show or hide timestamps, switch to the
 previous container instance (useful for troubleshooting crash loops), and

--- a/docs/web/web-actions.md
+++ b/docs/web/web-actions.md
@@ -135,13 +135,24 @@ The viewer provides a container selector (including init containers; containers
 that have restarted also expose a "(previous)" entry for the prior instance's
 logs, useful for troubleshooting crash loops), a free-text filter to show only
 entries containing a given substring (prefix the text with `!` to instead hide
-entries containing it, e.g. `!debug`), a control to choose how many lines to
+entries containing it, e.g. `!debug`), a level filter to show only entries of a
+chosen severity, a control to choose how many lines to
 fetch, and toggles to follow the logs (polling for new entries, enabled by
 default), pretty-print JSON-formatted lines (rendering structured logs as
 syntax-highlighted code blocks, leaving plain-text lines untouched), and expand
-to fullscreen. Each log entry is rendered on its own row,
-with its timestamp shown as a pill on the row separator; the latest timestamp
-pill is briefly highlighted when new entries arrive while following.
+to fullscreen. Each log entry is rendered on its own row, with its timestamp
+shown as a pill on the row separator; the latest timestamp pill is briefly
+highlighted when new entries arrive while following.
+
+The viewer detects the log level of each entry across the common formats emitted
+by mainstream loggers (JSON `level`/`severity`/`level_name`/`@level`/`s` fields,
+including the numeric pino/bunyan and MongoDB single-character scales; klog
+`I/W/E/F` prefixes; logfmt `level=`; bracketed tokens such as nginx's `[error]`
+or Envoy's `[warning]`; leading `error:`-style console prefixes; and plain-text
+level tokens), defaulting to `info` when no level is found. The detected level colors the entry's timestamp pill and
+separator rule (faint blue for info, escalating through amber for warnings and
+red for errors), and the footer summarizes the per-level counts, which doubles
+as the color legend. ANSI color escape codes in the logs are stripped.
 
 On the workload dashboard the action is available per pod in the Pods list, and
 from the action bar as a "View logs" dropdown listing all the pods of the

--- a/docs/web/web-actions.md
+++ b/docs/web/web-actions.md
@@ -8,7 +8,8 @@ description: Guide for user actions in the Flux Web UI.
 The Flux Web UI provides interactive actions that allow users to manage
 Flux resources and Kubernetes workloads directly from the browser.
 Actions include triggering reconciliations, suspending and resuming resources,
-downloading artifacts, restarting workloads, running jobs, and deleting pods.
+downloading artifacts, restarting workloads, running jobs, deleting pods,
+and viewing pod logs.
 
 Actions are only available when [authentication](web-user-management.md) is configured.
 Each action requires specific RBAC permissions granted through Kubernetes
@@ -126,6 +127,25 @@ is performed.
 !!! note "RBAC"
 
     Requires the `delete` verb on `pods` in the core API group.
+
+### View Logs
+
+The View Logs action opens a viewer that displays the logs of a pod container.
+The viewer provides a container selector (including init containers), a
+free-text filter to show only entries containing a given substring, a control
+to choose how many lines to fetch, and toggles to follow the logs (polling for
+new entries), show or hide timestamps, switch to the previous container
+instance (useful for troubleshooting crash loops), and expand to fullscreen.
+Each log entry is rendered on its own separated row.
+
+Unlike the GitOps and workload mutation actions, viewing logs is a read-only
+operation. The logs are always read using the authenticated user's identity,
+so a user can only view the logs of pods they are explicitly authorized to read.
+This action is not audited.
+
+!!! note "RBAC"
+
+    Requires the `get` verb on the `pods/log` subresource in the core API group.
 
 ## Audit
 

--- a/docs/web/web-actions.md
+++ b/docs/web/web-actions.md
@@ -137,7 +137,9 @@ logs, useful for troubleshooting crash loops), a free-text filter to show only
 entries containing a given substring (prefix the text with `!` to instead hide
 entries containing it, e.g. `!debug`), a control to choose how many lines to
 fetch, and toggles to follow the logs (polling for new entries, enabled by
-default) and expand to fullscreen. Each log entry is rendered on its own row,
+default), pretty-print JSON-formatted lines (rendering structured logs as
+syntax-highlighted code blocks, leaving plain-text lines untouched), and expand
+to fullscreen. Each log entry is rendered on its own row,
 with its timestamp shown as a pill on the row separator; the latest timestamp
 pill is briefly highlighted when new entries arrive while following.
 

--- a/docs/web/web-actions.md
+++ b/docs/web/web-actions.md
@@ -91,6 +91,16 @@ Workload actions operate on Kubernetes workloads managed by Flux.
 These actions are available on the workload detail page for
 Deployments, StatefulSets, DaemonSets, CronJobs, and Pods.
 
+### View Logs
+
+The View Logs action streams a pod's container logs in a read-only viewer.
+It is available per pod from the Pods list and from the action bar as
+a "View logs" button that aggregates the logs of all the workload's pods.
+
+!!! note "RBAC"
+
+    Requires the `get` verb on the `pods/log` subresource in the core API group.
+
 ### Rollout Restart
 
 The Rollout Restart action triggers a rolling restart of a Deployment,
@@ -127,67 +137,6 @@ is performed.
 !!! note "RBAC"
 
     Requires the `delete` verb on `pods` in the core API group.
-
-### View Logs
-
-The View Logs action opens a viewer that displays the logs of a pod container.
-The viewer provides a container selector (including init containers; containers
-that have restarted also expose a "(previous)" entry for the prior instance's
-logs, useful for troubleshooting crash loops), a free-text filter to show only
-entries containing a given substring (prefix the text with `!` to instead hide
-entries containing it, e.g. `!debug`), a level filter to show only entries of a
-chosen severity, a control to choose how many lines to
-fetch, and toggles to follow the logs (polling for new entries, enabled by
-default), switch between formatted and raw output, and expand to fullscreen.
-On small screens the viewer opens full-screen with the toolbar laid out in a
-compact grid, and the fullscreen toggle is hidden.
-
-When following, each poll requests only the entries newer than the last one
-already shown and appends them, so the lines you are reading stay put instead of
-shifting on every refresh. Auto-scroll keeps the newest line in view only while
-the view is scrolled to the bottom, so scrolling up to read earlier entries is
-not interrupted by incoming logs. If a follow poll fails (for example because
-the pod was deleted), the error is shown inline at the tail of the feed and the
-already-fetched logs remain on screen; the viewer retries on the next poll.
-
-In the default formatted mode each log entry is rendered on its own row, with
-its timestamp shown as a pill on the row separator, JSON-formatted lines
-pretty-printed as syntax-highlighted code blocks (plain-text lines left
-untouched), and the latest timestamp pill briefly highlighted when new entries
-arrive while following. The raw mode strips all of that styling, rendering each
-line as plain text without separators, timestamp pills, level coloring, or the
-new-entry highlight.
-
-The viewer detects the log level of each entry across the common formats emitted
-by mainstream loggers (JSON `level`/`severity`/`level_name`/`@level`/`s` fields,
-including the numeric pino/bunyan and MongoDB single-character scales; klog
-`I/W/E/F` prefixes; logfmt `level=`; bracketed tokens such as nginx's `[error]`
-or Envoy's `[warning]`; leading `error:`-style console prefixes; and plain-text
-level tokens), defaulting to `info` when no level is found. The detected level colors the entry's timestamp pill and
-separator rule (faint blue for info, escalating through amber for warnings and
-red for errors), and the footer summarizes the per-level counts, which doubles
-as the color legend. ANSI color escape codes in the logs are stripped.
-
-On the workload dashboard the action is available per pod in the Pods list (opening
-the viewer on that pod), and from the action bar as a "View logs" button that opens
-the viewer on the merged "All pods" view; the viewer's own pod selector then narrows
-it to a single pod.
-
-The viewer keeps the page URL pointed at the pod currently shown (`?logs=<pod>`, or
-`?logs=*` for the merged "All pods" view), updating it both when the viewer is
-opened and whenever the pod is changed with the viewer's own selector. The link can
-be copied or bookmarked and, when reopened, loads the workload dashboard with the
-logs viewer already showing that pod's logs (subject to the same authorization).
-Closing the viewer removes the parameter.
-
-Unlike the GitOps and workload mutation actions, viewing logs is a read-only
-operation. The logs are always read using the authenticated user's identity,
-so a user can only view the logs of pods they are explicitly authorized to read.
-This action is not audited.
-
-!!! note "RBAC"
-
-    Requires the `get` verb on the `pods/log` subresource in the core API group.
 
 ## Audit
 

--- a/docs/web/web-actions.md
+++ b/docs/web/web-actions.md
@@ -138,11 +138,23 @@ entries containing a given substring (prefix the text with `!` to instead hide
 entries containing it, e.g. `!debug`), a level filter to show only entries of a
 chosen severity, a control to choose how many lines to
 fetch, and toggles to follow the logs (polling for new entries, enabled by
-default), pretty-print JSON-formatted lines (rendering structured logs as
-syntax-highlighted code blocks, leaving plain-text lines untouched), and expand
-to fullscreen. Each log entry is rendered on its own row, with its timestamp
-shown as a pill on the row separator; the latest timestamp pill is briefly
-highlighted when new entries arrive while following.
+default), switch between formatted and raw output, and expand to fullscreen.
+
+When following, each poll requests only the entries newer than the last one
+already shown and appends them, so the lines you are reading stay put instead of
+shifting on every refresh. Auto-scroll keeps the newest line in view only while
+the view is scrolled to the bottom, so scrolling up to read earlier entries is
+not interrupted by incoming logs. If a follow poll fails (for example because
+the pod was deleted), the error is shown inline at the tail of the feed and the
+already-fetched logs remain on screen; the viewer retries on the next poll.
+
+In the default formatted mode each log entry is rendered on its own row, with
+its timestamp shown as a pill on the row separator, JSON-formatted lines
+pretty-printed as syntax-highlighted code blocks (plain-text lines left
+untouched), and the latest timestamp pill briefly highlighted when new entries
+arrive while following. The raw mode strips all of that styling, rendering each
+line as plain text without separators, timestamp pills, level coloring, or the
+new-entry highlight.
 
 The viewer detects the log level of each entry across the common formats emitted
 by mainstream loggers (JSON `level`/`severity`/`level_name`/`@level`/`s` fields,

--- a/docs/web/web-actions.md
+++ b/docs/web/web-actions.md
@@ -134,9 +134,10 @@ The View Logs action opens a viewer that displays the logs of a pod container.
 The viewer provides a container selector (including init containers), a
 free-text filter to show only entries containing a given substring, a control
 to choose how many lines to fetch, and toggles to follow the logs (polling for
-new entries), show or hide timestamps, switch to the previous container
-instance (useful for troubleshooting crash loops), and expand to fullscreen.
-Each log entry is rendered on its own separated row.
+new entries, enabled by default), show or hide timestamps, switch to the
+previous container instance (useful for troubleshooting crash loops), and
+expand to fullscreen. Each log entry is rendered on its own separated row, and
+newly arrived entries are briefly highlighted while following.
 
 Unlike the GitOps and workload mutation actions, viewing logs is a read-only
 operation. The logs are always read using the authenticated user's identity,

--- a/docs/web/web-least-privilege-rbac.md
+++ b/docs/web/web-least-privilege-rbac.md
@@ -210,6 +210,79 @@ Users do not need cluster-wide `list` permissions on namespaces just to populate
 
 ---
 
+## 9. Inventory-Derived Workloads Index
+
+**Where:** The Workloads page and the global quick-search workload results.
+
+**Internal operation:**
+The system extracts the Kubernetes workloads (Deployment, StatefulSet,
+DaemonSet, CronJob) managed by every Flux applier from the appliers'
+`status.inventory.entries`, during the same privileged background pass that
+builds the dashboard report. No additional cluster queries (and therefore no
+`apps`/`batch` RBAC on the operator) are performed.
+
+**How it works:**
+While building the `FluxReport`, the reporter already lists every applier
+reconciler (FluxInstance, Kustomization, HelmRelease, ResourceSet) as a full
+object. Each applier's inventory enumerates the objects it manages with their
+GVK and namespace/name. The reporter keeps the workload-kind entries, stamps
+each with the owning reconciler's reference and status, and caches them in a
+workload index. When a user requests the Workloads page, the cached index is
+served filtered to the namespaces the user can access — the same per-namespace
+`get resourcesets` gate used for the dashboard
+(see [Namespace Visibility](#8-namespace-visibility)). There is **no
+live-query fallback**: the page is served exclusively from this privileged,
+inventory-derived index.
+
+**Least privilege benefit:**
+A user with Flux read access in a namespace (can `get resourcesets`) can
+enumerate all Deployment/StatefulSet/DaemonSet/CronJob **names** managed by Flux
+in that namespace **without** holding any `apps`/`batch` RBAC. The index never
+exposes workload spec, status conditions, pod data, or secrets — only the
+workload identity (kind, namespace, name, apiVersion) and the parent
+reconciler reference.
+
+**Security consequences to be aware of:**
+
+- Each workload row exposes its parent reconciler's **name and status badge**
+  (`Ready`/`Failed`/`Progressing`/`Suspended`/`Unknown`) — never the reconciler
+  message — even when that reconciler lives in a namespace the user cannot
+  otherwise access. The workload itself carries no status in the index; per-workload
+  live status is only fetched on the workload detail page and in Favorites.
+- **Remote-cluster appliers are excluded.** Kustomizations and HelmReleases with
+  `spec.kubeConfig` set target a remote cluster, so their workloads do not exist
+  locally; they are skipped during extraction to avoid broken links and remote
+  metadata exposure.
+- **HelmRelease on Flux ≤ 2.7 caveat.** Older HelmReleases store their inventory
+  in a Helm storage secret rather than `status.inventory.entries`. The index does
+  **not** read that secret (doing so would defeat the inventory-only, no-extra-RBAC
+  design), so HelmRelease-managed workloads on Flux ≤ 2.7 are absent from the
+  Workloads list and quick-search. They remain visible on the resource
+  detail/inventory page, which does perform the storage-secret read on demand
+  using the user's own client.
+- **Favorites use the user's own client.** When a workload is marked as a
+  favorite, its live status is fetched with the user's impersonated client and a
+  lightweight `kstatus` computation on the fetched object alone. Real `apps`/`batch`
+  `get` RBAC therefore applies to favorites. The lightweight status path needs only
+  `get` on the workload — it does **not** list pods — so a user who can `get` the
+  workload but not `list pods` still sees a valid status instead of `NotFound`.
+
+**API endpoints:**
+
+- `GET /api/v1/workloads?kind=&name=&namespace=` — returns the inventory-derived,
+  namespace-filtered list of workloads as `{ "workloads": [WorkloadRef, ...] }`.
+  Each `WorkloadRef` has the shape:
+  `{ "kind", "name", "namespace", "apiVersion", "reconcilerKind",
+  "reconcilerNamespace", "reconcilerName", "reconcilerStatus", "lastReconciled" }`.
+  `name` supports wildcards (`*`); `kind` and `namespace` are exact matches.
+  This route is distinct from the existing `POST /api/v1/workloads`, which
+  returns live workload status for the detail/inventory views.
+- `GET /api/v1/workloads/search?name=&namespace=&kind=` — the quick-search
+  variant of the above. A `name` without a wildcard is wrapped as `*name*` for a
+  partial match and results are capped at a small limit. Same response shape.
+
+---
+
 ## Summary
 
 | # | Feature | Internal Operation | Data Exposed to User |
@@ -222,3 +295,4 @@ Users do not need cluster-wide `list` permissions on namespaces just to populate
 | 6 | Controller metrics | System reads metrics API | CPU/memory usage of Flux controllers |
 | 7 | Fine-Grained GitOps Actions | System patches resource | None (server-side mutation only) |
 | 8 | Namespace visibility | System lists namespaces | Visible namespace names |
+| 9 | Workloads index | System extracts workloads from applier inventories | Workload identity + parent reconciler name/status, filtered by user namespace |

--- a/docs/web/web-least-privilege-rbac.md
+++ b/docs/web/web-least-privilege-rbac.md
@@ -11,12 +11,14 @@ by impersonating the authenticated user for every Kubernetes API call.
 However, a small number of operations intentionally bypass user impersonation
 and run with the operator's own service-account privileges instead.
 
-Every such internal operation is implemented by calling an internal `WithPrivileges()`
-option on the Kubernetes client. This page documents **every** call,
-explains how it leverages system privileges to minimize the amount of RBAC
-permissions administrators need to grant to users, and describes how the
-system fulfills these critical internal requirements without exposing
-sensitive data.
+Most such internal operations are implemented by calling an internal
+`WithPrivileges()` option on the Kubernetes client. The documented exception is
+namespace visibility: the kubeclient wrapper directly uses its privileged base
+client to enumerate namespaces before filtering the result through the user's
+RBAC checks. This page documents **every** elevated backend path, explains how
+it leverages system privileges to minimize the amount of RBAC permissions
+administrators need to grant to users, and describes how the system fulfills
+these critical internal requirements without exposing sensitive data.
 
 By relying on the system to safely handle these internal operations,
 administrators can enforce a much stricter least-privilege posture.
@@ -128,10 +130,13 @@ pipeline that manages them. The system handles this resolution internally withou
 
 ## 5. Cluster-Wide Report Building
 
-**Where:** The main dashboard and the periodic background report refresh.
+**Where:** The main dashboard, the periodic background report refresh,
+the Workloads search page, and the global quick-search workload results.
 
 **Internal operation:**
-The system scans all Flux custom resources across all namespaces to compute reconciler statistics and build the `FluxReport`.
+The system scans all Flux custom resources across all namespaces to compute
+reconciler statistics, build the `FluxReport`, and extract Kubernetes workload
+references from Flux applier inventories.
 
 **How it works:**
 The operator builds a `FluxReport` by scanning all Flux custom resources
@@ -141,11 +146,25 @@ single report object. This report is built periodically on a background
 goroutine and cached. When a user requests the report, the cached data
 is filtered to show only the namespaces the user has access to.
 
+During the same scan, the reporter also reads applier
+`status.inventory.entries`, keeps local Kubernetes workload entries
+(Deployment, StatefulSet, DaemonSet, CronJob), stamps them with the owning
+reconciler's reference and status, and caches them in a workload index.
+Appliers targeting remote clusters are skipped. The Workloads page and
+global quick-search workload results are served from this cache and filtered
+to the namespaces the user can access.
+
 **Least privilege benefit:**
 The report is the backbone of the Web UI dashboard. Building it requires
 cross-namespace visibility that no single user is guaranteed to have —
-especially in multi-tenant clusters. The privileged scan produces **aggregated statistics only**
-(counts, readiness percentages, status summaries). By handling this internally and filtering the response based on the user's namespace access, we avoid granting users cluster-wide read access while still delivering a meaningful, isolated dashboard experience.
+especially in multi-tenant clusters. The privileged scan exposes summarized
+reconciler data (counts, readiness percentages, status summaries) and
+inventory-derived workload reference (kind, namespace, name, apiVersion, and
+parent reconciler reference/status), never workload specs, workload status
+conditions, pod data, or secrets. By handling this internally and filtering the
+response based on the user's namespace access, we avoid granting users
+cluster-wide read access or `apps`/`batch` read permissions while still
+delivering a meaningful, isolated dashboard and workload search experience.
 
 ---
 
@@ -191,41 +210,21 @@ This feature is crucial for least-privilege security scenarios. If users were re
 **Where:** Namespace search filter dropdown and dashboard statistics filtering.
 
 **Internal operation:**
-The system lists all namespaces to determine which ones the user is permitted to view.
+The kubeclient wrapper lists all namespaces with its privileged base client to
+determine which ones the user is permitted to view.
 
 **How it works:**
-To populate the namespace filter dropdown and filter the main dashboard statistics, the backend needs to know which namespaces the user is allowed to see. It uses the system client to list all namespaces, and then performs a `SelfSubjectAccessReview` for the user to check if they have `get` permissions on `ResourceSets` in each namespace. If they do, the namespace's existence is revealed to the user in the UI.
+To populate the namespace filter dropdown and filter the main dashboard
+statistics, the backend needs to know which namespaces the user is allowed to
+see. This path does not call `WithPrivileges()` because it already runs inside
+the kubeclient wrapper: `ListUserNamespaces` uses the wrapper's privileged base
+client to list all namespaces, and then performs a `SelfSubjectAccessReview` for
+the user to check if they have `get` permissions on `ResourceSets` in each
+namespace. If they do, the namespace's existence is revealed to the user in the
+UI.
 
 **Least privilege benefit:**
 Users do not need cluster-wide `list` permissions on namespaces just to populate the UI dropdown. The system determines what the user is allowed to see internally, keeping user permissions tightly scoped to only the resources they actively manage. This preserves strict multi-tenant boundaries by removing the need for broad, cluster-level namespace access.
-
----
-
-## 9. Inventory-Derived Workloads Index
-
-**Where:** The Workloads search page and the global quick-search workload results.
-
-**Internal operation:**
-The system extracts the Kubernetes workloads (Deployment, StatefulSet,
-DaemonSet, CronJob) managed by every Flux applier from the appliers'
-`status.inventory.entries`, during the same privileged background pass that
-builds the dashboard report. No additional cluster queries (and therefore no
-`apps`/`batch` RBAC on the operator) are performed.
-
-**How it works:**
-While building the `FluxReport`, the reporter already reads every applier
-reconciler and its inventory. It keeps the workload-kind entries, stamps each
-with the owning reconciler's reference and status, and caches them in a workload
-index. The Workloads page is served from this cache, filtered to the namespaces
-the user can access via the same per-namespace `get resourcesets` gate used for
-the dashboard (see [Namespace Visibility](#8-namespace-visibility)).
-
-**Least privilege benefit:**
-A user with Flux read access in a namespace (can `get resourcesets`) can
-enumerate all Flux-managed workload **names** in that namespace **without**
-holding any `apps`/`batch` RBAC. The index exposes only the workload identity
-(kind, namespace, name, apiVersion) and the parent reconciler reference — never
-workload spec, status conditions, pod data, or secrets.
 
 ---
 
@@ -237,8 +236,7 @@ workload spec, status conditions, pod data, or secrets.
 | 2 | Flux GVK resolution         | System API discovery                               | None (internal metadata only)                                                 |
 | 3 | Audit event recording       | System writes event                                | None (server-side only)                                                       |
 | 4 | Audit pod-owner resolution  | System reads owner chain                           | None (server-side only)                                                       |
-| 5 | Dashboard report            | System scans cluster                               | Aggregated stats filtered by user namespace                                   |
+| 5 | Dashboard report and workloads index | System scans Flux resources and applier inventories | Aggregated stats and workload reference + parent reconciler status, filtered by user namespace |
 | 6 | Controller metrics          | System reads metrics API                           | CPU/memory usage of Flux controllers                                          |
 | 7 | Fine-Grained GitOps Actions | System patches resource                            | None (server-side mutation only)                                              |
-| 8 | Namespace visibility        | System lists namespaces                            | Visible namespace names                                                       |
-| 9 | Workloads index             | System extracts workloads from applier inventories | Workload identity + parent reconciler name/status, filtered by user namespace |
+| 8 | Namespace visibility        | Wrapper lists namespaces with privileged base client | Visible namespace names after RBAC filtering                                  |

--- a/docs/web/web-least-privilege-rbac.md
+++ b/docs/web/web-least-privilege-rbac.md
@@ -21,6 +21,15 @@ sensitive data.
 By relying on the system to safely handle these internal operations,
 administrators can enforce a much stricter least-privilege posture.
 
+!!! note "Pod log viewing"
+
+    Reading pod logs from the workload detail page is **not** one of these
+    privileged operations. Logs are always streamed using the impersonated
+    user's identity, so Kubernetes enforces the user's own `get` permission on
+    the `pods/log` subresource. A user can only view the logs of pods they are
+    explicitly authorized to read, and the operation never escalates to the
+    operator's service-account privileges.
+
 ## Guiding Principles
 
 1. **Least privilege by default.** All resource reads and writes go through

--- a/docs/web/web-least-privilege-rbac.md
+++ b/docs/web/web-least-privilege-rbac.md
@@ -23,7 +23,7 @@ administrators can enforce a much stricter least-privilege posture.
 
 !!! note "Pod log viewing"
 
-    Reading pod logs from the workload detail page is **not** one of these
+    Reading pod logs from the Web UI is **not** one of these
     privileged operations. Logs are always streamed using the impersonated
     user's identity, so Kubernetes enforces the user's own `get` permission on
     the `pods/log` subresource. A user can only view the logs of pods they are

--- a/docs/web/web-least-privilege-rbac.md
+++ b/docs/web/web-least-privilege-rbac.md
@@ -266,6 +266,14 @@ reconciler reference.
   `get` RBAC therefore applies to favorites. The lightweight status path needs only
   `get` on the workload — it does **not** list pods — so a user who can `get` the
   workload but not `list pods` still sees a valid status instead of `NotFound`.
+- **Inline details use the user's own client.** Each row on the Workloads list
+  offers an expandable, read-only detail panel (Overview / Specification /
+  Status) that lazy-loads on first expand from the existing RBAC-enforced
+  `GET /api/v1/workload` endpoint — the same endpoint the full workload dashboard
+  uses. It requires no new permissions: a user who cannot `get` the workload in
+  its namespace sees a not-found/forbidden state instead. Pod listing, events,
+  and actions are intentionally excluded from this inline panel and remain on the
+  full workload dashboard.
 
 **API endpoints:**
 

--- a/docs/web/web-least-privilege-rbac.md
+++ b/docs/web/web-least-privilege-rbac.md
@@ -21,15 +21,6 @@ sensitive data.
 By relying on the system to safely handle these internal operations,
 administrators can enforce a much stricter least-privilege posture.
 
-!!! note "Pod log viewing"
-
-    Reading pod logs from the Web UI is **not** one of these
-    privileged operations. Logs are always streamed using the impersonated
-    user's identity, so Kubernetes enforces the user's own `get` permission on
-    the `pods/log` subresource. A user can only view the logs of pods they are
-    explicitly authorized to read, and the operation never escalates to the
-    operator's service-account privileges.
-
 ## Guiding Principles
 
 1. **Least privilege by default.** All resource reads and writes go through
@@ -212,7 +203,7 @@ Users do not need cluster-wide `list` permissions on namespaces just to populate
 
 ## 9. Inventory-Derived Workloads Index
 
-**Where:** The Workloads page and the global quick-search workload results.
+**Where:** The Workloads search page and the global quick-search workload results.
 
 **Internal operation:**
 The system extracts the Kubernetes workloads (Deployment, StatefulSet,
@@ -222,85 +213,32 @@ builds the dashboard report. No additional cluster queries (and therefore no
 `apps`/`batch` RBAC on the operator) are performed.
 
 **How it works:**
-While building the `FluxReport`, the reporter already lists every applier
-reconciler (FluxInstance, Kustomization, HelmRelease, ResourceSet) as a full
-object. Each applier's inventory enumerates the objects it manages with their
-GVK and namespace/name. The reporter keeps the workload-kind entries, stamps
-each with the owning reconciler's reference and status, and caches them in a
-workload index. When a user requests the Workloads page, the cached index is
-served filtered to the namespaces the user can access — the same per-namespace
-`get resourcesets` gate used for the dashboard
-(see [Namespace Visibility](#8-namespace-visibility)). There is **no
-live-query fallback**: the page is served exclusively from this privileged,
-inventory-derived index.
+While building the `FluxReport`, the reporter already reads every applier
+reconciler and its inventory. It keeps the workload-kind entries, stamps each
+with the owning reconciler's reference and status, and caches them in a workload
+index. The Workloads page is served from this cache, filtered to the namespaces
+the user can access via the same per-namespace `get resourcesets` gate used for
+the dashboard (see [Namespace Visibility](#8-namespace-visibility)).
 
 **Least privilege benefit:**
 A user with Flux read access in a namespace (can `get resourcesets`) can
-enumerate all Deployment/StatefulSet/DaemonSet/CronJob **names** managed by Flux
-in that namespace **without** holding any `apps`/`batch` RBAC. The index never
-exposes workload spec, status conditions, pod data, or secrets — only the
-workload identity (kind, namespace, name, apiVersion) and the parent
-reconciler reference.
-
-**Security consequences to be aware of:**
-
-- Each workload row exposes its parent reconciler's **name and status badge**
-  (`Ready`/`Failed`/`Progressing`/`Suspended`/`Unknown`) — never the reconciler
-  message — even when that reconciler lives in a namespace the user cannot
-  otherwise access. The workload itself carries no status in the index; per-workload
-  live status is only fetched on the workload detail page and in Favorites.
-- **Remote-cluster appliers are excluded.** Kustomizations and HelmReleases with
-  `spec.kubeConfig` set target a remote cluster, so their workloads do not exist
-  locally; they are skipped during extraction to avoid broken links and remote
-  metadata exposure.
-- **HelmRelease on Flux ≤ 2.7 caveat.** Older HelmReleases store their inventory
-  in a Helm storage secret rather than `status.inventory.entries`. The index does
-  **not** read that secret (doing so would defeat the inventory-only, no-extra-RBAC
-  design), so HelmRelease-managed workloads on Flux ≤ 2.7 are absent from the
-  Workloads list and quick-search. They remain visible on the resource
-  detail/inventory page, which does perform the storage-secret read on demand
-  using the user's own client.
-- **Favorites use the user's own client.** When a workload is marked as a
-  favorite, its live status is fetched with the user's impersonated client and a
-  lightweight `kstatus` computation on the fetched object alone. Real `apps`/`batch`
-  `get` RBAC therefore applies to favorites. The lightweight status path needs only
-  `get` on the workload — it does **not** list pods — so a user who can `get` the
-  workload but not `list pods` still sees a valid status instead of `NotFound`.
-- **Inline details use the user's own client.** Each row on the Workloads list
-  offers an expandable, read-only detail panel (Overview / Specification /
-  Status) that lazy-loads on first expand from the existing RBAC-enforced
-  `GET /api/v1/workload` endpoint — the same endpoint the full workload dashboard
-  uses. It requires no new permissions: a user who cannot `get` the workload in
-  its namespace sees a not-found/forbidden state instead. Pod listing, events,
-  and actions are intentionally excluded from this inline panel and remain on the
-  full workload dashboard.
-
-**API endpoints:**
-
-- `GET /api/v1/workloads?kind=&name=&namespace=` — returns the inventory-derived,
-  namespace-filtered list of workloads as `{ "workloads": [WorkloadRef, ...] }`.
-  Each `WorkloadRef` has the shape:
-  `{ "kind", "name", "namespace", "apiVersion", "reconcilerKind",
-  "reconcilerNamespace", "reconcilerName", "reconcilerStatus", "lastReconciled" }`.
-  `name` supports wildcards (`*`); `kind` and `namespace` are exact matches.
-  This route is distinct from the existing `POST /api/v1/workloads`, which
-  returns live workload status for the detail/inventory views.
-- `GET /api/v1/workloads/search?name=&namespace=&kind=` — the quick-search
-  variant of the above. A `name` without a wildcard is wrapped as `*name*` for a
-  partial match and results are capped at a small limit. Same response shape.
+enumerate all Flux-managed workload **names** in that namespace **without**
+holding any `apps`/`batch` RBAC. The index exposes only the workload identity
+(kind, namespace, name, apiVersion) and the parent reconciler reference — never
+workload spec, status conditions, pod data, or secrets.
 
 ---
 
 ## Summary
 
-| # | Feature | Internal Operation | Data Exposed to User |
-|---|---------|--------------------|----------------------|
-| 1 | CronJob pod listing | System reads Jobs/Pods | Pod name, phase, timestamps |
-| 2 | Flux GVK resolution | System API discovery | None (internal metadata only) |
-| 3 | Audit event recording | System writes event | None (server-side only) |
-| 4 | Audit pod-owner resolution | System reads owner chain | None (server-side only) |
-| 5 | Dashboard report | System scans cluster | Aggregated stats filtered by user namespace |
-| 6 | Controller metrics | System reads metrics API | CPU/memory usage of Flux controllers |
-| 7 | Fine-Grained GitOps Actions | System patches resource | None (server-side mutation only) |
-| 8 | Namespace visibility | System lists namespaces | Visible namespace names |
-| 9 | Workloads index | System extracts workloads from applier inventories | Workload identity + parent reconciler name/status, filtered by user namespace |
+| # | Feature                     | Internal Operation                                 | Data Exposed to User                                                          |
+|---|-----------------------------|----------------------------------------------------|-------------------------------------------------------------------------------|
+| 1 | CronJob pod listing         | System reads Jobs/Pods                             | Pod name, phase, timestamps                                                   |
+| 2 | Flux GVK resolution         | System API discovery                               | None (internal metadata only)                                                 |
+| 3 | Audit event recording       | System writes event                                | None (server-side only)                                                       |
+| 4 | Audit pod-owner resolution  | System reads owner chain                           | None (server-side only)                                                       |
+| 5 | Dashboard report            | System scans cluster                               | Aggregated stats filtered by user namespace                                   |
+| 6 | Controller metrics          | System reads metrics API                           | CPU/memory usage of Flux controllers                                          |
+| 7 | Fine-Grained GitOps Actions | System patches resource                            | None (server-side mutation only)                                              |
+| 8 | Namespace visibility        | System lists namespaces                            | Visible namespace names                                                       |
+| 9 | Workloads index             | System extracts workloads from applier inventories | Workload identity + parent reconciler name/status, filtered by user namespace |

--- a/docs/web/web-user-management.md
+++ b/docs/web/web-user-management.md
@@ -259,6 +259,12 @@ rules:
       - pods
     verbs:
       - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
 ```
 
 Note that the `patch` verb is not enough to allow a user to perform actions in the Web UI.
@@ -274,3 +280,9 @@ The `restart` verb allows users to trigger a rollout restart on workloads
 
 The `delete` verb on pods allows users to delete individual pods,
 which will be recreated by their controller.
+
+The `get` verb on the `pods/log` subresource allows users to view the logs
+of pod containers from the workload detail page. This is a read-only
+capability performed under the user's own identity. The read-only
+`flux-web-user` role already grants this permission through its wildcard
+`get` rule.

--- a/internal/reporter/reconcilers.go
+++ b/internal/reporter/reconcilers.go
@@ -72,10 +72,11 @@ func FilterReconcilerStatsByNamespaces(statsByNamespace []ReconcilerStatsByNames
 }
 
 func (r *FluxStatusReporter) getReconcilersStatus(ctx context.Context,
-	crds []metav1.GroupVersionKind) ([]fluxcdv1.FluxReconcilerStatus, []ReconcilerStatsByNamespace, []ResourceStatus, error) {
+	crds []metav1.GroupVersionKind) ([]fluxcdv1.FluxReconcilerStatus, []ReconcilerStatsByNamespace, []ResourceStatus, []WorkloadRef, error) {
 
 	var multiErr error
 	var resources []ResourceStatus
+	var workloads []WorkloadRef
 	metricList := make([]prometheus.Labels, 0)
 	resStats := make([]fluxcdv1.FluxReconcilerStatus, len(crds))
 	statsByNamespace := make([]ReconcilerStatsByNamespace, len(crds))
@@ -101,7 +102,17 @@ func (r *FluxStatusReporter) getReconcilersStatus(ctx context.Context,
 			globalStats.total = len(list.Items)
 			for _, item := range list.Items {
 				metricList = append(metricList, fluxLabelsToValues(item))
-				resources = append(resources, NewResourceStatus(item))
+				rs := NewResourceStatus(item)
+				resources = append(resources, rs)
+
+				// Extract the workloads managed by this applier from its
+				// inventory, skipping appliers that target a remote cluster.
+				// Only Kustomization and HelmRelease (the remote-capable kinds)
+				// appear in this loop and carry workload inventories; FluxInstance
+				// and ResourceSet are handled by getOperatorReconcilersStatus.
+				if isRemoteApplier(gvk.Kind) && !hasRemoteKubeConfig(item) {
+					workloads = append(workloads, extractWorkloads(item, rs)...)
+				}
 
 				ns := item.GetNamespace()
 				if _, exists := statsByNamespace[i].stats[ns]; !exists {
@@ -151,13 +162,14 @@ func (r *FluxStatusReporter) getReconcilersStatus(ctx context.Context,
 		metrics["FluxResource"].With(labels).Set(1)
 	}
 
-	opStats, opStatsByNamespace, opResources, err := r.getOperatorReconcilersStatus(ctx)
+	opStats, opStatsByNamespace, opResources, opWorkloads, err := r.getOperatorReconcilersStatus(ctx)
 	if err != nil {
 		multiErr = kerrors.NewAggregate([]error{multiErr, err})
 	} else {
 		resStats = append(resStats, opStats...)
 		statsByNamespace = append(statsByNamespace, opStatsByNamespace...)
 		resources = append(resources, opResources...)
+		workloads = append(workloads, opWorkloads...)
 	}
 
 	slices.SortStableFunc(resStats, func(i, j fluxcdv1.FluxReconcilerStatus) int {
@@ -167,14 +179,15 @@ func (r *FluxStatusReporter) getReconcilersStatus(ctx context.Context,
 		return cmp.Compare(i.apiVersion+i.kind, j.apiVersion+j.kind)
 	})
 
-	return resStats, statsByNamespace, resources, multiErr
+	return resStats, statsByNamespace, resources, workloads, multiErr
 }
 
 func (r *FluxStatusReporter) getOperatorReconcilersStatus(
-	ctx context.Context) ([]fluxcdv1.FluxReconcilerStatus, []ReconcilerStatsByNamespace, []ResourceStatus, error) {
+	ctx context.Context) ([]fluxcdv1.FluxReconcilerStatus, []ReconcilerStatsByNamespace, []ResourceStatus, []WorkloadRef, error) {
 
 	var multiErr error
 	var resources []ResourceStatus
+	var workloads []WorkloadRef
 	crds := []schema.GroupVersionKind{
 		fluxcdv1.GroupVersion.WithKind(fluxcdv1.FluxInstanceKind),
 		fluxcdv1.GroupVersion.WithKind(fluxcdv1.ResourceSetKind),
@@ -204,7 +217,15 @@ func (r *FluxStatusReporter) getOperatorReconcilersStatus(
 			globalStats.total = len(list.Items)
 
 			for _, item := range list.Items {
-				resources = append(resources, NewResourceStatus(item))
+				rs := NewResourceStatus(item)
+				resources = append(resources, rs)
+
+				// Extract the workloads managed by this operator reconciler
+				// from its inventory (FluxInstance and ResourceSet). Neither
+				// targets a remote cluster.
+				if reconcilerManagesWorkloads(gvk.Kind) {
+					workloads = append(workloads, extractWorkloads(item, rs)...)
+				}
 
 				ns := item.GetNamespace()
 				if _, exists := statsByNamespace[i].stats[ns]; !exists {
@@ -242,7 +263,7 @@ func (r *FluxStatusReporter) getOperatorReconcilersStatus(
 		}
 	}
 
-	return resStats, statsByNamespace, resources, multiErr
+	return resStats, statsByNamespace, resources, workloads, multiErr
 }
 
 func formatSize(b int64) string {

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -22,6 +22,7 @@ type FluxStatusReport struct {
 	Spec             fluxcdv1.FluxReportSpec
 	StatsByNamespace []ReconcilerStatsByNamespace
 	Resources        []ResourceStatus
+	Workloads        []WorkloadRef
 }
 
 // FluxStatusReporter is responsible for computing
@@ -71,13 +72,14 @@ func (r *FluxStatusReporter) Compute(ctx context.Context) (*FluxStatusReport, er
 	}
 	result.Spec.ComponentsStatus = componentsStatus
 
-	reconcilersStatus, statsByNamespace, resources, err := r.getReconcilersStatus(ctx, crds)
+	reconcilersStatus, statsByNamespace, resources, workloads, err := r.getReconcilersStatus(ctx, crds)
 	if err != nil {
 		return result, fmt.Errorf("failed to compute reconcilers status: %w", err)
 	}
 	result.Spec.ReconcilersStatus = reconcilersStatus
 	result.StatsByNamespace = statsByNamespace
 	result.Resources = resources
+	result.Workloads = workloads
 
 	syncStatus, err := r.getSyncStatus(ctx, crds)
 	if err != nil {

--- a/internal/reporter/workloads.go
+++ b/internal/reporter/workloads.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package reporter
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/inventory"
+)
+
+// WorkloadRef represents a Kubernetes workload (Deployment, StatefulSet,
+// DaemonSet or CronJob) managed by a Flux applier reconciler, extracted from
+// the reconciler's inventory. It carries the owning reconciler's reference and
+// status so the workloads index can be served without extra cluster queries.
+type WorkloadRef struct {
+	// Kind is the workload kind: Deployment, StatefulSet, DaemonSet or CronJob.
+	Kind string `json:"kind"`
+
+	// Name is the name of the workload.
+	Name string `json:"name"`
+
+	// Namespace is the namespace of the workload.
+	Namespace string `json:"namespace"`
+
+	// APIVersion is the workload apiVersion (apps/v1 or batch/v1).
+	APIVersion string `json:"apiVersion"`
+
+	// ReconcilerKind is the kind of the owning Flux applier reconciler.
+	ReconcilerKind string `json:"reconcilerKind"`
+
+	// ReconcilerNamespace is the namespace of the owning Flux applier reconciler.
+	ReconcilerNamespace string `json:"reconcilerNamespace"`
+
+	// ReconcilerName is the name of the owning Flux applier reconciler.
+	ReconcilerName string `json:"reconcilerName"`
+
+	// ReconcilerStatus is the owning reconciler's status, one of:
+	// "Ready", "Failed", "Progressing", "Suspended", "Unknown".
+	// It drives a status badge only and is never a free-form message.
+	ReconcilerStatus string `json:"reconcilerStatus"`
+
+	// LastReconciled is the timestamp of the owning reconciler's last
+	// reconciliation.
+	LastReconciled metav1.Time `json:"lastReconciled"`
+}
+
+// workloadKinds is the set of Kubernetes workload kinds extracted from
+// reconciler inventories for the workloads index.
+var workloadKinds = map[string]struct{}{
+	"Deployment":  {},
+	"StatefulSet": {},
+	"DaemonSet":   {},
+	"CronJob":     {},
+}
+
+// extractWorkloads parses the inventory of a Flux applier reconciler (the given
+// unstructured object) and returns the workloads it manages, stamped with the
+// reconciler's reference and the provided ResourceStatus.
+//
+// Appliers targeting a remote cluster (spec.kubeConfig set) are skipped by the
+// caller, since their workloads do not exist on the local cluster.
+func extractWorkloads(item unstructured.Unstructured, rs ResourceStatus) []WorkloadRef {
+	entries, err := inventory.FromUnstructured(&item)
+	if err != nil || len(entries) == 0 {
+		return nil
+	}
+
+	objects, err := inventory.List(&fluxcdv1.ResourceInventory{Entries: entries})
+	if err != nil {
+		return nil
+	}
+
+	result := make([]WorkloadRef, 0)
+	for _, obj := range objects {
+		if _, ok := workloadKinds[obj.GetKind()]; !ok {
+			continue
+		}
+
+		// Only keep apps/* and batch/* workloads, skipping unrelated kinds
+		// that happen to share a name (e.g. a CRD named "CronJob").
+		group := obj.GroupVersionKind().Group
+		if group != "apps" && group != "batch" {
+			continue
+		}
+
+		result = append(result, WorkloadRef{
+			Kind:                obj.GetKind(),
+			Name:                obj.GetName(),
+			Namespace:           obj.GetNamespace(),
+			APIVersion:          obj.GetAPIVersion(),
+			ReconcilerKind:      rs.Kind,
+			ReconcilerNamespace: rs.Namespace,
+			ReconcilerName:      rs.Name,
+			ReconcilerStatus:    rs.Status,
+			LastReconciled:      rs.LastReconciled,
+		})
+	}
+
+	return result
+}
+
+// hasRemoteKubeConfig reports whether the given reconciler targets a remote
+// cluster via spec.kubeConfig. Such appliers manage workloads that do not exist
+// on the local cluster and must be skipped during inventory extraction.
+func hasRemoteKubeConfig(item unstructured.Unstructured) bool {
+	_, found, _ := unstructured.NestedFieldCopy(item.Object, "spec", "kubeConfig")
+	return found
+}
+
+// reconcilerManagesWorkloads reports whether the given reconciler kind can carry
+// a workload inventory. ResourceSetInputProvider has no inventory.
+func reconcilerManagesWorkloads(kind string) bool {
+	switch kind {
+	case fluxcdv1.FluxKustomizationKind,
+		fluxcdv1.FluxHelmReleaseKind,
+		fluxcdv1.ResourceSetKind,
+		fluxcdv1.FluxInstanceKind:
+		return true
+	default:
+		return false
+	}
+}
+
+// isRemoteApplier reports whether the given reconciler kind can target a remote
+// cluster via spec.kubeConfig. Only Kustomization and HelmRelease support it;
+// ResourceSet and FluxInstance always target the local cluster.
+func isRemoteApplier(kind string) bool {
+	return kind == fluxcdv1.FluxKustomizationKind || kind == fluxcdv1.FluxHelmReleaseKind
+}

--- a/internal/reporter/workloads_test.go
+++ b/internal/reporter/workloads_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package reporter
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func newKustomizationWithInventory(name string, entries []any, kubeConfig bool) unstructured.Unstructured {
+	spec := map[string]any{}
+	if kubeConfig {
+		spec["kubeConfig"] = map[string]any{
+			"secretRef": map[string]any{"name": "remote"},
+		}
+	}
+	return unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       fluxcdv1.FluxKustomizationKind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "flux-system",
+			},
+			"spec": spec,
+			"status": map[string]any{
+				"inventory": map[string]any{
+					"entries": entries,
+				},
+			},
+		},
+	}
+}
+
+func TestExtractWorkloads_FiltersKindsAndGroups(t *testing.T) {
+	g := NewWithT(t)
+
+	entries := []any{
+		map[string]any{"id": "apps-ns_web_apps_Deployment", "v": "v1"},
+		map[string]any{"id": "apps-ns_db_apps_StatefulSet", "v": "v1"},
+		map[string]any{"id": "apps-ns_agent_apps_DaemonSet", "v": "v1"},
+		map[string]any{"id": "apps-ns_backup_batch_CronJob", "v": "v1"},
+		// Non-workload kinds and non-apps/batch groups must be skipped.
+		map[string]any{"id": "apps-ns_web__Service", "v": "v1"},
+		map[string]any{"id": "apps-ns_cfg__ConfigMap", "v": "v1"},
+		map[string]any{"id": "apps-ns_job_batch_Job", "v": "v1"},
+		// A CRD that happens to be named like a workload kind but in a foreign group.
+		map[string]any{"id": "apps-ns_CronJob_example.com_CronJob", "v": "v1"},
+	}
+
+	item := newKustomizationWithInventory("app", entries, false)
+	rs := ResourceStatus{
+		Kind:      fluxcdv1.FluxKustomizationKind,
+		Name:      "app",
+		Namespace: "flux-system",
+		Status:    StatusReady,
+	}
+
+	workloads := extractWorkloads(item, rs)
+	g.Expect(workloads).To(HaveLen(4))
+
+	kinds := map[string]bool{}
+	for _, wl := range workloads {
+		kinds[wl.Kind] = true
+		g.Expect(wl.ReconcilerKind).To(Equal(fluxcdv1.FluxKustomizationKind))
+		g.Expect(wl.ReconcilerName).To(Equal("app"))
+		g.Expect(wl.ReconcilerNamespace).To(Equal("flux-system"))
+		g.Expect(wl.ReconcilerStatus).To(Equal(StatusReady))
+		g.Expect(wl.Namespace).To(Equal("apps-ns"))
+	}
+	g.Expect(kinds).To(HaveKey("Deployment"))
+	g.Expect(kinds).To(HaveKey("StatefulSet"))
+	g.Expect(kinds).To(HaveKey("DaemonSet"))
+	g.Expect(kinds).To(HaveKey("CronJob"))
+
+	// Verify apiVersion is set correctly per group.
+	for _, wl := range workloads {
+		switch wl.Kind {
+		case "CronJob":
+			g.Expect(wl.APIVersion).To(Equal("batch/v1"))
+		default:
+			g.Expect(wl.APIVersion).To(Equal("apps/v1"))
+		}
+	}
+}
+
+func TestExtractWorkloads_EmptyInventory(t *testing.T) {
+	g := NewWithT(t)
+
+	item := newKustomizationWithInventory("app", []any{}, false)
+	g.Expect(extractWorkloads(item, ResourceStatus{})).To(BeEmpty())
+}
+
+func TestHasRemoteKubeConfig(t *testing.T) {
+	g := NewWithT(t)
+
+	local := newKustomizationWithInventory("local-app", nil, false)
+	remote := newKustomizationWithInventory("remote-app", nil, true)
+
+	g.Expect(hasRemoteKubeConfig(local)).To(BeFalse())
+	g.Expect(hasRemoteKubeConfig(remote)).To(BeTrue())
+}
+
+func TestReconcilerManagesWorkloads(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(reconcilerManagesWorkloads(fluxcdv1.FluxKustomizationKind)).To(BeTrue())
+	g.Expect(reconcilerManagesWorkloads(fluxcdv1.FluxHelmReleaseKind)).To(BeTrue())
+	g.Expect(reconcilerManagesWorkloads(fluxcdv1.ResourceSetKind)).To(BeTrue())
+	g.Expect(reconcilerManagesWorkloads(fluxcdv1.FluxInstanceKind)).To(BeTrue())
+	g.Expect(reconcilerManagesWorkloads(fluxcdv1.ResourceSetInputProviderKind)).To(BeFalse())
+	g.Expect(reconcilerManagesWorkloads(fluxcdv1.FluxGitRepositoryKind)).To(BeFalse())
+}
+
+func TestIsRemoteApplier(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(isRemoteApplier(fluxcdv1.FluxKustomizationKind)).To(BeTrue())
+	g.Expect(isRemoteApplier(fluxcdv1.FluxHelmReleaseKind)).To(BeTrue())
+	g.Expect(isRemoteApplier(fluxcdv1.ResourceSetKind)).To(BeFalse())
+	g.Expect(isRemoteApplier(fluxcdv1.FluxInstanceKind)).To(BeFalse())
+}
+
+// TestGetReconcilersStatus_SkipsRemoteApplier exercises the remote-cluster skip
+// guard end-to-end: a local Kustomization's workloads are extracted while a
+// Kustomization targeting a remote cluster (spec.kubeConfig set) is skipped.
+func TestGetReconcilersStatus_SkipsRemoteApplier(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	g.Expect(fluxcdv1.AddToScheme(scheme)).To(Succeed())
+	ksGVK := schema.GroupVersionKind{
+		Group:   "kustomize.toolkit.fluxcd.io",
+		Version: "v1",
+		Kind:    fluxcdv1.FluxKustomizationKind,
+	}
+	scheme.AddKnownTypeWithName(ksGVK, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(ksGVK.GroupVersion().WithKind(ksGVK.Kind+"List"), &unstructured.UnstructuredList{})
+
+	local := newKustomizationWithInventory("local", []any{
+		map[string]any{"id": "apps_web_apps_Deployment", "v": "v1"},
+	}, false)
+	remote := newKustomizationWithInventory("remote", []any{
+		map[string]any{"id": "apps_api_apps_Deployment", "v": "v1"},
+	}, true)
+
+	r := newTestReporter(scheme, &local, &remote)
+
+	crds := []metav1.GroupVersionKind{{Group: ksGVK.Group, Version: ksGVK.Version, Kind: ksGVK.Kind}}
+	_, _, _, workloads, err := r.getReconcilersStatus(ctx, crds)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Only the local Kustomization's workload is extracted; the remote one is skipped.
+	g.Expect(workloads).To(HaveLen(1))
+	g.Expect(workloads[0].Name).To(Equal("web"))
+	g.Expect(workloads[0].ReconcilerName).To(Equal("local"))
+}
+
+// TestGetOperatorReconcilersStatus_IncludesFluxInstanceControllers verifies that
+// the Flux controllers' own Deployments, recorded in the FluxInstance inventory,
+// surface as workloads through the operator reconcilers pass.
+func TestGetOperatorReconcilersStatus_IncludesFluxInstanceControllers(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	g.Expect(fluxcdv1.AddToScheme(scheme)).To(Succeed())
+
+	instance := &fluxcdv1.FluxInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flux",
+			Namespace: "flux-system",
+		},
+		Status: fluxcdv1.FluxInstanceStatus{
+			Inventory: &fluxcdv1.ResourceInventory{
+				Entries: []fluxcdv1.ResourceRef{
+					{ID: "flux-system_source-controller_apps_Deployment", Version: "v1"},
+					{ID: "flux-system_kustomize-controller_apps_Deployment", Version: "v1"},
+				},
+			},
+		},
+	}
+
+	r := newTestReporter(scheme, instance)
+
+	_, _, _, workloads, err := r.getOperatorReconcilersStatus(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	byName := map[string]string{}
+	for _, wl := range workloads {
+		byName[wl.Name] = wl.ReconcilerKind
+		g.Expect(wl.Kind).To(Equal("Deployment"))
+		g.Expect(wl.Namespace).To(Equal("flux-system"))
+	}
+	g.Expect(byName).To(HaveKeyWithValue("source-controller", fluxcdv1.FluxInstanceKind))
+	g.Expect(byName).To(HaveKeyWithValue("kustomize-controller", fluxcdv1.FluxInstanceKind))
+}

--- a/internal/web/favorites.go
+++ b/internal/web/favorites.go
@@ -10,13 +10,25 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/fluxcd/cli-utils/pkg/kstatus/status"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/reporter"
 )
+
+// favoriteWorkloadKinds is the set of Kubernetes workload kinds supported as
+// favorites. Unlike supportedWorkloadKinds, it does not include Pod, since pods
+// are not standalone favorites.
+var favoriteWorkloadKinds = map[string]struct{}{
+	workloadKindDeployment:  {},
+	workloadKindStatefulSet: {},
+	workloadKindDaemonSet:   {},
+	workloadKindCronJob:     {},
+}
 
 // FavoriteItem represents a single favorite resource request.
 type FavoriteItem struct {
@@ -96,6 +108,18 @@ func (h *Handler) GetFavoritesStatus(ctx context.Context, favorites []FavoriteIt
 				mu.Unlock()
 			}
 
+			// Workload favorites (Deployment, StatefulSet, DaemonSet, CronJob)
+			// are resolved with the user's own client and a lightweight status
+			// computed on the fetched object alone. This needs only get on the
+			// workload, not list on pods.
+			if _, ok := favoriteWorkloadKinds[fav.Kind]; ok {
+				rs := h.getWorkloadFavoriteStatus(ctx, fav)
+				mu.Lock()
+				result[i] = rs
+				mu.Unlock()
+				return
+			}
+
 			gvk, err := h.preferredFluxGVK(ctx, fav.Kind)
 			if err != nil {
 				var message string
@@ -151,4 +175,73 @@ func (h *Handler) GetFavoritesStatus(ctx context.Context, favorites []FavoriteIt
 	wg.Wait()
 
 	return result
+}
+
+// getWorkloadFavoriteStatus fetches a workload favorite with the user's own
+// client and computes a lightweight rollout status from the fetched object
+// alone, without listing pods, extracting images, or running SSARs. This means
+// a user who can get the workload but not list its pods still sees a valid
+// status instead of NotFound.
+//
+// It always returns a populated ResourceStatus: a "NotFound" status (with an
+// explanatory message) when the workload cannot be fetched, otherwise the
+// computed status. The returned Status uses the kstatus vocabulary
+// (Current/InProgress/...), which the client renders via the workload badge
+// helper based on the favorite's kind.
+func (h *Handler) getWorkloadFavoriteStatus(ctx context.Context, fav FavoriteItem) reporter.ResourceStatus {
+	notFound := func(message string) reporter.ResourceStatus {
+		return reporter.ResourceStatus{
+			Kind:      fav.Kind,
+			Name:      fav.Name,
+			Namespace: fav.Namespace,
+			Status:    "NotFound",
+			Message:   message,
+		}
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(getWorkloadGVK(fav.Kind))
+
+	err := h.kubeClient.GetClient(ctx).Get(ctx, client.ObjectKey{
+		Namespace: fav.Namespace,
+		Name:      fav.Name,
+	}, obj)
+	if err != nil {
+		switch {
+		case errors.IsNotFound(err):
+			return notFound("Workload not found in the cluster")
+		case errors.IsForbidden(err):
+			return notFound("User does not have access to the workload")
+		default:
+			log.FromContext(ctx).Error(err, "failed to get favorite workload",
+				"kind", fav.Kind,
+				"name", fav.Name,
+				"namespace", fav.Namespace)
+			return notFound("Internal error while fetching workload")
+		}
+	}
+
+	// Compute the rollout status using kstatus on the object alone.
+	workloadStatus := string(status.UnknownStatus)
+	message := ""
+	if res, err := status.Compute(obj); err != nil {
+		message = "Failed to compute status"
+	} else {
+		workloadStatus = string(res.Status)
+		message = res.Message
+
+		// For CronJob, override the status based on suspend state and active jobs.
+		if fav.Kind == workloadKindCronJob {
+			workloadStatus, message = getCronJobWorkloadStatus(obj, res.Status, res.Message)
+		}
+	}
+
+	return reporter.ResourceStatus{
+		Kind:           fav.Kind,
+		Name:           fav.Name,
+		Namespace:      fav.Namespace,
+		Status:         workloadStatus,
+		Message:        message,
+		LastReconciled: metav1.Time{Time: obj.GetCreationTimestamp().Time},
+	}
 }

--- a/internal/web/favorites_test.go
+++ b/internal/web/favorites_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -458,4 +460,210 @@ func TestGetFavoritesStatus_EmptyList(t *testing.T) {
 
 	// Should return empty result
 	g.Expect(resources).To(BeEmpty())
+}
+
+func TestGetFavoritesStatus_Workload_Privileged_Success(t *testing.T) {
+	g := NewWithT(t)
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-fav-workload",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: new(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test-fav-workload"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test-fav-workload"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, deployment)).To(Succeed())
+	defer testClient.Delete(ctx, deployment)
+
+	handler := &Handler{
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	favorites := []FavoriteItem{
+		{Kind: "Deployment", Namespace: "default", Name: "test-fav-workload"},
+	}
+	resources := handler.GetFavoritesStatus(ctx, favorites)
+
+	g.Expect(resources).To(HaveLen(1))
+	g.Expect(resources[0].Kind).To(Equal("Deployment"))
+	g.Expect(resources[0].Name).To(Equal("test-fav-workload"))
+	g.Expect(resources[0].Namespace).To(Equal("default"))
+	// kstatus vocabulary, not the Flux Ready/Failed set.
+	g.Expect(resources[0].Status).NotTo(Equal("NotFound"))
+	g.Expect(resources[0].Status).To(BeElementOf("Current", "InProgress", "Unknown"))
+	// LastReconciled is mapped from the workload's creation timestamp.
+	g.Expect(resources[0].LastReconciled.IsZero()).To(BeFalse())
+}
+
+func TestGetFavoritesStatus_Workload_NotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := &Handler{
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	favorites := []FavoriteItem{
+		{Kind: "Deployment", Namespace: "default", Name: "nonexistent-workload-fav"},
+	}
+	resources := handler.GetFavoritesStatus(ctx, favorites)
+
+	g.Expect(resources).To(HaveLen(1))
+	g.Expect(resources[0].Status).To(Equal("NotFound"))
+	g.Expect(resources[0].Message).To(Equal("Workload not found in the cluster"))
+}
+
+func TestGetFavoritesStatus_Workload_CronJob(t *testing.T) {
+	g := NewWithT(t)
+
+	cronJob := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-fav-cronjob",
+			Namespace: "default",
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "*/5 * * * *",
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyOnFailure,
+							Containers:    []corev1.Container{{Name: "busybox", Image: "busybox:latest"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, cronJob)).To(Succeed())
+	defer testClient.Delete(ctx, cronJob)
+
+	handler := &Handler{
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	favorites := []FavoriteItem{
+		{Kind: "CronJob", Namespace: "default", Name: "test-fav-cronjob"},
+	}
+	resources := handler.GetFavoritesStatus(ctx, favorites)
+
+	g.Expect(resources).To(HaveLen(1))
+	g.Expect(resources[0].Kind).To(Equal("CronJob"))
+	g.Expect(resources[0].Status).NotTo(Equal("NotFound"))
+	// CronJob override yields the schedule as the message when idle.
+	g.Expect(resources[0].Status).To(BeElementOf("Idle", "Progressing", "Suspended"))
+}
+
+func TestGetFavoritesStatus_Workload_GetButNoListPods(t *testing.T) {
+	g := NewWithT(t)
+
+	// The favorites workload path computes a lightweight status without listing
+	// pods. A user who can get the Deployment but not list pods must still see a
+	// valid status, never NotFound.
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-fav-workload-no-pods",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: new(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test-fav-workload-no-pods"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test-fav-workload-no-pods"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, deployment)).To(Succeed())
+	defer testClient.Delete(ctx, deployment)
+
+	// Grant get on deployments only, deliberately omitting pods access.
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-fav-workload-no-pods-reader",
+			Namespace: "default",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments"},
+				Verbs:     []string{"get"},
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, role)).To(Succeed())
+	defer testClient.Delete(ctx, role)
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-fav-workload-no-pods-binding",
+			Namespace: "default",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: "fav-workload-no-pods-user"},
+		},
+	}
+	g.Expect(testClient.Create(ctx, roleBinding)).To(Succeed())
+	defer testClient.Delete(ctx, roleBinding)
+
+	handler := &Handler{
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	imp := user.Impersonation{
+		Username: "fav-workload-no-pods-user",
+		Groups:   []string{"system:authenticated"},
+	}
+	userClient, err := kubeClient.GetUserClientFromCache(imp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	userCtx := user.StoreSession(ctx, user.Details{
+		Profile:       user.Profile{Name: "No Pod Access User"},
+		Impersonation: imp,
+	}, userClient)
+
+	favorites := []FavoriteItem{
+		{Kind: "Deployment", Namespace: "default", Name: "test-fav-workload-no-pods"},
+	}
+	resources := handler.GetFavoritesStatus(userCtx, favorites)
+
+	g.Expect(resources).To(HaveLen(1))
+	g.Expect(resources[0].Kind).To(Equal("Deployment"))
+	g.Expect(resources[0].Status).NotTo(Equal("NotFound"),
+		"user with get on the workload but no list on pods must still see a valid status")
 }

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -73,6 +73,7 @@ func NewHandler(ctx context.Context, conf *fluxcdv1.WebConfigSpec, spaHandler ht
 	mux.HandleFunc("GET /api/v1/resources", h.ResourcesHandler)
 	mux.HandleFunc("GET /api/v1/search", h.SearchHandler)
 	mux.HandleFunc("GET /api/v1/workload", h.WorkloadHandler)
+	mux.HandleFunc("GET /api/v1/workload/logs", h.WorkloadLogsHandler)
 	mux.HandleFunc("POST /api/v1/workload/action", h.WorkloadActionHandler)
 	mux.HandleFunc("POST /api/v1/workloads", h.WorkloadsHandler)
 

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -34,6 +34,9 @@ type Handler struct {
 
 	// Search index
 	searchIndex *SearchIndex
+
+	// Workload index
+	workloadIndex *WorkloadIndex
 }
 
 // NewHandler creates a new handler for the web server.
@@ -55,6 +58,7 @@ func NewHandler(ctx context.Context, conf *fluxcdv1.WebConfigSpec, spaHandler ht
 		statusManager: statusManager,
 		namespace:     namespace,
 		searchIndex:   &SearchIndex{},
+		workloadIndex: &WorkloadIndex{},
 	}
 
 	// Create HTTP request multiplexer.
@@ -75,6 +79,8 @@ func NewHandler(ctx context.Context, conf *fluxcdv1.WebConfigSpec, spaHandler ht
 	mux.HandleFunc("GET /api/v1/workload", h.WorkloadHandler)
 	mux.HandleFunc("GET /api/v1/workload/logs", h.WorkloadLogsHandler)
 	mux.HandleFunc("POST /api/v1/workload/action", h.WorkloadActionHandler)
+	mux.HandleFunc("GET /api/v1/workloads", h.WorkloadsListHandler)
+	mux.HandleFunc("GET /api/v1/workloads/search", h.WorkloadsSearchHandler)
 	mux.HandleFunc("POST /api/v1/workloads", h.WorkloadsHandler)
 
 	// Wrap the mux with middlewares to produce the final handler.

--- a/internal/web/kubeclient/client.go
+++ b/internal/web/kubeclient/client.go
@@ -334,3 +334,34 @@ func (c *Client) CanActOnResource(ctx context.Context, action, group, plural, na
 
 	return ssar.Status.Allowed, nil
 }
+
+// CanViewPodLogs checks if the user has permission to read pod logs in the
+// given namespace by performing a SelfSubjectAccessReview for the "get" verb
+// on the "pods/log" subresource. When name is empty, the check is performed
+// namespace-wide.
+//
+// Pod logs are exposed through a subresource, so the SelfSubjectAccessReview
+// must set Resource="pods" and Subresource="log" (unlike CanActOnResource,
+// which only sets Resource). This is the native RBAC verb Kubernetes enforces
+// when streaming logs; there is no custom action verb for log viewing.
+func (c *Client) CanViewPodLogs(ctx context.Context, namespace, name string) (bool, error) {
+	kubeClient := c.GetClient(ctx)
+
+	ssar := &authzv1.SelfSubjectAccessReview{
+		Spec: authzv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Verb:        "get",
+				Resource:    "pods",
+				Subresource: "log",
+				Namespace:   namespace,
+				Name:        name,
+			},
+		},
+	}
+
+	if err := kubeClient.Create(ctx, ssar); err != nil {
+		return false, fmt.Errorf("failed to create SelfSubjectAccessReview: %w", err)
+	}
+
+	return ssar.Status.Allowed, nil
+}

--- a/internal/web/report.go
+++ b/internal/web/report.go
@@ -147,6 +147,9 @@ func (h *Handler) refreshReportCache(ctx context.Context) {
 
 	// Update the search index from the reporter's resource statuses.
 	h.searchIndex.Update(computeResult.Resources)
+
+	// Update the workload index from the reporter's inventory-derived workloads.
+	h.workloadIndex.Update(computeResult.Workloads)
 }
 
 // getCachedReport returns the cached report if available.

--- a/internal/web/report_test.go
+++ b/internal/web/report_test.go
@@ -393,6 +393,7 @@ func TestGetReport_CachedAndPrivileged(t *testing.T) {
 		statusManager: "test-status-manager",
 		namespace:     "flux-system",
 		searchIndex:   &SearchIndex{},
+		workloadIndex: &WorkloadIndex{},
 	}
 
 	// Start report cache.

--- a/internal/web/workload.go
+++ b/internal/web/workload.go
@@ -257,6 +257,16 @@ func (h *Handler) GetWorkloadStatus(ctx context.Context, kind, name, namespace s
 		} else if canDelete {
 			workload.UserActions = append(workload.UserActions, fluxcdv1.UserActionDeletePods)
 		}
+
+		// Check if the user can view pod logs in this namespace
+		// (native "get" on the "pods/log" subresource).
+		canViewLogs, err := h.kubeClient.CanViewPodLogs(ctx, namespace, "")
+		if err != nil {
+			log.FromContext(ctx).Error(err, "failed to check pod logs RBAC",
+				"namespace", namespace)
+		} else if canViewLogs {
+			workload.UserActions = append(workload.UserActions, fluxcdv1.UserActionViewLogs)
+		}
 	}
 
 	return workload, nil

--- a/internal/web/workload.go
+++ b/internal/web/workload.go
@@ -166,9 +166,10 @@ func getWorkloadGVK(kind string) schema.GroupVersionKind {
 	return schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kind}
 }
 
-// GetWorkloadStatus should fetch the Deployment/StatefulSet/DaemonSet/CronJob and return the WorkloadStatus.
-// When includeFullStatus is true, the full Kubernetes PodStatus is included for each pod.
-func (h *Handler) GetWorkloadStatus(ctx context.Context, kind, name, namespace string, includeFullStatus bool) (*WorkloadStatus, error) {
+// GetWorkloadStatus returns the WorkloadStatus for the given workload.
+// When detailed is true, the managed pods (with their full Kubernetes PodStatus)
+// and the user-permitted actions are included.
+func (h *Handler) GetWorkloadStatus(ctx context.Context, kind, name, namespace string, detailed bool) (*WorkloadStatus, error) {
 	// Create an unstructured object to fetch the resource
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(getWorkloadGVK(kind))
@@ -222,50 +223,52 @@ func (h *Handler) GetWorkloadStatus(ctx context.Context, kind, name, namespace s
 		workload.StatusMessage = getAppsWorkloadStatusMessage(obj, kind)
 	}
 
-	// Get the pods managed by the workload
-	podsStatus, err := h.GetWorkloadPods(ctx, obj, includeFullStatus)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get pods for workload %s/%s: %w", namespace, name, err)
-	}
-	workload.Pods = podsStatus
+	if detailed {
+		// Get the pods managed by the workload
+		podsStatus, err := h.GetWorkloadPods(ctx, obj, detailed)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get pods for workload %s/%s: %w", namespace, name, err)
+		}
+		workload.Pods = podsStatus
 
-	// Check which actions the user can perform on this workload
-	if h.conf.UserActionsEnabled() {
-		kindInfo, ok := supportedWorkloadKinds[kind]
-		if ok {
-			for _, action := range kindInfo.actions {
-				canAct, err := h.kubeClient.CanActOnResource(ctx, action, kindInfo.group, kindInfo.plural, namespace, name)
-				if err != nil {
-					log.FromContext(ctx).Error(err, "failed to check RBAC for action",
-						"action", action,
-						"kind", kind,
-						"name", name,
-						"namespace", namespace)
-					continue
-				}
-				if canAct {
-					workload.UserActions = append(workload.UserActions, action)
+		// Check which actions the user can perform on this workload
+		if h.conf.UserActionsEnabled() {
+			kindInfo, ok := supportedWorkloadKinds[kind]
+			if ok {
+				for _, action := range kindInfo.actions {
+					canAct, err := h.kubeClient.CanActOnResource(ctx, action, kindInfo.group, kindInfo.plural, namespace, name)
+					if err != nil {
+						log.FromContext(ctx).Error(err, "failed to check RBAC for action",
+							"action", action,
+							"kind", kind,
+							"name", name,
+							"namespace", namespace)
+						continue
+					}
+					if canAct {
+						workload.UserActions = append(workload.UserActions, action)
+					}
 				}
 			}
-		}
 
-		// Check if the user can delete pods in this namespace
-		canDelete, err := h.kubeClient.CanActOnResource(ctx, fluxcdv1.UserActionDelete, "", "pods", namespace, "")
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to check delete pod RBAC",
-				"namespace", namespace)
-		} else if canDelete {
-			workload.UserActions = append(workload.UserActions, fluxcdv1.UserActionDeletePods)
-		}
+			// Check if the user can delete pods in this namespace
+			canDelete, err := h.kubeClient.CanActOnResource(ctx, fluxcdv1.UserActionDelete, "", "pods", namespace, "")
+			if err != nil {
+				log.FromContext(ctx).Error(err, "failed to check delete pod RBAC",
+					"namespace", namespace)
+			} else if canDelete {
+				workload.UserActions = append(workload.UserActions, fluxcdv1.UserActionDeletePods)
+			}
 
-		// Check if the user can view pod logs in this namespace
-		// (native "get" on the "pods/log" subresource).
-		canViewLogs, err := h.kubeClient.CanViewPodLogs(ctx, namespace, "")
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to check pod logs RBAC",
-				"namespace", namespace)
-		} else if canViewLogs {
-			workload.UserActions = append(workload.UserActions, fluxcdv1.UserActionViewLogs)
+			// Check if the user can view pod logs in this namespace
+			// (native "get" on the "pods/log" subresource).
+			canViewLogs, err := h.kubeClient.CanViewPodLogs(ctx, namespace, "")
+			if err != nil {
+				log.FromContext(ctx).Error(err, "failed to check pod logs RBAC",
+					"namespace", namespace)
+			} else if canViewLogs {
+				workload.UserActions = append(workload.UserActions, fluxcdv1.UserActionViewLogs)
+			}
 		}
 	}
 
@@ -360,13 +363,13 @@ func (h *Handler) GetWorkloadDetails(ctx context.Context, kind, name, namespace 
 // GetWorkloadPods returns the pods managed by a workload (Deployment, StatefulSet, DaemonSet, or CronJob).
 // For apps/v1 workloads, it uses the selector labels to find pods.
 // For CronJobs, it delegates to getCronJobPods which traverses the CronJob -> Job -> Pod ownership chain.
-// When includeFullStatus is true, the full Kubernetes PodStatus is included for each pod.
-func (h *Handler) GetWorkloadPods(ctx context.Context, obj *unstructured.Unstructured, includeFullStatus bool) ([]WorkloadPodStatus, error) {
+// When detailed is true, the full Kubernetes PodStatus is included for each pod.
+func (h *Handler) GetWorkloadPods(ctx context.Context, obj *unstructured.Unstructured, detailed bool) ([]WorkloadPodStatus, error) {
 	podList := &corev1.PodList{}
 
 	// For CronJob, we need to find Jobs owned by the CronJob, then Pods owned by those Jobs
 	if obj.GetKind() == workloadKindCronJob {
-		return h.getCronJobPods(ctx, obj, includeFullStatus)
+		return h.getCronJobPods(ctx, obj, detailed)
 	}
 
 	selector, found, err := unstructured.NestedStringMap(obj.Object, "spec", "selector", "matchLabels")
@@ -407,7 +410,7 @@ func (h *Handler) GetWorkloadPods(ctx context.Context, obj *unstructured.Unstruc
 			StatusMessage: podMessage,
 			CreatedAt:     pod.GetCreationTimestamp().Time,
 		}
-		if includeFullStatus {
+		if detailed {
 			ps.PodStatus = &pod.Status
 		}
 		podsStatus = append(podsStatus, ps)
@@ -423,8 +426,8 @@ func (h *Handler) GetWorkloadPods(ctx context.Context, obj *unstructured.Unstruc
 
 // getCronJobPods returns the pods managed by a CronJob.
 // CronJob ownership is cascading: CronJob -> Job -> Pod.
-// When includeFullStatus is true, the full Kubernetes PodStatus is included for each pod.
-func (h *Handler) getCronJobPods(ctx context.Context, cronJob *unstructured.Unstructured, includeFullStatus bool) ([]WorkloadPodStatus, error) {
+// When detailed is true, the full Kubernetes PodStatus is included for each pod.
+func (h *Handler) getCronJobPods(ctx context.Context, cronJob *unstructured.Unstructured, detailed bool) ([]WorkloadPodStatus, error) {
 	// Query Jobs owned by this CronJob using the field index on the cluster's cached client.
 	// We use WithPrivileges() because the user already has access to the CronJob,
 	// and the index is only available on the privileged cache. This effectively results
@@ -477,7 +480,7 @@ func (h *Handler) getCronJobPods(ctx context.Context, cronJob *unstructured.Unst
 			CreatedAt:     pod.GetCreationTimestamp().Time,
 			CreatedBy:     pod.GetAnnotations()[fluxcdv1.CreatedByAnnotation],
 		}
-		if includeFullStatus {
+		if detailed {
 			ps.PodStatus = &pod.Status
 		}
 		podsStatus = append(podsStatus, ps)

--- a/internal/web/workload_index.go
+++ b/internal/web/workload_index.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package web
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/reporter"
+)
+
+// WorkloadIndex holds cached workload data built from the reporter's Compute()
+// results. Workloads are extracted from Flux applier inventories and carry the
+// owning reconciler's reference and status (badge only).
+type WorkloadIndex struct {
+	mu        sync.RWMutex
+	workloads []reporter.WorkloadRef
+	updatedAt time.Time
+}
+
+// Update sorts and stores the given workloads in the index, replacing any
+// existing data.
+func (idx *WorkloadIndex) Update(workloads []reporter.WorkloadRef) {
+	sorted := buildWorkloadIndex(workloads)
+	idx.mu.Lock()
+	idx.workloads = sorted
+	idx.updatedAt = time.Now()
+	idx.mu.Unlock()
+}
+
+// SearchWorkloads filters indexed workloads by the given criteria.
+// allowedNamespaces restricts results to RBAC-visible namespaces:
+// nil means no RBAC filtering (cluster-wide access),
+// non-nil (including empty) means only return workloads in those namespaces.
+// kind filters by exact match (empty means all kinds).
+// name filters by wildcard match using matchesWildcard() (empty means all names).
+// namespace filters by exact match (empty means all namespaces).
+// limit caps the number of returned results (0 means unlimited).
+// Results are sorted by LastReconciled (newest first), with a (namespace, name,
+// kind) tiebreaker since all workloads under one applier share the applier timestamp.
+func (idx *WorkloadIndex) SearchWorkloads(allowedNamespaces []string, kind, name, namespace string, limit int) []reporter.WorkloadRef {
+	idx.mu.RLock()
+	workloads := idx.workloads
+	idx.mu.RUnlock()
+
+	// Build namespace allowlist for fast lookup.
+	// nil allowedNamespaces = cluster-wide access (no filtering).
+	// Non-nil (including empty) = only allow listed namespaces.
+	var nsAllowed map[string]struct{}
+	if allowedNamespaces != nil {
+		nsAllowed = make(map[string]struct{}, len(allowedNamespaces))
+		for _, ns := range allowedNamespaces {
+			nsAllowed[ns] = struct{}{}
+		}
+	}
+
+	// Lowercase the name pattern once before the loop so that
+	// matchesWildcard's per-item ToLower is a no-op on pre-normalized index data.
+	name = strings.ToLower(name)
+
+	result := []reporter.WorkloadRef{}
+	for _, wl := range workloads {
+		// Filter by RBAC-visible namespaces.
+		if nsAllowed != nil {
+			if _, ok := nsAllowed[wl.Namespace]; !ok {
+				continue
+			}
+		}
+
+		// Filter by namespace (exact match).
+		if namespace != "" && wl.Namespace != namespace {
+			continue
+		}
+
+		// Filter by kind (exact match).
+		if kind != "" && wl.Kind != kind {
+			continue
+		}
+
+		// Filter by name (wildcard match).
+		if name != "" && !matchesWildcard(wl.Name, name) {
+			continue
+		}
+
+		result = append(result, wl)
+	}
+
+	// Sort by LastReconciled (newest first), with a (namespace, name, kind)
+	// tiebreaker for stable ordering, then truncate to limit. Kind is included
+	// because two workloads of different kinds can share a namespace and name.
+	sort.Slice(result, func(i, j int) bool {
+		if !result[i].LastReconciled.Time.Equal(result[j].LastReconciled.Time) {
+			return result[i].LastReconciled.Time.After(result[j].LastReconciled.Time)
+		}
+		if result[i].Namespace != result[j].Namespace {
+			return result[i].Namespace < result[j].Namespace
+		}
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Kind < result[j].Kind
+	})
+
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+
+	return result
+}
+
+// buildWorkloadIndex normalises workload names for case-insensitive matching
+// and returns a stable-sorted copy suitable for the WorkloadIndex.
+func buildWorkloadIndex(workloads []reporter.WorkloadRef) []reporter.WorkloadRef {
+	if len(workloads) == 0 {
+		return nil
+	}
+
+	out := make([]reporter.WorkloadRef, len(workloads))
+	copy(out, workloads)
+
+	for i := range out {
+		out[i].Name = strings.ToLower(out[i].Name)
+	}
+
+	// Sort by kind, namespace, then name for stable ordering.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Name < out[j].Name
+	})
+
+	return out
+}

--- a/internal/web/workload_index_test.go
+++ b/internal/web/workload_index_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package web
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/reporter"
+)
+
+func TestBuildWorkloadIndex(t *testing.T) {
+	g := NewWithT(t)
+
+	input := []reporter.WorkloadRef{
+		{Name: "Web-1", Kind: "Deployment", Namespace: "default"},
+		{Name: "Db", Kind: "StatefulSet", Namespace: "team-a"},
+		{Name: "Agent", Kind: "DaemonSet", Namespace: "default"},
+	}
+
+	out := buildWorkloadIndex(input)
+	g.Expect(out).To(HaveLen(3))
+
+	// Sorted by kind, namespace, then name; names lowercased.
+	g.Expect(out[0].Kind).To(Equal("DaemonSet"))
+	g.Expect(out[0].Name).To(Equal("agent"))
+	g.Expect(out[1].Kind).To(Equal("Deployment"))
+	g.Expect(out[1].Name).To(Equal("web-1"))
+	g.Expect(out[2].Kind).To(Equal("StatefulSet"))
+	g.Expect(out[2].Name).To(Equal("db"))
+
+	// Input is not mutated.
+	g.Expect(input[0].Name).To(Equal("Web-1"))
+}
+
+func TestBuildWorkloadIndex_Empty(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(buildWorkloadIndex(nil)).To(BeNil())
+	g.Expect(buildWorkloadIndex([]reporter.WorkloadRef{})).To(BeNil())
+}
+
+func TestWorkloadIndex_Update(t *testing.T) {
+	g := NewWithT(t)
+
+	idx := &WorkloadIndex{}
+	g.Expect(idx.updatedAt.IsZero()).To(BeTrue())
+
+	idx.Update([]reporter.WorkloadRef{
+		{Name: "web", Kind: "Deployment", Namespace: "default"},
+	})
+
+	g.Expect(idx.updatedAt.IsZero()).To(BeFalse())
+	g.Expect(idx.workloads).To(HaveLen(1))
+}
+
+func TestWorkloadIndex_SearchWorkloads_Filters(t *testing.T) {
+	g := NewWithT(t)
+
+	idx := &WorkloadIndex{}
+	idx.Update([]reporter.WorkloadRef{
+		{Name: "podinfo", Kind: "Deployment", Namespace: "team-a", LastReconciled: metav1.Now()},
+		{Name: "podinfo-cache", Kind: "StatefulSet", Namespace: "team-a", LastReconciled: metav1.Now()},
+		{Name: "backup", Kind: "CronJob", Namespace: "team-b", LastReconciled: metav1.Now()},
+	})
+
+	// Name wildcard.
+	results := idx.SearchWorkloads(nil, "", "*podinfo*", "", 0)
+	g.Expect(results).To(HaveLen(2))
+
+	// Kind filter.
+	results = idx.SearchWorkloads(nil, "CronJob", "", "", 0)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Name).To(Equal("backup"))
+
+	// Namespace filter.
+	results = idx.SearchWorkloads(nil, "", "", "team-a", 0)
+	g.Expect(results).To(HaveLen(2))
+
+	// Combined filters.
+	results = idx.SearchWorkloads(nil, "Deployment", "*podinfo*", "team-a", 0)
+	g.Expect(results).To(HaveLen(1))
+	g.Expect(results[0].Name).To(Equal("podinfo"))
+}
+
+func TestWorkloadIndex_SearchWorkloads_NoStatusFilterArgument(t *testing.T) {
+	// The workload index intentionally has no status filter: workloads carry
+	// only the parent reconciler's status badge, which is not a filterable
+	// dimension. This test simply documents that SearchWorkloads has no status
+	// parameter by returning all entries regardless of ReconcilerStatus.
+	g := NewWithT(t)
+
+	idx := &WorkloadIndex{}
+	idx.Update([]reporter.WorkloadRef{
+		{Name: "a", Kind: "Deployment", Namespace: "default", ReconcilerStatus: reporter.StatusReady, LastReconciled: metav1.Now()},
+		{Name: "b", Kind: "Deployment", Namespace: "default", ReconcilerStatus: reporter.StatusFailed, LastReconciled: metav1.Now()},
+	})
+
+	results := idx.SearchWorkloads(nil, "", "", "", 0)
+	g.Expect(results).To(HaveLen(2))
+}
+
+func TestWorkloadIndex_SearchWorkloads_SortedByLastReconciledWithTiebreaker(t *testing.T) {
+	g := NewWithT(t)
+
+	older := metav1.Date(2025, 1, 1, 0, 0, 0, 0, metav1.Now().Location())
+	newer := metav1.Date(2025, 6, 1, 0, 0, 0, 0, metav1.Now().Location())
+
+	idx := &WorkloadIndex{}
+	idx.Update([]reporter.WorkloadRef{
+		// Same (newer) timestamp: tiebreaker (namespace, name) decides order.
+		{Name: "zeta", Kind: "Deployment", Namespace: "team-b", LastReconciled: newer},
+		{Name: "alpha", Kind: "Deployment", Namespace: "team-b", LastReconciled: newer},
+		{Name: "gamma", Kind: "Deployment", Namespace: "team-a", LastReconciled: newer},
+		// Older timestamp sorts last.
+		{Name: "old", Kind: "Deployment", Namespace: "team-a", LastReconciled: older},
+	})
+
+	results := idx.SearchWorkloads(nil, "", "", "", 0)
+	g.Expect(results).To(HaveLen(4))
+
+	// Newest first, with (namespace, name) tiebreaker among equal timestamps.
+	g.Expect(results[0].Namespace).To(Equal("team-a"))
+	g.Expect(results[0].Name).To(Equal("gamma"))
+	g.Expect(results[1].Namespace).To(Equal("team-b"))
+	g.Expect(results[1].Name).To(Equal("alpha"))
+	g.Expect(results[2].Namespace).To(Equal("team-b"))
+	g.Expect(results[2].Name).To(Equal("zeta"))
+	g.Expect(results[3].Name).To(Equal("old"))
+}
+
+func TestWorkloadIndex_SearchWorkloads_Limit(t *testing.T) {
+	g := NewWithT(t)
+
+	oldest := metav1.Date(2025, 1, 1, 0, 0, 0, 0, metav1.Now().Location())
+	middle := metav1.Date(2025, 6, 1, 0, 0, 0, 0, metav1.Now().Location())
+	newest := metav1.Date(2025, 12, 1, 0, 0, 0, 0, metav1.Now().Location())
+
+	idx := &WorkloadIndex{}
+	idx.Update([]reporter.WorkloadRef{
+		{Name: "old", Kind: "Deployment", Namespace: "default", LastReconciled: oldest},
+		{Name: "new", Kind: "Deployment", Namespace: "default", LastReconciled: newest},
+		{Name: "mid", Kind: "Deployment", Namespace: "default", LastReconciled: middle},
+	})
+
+	results := idx.SearchWorkloads(nil, "", "", "", 2)
+	g.Expect(results).To(HaveLen(2))
+	g.Expect(results[0].Name).To(Equal("new"))
+	g.Expect(results[1].Name).To(Equal("mid"))
+}
+
+func TestWorkloadIndex_SearchWorkloads_AllowedNamespaces(t *testing.T) {
+	g := NewWithT(t)
+
+	idx := &WorkloadIndex{}
+	idx.Update([]reporter.WorkloadRef{
+		{Name: "a", Kind: "Deployment", Namespace: "team-a", LastReconciled: metav1.Now()},
+		{Name: "b", Kind: "Deployment", Namespace: "team-b", LastReconciled: metav1.Now()},
+		{Name: "c", Kind: "Deployment", Namespace: "team-c", LastReconciled: metav1.Now()},
+	})
+
+	// Only team-a and team-c visible.
+	results := idx.SearchWorkloads([]string{"team-a", "team-c"}, "", "", "", 0)
+	g.Expect(results).To(HaveLen(2))
+	for _, r := range results {
+		g.Expect(r.Namespace).To(BeElementOf("team-a", "team-c"))
+	}
+
+	// nil allowedNamespaces means cluster-wide access.
+	results = idx.SearchWorkloads(nil, "", "", "", 0)
+	g.Expect(results).To(HaveLen(3))
+
+	// Empty non-nil allowedNamespaces means no access.
+	results = idx.SearchWorkloads([]string{}, "", "", "", 0)
+	g.Expect(results).To(BeEmpty())
+}
+
+func TestWorkloadIndex_SearchWorkloads_EmptyIndex(t *testing.T) {
+	g := NewWithT(t)
+
+	idx := &WorkloadIndex{}
+	results := idx.SearchWorkloads(nil, "", "*x*", "", 10)
+	g.Expect(results).To(BeEmpty())
+}

--- a/internal/web/workload_logs.go
+++ b/internal/web/workload_logs.go
@@ -27,31 +27,70 @@ import (
 const (
 	// defaultLogTailLines is the number of log lines returned when the
 	// tailLines query parameter is not set.
-	defaultLogTailLines int64 = 1000
+	defaultLogTailLines = 1000
 
 	// maxLogTailLines caps the number of log lines a client can request.
-	maxLogTailLines int64 = 5000
+	maxLogTailLines = 5000
 
 	// maxLogBytes caps the size of the log payload returned to the client.
 	maxLogBytes int64 = 512 * 1024 // 512 KiB
 
-	// maxLogContainers caps the number of containers streamed for the
-	// all-containers view, bounding the per-request log-stream fan-out. Real
-	// pods have only a handful of containers; this is a defensive ceiling for a
-	// request that names many directly.
-	maxLogContainers = 64
+	// maxLogContainers caps the number of containers streamed per pod for the
+	// all-containers view. Real pods have only a handful of containers; this is a
+	// defensive ceiling for a request that names many directly.
+	maxLogContainers = 50
+
+	// maxLogPods caps the number of pods streamed for the all-pods view, bounding
+	// the pod dimension of the fan-out independently of the container dimension.
+	maxLogPods = 100
+
+	// maxLogStreams caps the total number of concurrent log streams (pods ×
+	// containers) a single request can open, bounding the overall fan-out.
+	maxLogStreams = 50
+
+	// maxLogStreamConcurrency caps how many of a request's streams are read at
+	// once, so the all-pods view does not open every stream simultaneously.
+	maxLogStreamConcurrency = 10
+
+	// minPerStreamLogBytes floors the per-stream byte budget when the byte cap is
+	// divided across a multi-stream fan-out, so each stream still returns a useful
+	// tail even when many streams share the overall maxLogBytes budget.
+	minPerStreamLogBytes = 64 * 1024 // 64 KiB
 )
 
 // WorkloadLogsResponse represents the response body for GET /api/v1/workload/logs.
 type WorkloadLogsResponse struct {
-	// Pod is the name of the pod the logs belong to.
+	// Pod is the name of the pod the logs belong to (or a comma-joined list of
+	// pods for the all-pods view).
 	Pod string `json:"pod"`
 
-	// Container is the name of the container the logs belong to.
+	// Container is the name of the container the logs belong to (or a comma-joined
+	// list for the all-containers view).
 	Container string `json:"container"`
 
-	// Logs is the plain-text log output of the container.
+	// Logs is the plain-text log output.
 	Logs string `json:"logs"`
+
+	// Tagged reports whether each timestamped line in Logs is prefixed with its
+	// pod of origin ("<pod> <timestamp> <message>"). Set only for the all-pods
+	// view (more than one pod streamed); absent for single-pod responses.
+	Tagged bool `json:"tagged,omitempty"`
+
+	// Total is the number of distinct pods the client requested. Set only for the
+	// multi-stream (all-pods/all-containers) path.
+	Total int `json:"total,omitempty"`
+
+	// Streamed is the number of those pods that produced logs. When it is less
+	// than Total some pods were skipped (forbidden, missing, or capped).
+	Streamed int `json:"streamed,omitempty"`
+
+	// Partial reports that the response does not cover every requested pod
+	// (Streamed < Total) or that the fan-out was truncated by a cap.
+	Partial bool `json:"partial,omitempty"`
+
+	// Forbidden is the number of pods skipped because the user is not allowed to
+	// read their logs, so the UI can explain a partial result.
+	Forbidden int `json:"forbidden,omitempty"`
 }
 
 // trimPartialLogLine drops a trailing partial log line from the payload.
@@ -128,18 +167,20 @@ func trimPartialFirstLine(logs string) string {
 }
 
 // fetchContainerLog streams the logs of a single container with the given
-// options and returns the payload trimmed of any partial first/last line. It is
-// shared by the single-container and all-containers paths of the handler.
-func fetchContainerLog(ctx context.Context, clientset kubernetes.Interface, namespace, name string, opts *corev1.PodLogOptions) (string, error) {
+// options and returns the payload trimmed of any partial first/last line,
+// keeping only the newest byteLimit bytes. It is shared by the single-stream and
+// fan-out paths of the handler; the fan-out passes a smaller per-stream limit so
+// many concurrent streams stay within the overall byte budget.
+func fetchContainerLog(ctx context.Context, clientset kubernetes.Interface, namespace, name string, opts *corev1.PodLogOptions, byteLimit int) (string, error) {
 	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(name, opts).Stream(ctx)
 	if err != nil {
 		return "", err
 	}
 	defer stream.Close()
 
-	// Read the stream, keeping only the newest maxLogBytes so the payload stays
-	// bounded while returning the most recent lines.
-	data, partialFirst, err := tailLogBytes(stream, int(maxLogBytes))
+	// Read the stream, keeping only the newest byteLimit bytes so the payload
+	// stays bounded while returning the most recent lines.
+	data, partialFirst, err := tailLogBytes(stream, byteLimit)
 	if err != nil {
 		return "", err
 	}
@@ -155,14 +196,25 @@ func fetchContainerLog(ctx context.Context, clientset kubernetes.Interface, name
 }
 
 // writeLogStreamError maps a GetLogs stream error to an HTTP response: 403 for a
-// forbidden user, 404 for a missing pod, and 500 otherwise (logged).
+// forbidden user, 404 for a missing pod, and 500 otherwise (logged). An empty
+// name produces a workload-scoped message for the all-pods fan-out, where the
+// failure is not attributable to one named pod.
 func writeLogStreamError(ctx context.Context, w http.ResponseWriter, err error, namespace, name, container string) {
 	switch {
 	case errors.IsForbidden(err):
 		perms := user.Permissions(ctx)
+		if name == "" {
+			http.Error(w, fmt.Sprintf("Permission denied. User %s does not have access to read the workload pod logs in namespace %s",
+				perms.Username, namespace), http.StatusForbidden)
+			return
+		}
 		http.Error(w, fmt.Sprintf("Permission denied. User %s does not have access to read logs for pod %s/%s",
 			perms.Username, namespace, name), http.StatusForbidden)
 	case errors.IsNotFound(err):
+		if name == "" {
+			http.Error(w, fmt.Sprintf("No readable pods found in namespace %s", namespace), http.StatusNotFound)
+			return
+		}
 		http.Error(w, fmt.Sprintf("Pod %s/%s not found", namespace, name), http.StatusNotFound)
 	default:
 		log.FromContext(ctx).Error(err, "failed to stream pod logs",
@@ -171,27 +223,49 @@ func writeLogStreamError(ctx context.Context, w http.ResponseWriter, err error, 
 	}
 }
 
-// writeWorkloadLogs encodes the log payload as the JSON WorkloadLogsResponse.
+// writeWorkloadLogs encodes a single-stream log payload as the JSON
+// WorkloadLogsResponse, leaving the multi-stream metadata fields unset.
 func writeWorkloadLogs(w http.ResponseWriter, pod, container, logs string) {
-	w.Header().Set("Content-Type", "application/json")
-	resp := WorkloadLogsResponse{
+	writeWorkloadLogsResponse(w, WorkloadLogsResponse{
 		Pod:       pod,
 		Container: container,
 		Logs:      logs,
-	}
+	})
+}
+
+// writeWorkloadLogsResponse encodes the given response as JSON.
+func writeWorkloadLogsResponse(w http.ResponseWriter, resp WorkloadLogsResponse) {
+	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
 
-// logEntry is one record used when interleaving multiple container streams: a
-// line carrying a leading RFC3339 timestamp plus any immediately following
+// logTarget is one (pod, container) stream to read in the fan-out. An empty
+// container lets the kubelet pick the pod's default container.
+type logTarget struct {
+	pod       string
+	container string
+}
+
+// logStream is one source blob in the fan-out: the raw timestamped log payload
+// of a single (pod, container) target plus the pod it came from, so the merge
+// can tag each line with its origin in the all-pods view.
+type logStream struct {
+	pod  string
+	blob string
+}
+
+// logEntry is one record used when interleaving multiple streams: a line
+// carrying a leading RFC3339 timestamp plus any immediately following
 // continuation lines that lack their own timestamp (e.g. stack-trace frames).
 // The parsed timestamp is the sort key; text retains the original line(s),
-// including the timestamp prefix, since the frontend strips it for display.
+// including the timestamp prefix, since the frontend strips it for display. pod
+// records the originating pod so the merge can prefix the line in tagged mode.
 type logEntry struct {
 	ts   time.Time
 	text string
+	pod  string
 }
 
 // parseLogTimestamp parses the leading RFC3339 timestamp token kubelet prepends
@@ -209,39 +283,46 @@ func parseLogTimestamp(line string) (time.Time, bool) {
 	return t, true
 }
 
-// parseLogEntries splits a timestamped log payload into entries. Each entry
-// begins at a line whose first token parses as an RFC3339 timestamp and absorbs
-// subsequent lines without such a prefix, so multi-line records (stack traces)
-// stay intact and ordered. A continuation line with no preceding entry becomes
-// its own zero-timestamped entry, which sorts to the front.
-func parseLogEntries(blob string) []logEntry {
+// parseLogEntries splits a timestamped log payload into entries, stamping each
+// with pod. Each entry begins at a line whose first token parses as an RFC3339
+// timestamp and absorbs subsequent lines without such a prefix, so multi-line
+// records (stack traces) stay intact and ordered. A continuation line with no
+// preceding entry becomes its own zero-timestamped entry, which sorts to the
+// front.
+func parseLogEntries(blob, pod string) []logEntry {
 	var entries []logEntry
 	for line := range strings.SplitSeq(blob, "\n") {
 		if line == "" {
 			continue
 		}
 		if ts, ok := parseLogTimestamp(line); ok {
-			entries = append(entries, logEntry{ts: ts, text: line})
+			entries = append(entries, logEntry{ts: ts, text: line, pod: pod})
 			continue
 		}
 		if n := len(entries); n > 0 {
 			entries[n-1].text += "\n" + line
 		} else {
-			entries = append(entries, logEntry{text: line})
+			entries = append(entries, logEntry{text: line, pod: pod})
 		}
 	}
 	return entries
 }
 
-// mergeLogStreams interleaves the timestamped log payloads of multiple
-// containers into a single chronological stream. Entries are stable-sorted by
-// their timestamp (so records logged at the same instant keep a deterministic
-// order), capped to the newest tailLines entries, and finally to the newest
-// maxLogBytes bytes on a line boundary so the payload stays bounded.
-func mergeLogStreams(blobs []string, tailLines int) string {
+// mergeLogStreams interleaves the timestamped payloads of multiple streams into
+// a single chronological stream. Entries are stable-sorted by their timestamp
+// (so records logged at the same instant keep a deterministic order), capped to
+// the newest tailLines entries, and finally to the newest maxLogBytes bytes on a
+// line boundary so the payload stays bounded.
+//
+// When tagPod is set, each entry that carries a timestamp is prefixed with its
+// pod of origin ("<pod> <timestamp> <message>") so the client can attribute the
+// line; zero-timestamped orphan entries are left untagged so every tagged line
+// is uniformly "<pod> <timestamp> ..." and parses unambiguously. With tagPod
+// false the output is byte-for-byte the original single-pod merge.
+func mergeLogStreams(streams []logStream, tailLines int, tagPod bool) string {
 	var entries []logEntry
-	for _, b := range blobs {
-		entries = append(entries, parseLogEntries(b)...)
+	for _, s := range streams {
+		entries = append(entries, parseLogEntries(s.blob, s.pod)...)
 	}
 	sort.SliceStable(entries, func(i, j int) bool {
 		return entries[i].ts.Before(entries[j].ts)
@@ -251,53 +332,79 @@ func mergeLogStreams(blobs []string, tailLines int) string {
 	}
 	var sb strings.Builder
 	for _, e := range entries {
+		if tagPod && !e.ts.IsZero() {
+			sb.WriteString(e.pod)
+			sb.WriteByte(' ')
+		}
 		sb.WriteString(e.text)
 		sb.WriteByte('\n')
 	}
 	return capLogBytes(sb.String(), int(maxLogBytes))
 }
 
-// dedupeContainers removes duplicate container names (keeping first occurrence)
-// and caps the result to limit, so a request naming the same container twice
-// does not stream it twice and a request naming many containers cannot fan out
-// without bound. Order is preserved so the merge input stays deterministic.
-func dedupeContainers(names []string, limit int) []string {
+// dedupeNames removes duplicate names (keeping first occurrence) and caps the
+// result to limit, so a request naming the same pod or container twice does not
+// stream it twice and a request naming many cannot fan out without bound. Order
+// is preserved so the merge input stays deterministic. It reports whether any
+// name was dropped by the cap (not by de-duplication).
+func dedupeNames(names []string, limit int) ([]string, bool) {
 	if len(names) == 0 {
-		return names
+		return names, false
 	}
 	seen := make(map[string]struct{}, len(names))
 	out := make([]string, 0, len(names))
+	truncated := false
 	for _, n := range names {
 		if _, ok := seen[n]; ok {
 			continue
 		}
 		seen[n] = struct{}{}
-		out = append(out, n)
 		if len(out) == limit {
+			truncated = true
 			break
 		}
+		out = append(out, n)
 	}
-	return out
+	return out, truncated
 }
 
-// collectContainerLogs partitions the per-container fan-out results into the
-// successful log payloads and the first error encountered. It implements the
-// best-effort policy of the all-containers view: a container that failed (e.g.
-// is still waiting to start) is skipped as long as another succeeded, so the
-// returned error is only meaningful to the caller when no blob was collected.
-func collectContainerLogs(logs []string, errs []error) ([]string, error) {
-	var blobs []string
-	var firstErr error
-	for i := range logs {
+// logFanOut is the outcome of a per-target log fan-out: the successful streams
+// (tagged with their pod), the set of distinct pods that produced logs, the
+// number of distinct pods skipped because the user is forbidden to read them, and
+// the first error encountered. It implements the best-effort policy of the
+// all-pods/all-containers view: a target that failed (e.g. waiting to start,
+// deleted, or forbidden) is skipped as long as another succeeded, so firstErr is
+// only meaningful when no stream was collected.
+type logFanOut struct {
+	streams     []logStream
+	streamedSet map[string]struct{}
+	forbidden   int
+	firstErr    error
+}
+
+// collectLogStreams partitions the per-target fan-out results into the
+// successful streams, the distinct pods that produced logs, the count of distinct
+// pods forbidden, and the first error. targets, logs, and errs are index-aligned.
+// Forbidden is counted per pod (not per target) so a forbidden pod with several
+// containers is reported once, matching the pod-based Total/Streamed fields.
+func collectLogStreams(targets []logTarget, logs []string, errs []error) logFanOut {
+	out := logFanOut{streamedSet: make(map[string]struct{})}
+	forbiddenPods := make(map[string]struct{})
+	for i := range targets {
 		if errs[i] != nil {
-			if firstErr == nil {
-				firstErr = errs[i]
+			if out.firstErr == nil {
+				out.firstErr = errs[i]
+			}
+			if errors.IsForbidden(errs[i]) {
+				forbiddenPods[targets[i].pod] = struct{}{}
 			}
 			continue
 		}
-		blobs = append(blobs, logs[i])
+		out.streams = append(out.streams, logStream{pod: targets[i].pod, blob: logs[i]})
+		out.streamedSet[targets[i].pod] = struct{}{}
 	}
-	return blobs, firstErr
+	out.forbidden = len(forbiddenPods)
+	return out
 }
 
 // capLogBytes keeps only the newest limit bytes of a newline-terminated log
@@ -334,12 +441,20 @@ func capLogBytes(logs string, limit int) string {
 // returned instead, so a following client can incrementally append new lines
 // rather than re-fetching and replacing the whole tail window on every poll.
 //
-// The container query parameter may be repeated to request the "All containers"
-// view: each named container's logs are streamed and interleaved chronologically
-// into a single payload (the previous-instance option is not offered there). A
-// single or absent container keeps the per-container behavior. The frontend
-// supplies the container names, so no pod read is required and access stays
-// governed solely by the pods/log RBAC, which is enforced per pod.
+// The container query parameter may be repeated for the "All containers" view and
+// the pod query parameter (in addition to the required name) for the "All pods"
+// view: every (pod, container) target is streamed and interleaved chronologically
+// into a single payload (the previous-instance option is not offered there). When
+// more than one pod is requested, each timestamped line is prefixed with its pod
+// of origin ("<pod> <timestamp> <message>") and the response sets tagged=true plus
+// the total/streamed/partial/forbidden coverage fields. The frontend supplies the
+// pod and container names, so no pod read is required and access stays governed
+// solely by the pods/log RBAC, enforced per pod; a user who cannot read some pods
+// simply gets a partial result.
+//
+// Following uses sinceTime for the single-stream path and a repeated since
+// parameter ("<pod>=<rfc3339>") for the all-pods path, so each pod advances its
+// own cursor independently of clock skew between nodes.
 //
 // Example: /api/v1/workload/logs?namespace=flux-system&name=source-controller-xx-yy&container=manager
 func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) {
@@ -361,7 +476,7 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 	// Parse the optional tailLines parameter, clamping it to a sane range.
 	tailLines := defaultLogTailLines
 	if v := req.URL.Query().Get("tailLines"); v != "" {
-		parsed, err := strconv.ParseInt(v, 10, 64)
+		parsed, err := strconv.Atoi(v)
 		if err != nil || parsed <= 0 {
 			http.Error(w, "Invalid tailLines parameter", http.StatusBadRequest)
 			return
@@ -381,9 +496,9 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 		previous = parsed
 	}
 
-	// Parse the optional sinceTime parameter (RFC3339). When set, only entries
-	// newer than this time are returned, letting a following client append new
-	// lines instead of replacing the whole tail on every poll.
+	// Parse the optional sinceTime parameter (RFC3339) for the single-stream path.
+	// When set, only entries newer than this time are returned, letting a
+	// following client append new lines instead of replacing the whole tail.
 	var sinceTime *metav1.Time
 	if v := req.URL.Query().Get("sinceTime"); v != "" {
 		parsed, err := time.Parse(time.RFC3339, v)
@@ -393,6 +508,26 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 		}
 		t := metav1.NewTime(parsed)
 		sinceTime = &t
+	}
+
+	// Parse the optional per-pod follow cursors for the all-pods view. Each
+	// repeated "since" parameter carries "<pod>=<rfc3339>", so a following client
+	// advances each pod independently (pods can sit on nodes with skewed clocks,
+	// where a single shared cursor would drop a lagging pod's lines).
+	sinceByPod := make(map[string]*metav1.Time)
+	for _, v := range req.URL.Query()["since"] {
+		pod, ts, found := strings.Cut(v, "=")
+		if !found || pod == "" || ts == "" {
+			http.Error(w, "Invalid since parameter", http.StatusBadRequest)
+			return
+		}
+		parsed, err := time.Parse(time.RFC3339, ts)
+		if err != nil {
+			http.Error(w, "Invalid since parameter", http.StatusBadRequest)
+			return
+		}
+		t := metav1.NewTime(parsed)
+		sinceByPod[pod] = &t
 	}
 
 	ctx := req.Context()
@@ -409,85 +544,172 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	// Collect the requested container names. Repeated container params request
-	// the "All containers" view; a single or absent container keeps the original
-	// per-container behavior. Empty values are dropped so an explicit container=
-	// does not select a phantom container, and the list is de-duplicated and
-	// capped so a direct caller cannot stream a container twice or fan out
-	// without bound.
+	// Collect the requested pods: the required primary pod (name) plus any repeated
+	// "pod" params for the all-pods view. Empty values are dropped, the list is
+	// de-duplicated, and the pod and container dimensions are capped independently
+	// so neither can fan out without bound.
+	pods := []string{name}
+	for _, p := range req.URL.Query()["pod"] {
+		if p != "" {
+			pods = append(pods, p)
+		}
+	}
+	// total is the number of distinct pods the client asked for, measured before
+	// the cap so a truncated all-pods view can be reported as partial.
+	deduped, _ := dedupeNames(pods, len(pods))
+	total := len(deduped)
+	pods, podsTruncated := dedupeNames(pods, maxLogPods)
+
+	// Collect the requested container names. An absent container lets the kubelet
+	// pick the pod's default container.
 	var containers []string
 	for _, c := range req.URL.Query()["container"] {
 		if c != "" {
 			containers = append(containers, c)
 		}
 	}
-	containers = dedupeContainers(containers, maxLogContainers)
+	containers, containersTruncated := dedupeNames(containers, maxLogContainers)
 
-	// TailLines is always set so the kubelet returns the newest lines (and
-	// bounds the read to at most tailLines lines). When following, SinceTime
-	// additionally restricts the range to entries after the last seen line, so
-	// the response is the newest lines since then. LimitBytes is deliberately
-	// not used: it keeps the oldest bytes of the range, dropping the most recent
-	// lines; the byte cap is enforced by keeping the trailing bytes.
+	// Tagging is decided from the client's request (more than one pod), before the
+	// stream cap, so the client and server agree on the wire format regardless of
+	// which streams survive truncation.
+	tagPod := total > 1
 
-	// Single-container path (one or no container): preserves the previous-instance
-	// and follow semantics unchanged. An absent container lets the kubelet pick
-	// the pod's default container.
-	if len(containers) <= 1 {
-		container := ""
-		if len(containers) == 1 {
-			container = containers[0]
+	// Build the (pod, container) targets as the product of the two dimensions,
+	// capped to maxLogStreams overall. An empty container list yields one target
+	// per pod (kubelet default container).
+	targets, streamsTruncated := buildLogTargets(pods, containers, maxLogStreams)
+	truncated := podsTruncated || containersTruncated || streamsTruncated
+
+	// TailLines is always set so the kubelet returns the newest lines (and bounds
+	// the read to at most tailLines lines). SinceTime narrows a follow poll to
+	// entries after the last seen line. LimitBytes is deliberately not used: it
+	// keeps the oldest bytes of the range, dropping the most recent lines; the
+	// byte cap is enforced by keeping the trailing bytes.
+	//
+	// tailLines64 widens the clamped line count for the kubelet API, which takes
+	// a *int64; the value is bounded by maxLogTailLines so the conversion is safe.
+	tailLines64 := int64(tailLines)
+
+	// Single-stream path (one pod, one or no container, no pod tagging): preserves
+	// the previous-instance and follow semantics unchanged. An all-pods request
+	// (tagPod) always uses the fan-out path so it carries the tagged/partial
+	// metadata even if a cap collapsed it to a single surviving stream.
+	if !tagPod && len(targets) <= 1 {
+		t := logTarget{pod: name}
+		if len(targets) == 1 {
+			t = targets[0]
 		}
 		opts := &corev1.PodLogOptions{
-			Container:  container,
-			TailLines:  &tailLines,
+			Container:  t.container,
+			TailLines:  &tailLines64,
 			Previous:   previous,
 			Timestamps: true,
 		}
 		if sinceTime != nil {
 			opts.SinceTime = sinceTime
 		}
-		logs, err := fetchContainerLog(ctx, clientset, namespace, name, opts)
+		logs, err := fetchContainerLog(ctx, clientset, namespace, t.pod, opts, int(maxLogBytes))
 		if err != nil {
-			writeLogStreamError(ctx, w, err, namespace, name, container)
+			writeLogStreamError(ctx, w, err, namespace, t.pod, t.container)
 			return
 		}
-		writeWorkloadLogs(w, name, container, logs)
+		writeWorkloadLogs(w, t.pod, t.container, logs)
 		return
 	}
 
-	// All-containers path: stream every named container concurrently and merge
-	// the results by timestamp. Previous-instance logs are not offered here, so
-	// Previous is always false. The fetch is best-effort: a container with no
-	// readable logs yet (e.g. waiting to start) is skipped, and an error is only
-	// returned to the client when every container fails.
-	logsByContainer := make([]string, len(containers))
-	errsByContainer := make([]error, len(containers))
+	// Fan-out path (all-pods and/or all-containers): stream every target
+	// concurrently (bounded by a semaphore) and merge by timestamp. Previous logs
+	// are not offered here. The per-stream byte budget is the overall cap divided
+	// across the streams (floored) so transient memory stays bounded. The fetch is
+	// best-effort: a target with no readable logs yet (waiting, deleted, or
+	// forbidden) is skipped as long as another succeeds, and an error is returned
+	// only when every target fails.
+	perStreamBytes := max(int(maxLogBytes)/len(targets), minPerStreamLogBytes)
+	logsByTarget := make([]string, len(targets))
+	errsByTarget := make([]error, len(targets))
+	sem := make(chan struct{}, maxLogStreamConcurrency)
 	var wg sync.WaitGroup
-	for i, c := range containers {
+	for i, t := range targets {
 		wg.Add(1)
-		go func(i int, c string) {
+		go func(i int, t logTarget) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			opts := &corev1.PodLogOptions{
-				Container:  c,
-				TailLines:  &tailLines,
+				Container:  t.container,
+				TailLines:  &tailLines64,
 				Timestamps: true,
 			}
-			if sinceTime != nil {
+			// Follow cursor: a per-pod `since` for the all-pods view, falling back
+			// to the single global sinceTime (used by a single-pod, multi-container
+			// follow, which routes here yet sends one cursor).
+			if st := sinceByPod[t.pod]; st != nil {
+				opts.SinceTime = st
+			} else if sinceTime != nil {
 				opts.SinceTime = sinceTime
 			}
-			logsByContainer[i], errsByContainer[i] = fetchContainerLog(ctx, clientset, namespace, name, opts)
-		}(i, c)
+			logsByTarget[i], errsByTarget[i] = fetchContainerLog(ctx, clientset, namespace, t.pod, opts, perStreamBytes)
+		}(i, t)
 	}
 	wg.Wait()
 
-	blobs, firstErr := collectContainerLogs(logsByContainer, errsByContainer)
-	// Only fail when no container produced logs; otherwise return what we have.
-	if len(blobs) == 0 && firstErr != nil {
-		writeLogStreamError(ctx, w, firstErr, namespace, name, strings.Join(containers, ","))
+	fanOut := collectLogStreams(targets, logsByTarget, errsByTarget)
+	if len(fanOut.streams) == 0 && fanOut.firstErr != nil {
+		// Attribute the error to the single pod when only one was requested;
+		// otherwise keep it workload-scoped.
+		errName := ""
+		if total == 1 {
+			errName = name
+		}
+		writeLogStreamError(ctx, w, fanOut.firstErr, namespace, errName, strings.Join(containers, ","))
 		return
 	}
 
-	merged := mergeLogStreams(blobs, int(tailLines))
-	writeWorkloadLogs(w, name, strings.Join(containers, ","), merged)
+	writeWorkloadLogsResponse(w, buildWorkloadLogsResponse(pods, containers, fanOut, total, tailLines, tagPod, truncated))
+}
+
+// buildWorkloadLogsResponse assembles the multi-stream (all-pods/all-containers)
+// response from a completed fan-out: it merges the collected streams and reports
+// the coverage so the UI can explain a partial view. Streamed is the number of
+// requested pods that produced logs; the result is Partial when fewer pods
+// streamed than were requested (some forbidden, missing, or still starting) or
+// when a cap truncated the fan-out. Forbidden carries the count of pods skipped
+// for lack of pods/log access.
+func buildWorkloadLogsResponse(pods, containers []string, fanOut logFanOut, total, tailLines int, tagPod, truncated bool) WorkloadLogsResponse {
+	streamed := len(fanOut.streamedSet)
+	return WorkloadLogsResponse{
+		Pod:       strings.Join(pods, ","),
+		Container: strings.Join(containers, ","),
+		Logs:      mergeLogStreams(fanOut.streams, tailLines, tagPod),
+		Tagged:    tagPod,
+		Total:     total,
+		Streamed:  streamed,
+		Partial:   streamed < total || truncated,
+		Forbidden: fanOut.forbidden,
+	}
+}
+
+// buildLogTargets expands the pod and container dimensions into the (pod,
+// container) product, capped to limit targets overall. An empty container list
+// yields one target per pod (the kubelet default container). It reports whether
+// the cap dropped any target.
+func buildLogTargets(pods, containers []string, limit int) ([]logTarget, bool) {
+	var targets []logTarget
+	for _, p := range pods {
+		if len(containers) == 0 {
+			if len(targets) == limit {
+				return targets, true
+			}
+			targets = append(targets, logTarget{pod: p})
+			continue
+		}
+		for _, c := range containers {
+			if len(targets) == limit {
+				return targets, true
+			}
+			targets = append(targets, logTarget{pod: p, container: c})
+		}
+	}
+	return targets, false
 }

--- a/internal/web/workload_logs.go
+++ b/internal/web/workload_logs.go
@@ -4,16 +4,17 @@
 package web
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -29,7 +30,7 @@ const (
 	maxLogTailLines int64 = 5000
 
 	// maxLogBytes caps the size of the log payload returned to the client.
-	maxLogBytes int64 = 256 * 1024 // 256 KiB
+	maxLogBytes int64 = 512 * 1024 // 512 KiB
 )
 
 // WorkloadLogsResponse represents the response body for GET /api/v1/workload/logs.
@@ -47,18 +48,72 @@ type WorkloadLogsResponse struct {
 // trimPartialLogLine drops a trailing partial log line from the payload.
 //
 // Container runtimes newline-terminate every emitted log line, so a payload
-// that does not end with a newline has been truncated mid-line, either because
-// the container was writing the line when the logs were read (common while
-// following) or because the LimitBytes cap cut the newest line. Returning that
-// fragment as the latest entry shows only a few characters, so it is dropped;
-// the complete line reappears on the next fetch. A payload with no newline at
-// all is returned unchanged so a single short line is not lost.
+// that does not end with a newline has been truncated mid-line because the
+// container was writing the line when the logs were read (common while
+// following). Returning that fragment as the latest entry shows only a few
+// characters, so it is dropped; the complete line reappears on the next fetch.
+// A payload with no newline at all is returned unchanged so a single short line
+// is not lost.
 func trimPartialLogLine(logs string) string {
 	if logs == "" || logs[len(logs)-1] == '\n' {
 		return logs
 	}
 	if i := strings.LastIndexByte(logs, '\n'); i >= 0 {
 		return logs[:i+1]
+	}
+	return logs
+}
+
+// tailLogBytes reads r to EOF but retains only the most recent limit bytes, so
+// the response stays small while returning the newest log lines.
+//
+// The kubelet's PodLogOptions.LimitBytes keeps the *oldest* bytes of the range
+// it reads, which for a tail window drops the most recent lines. Reading the
+// whole window (bounded by TailLines) and keeping the trailing bytes here
+// returns the newest lines instead. Memory use is bounded to ~limit regardless
+// of the stream length.
+//
+// The returned bool is partialFirst: true when the retained slice begins
+// mid-line (the byte dropped just before it was not a newline), so the caller
+// should drop that leading fragment. A cut that lands exactly on a line boundary
+// keeps a complete first line and reports false.
+func tailLogBytes(r io.Reader, limit int) ([]byte, bool, error) {
+	const chunkSize = 32 * 1024
+	buf := make([]byte, 0, limit+chunkSize)
+	chunk := make([]byte, chunkSize)
+	partialFirst := false
+	for {
+		n, err := r.Read(chunk)
+		if n > 0 {
+			buf = append(buf, chunk[:n]...)
+			if len(buf) > limit {
+				// The byte dropped just before the retained window decides
+				// whether the first kept line is complete (preceded by '\n') or
+				// a mid-line fragment.
+				partialFirst = buf[len(buf)-limit-1] != '\n'
+				// Shift the trailing limit bytes (the newest output) to the
+				// front in place so the backing array, and thus memory, stays
+				// bounded.
+				copy(buf, buf[len(buf)-limit:])
+				buf = buf[:limit]
+			}
+		}
+		if err == io.EOF {
+			return buf, partialFirst, nil
+		}
+		if err != nil {
+			return nil, partialFirst, err
+		}
+	}
+}
+
+// trimPartialFirstLine drops a leading partial log line from the payload. It is
+// applied only when the payload was byte-truncated from the front (see
+// tailLogBytes), where the first line is a mid-line fragment. A payload with no
+// newline is returned unchanged so a single short line is not lost.
+func trimPartialFirstLine(logs string) string {
+	if _, rest, found := strings.Cut(logs, "\n"); found {
+		return rest
 	}
 	return logs
 }
@@ -71,6 +126,11 @@ func trimPartialLogLine(logs string) string {
 // logs of pods they are explicitly granted access to. This is a read-only
 // endpoint and is therefore not gated by UserActionsEnabled; access is governed
 // entirely by RBAC.
+//
+// By default the last tailLines entries are returned. When the sinceTime query
+// parameter is set (an RFC3339 timestamp), only entries newer than that time are
+// returned instead, so a following client can incrementally append new lines
+// rather than re-fetching and replacing the whole tail window on every poll.
 //
 // Example: /api/v1/workload/logs?namespace=flux-system&name=source-controller-xx-yy&container=manager
 func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) {
@@ -113,6 +173,20 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 		previous = parsed
 	}
 
+	// Parse the optional sinceTime parameter (RFC3339). When set, only entries
+	// newer than this time are returned, letting a following client append new
+	// lines instead of replacing the whole tail on every poll.
+	var sinceTime *metav1.Time
+	if v := req.URL.Query().Get("sinceTime"); v != "" {
+		parsed, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			http.Error(w, "Invalid sinceTime parameter", http.StatusBadRequest)
+			return
+		}
+		t := metav1.NewTime(parsed)
+		sinceTime = &t
+	}
+
 	ctx := req.Context()
 
 	// Build a typed clientset using the impersonated user's REST config so
@@ -127,14 +201,22 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	logBytes := maxLogBytes
-	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(name, &corev1.PodLogOptions{
+	// TailLines is always set so the kubelet returns the newest lines (and
+	// bounds the read to at most tailLines lines). When following, SinceTime
+	// additionally restricts the range to entries after the last seen line, so
+	// the response is the newest lines since then. LimitBytes is deliberately
+	// not used: it keeps the oldest bytes of the range, dropping the most recent
+	// lines; the byte cap is enforced below by keeping the trailing bytes.
+	opts := &corev1.PodLogOptions{
 		Container:  container,
 		TailLines:  &tailLines,
-		LimitBytes: &logBytes,
 		Previous:   previous,
 		Timestamps: true,
-	}).Stream(ctx)
+	}
+	if sinceTime != nil {
+		opts.SinceTime = sinceTime
+	}
+	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(name, opts).Stream(ctx)
 	if err != nil {
 		switch {
 		case errors.IsForbidden(err):
@@ -152,14 +234,22 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 	}
 	defer stream.Close()
 
-	// Read the log stream, enforcing the byte cap as a safety net in case
-	// LimitBytes is not honored by the API server.
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, io.LimitReader(stream, maxLogBytes)); err != nil {
+	// Read the stream, keeping only the newest maxLogBytes so the payload stays
+	// bounded while returning the most recent lines.
+	data, partialFirst, err := tailLogBytes(stream, int(maxLogBytes))
+	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to read pod logs stream",
 			"pod", name, "namespace", namespace, "container", container)
 		http.Error(w, "Failed to read logs", http.StatusInternalServerError)
 		return
+	}
+
+	// Drop the partial first line only when the byte cap cut mid-line (a cut on
+	// a line boundary keeps a complete first line), and the partial last line
+	// when the container was mid-write.
+	logs := trimPartialLogLine(string(data))
+	if partialFirst {
+		logs = trimPartialFirstLine(logs)
 	}
 
 	// Return the logs as a JSON object so the frontend fetch utility can
@@ -168,7 +258,7 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 	resp := WorkloadLogsResponse{
 		Pod:       name,
 		Container: container,
-		Logs:      trimPartialLogLine(buf.String()),
+		Logs:      logs,
 	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/web/workload_logs.go
+++ b/internal/web/workload_logs.go
@@ -4,12 +4,15 @@
 package web
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -31,6 +34,12 @@ const (
 
 	// maxLogBytes caps the size of the log payload returned to the client.
 	maxLogBytes int64 = 512 * 1024 // 512 KiB
+
+	// maxLogContainers caps the number of containers streamed for the
+	// all-containers view, bounding the per-request log-stream fan-out. Real
+	// pods have only a handful of containers; this is a defensive ceiling for a
+	// request that names many directly.
+	maxLogContainers = 64
 )
 
 // WorkloadLogsResponse represents the response body for GET /api/v1/workload/logs.
@@ -118,6 +127,199 @@ func trimPartialFirstLine(logs string) string {
 	return logs
 }
 
+// fetchContainerLog streams the logs of a single container with the given
+// options and returns the payload trimmed of any partial first/last line. It is
+// shared by the single-container and all-containers paths of the handler.
+func fetchContainerLog(ctx context.Context, clientset kubernetes.Interface, namespace, name string, opts *corev1.PodLogOptions) (string, error) {
+	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(name, opts).Stream(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+
+	// Read the stream, keeping only the newest maxLogBytes so the payload stays
+	// bounded while returning the most recent lines.
+	data, partialFirst, err := tailLogBytes(stream, int(maxLogBytes))
+	if err != nil {
+		return "", err
+	}
+
+	// Drop the partial first line only when the byte cap cut mid-line (a cut on
+	// a line boundary keeps a complete first line), and the partial last line
+	// when the container was mid-write.
+	logs := trimPartialLogLine(string(data))
+	if partialFirst {
+		logs = trimPartialFirstLine(logs)
+	}
+	return logs, nil
+}
+
+// writeLogStreamError maps a GetLogs stream error to an HTTP response: 403 for a
+// forbidden user, 404 for a missing pod, and 500 otherwise (logged).
+func writeLogStreamError(ctx context.Context, w http.ResponseWriter, err error, namespace, name, container string) {
+	switch {
+	case errors.IsForbidden(err):
+		perms := user.Permissions(ctx)
+		http.Error(w, fmt.Sprintf("Permission denied. User %s does not have access to read logs for pod %s/%s",
+			perms.Username, namespace, name), http.StatusForbidden)
+	case errors.IsNotFound(err):
+		http.Error(w, fmt.Sprintf("Pod %s/%s not found", namespace, name), http.StatusNotFound)
+	default:
+		log.FromContext(ctx).Error(err, "failed to stream pod logs",
+			"pod", name, "namespace", namespace, "container", container)
+		http.Error(w, fmt.Sprintf("Failed to read logs: %v", err), http.StatusInternalServerError)
+	}
+}
+
+// writeWorkloadLogs encodes the log payload as the JSON WorkloadLogsResponse.
+func writeWorkloadLogs(w http.ResponseWriter, pod, container, logs string) {
+	w.Header().Set("Content-Type", "application/json")
+	resp := WorkloadLogsResponse{
+		Pod:       pod,
+		Container: container,
+		Logs:      logs,
+	}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// logEntry is one record used when interleaving multiple container streams: a
+// line carrying a leading RFC3339 timestamp plus any immediately following
+// continuation lines that lack their own timestamp (e.g. stack-trace frames).
+// The parsed timestamp is the sort key; text retains the original line(s),
+// including the timestamp prefix, since the frontend strips it for display.
+type logEntry struct {
+	ts   time.Time
+	text string
+}
+
+// parseLogTimestamp parses the leading RFC3339 timestamp token kubelet prepends
+// to each line when PodLogOptions.Timestamps is set. It reports false when the
+// line does not start with such a token (e.g. a stack-trace continuation).
+func parseLogTimestamp(line string) (time.Time, bool) {
+	tsStr, _, found := strings.Cut(line, " ")
+	if !found {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339Nano, tsStr)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// parseLogEntries splits a timestamped log payload into entries. Each entry
+// begins at a line whose first token parses as an RFC3339 timestamp and absorbs
+// subsequent lines without such a prefix, so multi-line records (stack traces)
+// stay intact and ordered. A continuation line with no preceding entry becomes
+// its own zero-timestamped entry, which sorts to the front.
+func parseLogEntries(blob string) []logEntry {
+	var entries []logEntry
+	for line := range strings.SplitSeq(blob, "\n") {
+		if line == "" {
+			continue
+		}
+		if ts, ok := parseLogTimestamp(line); ok {
+			entries = append(entries, logEntry{ts: ts, text: line})
+			continue
+		}
+		if n := len(entries); n > 0 {
+			entries[n-1].text += "\n" + line
+		} else {
+			entries = append(entries, logEntry{text: line})
+		}
+	}
+	return entries
+}
+
+// mergeLogStreams interleaves the timestamped log payloads of multiple
+// containers into a single chronological stream. Entries are stable-sorted by
+// their timestamp (so records logged at the same instant keep a deterministic
+// order), capped to the newest tailLines entries, and finally to the newest
+// maxLogBytes bytes on a line boundary so the payload stays bounded.
+func mergeLogStreams(blobs []string, tailLines int) string {
+	var entries []logEntry
+	for _, b := range blobs {
+		entries = append(entries, parseLogEntries(b)...)
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].ts.Before(entries[j].ts)
+	})
+	if tailLines > 0 && len(entries) > tailLines {
+		entries = entries[len(entries)-tailLines:]
+	}
+	var sb strings.Builder
+	for _, e := range entries {
+		sb.WriteString(e.text)
+		sb.WriteByte('\n')
+	}
+	return capLogBytes(sb.String(), int(maxLogBytes))
+}
+
+// dedupeContainers removes duplicate container names (keeping first occurrence)
+// and caps the result to limit, so a request naming the same container twice
+// does not stream it twice and a request naming many containers cannot fan out
+// without bound. Order is preserved so the merge input stays deterministic.
+func dedupeContainers(names []string, limit int) []string {
+	if len(names) == 0 {
+		return names
+	}
+	seen := make(map[string]struct{}, len(names))
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out
+}
+
+// collectContainerLogs partitions the per-container fan-out results into the
+// successful log payloads and the first error encountered. It implements the
+// best-effort policy of the all-containers view: a container that failed (e.g.
+// is still waiting to start) is skipped as long as another succeeded, so the
+// returned error is only meaningful to the caller when no blob was collected.
+func collectContainerLogs(logs []string, errs []error) ([]string, error) {
+	var blobs []string
+	var firstErr error
+	for i := range logs {
+		if errs[i] != nil {
+			if firstErr == nil {
+				firstErr = errs[i]
+			}
+			continue
+		}
+		blobs = append(blobs, logs[i])
+	}
+	return blobs, firstErr
+}
+
+// capLogBytes keeps only the newest limit bytes of a newline-terminated log
+// payload, trimming any partial leading line so the result starts on a line
+// boundary.
+func capLogBytes(logs string, limit int) string {
+	if len(logs) <= limit {
+		return logs
+	}
+	cut := len(logs) - limit
+	// When the cut lands exactly on a line boundary (the preceding byte is a
+	// newline), the window already starts with a complete line and must not be
+	// trimmed further; otherwise drop the leading partial fragment.
+	if logs[cut-1] == '\n' {
+		return logs[cut:]
+	}
+	if i := strings.IndexByte(logs[cut:], '\n'); i >= 0 {
+		return logs[cut+i+1:]
+	}
+	return logs[cut:]
+}
+
 // WorkloadLogsHandler handles GET /api/v1/workload/logs requests and returns the
 // logs of a pod container managed by a Flux workload.
 //
@@ -132,6 +334,13 @@ func trimPartialFirstLine(logs string) string {
 // returned instead, so a following client can incrementally append new lines
 // rather than re-fetching and replacing the whole tail window on every poll.
 //
+// The container query parameter may be repeated to request the "All containers"
+// view: each named container's logs are streamed and interleaved chronologically
+// into a single payload (the previous-instance option is not offered there). A
+// single or absent container keeps the per-container behavior. The frontend
+// supplies the container names, so no pod read is required and access stays
+// governed solely by the pods/log RBAC, which is enforced per pod.
+//
 // Example: /api/v1/workload/logs?namespace=flux-system&name=source-controller-xx-yy&container=manager
 func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodGet {
@@ -142,7 +351,6 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 	// Parse query parameters.
 	namespace := req.URL.Query().Get("namespace")
 	name := req.URL.Query().Get("name")
-	container := req.URL.Query().Get("container")
 
 	// Validate required fields.
 	if namespace == "" || name == "" {
@@ -201,67 +409,85 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
+	// Collect the requested container names. Repeated container params request
+	// the "All containers" view; a single or absent container keeps the original
+	// per-container behavior. Empty values are dropped so an explicit container=
+	// does not select a phantom container, and the list is de-duplicated and
+	// capped so a direct caller cannot stream a container twice or fan out
+	// without bound.
+	var containers []string
+	for _, c := range req.URL.Query()["container"] {
+		if c != "" {
+			containers = append(containers, c)
+		}
+	}
+	containers = dedupeContainers(containers, maxLogContainers)
+
 	// TailLines is always set so the kubelet returns the newest lines (and
 	// bounds the read to at most tailLines lines). When following, SinceTime
 	// additionally restricts the range to entries after the last seen line, so
 	// the response is the newest lines since then. LimitBytes is deliberately
 	// not used: it keeps the oldest bytes of the range, dropping the most recent
-	// lines; the byte cap is enforced below by keeping the trailing bytes.
-	opts := &corev1.PodLogOptions{
-		Container:  container,
-		TailLines:  &tailLines,
-		Previous:   previous,
-		Timestamps: true,
-	}
-	if sinceTime != nil {
-		opts.SinceTime = sinceTime
-	}
-	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(name, opts).Stream(ctx)
-	if err != nil {
-		switch {
-		case errors.IsForbidden(err):
-			perms := user.Permissions(ctx)
-			http.Error(w, fmt.Sprintf("Permission denied. User %s does not have access to read logs for pod %s/%s",
-				perms.Username, namespace, name), http.StatusForbidden)
-		case errors.IsNotFound(err):
-			http.Error(w, fmt.Sprintf("Pod %s/%s not found", namespace, name), http.StatusNotFound)
-		default:
-			log.FromContext(ctx).Error(err, "failed to stream pod logs",
-				"pod", name, "namespace", namespace, "container", container)
-			http.Error(w, fmt.Sprintf("Failed to read logs: %v", err), http.StatusInternalServerError)
+	// lines; the byte cap is enforced by keeping the trailing bytes.
+
+	// Single-container path (one or no container): preserves the previous-instance
+	// and follow semantics unchanged. An absent container lets the kubelet pick
+	// the pod's default container.
+	if len(containers) <= 1 {
+		container := ""
+		if len(containers) == 1 {
+			container = containers[0]
 		}
+		opts := &corev1.PodLogOptions{
+			Container:  container,
+			TailLines:  &tailLines,
+			Previous:   previous,
+			Timestamps: true,
+		}
+		if sinceTime != nil {
+			opts.SinceTime = sinceTime
+		}
+		logs, err := fetchContainerLog(ctx, clientset, namespace, name, opts)
+		if err != nil {
+			writeLogStreamError(ctx, w, err, namespace, name, container)
+			return
+		}
+		writeWorkloadLogs(w, name, container, logs)
 		return
 	}
-	defer stream.Close()
 
-	// Read the stream, keeping only the newest maxLogBytes so the payload stays
-	// bounded while returning the most recent lines.
-	data, partialFirst, err := tailLogBytes(stream, int(maxLogBytes))
-	if err != nil {
-		log.FromContext(ctx).Error(err, "failed to read pod logs stream",
-			"pod", name, "namespace", namespace, "container", container)
-		http.Error(w, "Failed to read logs", http.StatusInternalServerError)
+	// All-containers path: stream every named container concurrently and merge
+	// the results by timestamp. Previous-instance logs are not offered here, so
+	// Previous is always false. The fetch is best-effort: a container with no
+	// readable logs yet (e.g. waiting to start) is skipped, and an error is only
+	// returned to the client when every container fails.
+	logsByContainer := make([]string, len(containers))
+	errsByContainer := make([]error, len(containers))
+	var wg sync.WaitGroup
+	for i, c := range containers {
+		wg.Add(1)
+		go func(i int, c string) {
+			defer wg.Done()
+			opts := &corev1.PodLogOptions{
+				Container:  c,
+				TailLines:  &tailLines,
+				Timestamps: true,
+			}
+			if sinceTime != nil {
+				opts.SinceTime = sinceTime
+			}
+			logsByContainer[i], errsByContainer[i] = fetchContainerLog(ctx, clientset, namespace, name, opts)
+		}(i, c)
+	}
+	wg.Wait()
+
+	blobs, firstErr := collectContainerLogs(logsByContainer, errsByContainer)
+	// Only fail when no container produced logs; otherwise return what we have.
+	if len(blobs) == 0 && firstErr != nil {
+		writeLogStreamError(ctx, w, firstErr, namespace, name, strings.Join(containers, ","))
 		return
 	}
 
-	// Drop the partial first line only when the byte cap cut mid-line (a cut on
-	// a line boundary keeps a complete first line), and the partial last line
-	// when the container was mid-write.
-	logs := trimPartialLogLine(string(data))
-	if partialFirst {
-		logs = trimPartialFirstLine(logs)
-	}
-
-	// Return the logs as a JSON object so the frontend fetch utility can
-	// decode it consistently with the other API endpoints.
-	w.Header().Set("Content-Type", "application/json")
-	resp := WorkloadLogsResponse{
-		Pod:       name,
-		Container: container,
-		Logs:      logs,
-	}
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	merged := mergeLogStreams(blobs, int(tailLines))
+	writeWorkloadLogs(w, name, strings.Join(containers, ","), merged)
 }

--- a/internal/web/workload_logs.go
+++ b/internal/web/workload_logs.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -41,6 +42,25 @@ type WorkloadLogsResponse struct {
 
 	// Logs is the plain-text log output of the container.
 	Logs string `json:"logs"`
+}
+
+// trimPartialLogLine drops a trailing partial log line from the payload.
+//
+// Container runtimes newline-terminate every emitted log line, so a payload
+// that does not end with a newline has been truncated mid-line, either because
+// the container was writing the line when the logs were read (common while
+// following) or because the LimitBytes cap cut the newest line. Returning that
+// fragment as the latest entry shows only a few characters, so it is dropped;
+// the complete line reappears on the next fetch. A payload with no newline at
+// all is returned unchanged so a single short line is not lost.
+func trimPartialLogLine(logs string) string {
+	if logs == "" || logs[len(logs)-1] == '\n' {
+		return logs
+	}
+	if i := strings.LastIndexByte(logs, '\n'); i >= 0 {
+		return logs[:i+1]
+	}
+	return logs
 }
 
 // WorkloadLogsHandler handles GET /api/v1/workload/logs requests and returns the
@@ -148,7 +168,7 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 	resp := WorkloadLogsResponse{
 		Pod:       name,
 		Container: container,
-		Logs:      buf.String(),
+		Logs:      trimPartialLogLine(buf.String()),
 	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/web/workload_logs.go
+++ b/internal/web/workload_logs.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
+)
+
+const (
+	// defaultLogTailLines is the number of log lines returned when the
+	// tailLines query parameter is not set.
+	defaultLogTailLines int64 = 1000
+
+	// maxLogTailLines caps the number of log lines a client can request.
+	maxLogTailLines int64 = 5000
+
+	// maxLogBytes caps the size of the log payload returned to the client.
+	maxLogBytes int64 = 256 * 1024 // 256 KiB
+)
+
+// WorkloadLogsResponse represents the response body for GET /api/v1/workload/logs.
+type WorkloadLogsResponse struct {
+	// Pod is the name of the pod the logs belong to.
+	Pod string `json:"pod"`
+
+	// Container is the name of the container the logs belong to.
+	Container string `json:"container"`
+
+	// Logs is the plain-text log output of the container.
+	Logs string `json:"logs"`
+}
+
+// WorkloadLogsHandler handles GET /api/v1/workload/logs requests and returns the
+// logs of a pod container managed by a Flux workload.
+//
+// Logs are read using the impersonated user's identity, so Kubernetes enforces
+// the native "get" verb on the "pods/log" subresource: a user can only view the
+// logs of pods they are explicitly granted access to. This is a read-only
+// endpoint and is therefore not gated by UserActionsEnabled; access is governed
+// entirely by RBAC.
+//
+// Example: /api/v1/workload/logs?namespace=flux-system&name=source-controller-xx-yy&container=manager
+func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse query parameters.
+	namespace := req.URL.Query().Get("namespace")
+	name := req.URL.Query().Get("name")
+	container := req.URL.Query().Get("container")
+
+	// Validate required fields.
+	if namespace == "" || name == "" {
+		http.Error(w, "Missing required query parameters: namespace, name", http.StatusBadRequest)
+		return
+	}
+
+	// Parse the optional tailLines parameter, clamping it to a sane range.
+	tailLines := defaultLogTailLines
+	if v := req.URL.Query().Get("tailLines"); v != "" {
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || parsed <= 0 {
+			http.Error(w, "Invalid tailLines parameter", http.StatusBadRequest)
+			return
+		}
+		tailLines = min(parsed, maxLogTailLines)
+	}
+
+	// Parse the optional previous parameter to fetch logs from the
+	// previous container instance (e.g. after a crash/restart).
+	var previous bool
+	if v := req.URL.Query().Get("previous"); v != "" {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			http.Error(w, "Invalid previous parameter", http.StatusBadRequest)
+			return
+		}
+		previous = parsed
+	}
+
+	ctx := req.Context()
+
+	// Build a typed clientset using the impersonated user's REST config so
+	// that Kubernetes enforces the user's RBAC on the pods/log subresource.
+	// The controller-runtime client cannot read the logs subresource, hence
+	// the dedicated clientset (see GetMetrics for the same pattern).
+	clientset, err := kubernetes.NewForConfig(h.kubeClient.GetConfig(ctx))
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to create clientset for pod logs",
+			"pod", name, "namespace", namespace)
+		http.Error(w, "Unable to read pod logs", http.StatusInternalServerError)
+		return
+	}
+
+	logBytes := maxLogBytes
+	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(name, &corev1.PodLogOptions{
+		Container:  container,
+		TailLines:  &tailLines,
+		LimitBytes: &logBytes,
+		Previous:   previous,
+		Timestamps: true,
+	}).Stream(ctx)
+	if err != nil {
+		switch {
+		case errors.IsForbidden(err):
+			perms := user.Permissions(ctx)
+			http.Error(w, fmt.Sprintf("Permission denied. User %s does not have access to read logs for pod %s/%s",
+				perms.Username, namespace, name), http.StatusForbidden)
+		case errors.IsNotFound(err):
+			http.Error(w, fmt.Sprintf("Pod %s/%s not found", namespace, name), http.StatusNotFound)
+		default:
+			log.FromContext(ctx).Error(err, "failed to stream pod logs",
+				"pod", name, "namespace", namespace, "container", container)
+			http.Error(w, fmt.Sprintf("Failed to read logs: %v", err), http.StatusInternalServerError)
+		}
+		return
+	}
+	defer stream.Close()
+
+	// Read the log stream, enforcing the byte cap as a safety net in case
+	// LimitBytes is not honored by the API server.
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, io.LimitReader(stream, maxLogBytes)); err != nil {
+		log.FromContext(ctx).Error(err, "failed to read pod logs stream",
+			"pod", name, "namespace", namespace, "container", container)
+		http.Error(w, "Failed to read logs", http.StatusInternalServerError)
+		return
+	}
+
+	// Return the logs as a JSON object so the frontend fetch utility can
+	// decode it consistently with the other API endpoints.
+	w.Header().Set("Content-Type", "application/json")
+	resp := WorkloadLogsResponse{
+		Pod:       name,
+		Container: container,
+		Logs:      buf.String(),
+	}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/internal/web/workload_logs.go
+++ b/internal/web/workload_logs.go
@@ -76,6 +76,13 @@ type WorkloadLogsResponse struct {
 	// view (more than one pod streamed); absent for single-pod responses.
 	Tagged bool `json:"tagged,omitempty"`
 
+	// ContainerTagged reports whether each timestamped line in Logs is prefixed
+	// with its container of origin, after the optional pod tag ("<pod> <container>
+	// <timestamp> <message>", or "<container> <timestamp> <message>" for a single
+	// pod). Set only for the all-containers view (more than one container
+	// streamed), so the client can scope multi-line folding per container.
+	ContainerTagged bool `json:"containerTagged,omitempty"`
+
 	// Total is the number of distinct pods the client requested. Set only for the
 	// multi-stream (all-pods/all-containers) path.
 	Total int `json:"total,omitempty"`
@@ -249,11 +256,12 @@ type logTarget struct {
 }
 
 // logStream is one source blob in the fan-out: the raw timestamped log payload
-// of a single (pod, container) target plus the pod it came from, so the merge
-// can tag each line with its origin in the all-pods view.
+// of a single (pod, container) target plus the pod and container it came from, so
+// the merge can tag each line with its origin in the all-pods/all-containers view.
 type logStream struct {
-	pod  string
-	blob string
+	pod       string
+	container string
+	blob      string
 }
 
 // logEntry is one record used when interleaving multiple streams: a line
@@ -261,11 +269,12 @@ type logStream struct {
 // continuation lines that lack their own timestamp (e.g. stack-trace frames).
 // The parsed timestamp is the sort key; text retains the original line(s),
 // including the timestamp prefix, since the frontend strips it for display. pod
-// records the originating pod so the merge can prefix the line in tagged mode.
+// and container record the origin so the merge can prefix the line in tagged mode.
 type logEntry struct {
-	ts   time.Time
-	text string
-	pod  string
+	ts        time.Time
+	text      string
+	pod       string
+	container string
 }
 
 // parseLogTimestamp parses the leading RFC3339 timestamp token kubelet prepends
@@ -284,25 +293,25 @@ func parseLogTimestamp(line string) (time.Time, bool) {
 }
 
 // parseLogEntries splits a timestamped log payload into entries, stamping each
-// with pod. Each entry begins at a line whose first token parses as an RFC3339
-// timestamp and absorbs subsequent lines without such a prefix, so multi-line
-// records (stack traces) stay intact and ordered. A continuation line with no
-// preceding entry becomes its own zero-timestamped entry, which sorts to the
-// front.
-func parseLogEntries(blob, pod string) []logEntry {
+// with pod and container. Each entry begins at a line whose first token parses as
+// an RFC3339 timestamp and absorbs subsequent lines without such a prefix, so
+// multi-line records (stack traces) stay intact and ordered. A continuation line
+// with no preceding entry becomes its own zero-timestamped entry, which sorts to
+// the front.
+func parseLogEntries(blob, pod, container string) []logEntry {
 	var entries []logEntry
 	for line := range strings.SplitSeq(blob, "\n") {
 		if line == "" {
 			continue
 		}
 		if ts, ok := parseLogTimestamp(line); ok {
-			entries = append(entries, logEntry{ts: ts, text: line, pod: pod})
+			entries = append(entries, logEntry{ts: ts, text: line, pod: pod, container: container})
 			continue
 		}
 		if n := len(entries); n > 0 {
 			entries[n-1].text += "\n" + line
 		} else {
-			entries = append(entries, logEntry{text: line, pod: pod})
+			entries = append(entries, logEntry{text: line, pod: pod, container: container})
 		}
 	}
 	return entries
@@ -314,15 +323,18 @@ func parseLogEntries(blob, pod string) []logEntry {
 // the newest tailLines entries, and finally to the newest maxLogBytes bytes on a
 // line boundary so the payload stays bounded.
 //
-// When tagPod is set, each entry that carries a timestamp is prefixed with its
-// pod of origin ("<pod> <timestamp> <message>") so the client can attribute the
-// line; zero-timestamped orphan entries are left untagged so every tagged line
-// is uniformly "<pod> <timestamp> ..." and parses unambiguously. With tagPod
-// false the output is byte-for-byte the original single-pod merge.
-func mergeLogStreams(streams []logStream, tailLines int, tagPod bool) string {
+// Each entry that carries a timestamp is prefixed with its origin tags, in
+// pod-then-container order, for whichever dimensions fanned out: tagPod writes the
+// pod, tagContainer the container ("<pod> <container> <timestamp> <message>", or
+// just one token when only one dimension is tagged), so the client can attribute
+// the line and scope multi-line folding. Zero-timestamped orphan entries are left
+// untagged so every tagged line is uniformly "<tags...> <timestamp> ..." and
+// parses unambiguously. With both flags false the output is byte-for-byte the
+// original single-pod merge.
+func mergeLogStreams(streams []logStream, tailLines int, tagPod, tagContainer bool) string {
 	var entries []logEntry
 	for _, s := range streams {
-		entries = append(entries, parseLogEntries(s.blob, s.pod)...)
+		entries = append(entries, parseLogEntries(s.blob, s.pod, s.container)...)
 	}
 	sort.SliceStable(entries, func(i, j int) bool {
 		return entries[i].ts.Before(entries[j].ts)
@@ -332,9 +344,15 @@ func mergeLogStreams(streams []logStream, tailLines int, tagPod bool) string {
 	}
 	var sb strings.Builder
 	for _, e := range entries {
-		if tagPod && !e.ts.IsZero() {
-			sb.WriteString(e.pod)
-			sb.WriteByte(' ')
+		if !e.ts.IsZero() {
+			if tagPod {
+				sb.WriteString(e.pod)
+				sb.WriteByte(' ')
+			}
+			if tagContainer {
+				sb.WriteString(e.container)
+				sb.WriteByte(' ')
+			}
 		}
 		sb.WriteString(e.text)
 		sb.WriteByte('\n')
@@ -400,7 +418,7 @@ func collectLogStreams(targets []logTarget, logs []string, errs []error) logFanO
 			}
 			continue
 		}
-		out.streams = append(out.streams, logStream{pod: targets[i].pod, blob: logs[i]})
+		out.streams = append(out.streams, logStream{pod: targets[i].pod, container: targets[i].container, blob: logs[i]})
 		out.streamedSet[targets[i].pod] = struct{}{}
 	}
 	out.forbidden = len(forbiddenPods)
@@ -570,10 +588,13 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 	}
 	containers, containersTruncated := dedupeNames(containers, maxLogContainers)
 
-	// Tagging is decided from the client's request (more than one pod), before the
-	// stream cap, so the client and server agree on the wire format regardless of
-	// which streams survive truncation.
+	// Tagging is decided from the client's request, before the stream cap, so the
+	// client and server agree on the wire format regardless of which streams
+	// survive truncation. Each fanned-out dimension is tagged: the pod when more
+	// than one pod is streamed, the container when more than one container is, so
+	// the client can scope multi-line folding per (pod, container).
 	tagPod := total > 1
+	tagContainer := len(containers) > 1
 
 	// Build the (pod, container) targets as the product of the two dimensions,
 	// capped to maxLogStreams overall. An empty container list yields one target
@@ -594,7 +615,11 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 	// Single-stream path (one pod, one or no container, no pod tagging): preserves
 	// the previous-instance and follow semantics unchanged. An all-pods request
 	// (tagPod) always uses the fan-out path so it carries the tagged/partial
-	// metadata even if a cap collapsed it to a single surviving stream.
+	// metadata even if a cap collapsed it to a single surviving stream. An
+	// all-containers request (tagContainer) cannot reach here: it has >1 container,
+	// so buildLogTargets yields min(len(containers), maxLogStreams) > 1 targets
+	// (maxLogStreams is 50). Were a future cap to collapse it to one target, the
+	// response would report ContainerTagged=false, so client and server still agree.
 	if !tagPod && len(targets) <= 1 {
 		t := logTarget{pod: name}
 		if len(targets) == 1 {
@@ -666,7 +691,7 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	writeWorkloadLogsResponse(w, buildWorkloadLogsResponse(pods, containers, fanOut, total, tailLines, tagPod, truncated))
+	writeWorkloadLogsResponse(w, buildWorkloadLogsResponse(pods, containers, fanOut, total, tailLines, tagPod, tagContainer, truncated))
 }
 
 // buildWorkloadLogsResponse assembles the multi-stream (all-pods/all-containers)
@@ -676,17 +701,18 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 // streamed than were requested (some forbidden, missing, or still starting) or
 // when a cap truncated the fan-out. Forbidden carries the count of pods skipped
 // for lack of pods/log access.
-func buildWorkloadLogsResponse(pods, containers []string, fanOut logFanOut, total, tailLines int, tagPod, truncated bool) WorkloadLogsResponse {
+func buildWorkloadLogsResponse(pods, containers []string, fanOut logFanOut, total, tailLines int, tagPod, tagContainer, truncated bool) WorkloadLogsResponse {
 	streamed := len(fanOut.streamedSet)
 	return WorkloadLogsResponse{
-		Pod:       strings.Join(pods, ","),
-		Container: strings.Join(containers, ","),
-		Logs:      mergeLogStreams(fanOut.streams, tailLines, tagPod),
-		Tagged:    tagPod,
-		Total:     total,
-		Streamed:  streamed,
-		Partial:   streamed < total || truncated,
-		Forbidden: fanOut.forbidden,
+		Pod:             strings.Join(pods, ","),
+		Container:       strings.Join(containers, ","),
+		Logs:            mergeLogStreams(fanOut.streams, tailLines, tagPod, tagContainer),
+		Tagged:          tagPod,
+		ContainerTagged: tagContainer,
+		Total:           total,
+		Streamed:        streamed,
+		Partial:         streamed < total || truncated,
+		Forbidden:       fanOut.forbidden,
 	}
 }
 

--- a/internal/web/workload_logs_test.go
+++ b/internal/web/workload_logs_test.go
@@ -5,6 +5,7 @@ package web
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -86,6 +87,162 @@ func TestTailLogBytes(t *testing.T) {
 			g.Expect(partialFirst).To(Equal(tt.wantPartialFirst))
 		})
 	}
+}
+
+func TestParseLogEntries(t *testing.T) {
+	t.Run("groups continuation lines with their timestamped entry", func(t *testing.T) {
+		g := NewWithT(t)
+
+		blob := "2026-01-01T00:00:00Z panic: boom\ngoroutine 1 [running]:\nmain.main()\n" +
+			"2026-01-01T00:00:01Z next line\n"
+		entries := parseLogEntries(blob)
+
+		g.Expect(entries).To(HaveLen(2))
+		// The two non-timestamped lines stay attached to the first entry.
+		g.Expect(entries[0].text).To(Equal("2026-01-01T00:00:00Z panic: boom\ngoroutine 1 [running]:\nmain.main()"))
+		g.Expect(entries[1].text).To(Equal("2026-01-01T00:00:01Z next line"))
+	})
+
+	t.Run("a leading continuation with no preceding entry becomes its own entry", func(t *testing.T) {
+		g := NewWithT(t)
+
+		entries := parseLogEntries("orphan continuation\n2026-01-01T00:00:00Z line\n")
+		g.Expect(entries).To(HaveLen(2))
+		g.Expect(entries[0].ts.IsZero()).To(BeTrue())
+		g.Expect(entries[0].text).To(Equal("orphan continuation"))
+		g.Expect(entries[1].text).To(Equal("2026-01-01T00:00:00Z line"))
+	})
+
+	t.Run("empty payload yields no entries", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(parseLogEntries("")).To(BeEmpty())
+	})
+}
+
+func TestMergeLogStreams(t *testing.T) {
+	t.Run("interleaves two streams in chronological order", func(t *testing.T) {
+		g := NewWithT(t)
+
+		app := "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"
+		sidecar := "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"
+
+		got := mergeLogStreams([]string{app, sidecar}, 0)
+		g.Expect(got).To(Equal(
+			"2026-01-01T00:00:00Z app a\n" +
+				"2026-01-01T00:00:01Z side a\n" +
+				"2026-01-01T00:00:02Z app b\n" +
+				"2026-01-01T00:00:03Z side b\n"))
+	})
+
+	t.Run("orders fractional timestamps numerically, not lexically", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// "0.12" is numerically after "0.1" but sorts before it lexically; the
+		// merge must parse the timestamps to get this right.
+		a := "2026-01-01T00:00:00.1Z first\n"
+		b := "2026-01-01T00:00:00.12Z second\n"
+
+		got := mergeLogStreams([]string{b, a}, 0)
+		g.Expect(got).To(Equal("2026-01-01T00:00:00.1Z first\n2026-01-01T00:00:00.12Z second\n"))
+	})
+
+	t.Run("keeps a multi-line entry attached after sorting", func(t *testing.T) {
+		g := NewWithT(t)
+
+		app := "2026-01-01T00:00:00Z panic\nstack frame\n"
+		sidecar := "2026-01-01T00:00:01Z side\n"
+
+		got := mergeLogStreams([]string{app, sidecar}, 0)
+		g.Expect(got).To(Equal("2026-01-01T00:00:00Z panic\nstack frame\n2026-01-01T00:00:01Z side\n"))
+	})
+
+	t.Run("caps to the newest tailLines entries across all streams", func(t *testing.T) {
+		g := NewWithT(t)
+
+		app := "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"
+		sidecar := "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"
+
+		got := mergeLogStreams([]string{app, sidecar}, 2)
+		g.Expect(got).To(Equal("2026-01-01T00:00:02Z app b\n2026-01-01T00:00:03Z side b\n"))
+	})
+
+	t.Run("empty streams yield an empty payload", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(mergeLogStreams(nil, 100)).To(BeEmpty())
+		g.Expect(mergeLogStreams([]string{"", ""}, 100)).To(BeEmpty())
+	})
+}
+
+func TestCapLogBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		limit int
+		want  string
+	}{
+		{name: "under limit returns all", in: "line1\nline2\n", limit: 100, want: "line1\nline2\n"},
+		{name: "trims partial leading line on a mid-line cut", in: "line1\nline2\nline3\n", limit: 13, want: "line2\nline3\n"},
+		// The cut lands exactly after "line1\n", so the window already starts with
+		// a complete line and the leading line must NOT be dropped.
+		{name: "keeps complete first line when cut lands on a boundary", in: "line1\nline2\nline3\n", limit: 12, want: "line2\nline3\n"},
+		{name: "no newline in window keeps tail bytes", in: "abcdef", limit: 3, want: "def"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(capLogBytes(tt.in, tt.limit)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestDedupeContainers(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    []string
+		limit int
+		want  []string
+	}{
+		{name: "nil stays nil", in: nil, limit: 8, want: nil},
+		{name: "preserves order without duplicates", in: []string{"app", "sidecar"}, limit: 8, want: []string{"app", "sidecar"}},
+		{name: "drops duplicates keeping first occurrence", in: []string{"app", "app", "sidecar", "app"}, limit: 8, want: []string{"app", "sidecar"}},
+		{name: "caps to the limit", in: []string{"a", "b", "c", "d"}, limit: 2, want: []string{"a", "b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(dedupeContainers(tt.in, tt.limit)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestCollectContainerLogs(t *testing.T) {
+	errA := errors.New("a waiting to start")
+	errB := errors.New("b forbidden")
+
+	t.Run("all succeed", func(t *testing.T) {
+		g := NewWithT(t)
+		blobs, firstErr := collectContainerLogs([]string{"x", "y"}, []error{nil, nil})
+		g.Expect(blobs).To(Equal([]string{"x", "y"}))
+		g.Expect(firstErr).NotTo(HaveOccurred())
+	})
+
+	t.Run("partial failure skips the failed container and keeps the rest", func(t *testing.T) {
+		g := NewWithT(t)
+		// Container 0 failed, 1 succeeded: the success is returned and the error
+		// is reported but, per the caller's policy, not surfaced to the client.
+		blobs, firstErr := collectContainerLogs([]string{"", "y"}, []error{errA, nil})
+		g.Expect(blobs).To(Equal([]string{"y"}))
+		g.Expect(firstErr).To(MatchError(errA))
+	})
+
+	t.Run("all fail returns no blobs and the first error", func(t *testing.T) {
+		g := NewWithT(t)
+		blobs, firstErr := collectContainerLogs([]string{"", ""}, []error{errA, errB})
+		g.Expect(blobs).To(BeEmpty())
+		g.Expect(firstErr).To(MatchError(errA))
+	})
 }
 
 func TestWorkloadLogsHandler_MethodNotAllowed(t *testing.T) {
@@ -200,6 +357,39 @@ func TestWorkloadLogsHandler_Forbidden(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/workload/logs?namespace=default&name=test-pod&container=app", nil).WithContext(userCtx)
+	rec := httptest.NewRecorder()
+
+	handler.WorkloadLogsHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusForbidden))
+	g.Expect(rec.Body.String()).To(ContainSubstring("Permission denied"))
+}
+
+func TestWorkloadLogsHandler_AllContainersForbidden(t *testing.T) {
+	g := NewWithT(t)
+
+	// The all-containers path (repeated container params) is governed by the same
+	// pods/log RBAC as the single-container path: a user without it gets 403 once
+	// every container stream fails.
+	username := "logs-forbidden-multi-user"
+	imp := user.Impersonation{Username: username, Groups: []string{"system:authenticated"}}
+	userClient, err := kubeClient.GetUserClientFromCache(imp)
+	g.Expect(err).NotTo(HaveOccurred())
+	userCtx := user.StoreSession(ctx, user.Details{
+		Profile:       user.Profile{Name: "Logs Forbidden Multi User"},
+		Impersonation: imp,
+	}, userClient)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/workload/logs?namespace=default&name=test-pod&container=app&container=sidecar", nil).WithContext(userCtx)
 	rec := httptest.NewRecorder()
 
 	handler.WorkloadLogsHandler(rec, req)

--- a/internal/web/workload_logs_test.go
+++ b/internal/web/workload_logs_test.go
@@ -663,7 +663,7 @@ func TestGetWorkloadStatus_ViewLogsCapability(t *testing.T) {
 		})
 		userCtx := bindWorkloadLogsUser(t, g, "logs-reader-user", rules)
 
-		workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-logs", "default", false)
+		workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-logs", "default", true)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(workload.UserActions).To(ContainElement(fluxcdv1.UserActionViewLogs))
 	})
@@ -673,7 +673,7 @@ func TestGetWorkloadStatus_ViewLogsCapability(t *testing.T) {
 
 		userCtx := bindWorkloadLogsUser(t, g, "logs-noreader-user", baseRules)
 
-		workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-logs", "default", false)
+		workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-logs", "default", true)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(workload.UserActions).NotTo(ContainElement(fluxcdv1.UserActionViewLogs))
 	})

--- a/internal/web/workload_logs_test.go
+++ b/internal/web/workload_logs_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -35,6 +36,54 @@ func TestTrimPartialLogLine(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			g.Expect(trimPartialLogLine(tt.in)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestTrimPartialFirstLine(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "drops partial leading fragment", in: "tial\nline two\nline three\n", want: "line two\nline three\n"},
+		{name: "single line with no newline kept", in: "only-line", want: "only-line"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(trimPartialFirstLine(tt.in)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestTailLogBytes(t *testing.T) {
+	tests := []struct {
+		name             string
+		in               string
+		limit            int
+		want             string
+		wantPartialFirst bool
+	}{
+		{name: "under limit returns all", in: "line1\nline2\n", limit: 100, want: "line1\nline2\n", wantPartialFirst: false},
+		{name: "exact limit not truncated", in: "abcd", limit: 4, want: "abcd", wantPartialFirst: false},
+		// The cut lands exactly after "line1\n", so the first retained line is
+		// complete and must NOT be reported as partial (or the caller drops it).
+		{name: "over limit cut on line boundary keeps complete first line", in: "line1\nline2\nline3\n", limit: 12, want: "line2\nline3\n", wantPartialFirst: false},
+		{name: "over limit cutting mid-line", in: "line1\nline2\n", limit: 8, want: "1\nline2\n", wantPartialFirst: true},
+		{name: "empty stream", in: "", limit: 16, want: "", wantPartialFirst: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			// strings.Reader hands out small reads, exercising the chunked loop.
+			got, partialFirst, err := tailLogBytes(strings.NewReader(tt.in), tt.limit)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(string(got)).To(Equal(tt.want))
+			g.Expect(partialFirst).To(Equal(tt.wantPartialFirst))
 		})
 	}
 }
@@ -109,6 +158,7 @@ func TestWorkloadLogsHandler_InvalidParams(t *testing.T) {
 		{name: "invalid tailLines", query: "namespace=default&name=test-pod&tailLines=abc", message: "Invalid tailLines parameter"},
 		{name: "negative tailLines", query: "namespace=default&name=test-pod&tailLines=-5", message: "Invalid tailLines parameter"},
 		{name: "invalid previous", query: "namespace=default&name=test-pod&previous=maybe", message: "Invalid previous parameter"},
+		{name: "invalid sinceTime", query: "namespace=default&name=test-pod&sinceTime=not-a-time", message: "Invalid sinceTime parameter"},
 	}
 
 	for _, tc := range testCases {

--- a/internal/web/workload_logs_test.go
+++ b/internal/web/workload_logs_test.go
@@ -15,7 +15,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
@@ -90,23 +92,25 @@ func TestTailLogBytes(t *testing.T) {
 }
 
 func TestParseLogEntries(t *testing.T) {
-	t.Run("groups continuation lines with their timestamped entry", func(t *testing.T) {
+	t.Run("groups continuation lines with their timestamped entry and stamps the pod", func(t *testing.T) {
 		g := NewWithT(t)
 
 		blob := "2026-01-01T00:00:00Z panic: boom\ngoroutine 1 [running]:\nmain.main()\n" +
 			"2026-01-01T00:00:01Z next line\n"
-		entries := parseLogEntries(blob)
+		entries := parseLogEntries(blob, "pod-a")
 
 		g.Expect(entries).To(HaveLen(2))
 		// The two non-timestamped lines stay attached to the first entry.
 		g.Expect(entries[0].text).To(Equal("2026-01-01T00:00:00Z panic: boom\ngoroutine 1 [running]:\nmain.main()"))
+		g.Expect(entries[0].pod).To(Equal("pod-a"))
 		g.Expect(entries[1].text).To(Equal("2026-01-01T00:00:01Z next line"))
+		g.Expect(entries[1].pod).To(Equal("pod-a"))
 	})
 
 	t.Run("a leading continuation with no preceding entry becomes its own entry", func(t *testing.T) {
 		g := NewWithT(t)
 
-		entries := parseLogEntries("orphan continuation\n2026-01-01T00:00:00Z line\n")
+		entries := parseLogEntries("orphan continuation\n2026-01-01T00:00:00Z line\n", "pod-a")
 		g.Expect(entries).To(HaveLen(2))
 		g.Expect(entries[0].ts.IsZero()).To(BeTrue())
 		g.Expect(entries[0].text).To(Equal("orphan continuation"))
@@ -115,18 +119,18 @@ func TestParseLogEntries(t *testing.T) {
 
 	t.Run("empty payload yields no entries", func(t *testing.T) {
 		g := NewWithT(t)
-		g.Expect(parseLogEntries("")).To(BeEmpty())
+		g.Expect(parseLogEntries("", "pod-a")).To(BeEmpty())
 	})
 }
 
 func TestMergeLogStreams(t *testing.T) {
-	t.Run("interleaves two streams in chronological order", func(t *testing.T) {
+	t.Run("interleaves two streams in chronological order untagged", func(t *testing.T) {
 		g := NewWithT(t)
 
-		app := "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"
-		sidecar := "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"
+		app := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"}
+		sidecar := logStream{pod: "pod-a", blob: "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"}
 
-		got := mergeLogStreams([]string{app, sidecar}, 0)
+		got := mergeLogStreams([]logStream{app, sidecar}, 0, false)
 		g.Expect(got).To(Equal(
 			"2026-01-01T00:00:00Z app a\n" +
 				"2026-01-01T00:00:01Z side a\n" +
@@ -139,37 +143,66 @@ func TestMergeLogStreams(t *testing.T) {
 
 		// "0.12" is numerically after "0.1" but sorts before it lexically; the
 		// merge must parse the timestamps to get this right.
-		a := "2026-01-01T00:00:00.1Z first\n"
-		b := "2026-01-01T00:00:00.12Z second\n"
+		a := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00.1Z first\n"}
+		b := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00.12Z second\n"}
 
-		got := mergeLogStreams([]string{b, a}, 0)
+		got := mergeLogStreams([]logStream{b, a}, 0, false)
 		g.Expect(got).To(Equal("2026-01-01T00:00:00.1Z first\n2026-01-01T00:00:00.12Z second\n"))
 	})
 
 	t.Run("keeps a multi-line entry attached after sorting", func(t *testing.T) {
 		g := NewWithT(t)
 
-		app := "2026-01-01T00:00:00Z panic\nstack frame\n"
-		sidecar := "2026-01-01T00:00:01Z side\n"
+		app := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00Z panic\nstack frame\n"}
+		sidecar := logStream{pod: "pod-a", blob: "2026-01-01T00:00:01Z side\n"}
 
-		got := mergeLogStreams([]string{app, sidecar}, 0)
+		got := mergeLogStreams([]logStream{app, sidecar}, 0, false)
 		g.Expect(got).To(Equal("2026-01-01T00:00:00Z panic\nstack frame\n2026-01-01T00:00:01Z side\n"))
 	})
 
 	t.Run("caps to the newest tailLines entries across all streams", func(t *testing.T) {
 		g := NewWithT(t)
 
-		app := "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"
-		sidecar := "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"
+		app := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"}
+		sidecar := logStream{pod: "pod-a", blob: "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"}
 
-		got := mergeLogStreams([]string{app, sidecar}, 2)
+		got := mergeLogStreams([]logStream{app, sidecar}, 2, false)
 		g.Expect(got).To(Equal("2026-01-01T00:00:02Z app b\n2026-01-01T00:00:03Z side b\n"))
 	})
 
 	t.Run("empty streams yield an empty payload", func(t *testing.T) {
 		g := NewWithT(t)
-		g.Expect(mergeLogStreams(nil, 100)).To(BeEmpty())
-		g.Expect(mergeLogStreams([]string{"", ""}, 100)).To(BeEmpty())
+		g.Expect(mergeLogStreams(nil, 100, false)).To(BeEmpty())
+		g.Expect(mergeLogStreams([]logStream{{pod: "pod-a"}, {pod: "pod-b"}}, 100, false)).To(BeEmpty())
+	})
+
+	t.Run("tagged mode prefixes each timestamped line with its pod, interleaved", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := logStream{pod: "frontend-abc-gqh2x", blob: "2026-01-01T00:00:00Z a one\n2026-01-01T00:00:02Z a two\n"}
+		b := logStream{pod: "frontend-abc-p8x2k", blob: "2026-01-01T00:00:01Z b one\n"}
+
+		got := mergeLogStreams([]logStream{a, b}, 0, true)
+		g.Expect(got).To(Equal(
+			"frontend-abc-gqh2x 2026-01-01T00:00:00Z a one\n" +
+				"frontend-abc-p8x2k 2026-01-01T00:00:01Z b one\n" +
+				"frontend-abc-gqh2x 2026-01-01T00:00:02Z a two\n"))
+	})
+
+	t.Run("tagged mode tags only timestamped lines, not continuation or orphan lines", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// A multi-line entry: only its timestamped first line is tagged; the
+		// stack-trace continuation stays untagged so every tagged line is
+		// uniformly "<pod> <timestamp> ...".
+		a := logStream{pod: "pod-a", blob: "2026-01-01T00:00:01Z panic\nstack frame\n"}
+		// A leading orphan continuation (zero ts) is left untagged too.
+		b := logStream{pod: "pod-b", blob: "orphan line\n"}
+
+		got := mergeLogStreams([]logStream{a, b}, 0, true)
+		g.Expect(got).To(Equal(
+			"orphan line\n" +
+				"pod-a 2026-01-01T00:00:01Z panic\nstack frame\n"))
 	})
 }
 
@@ -196,52 +229,147 @@ func TestCapLogBytes(t *testing.T) {
 	}
 }
 
-func TestDedupeContainers(t *testing.T) {
+func TestDedupeNames(t *testing.T) {
 	tests := []struct {
-		name  string
-		in    []string
-		limit int
-		want  []string
+		name          string
+		in            []string
+		limit         int
+		want          []string
+		wantTruncated bool
 	}{
 		{name: "nil stays nil", in: nil, limit: 8, want: nil},
 		{name: "preserves order without duplicates", in: []string{"app", "sidecar"}, limit: 8, want: []string{"app", "sidecar"}},
 		{name: "drops duplicates keeping first occurrence", in: []string{"app", "app", "sidecar", "app"}, limit: 8, want: []string{"app", "sidecar"}},
-		{name: "caps to the limit", in: []string{"a", "b", "c", "d"}, limit: 2, want: []string{"a", "b"}},
+		// De-duplication that leaves the result within the limit is not truncation.
+		{name: "dedup within limit is not truncation", in: []string{"a", "a", "b", "b"}, limit: 2, want: []string{"a", "b"}},
+		{name: "caps to the limit and reports truncation", in: []string{"a", "b", "c", "d"}, limit: 2, want: []string{"a", "b"}, wantTruncated: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(dedupeContainers(tt.in, tt.limit)).To(Equal(tt.want))
+			got, truncated := dedupeNames(tt.in, tt.limit)
+			g.Expect(got).To(Equal(tt.want))
+			g.Expect(truncated).To(Equal(tt.wantTruncated))
 		})
 	}
 }
 
-func TestCollectContainerLogs(t *testing.T) {
-	errA := errors.New("a waiting to start")
-	errB := errors.New("b forbidden")
-
-	t.Run("all succeed", func(t *testing.T) {
+func TestBuildLogTargets(t *testing.T) {
+	t.Run("product of pods and containers", func(t *testing.T) {
 		g := NewWithT(t)
-		blobs, firstErr := collectContainerLogs([]string{"x", "y"}, []error{nil, nil})
-		g.Expect(blobs).To(Equal([]string{"x", "y"}))
-		g.Expect(firstErr).NotTo(HaveOccurred())
+		targets, truncated := buildLogTargets([]string{"p1", "p2"}, []string{"app", "side"}, 64)
+		g.Expect(truncated).To(BeFalse())
+		g.Expect(targets).To(Equal([]logTarget{
+			{pod: "p1", container: "app"}, {pod: "p1", container: "side"},
+			{pod: "p2", container: "app"}, {pod: "p2", container: "side"},
+		}))
 	})
 
-	t.Run("partial failure skips the failed container and keeps the rest", func(t *testing.T) {
+	t.Run("empty containers yield one default-container target per pod", func(t *testing.T) {
 		g := NewWithT(t)
-		// Container 0 failed, 1 succeeded: the success is returned and the error
-		// is reported but, per the caller's policy, not surfaced to the client.
-		blobs, firstErr := collectContainerLogs([]string{"", "y"}, []error{errA, nil})
-		g.Expect(blobs).To(Equal([]string{"y"}))
-		g.Expect(firstErr).To(MatchError(errA))
+		targets, truncated := buildLogTargets([]string{"p1", "p2"}, nil, 64)
+		g.Expect(truncated).To(BeFalse())
+		g.Expect(targets).To(Equal([]logTarget{{pod: "p1"}, {pod: "p2"}}))
 	})
 
-	t.Run("all fail returns no blobs and the first error", func(t *testing.T) {
+	t.Run("caps to the stream limit and reports truncation", func(t *testing.T) {
 		g := NewWithT(t)
-		blobs, firstErr := collectContainerLogs([]string{"", ""}, []error{errA, errB})
-		g.Expect(blobs).To(BeEmpty())
-		g.Expect(firstErr).To(MatchError(errA))
+		targets, truncated := buildLogTargets([]string{"p1", "p2", "p3"}, []string{"app", "side"}, 3)
+		g.Expect(truncated).To(BeTrue())
+		g.Expect(targets).To(HaveLen(3))
+		g.Expect(targets).To(Equal([]logTarget{
+			{pod: "p1", container: "app"}, {pod: "p1", container: "side"},
+			{pod: "p2", container: "app"},
+		}))
+	})
+}
+
+func TestCollectLogStreams(t *testing.T) {
+	errWaiting := errors.New("waiting to start")
+	forbidden := apierrors.NewForbidden(schema.GroupResource{Resource: "pods/log"}, "p2", errors.New("nope"))
+
+	t.Run("all succeed across two pods", func(t *testing.T) {
+		g := NewWithT(t)
+		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
+		out := collectLogStreams(targets, []string{"x", "y"}, []error{nil, nil})
+		g.Expect(out.streams).To(Equal([]logStream{{pod: "p1", blob: "x"}, {pod: "p2", blob: "y"}}))
+		g.Expect(out.streamedSet).To(HaveLen(2))
+		g.Expect(out.forbidden).To(Equal(0))
+		g.Expect(out.firstErr).NotTo(HaveOccurred())
+	})
+
+	t.Run("partial failure skips the failed target and counts forbidden", func(t *testing.T) {
+		g := NewWithT(t)
+		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
+		out := collectLogStreams(targets, []string{"x", ""}, []error{nil, forbidden})
+		g.Expect(out.streams).To(Equal([]logStream{{pod: "p1", blob: "x"}}))
+		g.Expect(out.streamedSet).To(HaveLen(1))
+		g.Expect(out.forbidden).To(Equal(1))
+		g.Expect(out.firstErr).To(MatchError(forbidden))
+	})
+
+	t.Run("all fail returns no streams and the first error", func(t *testing.T) {
+		g := NewWithT(t)
+		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
+		out := collectLogStreams(targets, []string{"", ""}, []error{errWaiting, forbidden})
+		g.Expect(out.streams).To(BeEmpty())
+		g.Expect(out.streamedSet).To(BeEmpty())
+		g.Expect(out.forbidden).To(Equal(1))
+		g.Expect(out.firstErr).To(MatchError(errWaiting))
+	})
+
+	t.Run("forbidden is counted per pod, not per container target", func(t *testing.T) {
+		g := NewWithT(t)
+		// One forbidden pod with two containers must count once, not twice.
+		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p1", container: "side"}}
+		out := collectLogStreams(targets, []string{"", ""}, []error{forbidden, forbidden})
+		g.Expect(out.forbidden).To(Equal(1))
+	})
+}
+
+func TestBuildWorkloadLogsResponse(t *testing.T) {
+	forbidden := apierrors.NewForbidden(schema.GroupResource{Resource: "pods/log"}, "p2", errors.New("nope"))
+
+	t.Run("partial coverage when one requested pod is forbidden", func(t *testing.T) {
+		g := NewWithT(t)
+		// Two pods requested, only p1 streams; p2 is forbidden. The response must
+		// report 200-style partial coverage with the per-pod counts the UI shows.
+		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
+		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z hi\n", ""}, []error{nil, forbidden})
+		resp := buildWorkloadLogsResponse([]string{"p1", "p2"}, []string{"app"}, fanOut, 2, 1000, true, false)
+
+		g.Expect(resp.Tagged).To(BeTrue())
+		g.Expect(resp.Total).To(Equal(2))
+		g.Expect(resp.Streamed).To(Equal(1))
+		g.Expect(resp.Partial).To(BeTrue())
+		g.Expect(resp.Forbidden).To(Equal(1))
+		g.Expect(resp.Pod).To(Equal("p1,p2"))
+		g.Expect(resp.Logs).To(ContainSubstring("hi"))
+	})
+
+	t.Run("full coverage is not partial", func(t *testing.T) {
+		g := NewWithT(t)
+		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
+		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z a\n", "2026-01-01T00:00:01Z b\n"}, []error{nil, nil})
+		resp := buildWorkloadLogsResponse([]string{"p1", "p2"}, []string{"app"}, fanOut, 2, 1000, true, false)
+
+		g.Expect(resp.Streamed).To(Equal(2))
+		g.Expect(resp.Partial).To(BeFalse())
+		g.Expect(resp.Forbidden).To(Equal(0))
+	})
+
+	t.Run("truncation forces partial even when every requested pod streamed", func(t *testing.T) {
+		g := NewWithT(t)
+		// total counts requested pods (1) and that pod streamed, but the fan-out
+		// was capped, so the response must still flag the result as partial.
+		targets := []logTarget{{pod: "p1", container: "app"}}
+		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z x\n"}, []error{nil})
+		resp := buildWorkloadLogsResponse([]string{"p1"}, []string{"app"}, fanOut, 1, 1000, true, true)
+
+		g.Expect(resp.Streamed).To(Equal(1))
+		g.Expect(resp.Total).To(Equal(1))
+		g.Expect(resp.Partial).To(BeTrue())
 	})
 }
 
@@ -316,6 +444,9 @@ func TestWorkloadLogsHandler_InvalidParams(t *testing.T) {
 		{name: "negative tailLines", query: "namespace=default&name=test-pod&tailLines=-5", message: "Invalid tailLines parameter"},
 		{name: "invalid previous", query: "namespace=default&name=test-pod&previous=maybe", message: "Invalid previous parameter"},
 		{name: "invalid sinceTime", query: "namespace=default&name=test-pod&sinceTime=not-a-time", message: "Invalid sinceTime parameter"},
+		{name: "since without separator", query: "namespace=default&name=test-pod&pod=other&since=pod-a", message: "Invalid since parameter"},
+		{name: "since with empty pod", query: "namespace=default&name=test-pod&pod=other&since==2026-01-01T00:00:00Z", message: "Invalid since parameter"},
+		{name: "since with bad timestamp", query: "namespace=default&name=test-pod&pod=other&since=pod-a=not-a-time", message: "Invalid since parameter"},
 	}
 
 	for _, tc := range testCases {
@@ -396,6 +527,41 @@ func TestWorkloadLogsHandler_AllContainersForbidden(t *testing.T) {
 
 	g.Expect(rec.Code).To(Equal(http.StatusForbidden))
 	g.Expect(rec.Body.String()).To(ContainSubstring("Permission denied"))
+}
+
+func TestWorkloadLogsHandler_AllPodsForbidden(t *testing.T) {
+	g := NewWithT(t)
+
+	// The all-pods path (the primary name plus repeated pod params) is governed by
+	// the same pods/log RBAC. With more than one pod the failure is workload-scoped
+	// (no single pod is named), so the 403 message does not pin to one pod.
+	username := "logs-forbidden-allpods-user"
+	imp := user.Impersonation{Username: username, Groups: []string{"system:authenticated"}}
+	userClient, err := kubeClient.GetUserClientFromCache(imp)
+	g.Expect(err).NotTo(HaveOccurred())
+	userCtx := user.StoreSession(ctx, user.Details{
+		Profile:       user.Profile{Name: "Logs Forbidden All Pods User"},
+		Impersonation: imp,
+	}, userClient)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/workload/logs?namespace=default&name=pod-a&pod=pod-b&container=app", nil).WithContext(userCtx)
+	rec := httptest.NewRecorder()
+
+	handler.WorkloadLogsHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusForbidden))
+	g.Expect(rec.Body.String()).To(ContainSubstring("Permission denied"))
+	// Workload-scoped message: it does not name a single pod.
+	g.Expect(rec.Body.String()).To(ContainSubstring("workload pod logs"))
 }
 
 func TestGetWorkloadStatus_ViewLogsCapability(t *testing.T) {

--- a/internal/web/workload_logs_test.go
+++ b/internal/web/workload_logs_test.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
+)
+
+func TestWorkloadLogsHandler_MethodNotAllowed(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workload/logs", nil)
+	rec := httptest.NewRecorder()
+
+	handler.WorkloadLogsHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
+	g.Expect(rec.Body.String()).To(ContainSubstring("Method not allowed"))
+}
+
+func TestWorkloadLogsHandler_MissingParams(t *testing.T) {
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	testCases := []struct {
+		name  string
+		query string
+	}{
+		{name: "missing both", query: ""},
+		{name: "missing name", query: "namespace=default"},
+		{name: "missing namespace", query: "name=test-pod"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/workload/logs?"+tc.query, nil)
+			rec := httptest.NewRecorder()
+
+			handler.WorkloadLogsHandler(rec, req)
+
+			g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
+			g.Expect(rec.Body.String()).To(ContainSubstring("Missing required query parameters"))
+		})
+	}
+}
+
+func TestWorkloadLogsHandler_InvalidParams(t *testing.T) {
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	testCases := []struct {
+		name    string
+		query   string
+		message string
+	}{
+		{name: "invalid tailLines", query: "namespace=default&name=test-pod&tailLines=abc", message: "Invalid tailLines parameter"},
+		{name: "negative tailLines", query: "namespace=default&name=test-pod&tailLines=-5", message: "Invalid tailLines parameter"},
+		{name: "invalid previous", query: "namespace=default&name=test-pod&previous=maybe", message: "Invalid previous parameter"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/workload/logs?"+tc.query, nil)
+			rec := httptest.NewRecorder()
+
+			handler.WorkloadLogsHandler(rec, req)
+
+			g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
+			g.Expect(rec.Body.String()).To(ContainSubstring(tc.message))
+		})
+	}
+}
+
+func TestWorkloadLogsHandler_Forbidden(t *testing.T) {
+	g := NewWithT(t)
+
+	// A user without the pods/log permission must be rejected with 403 by the
+	// API server when the impersonated client attempts to read the logs.
+	username := "logs-forbidden-user"
+	imp := user.Impersonation{Username: username, Groups: []string{"system:authenticated"}}
+	userClient, err := kubeClient.GetUserClientFromCache(imp)
+	g.Expect(err).NotTo(HaveOccurred())
+	userCtx := user.StoreSession(ctx, user.Details{
+		Profile:       user.Profile{Name: "Logs Forbidden User"},
+		Impersonation: imp,
+	}, userClient)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/workload/logs?namespace=default&name=test-pod&container=app", nil).WithContext(userCtx)
+	rec := httptest.NewRecorder()
+
+	handler.WorkloadLogsHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusForbidden))
+	g.Expect(rec.Body.String()).To(ContainSubstring("Permission denied"))
+}
+
+func TestGetWorkloadStatus_ViewLogsCapability(t *testing.T) {
+	g := NewWithT(t)
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workload-logs",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: new(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test-workload-logs"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test-workload-logs"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "nginx", Image: "nginx:1.25"},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, deployment)).To(Succeed())
+	defer testClient.Delete(ctx, deployment)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	// baseRules grant enough access to read the workload and list its pods,
+	// but deliberately omit the pods/log subresource.
+	baseRules := []rbacv1.PolicyRule{
+		{APIGroups: []string{"apps"}, Resources: []string{"deployments"}, Verbs: []string{"get", "list"}},
+		{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"}},
+	}
+
+	t.Run("with pods/log permission", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rules := append([]rbacv1.PolicyRule{}, baseRules...)
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{""}, Resources: []string{"pods/log"}, Verbs: []string{"get"},
+		})
+		userCtx := bindWorkloadLogsUser(t, g, "logs-reader-user", rules)
+
+		workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-logs", "default", false)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(workload.UserActions).To(ContainElement(fluxcdv1.UserActionViewLogs))
+	})
+
+	t.Run("without pods/log permission", func(t *testing.T) {
+		g := NewWithT(t)
+
+		userCtx := bindWorkloadLogsUser(t, g, "logs-noreader-user", baseRules)
+
+		workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-logs", "default", false)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(workload.UserActions).NotTo(ContainElement(fluxcdv1.UserActionViewLogs))
+	})
+}
+
+// bindWorkloadLogsUser creates a namespaced Role with the given rules in the
+// default namespace, binds it to username, and returns an impersonated user
+// context for use with the handler.
+func bindWorkloadLogsUser(t *testing.T, g *WithT, username string, rules []rbacv1.PolicyRule) context.Context {
+	t.Helper()
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: username + "-role", Namespace: "default"},
+		Rules:      rules,
+	}
+	g.Expect(testClient.Create(ctx, role)).To(Succeed())
+	t.Cleanup(func() { _ = testClient.Delete(ctx, role) })
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: username + "-binding", Namespace: "default"},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{{Kind: "User", Name: username}},
+	}
+	g.Expect(testClient.Create(ctx, roleBinding)).To(Succeed())
+	t.Cleanup(func() { _ = testClient.Delete(ctx, roleBinding) })
+
+	imp := user.Impersonation{Username: username, Groups: []string{"system:authenticated"}}
+	userClient, err := kubeClient.GetUserClientFromCache(imp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	return user.StoreSession(ctx, user.Details{
+		Profile:       user.Profile{Name: username},
+		Impersonation: imp,
+	}, userClient)
+}

--- a/internal/web/workload_logs_test.go
+++ b/internal/web/workload_logs_test.go
@@ -92,34 +92,38 @@ func TestTailLogBytes(t *testing.T) {
 }
 
 func TestParseLogEntries(t *testing.T) {
-	t.Run("groups continuation lines with their timestamped entry and stamps the pod", func(t *testing.T) {
+	t.Run("groups continuation lines with their timestamped entry and stamps the pod and container", func(t *testing.T) {
 		g := NewWithT(t)
 
 		blob := "2026-01-01T00:00:00Z panic: boom\ngoroutine 1 [running]:\nmain.main()\n" +
 			"2026-01-01T00:00:01Z next line\n"
-		entries := parseLogEntries(blob, "pod-a")
+		entries := parseLogEntries(blob, "pod-a", "app")
 
 		g.Expect(entries).To(HaveLen(2))
 		// The two non-timestamped lines stay attached to the first entry.
 		g.Expect(entries[0].text).To(Equal("2026-01-01T00:00:00Z panic: boom\ngoroutine 1 [running]:\nmain.main()"))
 		g.Expect(entries[0].pod).To(Equal("pod-a"))
+		g.Expect(entries[0].container).To(Equal("app"))
 		g.Expect(entries[1].text).To(Equal("2026-01-01T00:00:01Z next line"))
 		g.Expect(entries[1].pod).To(Equal("pod-a"))
+		g.Expect(entries[1].container).To(Equal("app"))
 	})
 
-	t.Run("a leading continuation with no preceding entry becomes its own entry", func(t *testing.T) {
+	t.Run("a leading continuation with no preceding entry becomes its own entry, stamped", func(t *testing.T) {
 		g := NewWithT(t)
 
-		entries := parseLogEntries("orphan continuation\n2026-01-01T00:00:00Z line\n", "pod-a")
+		entries := parseLogEntries("orphan continuation\n2026-01-01T00:00:00Z line\n", "pod-a", "app")
 		g.Expect(entries).To(HaveLen(2))
 		g.Expect(entries[0].ts.IsZero()).To(BeTrue())
 		g.Expect(entries[0].text).To(Equal("orphan continuation"))
+		g.Expect(entries[0].container).To(Equal("app"))
 		g.Expect(entries[1].text).To(Equal("2026-01-01T00:00:00Z line"))
+		g.Expect(entries[1].container).To(Equal("app"))
 	})
 
 	t.Run("empty payload yields no entries", func(t *testing.T) {
 		g := NewWithT(t)
-		g.Expect(parseLogEntries("", "pod-a")).To(BeEmpty())
+		g.Expect(parseLogEntries("", "pod-a", "app")).To(BeEmpty())
 	})
 }
 
@@ -130,7 +134,7 @@ func TestMergeLogStreams(t *testing.T) {
 		app := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"}
 		sidecar := logStream{pod: "pod-a", blob: "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"}
 
-		got := mergeLogStreams([]logStream{app, sidecar}, 0, false)
+		got := mergeLogStreams([]logStream{app, sidecar}, 0, false, false)
 		g.Expect(got).To(Equal(
 			"2026-01-01T00:00:00Z app a\n" +
 				"2026-01-01T00:00:01Z side a\n" +
@@ -146,7 +150,7 @@ func TestMergeLogStreams(t *testing.T) {
 		a := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00.1Z first\n"}
 		b := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00.12Z second\n"}
 
-		got := mergeLogStreams([]logStream{b, a}, 0, false)
+		got := mergeLogStreams([]logStream{b, a}, 0, false, false)
 		g.Expect(got).To(Equal("2026-01-01T00:00:00.1Z first\n2026-01-01T00:00:00.12Z second\n"))
 	})
 
@@ -156,7 +160,7 @@ func TestMergeLogStreams(t *testing.T) {
 		app := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00Z panic\nstack frame\n"}
 		sidecar := logStream{pod: "pod-a", blob: "2026-01-01T00:00:01Z side\n"}
 
-		got := mergeLogStreams([]logStream{app, sidecar}, 0, false)
+		got := mergeLogStreams([]logStream{app, sidecar}, 0, false, false)
 		g.Expect(got).To(Equal("2026-01-01T00:00:00Z panic\nstack frame\n2026-01-01T00:00:01Z side\n"))
 	})
 
@@ -166,14 +170,14 @@ func TestMergeLogStreams(t *testing.T) {
 		app := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"}
 		sidecar := logStream{pod: "pod-a", blob: "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"}
 
-		got := mergeLogStreams([]logStream{app, sidecar}, 2, false)
+		got := mergeLogStreams([]logStream{app, sidecar}, 2, false, false)
 		g.Expect(got).To(Equal("2026-01-01T00:00:02Z app b\n2026-01-01T00:00:03Z side b\n"))
 	})
 
 	t.Run("empty streams yield an empty payload", func(t *testing.T) {
 		g := NewWithT(t)
-		g.Expect(mergeLogStreams(nil, 100, false)).To(BeEmpty())
-		g.Expect(mergeLogStreams([]logStream{{pod: "pod-a"}, {pod: "pod-b"}}, 100, false)).To(BeEmpty())
+		g.Expect(mergeLogStreams(nil, 100, false, false)).To(BeEmpty())
+		g.Expect(mergeLogStreams([]logStream{{pod: "pod-a"}, {pod: "pod-b"}}, 100, false, false)).To(BeEmpty())
 	})
 
 	t.Run("tagged mode prefixes each timestamped line with its pod, interleaved", func(t *testing.T) {
@@ -182,7 +186,7 @@ func TestMergeLogStreams(t *testing.T) {
 		a := logStream{pod: "frontend-abc-gqh2x", blob: "2026-01-01T00:00:00Z a one\n2026-01-01T00:00:02Z a two\n"}
 		b := logStream{pod: "frontend-abc-p8x2k", blob: "2026-01-01T00:00:01Z b one\n"}
 
-		got := mergeLogStreams([]logStream{a, b}, 0, true)
+		got := mergeLogStreams([]logStream{a, b}, 0, true, false)
 		g.Expect(got).To(Equal(
 			"frontend-abc-gqh2x 2026-01-01T00:00:00Z a one\n" +
 				"frontend-abc-p8x2k 2026-01-01T00:00:01Z b one\n" +
@@ -199,10 +203,39 @@ func TestMergeLogStreams(t *testing.T) {
 		// A leading orphan continuation (zero ts) is left untagged too.
 		b := logStream{pod: "pod-b", blob: "orphan line\n"}
 
-		got := mergeLogStreams([]logStream{a, b}, 0, true)
+		got := mergeLogStreams([]logStream{a, b}, 0, true, false)
 		g.Expect(got).To(Equal(
 			"orphan line\n" +
 				"pod-a 2026-01-01T00:00:01Z panic\nstack frame\n"))
+	})
+
+	t.Run("container-tagged mode prefixes each timestamped line with its container", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Single-pod all-containers view: tag the container, not the pod, so the
+		// client can scope folding per container.
+		app := logStream{pod: "pod-a", container: "app", blob: "2026-01-01T00:00:00Z a one\n2026-01-01T00:00:02Z a two\n"}
+		side := logStream{pod: "pod-a", container: "envoy", blob: "2026-01-01T00:00:01Z s one\n"}
+
+		got := mergeLogStreams([]logStream{app, side}, 0, false, true)
+		g.Expect(got).To(Equal(
+			"app 2026-01-01T00:00:00Z a one\n" +
+				"envoy 2026-01-01T00:00:01Z s one\n" +
+				"app 2026-01-01T00:00:02Z a two\n"))
+	})
+
+	t.Run("combined mode prefixes pod then container, in order", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// All-pods and all-containers: both dimensions fan out, so each timestamped
+		// line carries "<pod> <container> <ts> <msg>"; orphans stay untagged.
+		a := logStream{pod: "p1", container: "app", blob: "2026-01-01T00:00:00Z a\nframe\n"}
+		b := logStream{pod: "p2", container: "side", blob: "2026-01-01T00:00:01Z b\n"}
+
+		got := mergeLogStreams([]logStream{a, b}, 0, true, true)
+		g.Expect(got).To(Equal(
+			"p1 app 2026-01-01T00:00:00Z a\nframe\n" +
+				"p2 side 2026-01-01T00:00:01Z b\n"))
 	})
 }
 
@@ -293,7 +326,7 @@ func TestCollectLogStreams(t *testing.T) {
 		g := NewWithT(t)
 		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
 		out := collectLogStreams(targets, []string{"x", "y"}, []error{nil, nil})
-		g.Expect(out.streams).To(Equal([]logStream{{pod: "p1", blob: "x"}, {pod: "p2", blob: "y"}}))
+		g.Expect(out.streams).To(Equal([]logStream{{pod: "p1", container: "app", blob: "x"}, {pod: "p2", container: "app", blob: "y"}}))
 		g.Expect(out.streamedSet).To(HaveLen(2))
 		g.Expect(out.forbidden).To(Equal(0))
 		g.Expect(out.firstErr).NotTo(HaveOccurred())
@@ -303,7 +336,7 @@ func TestCollectLogStreams(t *testing.T) {
 		g := NewWithT(t)
 		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
 		out := collectLogStreams(targets, []string{"x", ""}, []error{nil, forbidden})
-		g.Expect(out.streams).To(Equal([]logStream{{pod: "p1", blob: "x"}}))
+		g.Expect(out.streams).To(Equal([]logStream{{pod: "p1", container: "app", blob: "x"}}))
 		g.Expect(out.streamedSet).To(HaveLen(1))
 		g.Expect(out.forbidden).To(Equal(1))
 		g.Expect(out.firstErr).To(MatchError(forbidden))
@@ -337,9 +370,10 @@ func TestBuildWorkloadLogsResponse(t *testing.T) {
 		// report 200-style partial coverage with the per-pod counts the UI shows.
 		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
 		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z hi\n", ""}, []error{nil, forbidden})
-		resp := buildWorkloadLogsResponse([]string{"p1", "p2"}, []string{"app"}, fanOut, 2, 1000, true, false)
+		resp := buildWorkloadLogsResponse([]string{"p1", "p2"}, []string{"app"}, fanOut, 2, 1000, true, false, false)
 
 		g.Expect(resp.Tagged).To(BeTrue())
+		g.Expect(resp.ContainerTagged).To(BeFalse())
 		g.Expect(resp.Total).To(Equal(2))
 		g.Expect(resp.Streamed).To(Equal(1))
 		g.Expect(resp.Partial).To(BeTrue())
@@ -352,7 +386,7 @@ func TestBuildWorkloadLogsResponse(t *testing.T) {
 		g := NewWithT(t)
 		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
 		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z a\n", "2026-01-01T00:00:01Z b\n"}, []error{nil, nil})
-		resp := buildWorkloadLogsResponse([]string{"p1", "p2"}, []string{"app"}, fanOut, 2, 1000, true, false)
+		resp := buildWorkloadLogsResponse([]string{"p1", "p2"}, []string{"app"}, fanOut, 2, 1000, true, false, false)
 
 		g.Expect(resp.Streamed).To(Equal(2))
 		g.Expect(resp.Partial).To(BeFalse())
@@ -365,11 +399,24 @@ func TestBuildWorkloadLogsResponse(t *testing.T) {
 		// was capped, so the response must still flag the result as partial.
 		targets := []logTarget{{pod: "p1", container: "app"}}
 		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z x\n"}, []error{nil})
-		resp := buildWorkloadLogsResponse([]string{"p1"}, []string{"app"}, fanOut, 1, 1000, true, true)
+		resp := buildWorkloadLogsResponse([]string{"p1"}, []string{"app"}, fanOut, 1, 1000, true, false, true)
 
 		g.Expect(resp.Streamed).To(Equal(1))
 		g.Expect(resp.Total).To(Equal(1))
 		g.Expect(resp.Partial).To(BeTrue())
+	})
+
+	t.Run("all-containers single pod tags the container, not the pod", func(t *testing.T) {
+		g := NewWithT(t)
+		// One pod, two containers: ContainerTagged is set and each line is prefixed
+		// with its container so the client scopes folding per container.
+		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p1", container: "envoy"}}
+		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z a\n", "2026-01-01T00:00:01Z e\n"}, []error{nil, nil})
+		resp := buildWorkloadLogsResponse([]string{"p1"}, []string{"app", "envoy"}, fanOut, 1, 1000, false, true, false)
+
+		g.Expect(resp.Tagged).To(BeFalse())
+		g.Expect(resp.ContainerTagged).To(BeTrue())
+		g.Expect(resp.Logs).To(Equal("app 2026-01-01T00:00:00Z a\nenvoy 2026-01-01T00:00:01Z e\n"))
 	})
 }
 

--- a/internal/web/workload_logs_test.go
+++ b/internal/web/workload_logs_test.go
@@ -19,6 +19,26 @@ import (
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
 )
 
+func TestTrimPartialLogLine(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "newline terminated", in: "line one\nline two\n", want: "line one\nline two\n"},
+		{name: "drops partial trailing line", in: "line one\nline two\npar", want: "line one\nline two\n"},
+		{name: "single partial line kept", in: "partial", want: "partial"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(trimPartialLogLine(tt.in)).To(Equal(tt.want))
+		})
+	}
+}
+
 func TestWorkloadLogsHandler_MethodNotAllowed(t *testing.T) {
 	g := NewWithT(t)
 

--- a/internal/web/workload_test.go
+++ b/internal/web/workload_test.go
@@ -1620,7 +1620,9 @@ func TestWorkloadHandler_Success_WithParentReconciler(t *testing.T) {
 			Name:      "test-wh-parent",
 			Namespace: "default",
 		},
-		Spec: fluxcdv1.ResourceSetSpec{},
+		Spec: fluxcdv1.ResourceSetSpec{
+			ResourcesTemplate: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\n  namespace: default\n",
+		},
 	}
 	g.Expect(testClient.Create(ctx, resourceSet)).To(Succeed())
 	defer func() { g.Expect(testClient.Delete(ctx, resourceSet)).To(Succeed()) }()

--- a/internal/web/workload_test.go
+++ b/internal/web/workload_test.go
@@ -73,6 +73,137 @@ func TestGetWorkloadStatus_Privileged(t *testing.T) {
 	g.Expect(workload.UserActions).To(BeEmpty())
 }
 
+func TestGetWorkloadStatus_Lightweight_SkipsPodsAndActions(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a Deployment for testing
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workload-lightweight",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: new(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test-workload-lightweight"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test-workload-lightweight"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "nginx", Image: "nginx:latest"},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, deployment)).To(Succeed())
+	defer testClient.Delete(ctx, deployment)
+
+	// Create a pod managed by the deployment (envtest has no controllers, so we
+	// create it explicitly) so a detailed call has a pod to list and the
+	// lightweight call can be shown to skip it.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workload-lightweight-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test-workload-lightweight"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       "test-workload-lightweight-abc123",
+					UID:        "test-lightweight-uid",
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "nginx", Image: "nginx:latest"},
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, pod)).To(Succeed())
+	defer testClient.Delete(ctx, pod)
+
+	// RBAC granting the user restart on deployments and full pod access, so a
+	// detailed call would populate both UserActions and Pods.
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lightweight-role",
+			Namespace: "default",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments"},
+				Verbs:     []string{"get", "list", "restart"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "list", "delete"},
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, role)).To(Succeed())
+	defer testClient.Delete(ctx, role)
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lightweight-binding",
+			Namespace: "default",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: "lightweight-user"},
+		},
+	}
+	g.Expect(testClient.Create(ctx, roleBinding)).To(Succeed())
+	defer testClient.Delete(ctx, roleBinding)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	imp := user.Impersonation{
+		Username: "lightweight-user",
+		Groups:   []string{"system:authenticated"},
+	}
+	userClient, err := kubeClient.GetUserClientFromCache(imp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	userCtx := user.StoreSession(ctx, user.Details{
+		Profile:       user.Profile{Name: "Lightweight User"},
+		Impersonation: imp,
+	}, userClient)
+
+	// Lightweight (detailed=false): the status is computed but the pod listing
+	// and the per-action RBAC checks are skipped.
+	lightweight, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-lightweight", "default", false)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(lightweight.Status).NotTo(BeEmpty())
+	g.Expect(lightweight.Pods).To(BeEmpty())
+	g.Expect(lightweight.UserActions).To(BeEmpty())
+
+	// Detailed (detailed=true): the managed pods and the user actions are computed.
+	detailed, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-lightweight", "default", true)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(detailed.Pods).To(HaveLen(1))
+	g.Expect(detailed.Pods[0].Name).To(Equal("test-workload-lightweight-pod"))
+	g.Expect(detailed.UserActions).To(ContainElement(fluxcdv1.UserActionRestart))
+}
+
 func TestGetWorkloadStatus_UnprivilegedUser_Forbidden(t *testing.T) {
 	g := NewWithT(t)
 
@@ -641,7 +772,7 @@ func TestGetWorkloadStatus_WithDeploymentAccessButNoPodAccess_Forbidden(t *testi
 	}, userClient)
 
 	// Call GetWorkloadStatus - user can get deployment but not list pods
-	_, err = handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-no-pods", "default", false)
+	_, err = handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-no-pods", "default", true)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(apierrors.IsForbidden(err)).To(BeTrue(), "expected forbidden error when user cannot list pods, got: %v", err)
 }
@@ -983,7 +1114,7 @@ func TestGetWorkloadStatus_UserActions_WithRestartAndDeletePods(t *testing.T) {
 		Impersonation: imp,
 	}, userClient)
 
-	workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-ua-both", "default", false)
+	workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-ua-both", "default", true)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(workload).NotTo(BeNil())
 	g.Expect(workload.UserActions).To(ContainElement(fluxcdv1.UserActionRestart))
@@ -1078,7 +1209,7 @@ func TestGetWorkloadStatus_UserActions_RestartOnly(t *testing.T) {
 		Impersonation: imp,
 	}, userClient)
 
-	workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-ua-restart", "default", false)
+	workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-ua-restart", "default", true)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(workload).NotTo(BeNil())
 	g.Expect(workload.UserActions).To(ContainElement(fluxcdv1.UserActionRestart))
@@ -1173,7 +1304,7 @@ func TestGetWorkloadStatus_UserActions_DeletePodsOnly(t *testing.T) {
 		Impersonation: imp,
 	}, userClient)
 
-	workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-ua-delpods", "default", false)
+	workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-ua-delpods", "default", true)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(workload).NotTo(BeNil())
 	g.Expect(workload.UserActions).NotTo(ContainElement(fluxcdv1.UserActionRestart))
@@ -1268,7 +1399,7 @@ func TestGetWorkloadStatus_UserActions_NoActions(t *testing.T) {
 		Impersonation: imp,
 	}, userClient)
 
-	workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-ua-none", "default", false)
+	workload, err := handler.GetWorkloadStatus(userCtx, "Deployment", "test-workload-ua-none", "default", true)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(workload).NotTo(BeNil())
 	g.Expect(workload.UserActions).To(BeEmpty())
@@ -1312,7 +1443,7 @@ func TestGetWorkloadStatus_UserActions_DisabledWithoutAuth(t *testing.T) {
 	}
 
 	// Call with privileged context (system:masters has all permissions)
-	workload, err := handler.GetWorkloadStatus(ctx, "Deployment", "test-workload-ua-disabled", "default", false)
+	workload, err := handler.GetWorkloadStatus(ctx, "Deployment", "test-workload-ua-disabled", "default", true)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(workload).NotTo(BeNil())
 	// Even though the privileged user has all permissions, UserActions should be empty
@@ -1409,7 +1540,7 @@ func TestGetWorkloadStatus_UserActions_StatefulSet(t *testing.T) {
 		Impersonation: imp,
 	}, userClient)
 
-	workload, err := handler.GetWorkloadStatus(userCtx, "StatefulSet", "test-workload-ua-sts", "default", false)
+	workload, err := handler.GetWorkloadStatus(userCtx, "StatefulSet", "test-workload-ua-sts", "default", true)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(workload).NotTo(BeNil())
 	g.Expect(workload.UserActions).To(ContainElement(fluxcdv1.UserActionRestart))
@@ -1511,7 +1642,7 @@ func TestGetWorkloadStatus_UserActions_CronJob(t *testing.T) {
 		Impersonation: imp,
 	}, userClient)
 
-	workload, err := handler.GetWorkloadStatus(userCtx, "CronJob", "test-workload-ua-cron", "default", false)
+	workload, err := handler.GetWorkloadStatus(userCtx, "CronJob", "test-workload-ua-cron", "default", true)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(workload).NotTo(BeNil())
 	g.Expect(workload.UserActions).To(ContainElement(fluxcdv1.UserActionRestart))
@@ -1604,7 +1735,7 @@ func TestGetWorkloadStatus_UserActions_DaemonSet(t *testing.T) {
 		Impersonation: imp,
 	}, userClient)
 
-	workload, err := handler.GetWorkloadStatus(userCtx, "DaemonSet", "test-workload-ua-ds", "default", false)
+	workload, err := handler.GetWorkloadStatus(userCtx, "DaemonSet", "test-workload-ua-ds", "default", true)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(workload).NotTo(BeNil())
 	g.Expect(workload.UserActions).To(ContainElement(fluxcdv1.UserActionRestart))

--- a/internal/web/workloads.go
+++ b/internal/web/workloads.go
@@ -79,7 +79,7 @@ func (h *Handler) GetWorkloadsStatus(ctx context.Context, workloads []WorkloadIt
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			ws, err := h.GetWorkloadStatus(ctx, item.Kind, item.Name, item.Namespace)
+			ws, err := h.GetWorkloadStatus(ctx, item.Kind, item.Name, item.Namespace, false)
 			if err != nil {
 				var statusMessage string
 				switch {

--- a/internal/web/workloads.go
+++ b/internal/web/workloads.go
@@ -11,6 +11,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/reporter"
 )
 
 // WorkloadItem represents a single workload request.
@@ -116,4 +118,90 @@ func (h *Handler) GetWorkloadsStatus(ctx context.Context, workloads []WorkloadIt
 	wg.Wait()
 
 	return result
+}
+
+// WorkloadsListHandler handles GET /api/v1/workloads requests and returns the
+// Flux-managed workloads (Deployment, StatefulSet, DaemonSet, CronJob) from the
+// cached, inventory-derived workload index, filtered by the user's namespace
+// access. Supports optional query parameters: kind, name, namespace.
+// Example: /api/v1/workloads?kind=Deployment&namespace=flux-system
+func (h *Handler) WorkloadsListHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet && req.Method != http.MethodHead {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse query parameters.
+	queryParams := req.URL.Query()
+	kind := queryParams.Get("kind")
+	name := queryParams.Get("name")
+	namespace := queryParams.Get("namespace")
+
+	// Query the cached workload index with RBAC filtering.
+	workloads := h.GetCachedWorkloads(req.Context(), kind, name, namespace, 2500)
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{"workloads": workloads}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+// WorkloadsSearchHandler handles GET /api/v1/workloads/search requests and
+// returns Flux-managed workloads from the cached workload index for the global
+// quick-search. Results are filtered by name with wildcard support and capped at
+// a small limit. Supports optional query parameters: kind, name, namespace.
+// Example: /api/v1/workloads/search?name=podinfo
+func (h *Handler) WorkloadsSearchHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet && req.Method != http.MethodHead {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse query parameters.
+	queryParams := req.URL.Query()
+	name := queryParams.Get("name")
+	namespace := queryParams.Get("namespace")
+	kind := queryParams.Get("kind")
+
+	// If name does not contain a wildcard, wrap it to perform a partial match.
+	if name != "" && !hasWildcard(name) {
+		name = "*" + name + "*"
+	}
+
+	// Query the cached workload index with RBAC filtering.
+	workloads := h.GetCachedWorkloads(req.Context(), kind, name, namespace, 10)
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{"workloads": workloads}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+// GetCachedWorkloads returns workloads from the cached workload index filtered
+// by the given criteria and the user's namespace access. If name and namespace
+// filters are empty, it returns workloads across all namespaces the user can
+// access (subject to RBAC on the parent reconcilers via ListUserNamespaces).
+func (h *Handler) GetCachedWorkloads(ctx context.Context, kind, name, namespace string, limit int) []reporter.WorkloadRef {
+	// Get user-visible namespaces for RBAC filtering.
+	userNamespaces, allNamespaces, err := h.kubeClient.ListUserNamespaces(ctx)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to list user namespaces for cached workloads")
+		return []reporter.WorkloadRef{}
+	}
+
+	// If the user has no access to any namespace, return empty results.
+	if !allNamespaces && len(userNamespaces) == 0 {
+		return []reporter.WorkloadRef{}
+	}
+
+	// For cluster-wide access, pass nil (no RBAC filtering).
+	// Otherwise, pass the user's namespace list.
+	var allowedNamespaces []string
+	if !allNamespaces {
+		allowedNamespaces = userNamespaces
+	}
+
+	return h.workloadIndex.SearchWorkloads(allowedNamespaces, kind, name, namespace, limit)
 }

--- a/internal/web/workloads.go
+++ b/internal/web/workloads.go
@@ -88,7 +88,7 @@ func (h *Handler) GetWorkloadsStatus(ctx context.Context, workloads []WorkloadIt
 				case errors.IsNotFound(err):
 					statusMessage = "Workload not found in the cluster"
 				case errors.IsForbidden(err):
-					statusMessage = "User does not have access to the workload or for listing its pods"
+					statusMessage = "User does not have access to the workload"
 				default:
 					statusMessage = "Internal error while fetching workload"
 					log.FromContext(ctx).Error(err, "failed to get workload status",

--- a/internal/web/workloads_test.go
+++ b/internal/web/workloads_test.go
@@ -4,6 +4,9 @@
 package web
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -12,6 +15,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/reporter"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
 )
 
@@ -726,4 +730,200 @@ func TestGetWorkloadsStatus_DaemonSet(t *testing.T) {
 	g.Expect(results[0].Name).To(Equal("test-daemonset"))
 	g.Expect(results[0].Kind).To(Equal("DaemonSet"))
 	g.Expect(results[0].Status).NotTo(Equal("NotFound"))
+}
+
+func newWorkloadIndexHandler() *Handler {
+	return &Handler{
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+		workloadIndex: &WorkloadIndex{},
+	}
+}
+
+func TestGetCachedWorkloads_Privileged(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := newWorkloadIndexHandler()
+	handler.workloadIndex.Update([]reporter.WorkloadRef{
+		{Kind: "Deployment", Name: "web", Namespace: "default", ReconcilerKind: "Kustomization", ReconcilerName: "apps", ReconcilerNamespace: "flux-system", ReconcilerStatus: reporter.StatusReady, LastReconciled: metav1.Now()},
+		{Kind: "CronJob", Name: "backup", Namespace: "team-a", ReconcilerKind: "Kustomization", ReconcilerName: "apps", ReconcilerNamespace: "flux-system", ReconcilerStatus: reporter.StatusReady, LastReconciled: metav1.Now()},
+	})
+
+	// Privileged context (no user session) = cluster-wide access.
+	workloads := handler.GetCachedWorkloads(ctx, "", "", "", 100)
+	g.Expect(workloads).To(HaveLen(2))
+}
+
+func TestGetCachedWorkloads_UnprivilegedUser(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := newWorkloadIndexHandler()
+	handler.workloadIndex.Update([]reporter.WorkloadRef{
+		{Kind: "Deployment", Name: "web", Namespace: "default", LastReconciled: metav1.Now()},
+	})
+
+	imp := user.Impersonation{
+		Username: "unprivileged-workload-list-user",
+		Groups:   []string{"unprivileged-group"},
+	}
+	userClient, err := kubeClient.GetUserClientFromCache(imp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	userCtx := user.StoreSession(ctx, user.Details{
+		Profile:       user.Profile{Name: "Unprivileged User"},
+		Impersonation: imp,
+	}, userClient)
+
+	workloads := handler.GetCachedWorkloads(userCtx, "", "", "", 100)
+	g.Expect(workloads).To(BeEmpty(), "unprivileged user should get empty result")
+}
+
+func TestGetCachedWorkloads_WithUserRBAC(t *testing.T) {
+	g := NewWithT(t)
+
+	// Grant the user get/list on resourcesets in the default namespace, which is
+	// what ListUserNamespaces uses to reveal namespaces.
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cached-workloads-reader",
+			Namespace: "default",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"fluxcd.controlplane.io"},
+				Resources: []string{"resourcesets"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, role)).To(Succeed())
+	defer func() { g.Expect(testClient.Delete(ctx, role)).To(Succeed()) }()
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cached-workloads-reader-binding",
+			Namespace: "default",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: "cached-workloads-user"},
+		},
+	}
+	g.Expect(testClient.Create(ctx, roleBinding)).To(Succeed())
+	defer func() { g.Expect(testClient.Delete(ctx, roleBinding)).To(Succeed()) }()
+
+	handler := newWorkloadIndexHandler()
+	handler.workloadIndex.Update([]reporter.WorkloadRef{
+		{Kind: "Deployment", Name: "web-default", Namespace: "default", LastReconciled: metav1.Now()},
+		{Kind: "Deployment", Name: "web-other", Namespace: "other-ns", LastReconciled: metav1.Now()},
+	})
+
+	imp := user.Impersonation{
+		Username: "cached-workloads-user",
+		Groups:   []string{"system:authenticated"},
+	}
+	userClient, err := kubeClient.GetUserClientFromCache(imp)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	userCtx := user.StoreSession(ctx, user.Details{
+		Profile:       user.Profile{Name: "Cached Workloads User"},
+		Impersonation: imp,
+	}, userClient)
+
+	workloads := handler.GetCachedWorkloads(userCtx, "", "", "", 100)
+	g.Expect(workloads).To(HaveLen(1))
+	g.Expect(workloads[0].Name).To(Equal("web-default"))
+	g.Expect(workloads[0].Namespace).To(Equal("default"))
+}
+
+func TestWorkloadsListHandler_MethodNotAllowed(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := newWorkloadIndexHandler()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/workloads", nil)
+	rec := httptest.NewRecorder()
+	handler.WorkloadsListHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusMethodNotAllowed))
+}
+
+func TestWorkloadsListHandler_ReturnsWorkloads(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := newWorkloadIndexHandler()
+	handler.workloadIndex.Update([]reporter.WorkloadRef{
+		{Kind: "Deployment", Name: "web", Namespace: "default", ReconcilerKind: "Kustomization", ReconcilerName: "apps", ReconcilerNamespace: "flux-system", ReconcilerStatus: reporter.StatusReady, LastReconciled: metav1.Now()},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workloads", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	handler.WorkloadsListHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusOK))
+
+	var response map[string]any
+	g.Expect(json.Unmarshal(rec.Body.Bytes(), &response)).To(Succeed())
+
+	workloads, ok := response["workloads"].([]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(workloads).To(HaveLen(1))
+
+	wl := workloads[0].(map[string]any)
+	g.Expect(wl["kind"]).To(Equal("Deployment"))
+	g.Expect(wl["name"]).To(Equal("web"))
+	g.Expect(wl["namespace"]).To(Equal("default"))
+	g.Expect(wl["reconcilerKind"]).To(Equal("Kustomization"))
+	g.Expect(wl["reconcilerName"]).To(Equal("apps"))
+	g.Expect(wl["reconcilerNamespace"]).To(Equal("flux-system"))
+	g.Expect(wl["reconcilerStatus"]).To(Equal(reporter.StatusReady))
+}
+
+func TestWorkloadsListHandler_EmptyIndex(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := newWorkloadIndexHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workloads", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	handler.WorkloadsListHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusOK))
+
+	var response map[string]any
+	g.Expect(json.Unmarshal(rec.Body.Bytes(), &response)).To(Succeed())
+
+	workloads, ok := response["workloads"].([]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(workloads).To(BeEmpty(), "empty index should return empty array, not null")
+}
+
+func TestWorkloadsSearchHandler_WildcardExpansion(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := newWorkloadIndexHandler()
+	handler.workloadIndex.Update([]reporter.WorkloadRef{
+		{Kind: "Deployment", Name: "podinfo", Namespace: "default", LastReconciled: metav1.Now()},
+		{Kind: "Deployment", Name: "podinfo-cache", Namespace: "default", LastReconciled: metav1.Now()},
+		{Kind: "Deployment", Name: "other", Namespace: "default", LastReconciled: metav1.Now()},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workloads/search?name=podinfo", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	handler.WorkloadsSearchHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusOK))
+
+	var response map[string]any
+	g.Expect(json.Unmarshal(rec.Body.Bytes(), &response)).To(Succeed())
+
+	workloads, ok := response["workloads"].([]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(workloads).To(HaveLen(2), "should match both podinfo and podinfo-cache")
 }

--- a/internal/web/workloads_test.go
+++ b/internal/web/workloads_test.go
@@ -161,7 +161,7 @@ func TestGetWorkloadsStatus_UnprivilegedUser_Forbidden(t *testing.T) {
 	g.Expect(results).To(HaveLen(1))
 	g.Expect(results[0].Name).To(Equal("test-workload-forbidden"))
 	g.Expect(results[0].Status).To(Equal("NotFound"))
-	g.Expect(results[0].StatusMessage).To(Equal("User does not have access to the workload or for listing its pods"))
+	g.Expect(results[0].StatusMessage).To(Equal("User does not have access to the workload"))
 }
 
 func TestGetWorkloadsStatus_WithUserRBAC_Success(t *testing.T) {
@@ -385,10 +385,10 @@ func TestGetWorkloadsStatus_WithNamespaceScopedRBAC_ForbiddenInOtherNamespace(t 
 	g.Expect(results).To(HaveLen(1))
 	g.Expect(results[0].Name).To(Equal("test-workload-other-ns"))
 	g.Expect(results[0].Status).To(Equal("NotFound"))
-	g.Expect(results[0].StatusMessage).To(Equal("User does not have access to the workload or for listing its pods"))
+	g.Expect(results[0].StatusMessage).To(Equal("User does not have access to the workload"))
 }
 
-func TestGetWorkloadsStatus_WithDeploymentAccessButNoPodAccess_Forbidden(t *testing.T) {
+func TestGetWorkloadsStatus_WithDeploymentAccessButNoPodAccess_Success(t *testing.T) {
 	g := NewWithT(t)
 
 	// Create a Deployment for testing
@@ -485,11 +485,14 @@ func TestGetWorkloadsStatus_WithDeploymentAccessButNoPodAccess_Forbidden(t *test
 	}
 	results := handler.GetWorkloadsStatus(userCtx, workloads)
 
-	// Should return forbidden message since pod listing fails
+	// The lightweight batch path does not list pods, so a user who can get the
+	// workload but not list its pods now receives the computed status (not the
+	// forbidden NotFound row).
 	g.Expect(results).To(HaveLen(1))
 	g.Expect(results[0].Name).To(Equal("test-workload-no-pod-access"))
-	g.Expect(results[0].Status).To(Equal("NotFound"))
-	g.Expect(results[0].StatusMessage).To(Equal("User does not have access to the workload or for listing its pods"))
+	g.Expect(results[0].Status).NotTo(Equal("NotFound"))
+	// A Deployment with no available replicas computes as InProgress via kstatus.
+	g.Expect(results[0].Status).To(Equal("InProgress"))
 }
 
 func TestGetWorkloadsStatus_MixedResults(t *testing.T) {

--- a/web/README.md
+++ b/web/README.md
@@ -22,6 +22,7 @@ on-call monitoring and Agentic AI incident response in production environments.
 - **Pinpoint Issues:** Quickly identify and troubleshoot failures within your app delivery pipelines.
 - **Navigate Efficiently:** Use advanced search and filtering to find specific resources instantly.
 - **Deep Dive:** Access dedicated dashboards for ResourceSets, HelmReleases, Kustomizations and Flux sources.
+- **Inspect Logs:** View the logs of workload pods directly from the browser, scoped to your RBAC permissions.
 - **Favorites:** Mark important resources as favorites for quick access and at-a-glance status monitoring.
 - **Mobile-Optimized:** Stay informed with a fully responsive interface designed for on-the-go checks.
 - **Adaptive Theming:** Toggle between dark and light modes to suit your environment and preference.

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -21,6 +21,7 @@ export default [
         document: 'readonly',
         console: 'readonly',
         setTimeout: 'readonly',
+        clearTimeout: 'readonly',
         setInterval: 'readonly',
         clearInterval: 'readonly',
         fetch: 'readonly',

--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -16,6 +16,7 @@ import { ClusterPage } from './components/dashboards/cluster/ClusterPage'
 import { EventList } from './components/search/EventList'
 import { ResourceList } from './components/search/ResourceList'
 import { ResourcePage } from './components/dashboards/resource/ResourcePage'
+import { WorkloadPage } from './components/dashboards/workload/WorkloadPage'
 import { FavoritesPage } from './components/favorites/FavoritesPage'
 import { ProfilePage } from './components/user/ProfilePage'
 import { NotFoundPage } from './components/layout/NotFoundPage'
@@ -311,6 +312,7 @@ function AppContent({ spec, namespace }) {
         <Route path="/events" component={EventList} />
         <Route path="/resources" component={ResourceList} />
         <Route path="/resource/:kind/:namespace/:name" component={ResourcePage} />
+        <Route path="/workload/:kind/:namespace/:name" component={WorkloadPage} />
         <Route path="/user/profile" component={ProfilePage} />
         <Route default component={NotFoundPage} />
       </Router>

--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -15,6 +15,7 @@ import { LoginPage } from './components/auth/LoginPage'
 import { ClusterPage } from './components/dashboards/cluster/ClusterPage'
 import { EventList } from './components/search/EventList'
 import { ResourceList } from './components/search/ResourceList'
+import { WorkloadList } from './components/search/WorkloadList'
 import { ResourcePage } from './components/dashboards/resource/ResourcePage'
 import { WorkloadPage } from './components/dashboards/workload/WorkloadPage'
 import { FavoritesPage } from './components/favorites/FavoritesPage'
@@ -124,6 +125,16 @@ function TabNavigation() {
             } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm focus:outline-none transition-colors`}
           >
             Resources
+          </a>
+          <a
+            href="/workloads"
+            class={`${
+              currentPath === '/workloads'
+                ? 'border-flux-blue text-flux-blue dark:text-blue-400'
+                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
+            } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm focus:outline-none transition-colors`}
+          >
+            Workloads
           </a>
           <a
             href="/events"
@@ -292,7 +303,7 @@ export function App() {
 function AppContent({ spec, namespace }) {
   const location = useLocation()
   const currentPath = location.path
-  const isTabView = currentPath === '/favorites' || currentPath === '/events' || currentPath === '/resources'
+  const isTabView = currentPath === '/favorites' || currentPath === '/events' || currentPath === '/resources' || currentPath === '/workloads'
 
   return (
     <div class="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors flex flex-col">
@@ -311,6 +322,7 @@ function AppContent({ spec, namespace }) {
         <Route path="/favorites" component={FavoritesPage} />
         <Route path="/events" component={EventList} />
         <Route path="/resources" component={ResourceList} />
+        <Route path="/workloads" component={WorkloadList} />
         <Route path="/resource/:kind/:namespace/:name" component={ResourcePage} />
         <Route path="/workload/:kind/:namespace/:name" component={WorkloadPage} />
         <Route path="/user/profile" component={ProfilePage} />

--- a/web/src/app.test.jsx
+++ b/web/src/app.test.jsx
@@ -55,6 +55,10 @@ vi.mock('./components/dashboards/resource/ResourcePage', () => ({
   ResourcePage: () => <div data-testid="resource-page">ResourcePage</div>
 }))
 
+vi.mock('./components/dashboards/workload/WorkloadPage', () => ({
+  WorkloadPage: () => <div data-testid="workload-page">WorkloadPage</div>
+}))
+
 vi.mock('./components/common/NotFoundPage', () => ({
   NotFoundPage: () => <div data-testid="not-found-page">NotFoundPage</div>
 }))

--- a/web/src/app.test.jsx
+++ b/web/src/app.test.jsx
@@ -51,6 +51,10 @@ vi.mock('./components/search/ResourceList', () => ({
   ResourceList: () => <div data-testid="resource-list">ResourceList</div>
 }))
 
+vi.mock('./components/search/WorkloadList', () => ({
+  WorkloadList: () => <div data-testid="workload-list">WorkloadList</div>
+}))
+
 vi.mock('./components/dashboards/resource/ResourcePage', () => ({
   ResourcePage: () => <div data-testid="resource-page">ResourcePage</div>
 }))

--- a/web/src/components/dashboards/cluster/SyncPanel.jsx
+++ b/web/src/components/dashboards/cluster/SyncPanel.jsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { useSignal } from '@preact/signals'
+import { getDashboardUrl } from '../../../utils/routing'
 
 /**
  * SyncPanel component - Displays cluster sync information
@@ -88,7 +89,7 @@ export function SyncPanel({ sync, namespace, namespaces }) {
           <div class="flex flex-col gap-2 text-sm text-gray-900 dark:text-white break-all">
             {namespaces?.includes(namespace) && (
               <a
-                href={`/resource/${encodeURIComponent('Kustomization')}/${encodeURIComponent(namespace)}/${encodeURIComponent(syncName)}`}
+                href={getDashboardUrl('Kustomization', namespace, syncName)}
                 class="flex items-start gap-2 text-flux-blue dark:text-blue-400 hover:underline text-left"
               >
                 <svg class="w-5 h-5 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/web/src/components/dashboards/common/yaml.jsx
+++ b/web/src/components/dashboards/common/yaml.jsx
@@ -13,14 +13,36 @@ import prismDark from 'prismjs/themes/prism-tomorrow.css?url'
 
 const LINK_ID = 'prism-theme-link'
 
+// Number of mounted components currently relying on the Prism theme link. The
+// link is shared, so it is created on the first mount and removed only when the
+// last consumer unmounts — otherwise closing one consumer (e.g. a modal) would
+// strip highlighting from others still on screen.
+let prismThemeRefCount = 0
+
+// (Re)create the shared theme <link>, replacing any stale one, using the href
+// for the current theme.
+function setPrismThemeLink() {
+  const existingLink = document.getElementById(LINK_ID)
+  if (existingLink) {
+    existingLink.remove()
+  }
+  const link = document.createElement('link')
+  link.id = LINK_ID
+  link.rel = 'stylesheet'
+  link.href = appliedTheme.value === 'dark' ? prismDark : prismLight
+  document.head.appendChild(link)
+}
+
 /**
  * Hook that dynamically loads the appropriate Prism theme based on the current app theme.
  *
- * This hook manages a <link> element in the document head that loads either:
+ * This hook manages a shared <link> element in the document head that loads either:
  * - prism.css (light theme)
  * - prism-tomorrow.css (dark theme)
  *
- * The theme automatically updates when appliedTheme changes.
+ * The link is reference-counted so multiple components can use it concurrently;
+ * it is removed only when the last consumer unmounts. The theme automatically
+ * updates when appliedTheme changes.
  *
  * @example
  * function MyComponent() {
@@ -30,26 +52,30 @@ const LINK_ID = 'prism-theme-link'
  * }
  */
 export function usePrismTheme() {
+  // Manage the shared link on first mount / last unmount.
   useEffect(() => {
-    // Remove existing Prism theme link if present
-    const existingLink = document.getElementById(LINK_ID)
-    if (existingLink) {
-      existingLink.remove()
+    if (prismThemeRefCount === 0) {
+      setPrismThemeLink()
     }
+    prismThemeRefCount++
 
-    // Add new theme link based on current theme
-    const link = document.createElement('link')
-    link.id = LINK_ID
-    link.rel = 'stylesheet'
-    link.href = appliedTheme.value === 'dark' ? prismDark : prismLight
-    document.head.appendChild(link)
-
-    // Cleanup on unmount
     return () => {
-      const link = document.getElementById(LINK_ID)
-      if (link) {
-        link.remove()
+      prismThemeRefCount--
+      if (prismThemeRefCount === 0) {
+        const link = document.getElementById(LINK_ID)
+        if (link) {
+          link.remove()
+        }
       }
+    }
+  }, [])
+
+  // Update the href in place when the theme changes, without disturbing the
+  // reference count or removing the link other consumers still rely on.
+  useEffect(() => {
+    const link = document.getElementById(LINK_ID)
+    if (link) {
+      link.href = appliedTheme.value === 'dark' ? prismDark : prismLight
     }
   }, [appliedTheme.value])
 }

--- a/web/src/components/dashboards/common/yaml.test.jsx
+++ b/web/src/components/dashboards/common/yaml.test.jsx
@@ -77,6 +77,21 @@ describe('usePrismTheme', () => {
     expect(document.getElementById(LINK_ID)).toBeNull()
   })
 
+  it('keeps the link while another consumer is still mounted (reference counted)', () => {
+    // Two components use the shared theme link concurrently.
+    const first = renderHook(() => usePrismTheme())
+    const second = renderHook(() => usePrismTheme())
+    expect(document.getElementById(LINK_ID)).not.toBeNull()
+
+    // Unmounting one must NOT remove the link the other still relies on.
+    first.unmount()
+    expect(document.getElementById(LINK_ID)).not.toBeNull()
+
+    // Removed only once the last consumer unmounts.
+    second.unmount()
+    expect(document.getElementById(LINK_ID)).toBeNull()
+  })
+
   it('should recreate link when theme changes', async () => {
     appliedTheme.value = 'light'
 

--- a/web/src/components/dashboards/resource/ActionBar.jsx
+++ b/web/src/components/dashboards/resource/ActionBar.jsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useRef } from 'preact/hooks'
 import { fetchWithMock } from '../../../utils/fetch'
+import { downloadBlob } from '../../../utils/download'
 
 /**
  * ActionBar - Action buttons for Flux resources (Reconcile, Reconcile Source, Suspend/Resume)
@@ -198,16 +199,7 @@ export function ActionBar({ kind, namespace, name, resourceData, onActionComplet
       }
 
       const blob = await response.blob()
-      const blobUrl = window.URL.createObjectURL(blob)
-
-      const a = document.createElement('a')
-      a.href = blobUrl
-      a.download = `${kind}-${namespace}-${name}.tar.gz`
-      document.body.appendChild(a)
-      a.click()
-
-      document.body.removeChild(a)
-      window.URL.revokeObjectURL(blobUrl)
+      downloadBlob(blob, `${kind}-${namespace}-${name}.tar.gz`)
     } catch (err) {
       setError(err.message)
     } finally {
@@ -232,16 +224,7 @@ export function ActionBar({ kind, namespace, name, resourceData, onActionComplet
       }
 
       const blob = await response.blob()
-      const blobUrl = window.URL.createObjectURL(blob)
-
-      const a = document.createElement('a')
-      a.href = blobUrl
-      a.download = artifact.filename || `${artifact.name}.tar.gz`
-      document.body.appendChild(a)
-      a.click()
-
-      document.body.removeChild(a)
-      window.URL.revokeObjectURL(blobUrl)
+      downloadBlob(blob, artifact.filename || `${artifact.name}.tar.gz`)
     } catch (err) {
       setError(err.message)
     } finally {

--- a/web/src/components/dashboards/resource/GraphTabContent.jsx
+++ b/web/src/components/dashboards/resource/GraphTabContent.jsx
@@ -4,6 +4,7 @@
 import { useMemo, useState, useEffect } from 'preact/hooks'
 import { fluxKinds, isFluxInventoryItem, isWorkloadInventoryItem } from '../../../utils/constants'
 import { fetchWithMock } from '../../../utils/fetch'
+import { getDashboardUrl } from '../../../utils/routing'
 
 /**
  * Build graph data from resource data
@@ -251,13 +252,14 @@ function NodeCard({ kind, name, namespace, status, revision, version, url, messa
  * @param {array|object} items - Array of items (for itemList mode) or object of kind counts
  * @param {boolean} isItemList - If true, renders individual items; if false, renders grouped counts
  * @param {function} onItemClick - Click handler for individual items
+ * @param {function} getItemHref - Optional function returning a dashboard link for an item; when set, the item name renders as an anchor
  * @param {function} onTitleClick - Click handler for the title
  * @param {boolean} alwaysShow - If true, always render even with no items
  * @param {boolean} isProgressing - If true, applies blue border styling
  * @param {object} itemStatuses - Optional map of item key to status for displaying status dots
  * @param {string} defaultNamespace - Default namespace for items without explicit namespace
  */
-function GroupCard({ title, count, items, isItemList, onItemClick, onTitleClick, alwaysShow, isProgressing, itemStatuses, defaultNamespace }) {
+function GroupCard({ title, count, items, isItemList, onItemClick, getItemHref, onTitleClick, alwaysShow, isProgressing, itemStatuses, defaultNamespace }) {
   const hasItems = isItemList ? items.length > 0 : Object.keys(items).length > 0
 
   if (!hasItems && !alwaysShow) return null
@@ -288,6 +290,7 @@ function GroupCard({ title, count, items, isItemList, onItemClick, onTitleClick,
           items.map((item, idx) => {
             const isClickable = onItemClick && isFluxInventoryItem(item)
             const resolvedNamespace = item.namespace || defaultNamespace
+            const itemHref = getItemHref?.(item)
             const itemKey = `${item.kind}/${resolvedNamespace}/${item.name}`
             const itemData = itemStatuses?.[itemKey]
             const itemStatus = itemData?.status
@@ -304,12 +307,22 @@ function GroupCard({ title, count, items, isItemList, onItemClick, onTitleClick,
                 tabIndex={isClickable ? 0 : undefined}
               >
                 <div class="text-xs text-gray-500 dark:text-gray-400">{item.kind}</div>
-                <div
-                  class={`text-sm truncate ${isClickable ? 'hover:underline hover:text-flux-blue dark:hover:text-blue-400 cursor-pointer' : ''} font-medium`}
-                  title={`${item.namespace}/${item.name}`}
-                >
-                  {item.name}{isClickable && ' →'}
-                </div>
+                {itemHref ? (
+                  <a
+                    href={itemHref}
+                    class="block text-sm truncate hover:underline hover:text-flux-blue dark:hover:text-blue-400 cursor-pointer font-medium text-gray-900 dark:text-white"
+                    title={`${resolvedNamespace}/${item.name}`}
+                  >
+                    {item.name} →
+                  </a>
+                ) : (
+                  <div
+                    class={`text-sm truncate ${isClickable ? 'hover:underline hover:text-flux-blue dark:hover:text-blue-400 cursor-pointer' : ''} font-medium`}
+                    title={`${item.namespace}/${item.name}`}
+                  >
+                    {item.name}{isClickable && ' →'}
+                  </div>
+                )}
                 {itemStatusMessage && (
                   <div class="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5 flex items-center gap-1.5" title={itemStatusMessage} data-testid="workload-status-message">
                     {itemStatus !== undefined && (
@@ -768,7 +781,7 @@ export function GraphTabContent({ resourceData, namespace, onNavigate, setActive
                 count={workloadsCount}
                 items={workloads}
                 isItemList={true}
-                onTitleClick={setActiveTab ? () => setActiveTab('workloads') : undefined}
+                getItemHref={(item) => getDashboardUrl(item.kind, item.namespace || namespace, item.name)}
                 isProgressing={reconciler.status === 'Progressing'}
                 itemStatuses={workloadStatuses}
                 defaultNamespace={namespace}

--- a/web/src/components/dashboards/resource/GraphTabContent.jsx
+++ b/web/src/components/dashboards/resource/GraphTabContent.jsx
@@ -1,9 +1,8 @@
 // Copyright 2025 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { useMemo, useState, useEffect } from 'preact/hooks'
+import { useMemo } from 'preact/hooks'
 import { fluxKinds, isFluxInventoryItem, isWorkloadInventoryItem } from '../../../utils/constants'
-import { fetchWithMock } from '../../../utils/fetch'
 import { getDashboardUrl } from '../../../utils/routing'
 
 /**
@@ -264,6 +263,11 @@ function GroupCard({ title, count, items, isItemList, onItemClick, getItemHref, 
 
   if (!hasItems && !alwaysShow) return null
 
+  // Only groups that carry live status (workloads) show a "computing..."
+  // placeholder while the status fetch is in flight, keeping the row structure
+  // stable from first paint instead of popping the status in.
+  const isStatusTracked = itemStatuses != null
+
   // Check if all items share the same namespace (for item lists)
   // Use resolved namespaces to account for items without explicit namespace
   const showNamespace = isItemList && items.length > 0 && (() => {
@@ -323,7 +327,12 @@ function GroupCard({ title, count, items, isItemList, onItemClick, getItemHref, 
                     {item.name}{isClickable && ' →'}
                   </div>
                 )}
-                {itemStatusMessage && (
+                {itemStatus === undefined && isStatusTracked ? (
+                  <div class="text-xs text-gray-400 dark:text-gray-500 truncate mt-0.5 flex items-center gap-1.5 animate-pulse" data-testid="workload-status-computing">
+                    <span class="inline-block w-2 h-2 rounded-full flex-shrink-0 bg-gray-300 dark:bg-gray-600" />
+                    computing...
+                  </div>
+                ) : itemStatusMessage ? (
                   <div class="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5 flex items-center gap-1.5" title={itemStatusMessage} data-testid="workload-status-message">
                     {itemStatus !== undefined && (
                       <span
@@ -334,7 +343,7 @@ function GroupCard({ title, count, items, isItemList, onItemClick, getItemHref, 
                     )}
                     {itemStatusMessage}
                   </div>
-                )}
+                ) : null}
                 {showNamespace && (
                   <div class="text-xs text-gray-400 dark:text-gray-500 truncate">{resolvedNamespace}</div>
                 )}
@@ -520,58 +529,12 @@ function SourcesConnector({ sourceCount }) {
  * @param {string} namespace - Default namespace for items without explicit namespace
  * @param {function} onNavigate - Callback for navigation to other resources
  * @param {function} setActiveTab - Callback to switch tabs
- * @param {boolean} isActive - Whether this tab is currently active (controls workload fetching)
+ * @param {object} workloadStatuses - Map of workload key to {status, statusMessage},
+ *   fetched and owned by InventoryPanel so it is shared with the Workloads tab and
+ *   survives tab switches
  */
-export function GraphTabContent({ resourceData, namespace, onNavigate, setActiveTab, isActive = true }) {
+export function GraphTabContent({ resourceData, namespace, onNavigate, setActiveTab, workloadStatuses = {} }) {
   const graphData = useMemo(() => buildGraphData(resourceData), [resourceData])
-  const [workloadStatuses, setWorkloadStatuses] = useState({})
-
-  // Fetch workload statuses when tab is active and resourceData changes
-  useEffect(() => {
-    // Skip if tab is not active or no workloads
-    if (!isActive || graphData.inventory.workloads.length === 0) {
-      return
-    }
-
-    let cancelled = false
-
-    const fetchWorkloadStatuses = async () => {
-      try {
-        // Build workloads array with resolved namespaces
-        const workloads = graphData.inventory.workloads.map(item => ({
-          kind: item.kind,
-          name: item.name,
-          namespace: item.namespace || namespace
-        }))
-
-        // Send all workloads in a single POST request
-        const response = await fetchWithMock({
-          endpoint: '/api/v1/workloads',
-          mockPath: '../mock/workload',
-          mockExport: 'getMockWorkloads',
-          method: 'POST',
-          body: { workloads }
-        })
-
-        // Build workloadStatuses map from response (includes status and statusMessage)
-        const newStatuses = {}
-        const returnedWorkloads = response.workloads || []
-        returnedWorkloads.forEach(workload => {
-          const key = `${workload.kind}/${workload.namespace}/${workload.name}`
-          newStatuses[key] = {
-            status: workload.status,
-            statusMessage: workload.statusMessage
-          }
-        })
-        if (!cancelled) setWorkloadStatuses(newStatuses)
-      } catch (err) {
-        console.error('Failed to fetch workload statuses:', err)
-      }
-    }
-
-    fetchWorkloadStatuses()
-    return () => { cancelled = true }
-  }, [isActive, resourceData, namespace, graphData.inventory.workloads])
 
   const { upstream, sources, helmChart, reconciler, inventory } = graphData
   const { flux, workloads, resources } = inventory

--- a/web/src/components/dashboards/resource/GraphTabContent.test.jsx
+++ b/web/src/components/dashboards/resource/GraphTabContent.test.jsx
@@ -608,6 +608,20 @@ describe('GraphTabContent component', () => {
     expect(screen.getByText(/^Resources \(2\)/)).toBeInTheDocument()
   })
 
+  it('should show a computing placeholder only for workloads until status resolves', () => {
+    render(
+      <GraphTabContent
+        resourceData={mockResourceData}
+        namespace="flux-system"
+      />
+    )
+
+    // Inventory has 2 Flux resources and 2 workloads; only the workloads group
+    // tracks live status, so exactly the 2 workload rows show the placeholder
+    // on first paint (Flux rows never do).
+    expect(screen.getAllByTestId('workload-status-computing')).toHaveLength(2)
+  })
+
   it('should render source URL as subtext', () => {
     render(
       <GraphTabContent
@@ -1440,79 +1454,57 @@ describe('formatWorkloadGraphMessage function', () => {
   })
 })
 
-describe('GraphTabContent workload status fetching', () => {
-  it('should not fetch workloads when isActive is false', () => {
-    const fetchSpy = vi.spyOn(global, 'fetch')
-
-    const resourceData = {
-      kind: 'Kustomization',
-      metadata: { name: 'test-ks', namespace: 'flux-system' },
-      status: {
-        reconcilerRef: { status: 'Ready' },
-        inventory: [
-          { apiVersion: 'apps/v1', kind: 'Deployment', name: 'app1', namespace: 'default' }
-        ]
-      }
+describe('GraphTabContent workload status', () => {
+  const resourceData = {
+    kind: 'Kustomization',
+    metadata: { name: 'test-ks', namespace: 'flux-system' },
+    status: {
+      reconcilerRef: { status: 'Ready' },
+      inventory: [
+        { apiVersion: 'apps/v1', kind: 'Deployment', name: 'app1', namespace: 'default' }
+      ]
     }
+  }
 
+  it('should show a computing placeholder for workloads when no statuses are provided', () => {
     render(
       <GraphTabContent
         resourceData={resourceData}
         namespace="flux-system"
-        isActive={false}
       />
     )
 
-    // Workloads group should still render
-    expect(screen.getByText(/Workloads \(1\)/)).toBeInTheDocument()
-
-    // But fetch should not have been called for workloads
-    expect(fetchSpy).not.toHaveBeenCalledWith('/api/v1/workloads', expect.anything())
-
-    fetchSpy.mockRestore()
-  })
-
-  it('should render workloads without status dots when no data fetched', () => {
-    const resourceData = {
-      kind: 'Kustomization',
-      metadata: { name: 'test-ks', namespace: 'flux-system' },
-      status: {
-        reconcilerRef: { status: 'Ready' },
-        inventory: [
-          { apiVersion: 'apps/v1', kind: 'Deployment', name: 'app1', namespace: 'default' }
-        ]
-      }
-    }
-
-    render(
-      <GraphTabContent
-        resourceData={resourceData}
-        namespace="flux-system"
-        isActive={false}
-      />
-    )
-
-    // Workload name should be visible as a dashboard link
+    // Workload name renders as a dashboard link with the placeholder, no real dot
     expect(screen.getByText('app1 →')).toBeInTheDocument()
-
-    // But no status dots should be rendered
+    expect(screen.getByTestId('workload-status-computing')).toBeInTheDocument()
     expect(screen.queryByTestId('workload-status-dot')).not.toBeInTheDocument()
   })
 
-  it('should default isActive to true', () => {
-    const resourceData = {
-      kind: 'Kustomization',
-      metadata: { name: 'test-ks', namespace: 'flux-system' },
-      status: {
-        reconcilerRef: { status: 'Ready' },
-        inventory: []
-      }
-    }
-
-    // Should render without error when isActive is not provided
+  it('should render a status dot when workloadStatuses is provided', () => {
     render(
       <GraphTabContent
         resourceData={resourceData}
+        namespace="flux-system"
+        workloadStatuses={{ 'Deployment/default/app1': { status: 'Current', statusMessage: 'Replicas: 3' } }}
+      />
+    )
+
+    expect(screen.getByTestId('workload-status-dot')).toBeInTheDocument()
+    expect(screen.getByText('Replicas: 3')).toBeInTheDocument()
+    // The placeholder is replaced by the real status
+    expect(screen.queryByTestId('workload-status-computing')).not.toBeInTheDocument()
+  })
+
+  it('should render without error when workloadStatuses is omitted', () => {
+    const emptyResource = {
+      kind: 'Kustomization',
+      metadata: { name: 'test-ks', namespace: 'flux-system' },
+      status: { reconcilerRef: { status: 'Ready' }, inventory: [] }
+    }
+
+    render(
+      <GraphTabContent
+        resourceData={emptyResource}
         namespace="flux-system"
       />
     )

--- a/web/src/components/dashboards/resource/GraphTabContent.test.jsx
+++ b/web/src/components/dashboards/resource/GraphTabContent.test.jsx
@@ -699,8 +699,7 @@ describe('GraphTabContent component', () => {
     })
   })
 
-  it('should call setActiveTab when clicking Workloads title', async () => {
-    const user = userEvent.setup()
+  it('should not make the Workloads title clickable', () => {
     const setActiveTab = vi.fn()
 
     render(
@@ -711,11 +710,25 @@ describe('GraphTabContent component', () => {
       />
     )
 
-    // Find and click the Workloads title
-    const workloadsTitle = screen.getByText('Workloads (2) →')
-    await user.click(workloadsTitle)
+    // The Workloads title has no arrow and is not a navigation target
+    expect(screen.queryByText('Workloads (2) →')).not.toBeInTheDocument()
+    expect(screen.getByText(/Workloads \(2\)/)).toBeInTheDocument()
+  })
 
-    expect(setActiveTab).toHaveBeenCalledWith('workloads')
+  it('should link each workload item to its workload dashboard', () => {
+    render(
+      <GraphTabContent
+        resourceData={mockResourceData}
+        namespace="flux-system"
+      />
+    )
+
+    // Each workload name renders as a link to the workload dashboard
+    const app1Link = screen.getByText('app1 →').closest('a')
+    expect(app1Link).toHaveAttribute('href', '/workload/Deployment/default/app1')
+
+    const app2Link = screen.getByText('app2 →').closest('a')
+    expect(app2Link).toHaveAttribute('href', '/workload/Deployment/default/app2')
   })
 
   it('should call setActiveTab when clicking Resources title', async () => {
@@ -886,9 +899,9 @@ describe('GraphTabContent component', () => {
       />
     )
 
-    // Check workload items are rendered individually
-    expect(screen.getByText('app1')).toBeInTheDocument()
-    expect(screen.getByText('app2')).toBeInTheDocument()
+    // Check workload items are rendered individually as dashboard links
+    expect(screen.getByText('app1 →')).toBeInTheDocument()
+    expect(screen.getByText('app2 →')).toBeInTheDocument()
   })
 
   it('should display resource counts alphabetically', () => {
@@ -1479,8 +1492,8 @@ describe('GraphTabContent workload status fetching', () => {
       />
     )
 
-    // Workload name should be visible
-    expect(screen.getByText('app1')).toBeInTheDocument()
+    // Workload name should be visible as a dashboard link
+    expect(screen.getByText('app1 →')).toBeInTheDocument()
 
     // But no status dots should be rendered
     expect(screen.queryByTestId('workload-status-dot')).not.toBeInTheDocument()

--- a/web/src/components/dashboards/resource/InputsPanel.jsx
+++ b/web/src/components/dashboards/resource/InputsPanel.jsx
@@ -8,6 +8,7 @@ import { DashboardPanel, TabButton } from '../common/panel'
 import { YamlBlock } from '../common/yaml'
 import { FluxOperatorIcon } from '../../layout/Icons'
 import { useHashTab } from '../../../utils/hash'
+import { getDashboardUrl } from '../../../utils/routing'
 
 // Valid tabs for the InputsPanel
 const INPUTS_TABS = ['overview', 'values']
@@ -220,7 +221,7 @@ export function InputsPanel({ resourceData, namespace }) {
                       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 mb-1">
                         <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
                           <a
-                            href={`/resource/ResourceSetInputProvider/${provider.namespace}/${provider.name}`}
+                            href={getDashboardUrl('ResourceSetInputProvider', provider.namespace, provider.name)}
                             class="text-sm font-medium text-flux-blue hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 inline-flex items-center gap-1"
                           >
                             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/web/src/components/dashboards/resource/InventoryPanel.jsx
+++ b/web/src/components/dashboards/resource/InventoryPanel.jsx
@@ -116,10 +116,16 @@ export function InventoryPanel({ resourceData, onNavigate }) {
     return resourceData.status.inventory.filter(item => isWorkloadInventoryItem(item))
   }, [resourceData, hasInventory])
 
-  // Build URL for a resource
+  // Build URL for a Flux resource
   const getResourceUrl = (item) => {
     const ns = item.namespace || resourceData.metadata.namespace
     return `/resource/${encodeURIComponent(item.kind)}/${encodeURIComponent(ns)}/${encodeURIComponent(item.name)}`
+  }
+
+  // Build URL for a workload
+  const getWorkloadUrl = (item) => {
+    const ns = item.namespace || resourceData.metadata.namespace
+    return `/workload/${encodeURIComponent(item.kind)}/${encodeURIComponent(ns)}/${encodeURIComponent(item.name)}`
   }
 
   return (
@@ -252,12 +258,20 @@ export function InventoryPanel({ resourceData, onNavigate }) {
             <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
               {sortedInventory.map((item, idx) => {
                 const isFluxResource = isFluxInventoryItem(item)
+                const isWorkload = !isFluxResource && isWorkloadInventoryItem(item)
                 return (
                   <tr key={idx} class="hover:bg-gray-50 dark:hover:bg-gray-800">
                     <td class="px-3 py-2 text-sm">
                       {isFluxResource ? (
                         <a
                           href={getResourceUrl(item)}
+                          class="text-flux-blue dark:text-blue-400 hover:underline"
+                        >
+                          {item.name}
+                        </a>
+                      ) : isWorkload ? (
+                        <a
+                          href={getWorkloadUrl(item)}
                           class="text-flux-blue dark:text-blue-400 hover:underline"
                         >
                           {item.name}

--- a/web/src/components/dashboards/resource/InventoryPanel.jsx
+++ b/web/src/components/dashboards/resource/InventoryPanel.jsx
@@ -3,6 +3,7 @@
 
 import { useMemo } from 'preact/compat'
 import { isKindWithInventory, isFluxInventoryItem, isWorkloadInventoryItem } from '../../../utils/constants'
+import { getDashboardUrl } from '../../../utils/routing'
 import { DashboardPanel, TabButton } from '../common/panel'
 import { WorkloadsTabContent } from './WorkloadsTabContent'
 import { GraphTabContent } from './GraphTabContent'
@@ -116,17 +117,10 @@ export function InventoryPanel({ resourceData, onNavigate }) {
     return resourceData.status.inventory.filter(item => isWorkloadInventoryItem(item))
   }, [resourceData, hasInventory])
 
-  // Build URL for a Flux resource
-  const getResourceUrl = (item) => {
-    const ns = item.namespace || resourceData.metadata.namespace
-    return `/resource/${encodeURIComponent(item.kind)}/${encodeURIComponent(ns)}/${encodeURIComponent(item.name)}`
-  }
-
-  // Build URL for a workload
-  const getWorkloadUrl = (item) => {
-    const ns = item.namespace || resourceData.metadata.namespace
-    return `/workload/${encodeURIComponent(item.kind)}/${encodeURIComponent(ns)}/${encodeURIComponent(item.name)}`
-  }
+  // Build the dashboard URL for an inventory item, routing workloads to the
+  // workload dashboard and Flux resources to the resource dashboard.
+  const getItemUrl = (item) =>
+    getDashboardUrl(item.kind, item.namespace || resourceData.metadata.namespace, item.name)
 
   return (
     <DashboardPanel title="Managed Objects" id="inventory-panel">
@@ -262,16 +256,9 @@ export function InventoryPanel({ resourceData, onNavigate }) {
                 return (
                   <tr key={idx} class="hover:bg-gray-50 dark:hover:bg-gray-800">
                     <td class="px-3 py-2 text-sm">
-                      {isFluxResource ? (
+                      {(isFluxResource || isWorkload) ? (
                         <a
-                          href={getResourceUrl(item)}
-                          class="text-flux-blue dark:text-blue-400 hover:underline"
-                        >
-                          {item.name}
-                        </a>
-                      ) : isWorkload ? (
-                        <a
-                          href={getWorkloadUrl(item)}
+                          href={getItemUrl(item)}
                           class="text-flux-blue dark:text-blue-400 hover:underline"
                         >
                           {item.name}

--- a/web/src/components/dashboards/resource/InventoryPanel.jsx
+++ b/web/src/components/dashboards/resource/InventoryPanel.jsx
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { useMemo } from 'preact/compat'
+import { useState, useEffect } from 'preact/hooks'
 import { isKindWithInventory, isFluxInventoryItem, isWorkloadInventoryItem } from '../../../utils/constants'
+import { fetchWithMock } from '../../../utils/fetch'
 import { getDashboardUrl } from '../../../utils/routing'
 import { DashboardPanel, TabButton } from '../common/panel'
 import { WorkloadsTabContent } from './WorkloadsTabContent'
@@ -116,6 +118,55 @@ export function InventoryPanel({ resourceData, onNavigate }) {
     if (!hasInventory) return []
     return resourceData.status.inventory.filter(item => isWorkloadInventoryItem(item))
   }, [resourceData, hasInventory])
+
+  // Live workload status (status + statusMessage) shared by the Graph and
+  // Workloads tabs. Owned here, at the panel level — not inside the tab
+  // components — so it survives tab switches: re-entering a tab shows the
+  // last-known status immediately instead of refetching and flickering the
+  // badge in. It refreshes when the inventory changes, which the parent resource
+  // poll drives, so no dedicated polling loop is needed.
+  const [workloadStatuses, setWorkloadStatuses] = useState({})
+  const tracksWorkloadStatus = activeTab === 'graph' || activeTab === 'workloads'
+  useEffect(() => {
+    if (!tracksWorkloadStatus || workloadItems.length === 0) {
+      return
+    }
+
+    let cancelled = false
+
+    const fetchWorkloadStatuses = async () => {
+      try {
+        const workloads = workloadItems.map(item => ({
+          kind: item.kind,
+          name: item.name,
+          namespace: item.namespace || resourceData.metadata.namespace
+        }))
+
+        const response = await fetchWithMock({
+          endpoint: '/api/v1/workloads',
+          mockPath: '../mock/workload',
+          mockExport: 'getMockWorkloads',
+          method: 'POST',
+          body: { workloads }
+        })
+
+        const newStatuses = {}
+        for (const workload of (response.workloads || [])) {
+          const key = `${workload.kind}/${workload.namespace}/${workload.name}`
+          newStatuses[key] = {
+            status: workload.status,
+            statusMessage: workload.statusMessage
+          }
+        }
+        if (!cancelled) setWorkloadStatuses(newStatuses)
+      } catch (err) {
+        console.error('Failed to fetch workload statuses:', err)
+      }
+    }
+
+    fetchWorkloadStatuses()
+    return () => { cancelled = true }
+  }, [tracksWorkloadStatus, workloadItems, resourceData])
 
   // Build the dashboard URL for an inventory item, routing workloads to the
   // workload dashboard and Flux resources to the resource dashboard.
@@ -236,6 +287,7 @@ export function InventoryPanel({ resourceData, onNavigate }) {
           namespace={resourceData.metadata.namespace}
           onNavigate={onNavigate}
           setActiveTab={setActiveTab}
+          workloadStatuses={workloadStatuses}
         />
       )}
 
@@ -281,6 +333,7 @@ export function InventoryPanel({ resourceData, onNavigate }) {
         <WorkloadsTabContent
           workloadItems={workloadItems}
           namespace={resourceData.metadata.namespace}
+          workloadStatuses={workloadStatuses}
         />
       )}
     </DashboardPanel>

--- a/web/src/components/dashboards/resource/InventoryPanel.test.jsx
+++ b/web/src/components/dashboards/resource/InventoryPanel.test.jsx
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen } from '@testing-library/preact'
 import userEvent from '@testing-library/user-event'
 import { InventoryPanel } from './InventoryPanel'
+import { fetchWithMock } from '../../../utils/fetch'
 import { getPanelById } from '../common/panel.test'
 
 // Mock useHashTab to use simple useState instead
@@ -14,6 +15,11 @@ vi.mock('../../../utils/hash', async () => {
     useHashTab: (panel, defaultTab) => useState(defaultTab)
   }
 })
+
+// Mock the workload status fetch the panel issues for the Graph/Workloads tabs
+vi.mock('../../../utils/fetch', () => ({
+  fetchWithMock: vi.fn(() => Promise.resolve({ workloads: [] }))
+}))
 
 describe('InventoryPanel component', () => {
   const mockKustomizationData = {
@@ -746,6 +752,46 @@ describe('InventoryPanel component', () => {
 
     // Tab should be active
     expect(workloadsTab).toHaveClass('border-flux-blue')
+  })
+
+  it('fetches workload status at the panel level and propagates it to the Workloads tab', async () => {
+    const user = userEvent.setup()
+
+    // The panel owns the fetch; return a real status for the inventory's Deployment
+    fetchWithMock.mockResolvedValueOnce({
+      workloads: [
+        {
+          kind: 'Deployment',
+          namespace: 'production',
+          name: 'app',
+          status: 'Current',
+          statusMessage: 'Deployment has minimum availability.'
+        }
+      ]
+    })
+
+    render(
+      <InventoryPanel
+        resourceData={mockKustomizationData}
+        onNavigate={mockOnNavigate}
+      />
+    )
+
+    await user.click(screen.getByText('Workloads'))
+
+    // The fetched status renders as a badge in the tab row, replacing the placeholder
+    expect(await screen.findByText('Ready')).toBeInTheDocument()
+    expect(screen.queryByTestId('workload-status-computing')).not.toBeInTheDocument()
+
+    // The panel issued the batch POST with the resolved workload
+    expect(fetchWithMock).toHaveBeenCalledWith(expect.objectContaining({
+      endpoint: '/api/v1/workloads',
+      method: 'POST',
+      body: { workloads: [{ kind: 'Deployment', name: 'app', namespace: 'production' }] }
+    }))
+
+    // And the row links to the dedicated workload dashboard
+    expect(document.querySelector('a[href="/workload/Deployment/production/app"]')).not.toBeNull()
   })
 
   it('should not show Workloads tab when there are no workload items', () => {

--- a/web/src/components/dashboards/resource/ReconcilerPanel.jsx
+++ b/web/src/components/dashboards/resource/ReconcilerPanel.jsx
@@ -5,6 +5,7 @@ import { useMemo, useEffect, useRef, useState } from 'preact/hooks'
 import { fetchWithMock } from '../../../utils/fetch'
 import { formatTimestamp } from '../../../utils/time'
 import { getControllerName, getKindAlias } from '../../../utils/constants'
+import { getDashboardUrl } from '../../../utils/routing'
 import { DashboardPanel, TabButton } from '../common/panel'
 import { YamlBlock } from '../common/yaml'
 import { getStatusBadgeClass, getEventBadgeClass, cleanStatus } from '../../../utils/status'
@@ -265,7 +266,7 @@ export function ReconcilerPanel({ kind, name, namespace, resourceData }) {
                   const [refKind, refNamespace, refName] = reconcilerRef.managedBy.split('/')
                   return (
                     <a
-                      href={`/resource/${encodeURIComponent(refKind)}/${encodeURIComponent(refNamespace)}/${encodeURIComponent(refName)}`}
+                      href={getDashboardUrl(refKind, refNamespace, refName)}
                       class="ml-1 text-flux-blue dark:text-blue-400 hover:underline"
                     >
                       <span class="hidden md:inline break-all">{reconcilerRef.managedBy}</span>

--- a/web/src/components/dashboards/resource/ResourcePage.jsx
+++ b/web/src/components/dashboards/resource/ResourcePage.jsx
@@ -17,6 +17,7 @@ import { ArtifactPanel } from './ArtifactPanel'
 import { ExportedInputsPanel } from './ExportedInputsPanel'
 import { InputsPanel } from './InputsPanel'
 import { isKindWithInventory, POLL_INTERVAL_MS, FAST_POLL_INTERVAL_MS, FAST_POLL_TIMEOUT_MS } from '../../../utils/constants'
+import { getDashboardUrl } from '../../../utils/routing'
 
 /**
  * Get loading status styling info with spinning refresh icon
@@ -266,7 +267,7 @@ export function ResourcePage({ kind, namespace, name }) {
   // Navigate to another resource
   const handleNavigate = (item) => {
     const ns = item.namespace || namespace
-    const basePath = `/resource/${encodeURIComponent(item.kind)}/${encodeURIComponent(ns)}/${encodeURIComponent(item.name)}`
+    const basePath = getDashboardUrl(item.kind, ns, item.name)
     // If navigating to a resource that has inventory (from Graph), deep link to its Graph tab
     const hash = isKindWithInventory(item.kind) ? '#inventory-graph' : ''
     location.route(basePath + hash)

--- a/web/src/components/dashboards/resource/SourcePanel.jsx
+++ b/web/src/components/dashboards/resource/SourcePanel.jsx
@@ -4,6 +4,7 @@
 import { useState, useMemo, useEffect, useRef } from 'preact/hooks'
 import { fetchWithMock } from '../../../utils/fetch'
 import { getControllerName, getKindAlias } from '../../../utils/constants'
+import { getDashboardUrl } from '../../../utils/routing'
 import { formatTimestamp } from '../../../utils/time'
 import { DashboardPanel, TabButton } from '../common/panel'
 import { YamlBlock } from '../common/yaml'
@@ -299,7 +300,7 @@ export function SourcePanel({ resourceData }) {
             <div class="space-y-4">
               {/* Resource Link */}
               <a
-                href={`/resource/${encodeURIComponent(sourceRef.kind)}/${encodeURIComponent(sourceRef.namespace || namespace)}/${encodeURIComponent(sourceRef.name)}`}
+                href={getDashboardUrl(sourceRef.kind, sourceRef.namespace || namespace, sourceRef.name)}
                 class="flex items-center gap-2 text-sm text-flux-blue dark:text-blue-400 hover:underline"
               >
                 <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -424,7 +425,7 @@ export function SourcePanel({ resourceData }) {
                 <div class="space-y-4">
                   {/* Resource Link */}
                   <a
-                    href={`/resource/HelmChart/${encodeURIComponent(helmChartRef.namespace)}/${encodeURIComponent(helmChartRef.name)}`}
+                    href={getDashboardUrl('HelmChart', helmChartRef.namespace, helmChartRef.name)}
                     class="flex items-center gap-2 text-sm text-flux-blue dark:text-blue-400 hover:underline"
                   >
                     <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/web/src/components/dashboards/resource/WorkloadsTabContent.jsx
+++ b/web/src/components/dashboards/resource/WorkloadsTabContent.jsx
@@ -1,352 +1,75 @@
 // Copyright 2025 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { useState, useEffect, useRef, useCallback } from 'preact/hooks'
-import { fetchWithMock } from '../../../utils/fetch'
-import { formatTimestamp } from '../../../utils/time'
 import { getWorkloadStatusBadgeClass, formatWorkloadStatus } from '../../../utils/status'
 import { formatScheduleMessage } from '../../../utils/cron'
-import { FluxOperatorIcon } from '../../layout/Icons'
-import { WorkloadActionBar } from './WorkloadActionBar'
-import { WorkloadDeleteAction } from './WorkloadDeleteAction'
-
-// Polling intervals
-const NORMAL_POLL_INTERVAL = 10000 // 10 seconds
-const FAST_POLL_INTERVAL = 5000 // 5 seconds
-const FAST_POLL_DURATION = 60000 // 60 seconds
-
-// Highlight threshold for recently changed pods
-const RECENT_POD_THRESHOLD = 30000 // 30 seconds
+import { getDashboardUrl } from '../../../utils/routing'
 
 /**
- * Check if a timestamp is within the recent threshold
- * @param {string} timestamp - ISO timestamp string
- * @returns {boolean} true if the timestamp is within the last 30 seconds
+ * WorkloadsTabContent - Launchpad list of the Kubernetes workloads managed by a
+ * Flux resource. Each row shows the workload's aggregate status and links to the
+ * dedicated workload dashboard, where pods, container images, logs, events and
+ * actions live.
+ *
+ * Status (status + statusMessage only — not pods, images, or actions) is fetched
+ * and owned by InventoryPanel and passed in via workloadStatuses, so it is shared
+ * with the Graph tab and survives tab switches without refetching.
+ *
+ * @param {array} workloadItems - Inventory items of workload kinds
+ * @param {string} namespace - Default namespace for items without explicit namespace
+ * @param {object} workloadStatuses - Map of workload key to {status, statusMessage}
  */
-function isRecentTimestamp(timestamp) {
-  if (!timestamp) return false
-  const podTime = new Date(timestamp).getTime()
-  const now = Date.now()
-  return (now - podTime) < RECENT_POD_THRESHOLD
-}
-
-/**
- * WorkloadsTabContent - Displays detailed Kubernetes workload information
- * Handles data fetching and state management for workload details
- */
-export function WorkloadsTabContent({ workloadItems, namespace }) {
-  // State
-  const [workloadsData, setWorkloadsData] = useState({})
-  const [loading, setLoading] = useState(true)
-  const [expandedWorkloads, setExpandedWorkloads] = useState({})
-  const [pollInterval, setPollInterval] = useState(NORMAL_POLL_INTERVAL)
-  const [pendingDeletions, setPendingDeletions] = useState(new Set())
-
-  // Refs for polling and initial load tracking
-  const fastPollTimeoutRef = useRef(null)
-  const hasLoadedRef = useRef(false)
-
-  // Fetch workloads data function
-  const fetchWorkloadsData = useCallback(async () => {
-    // Only show loading spinner on initial load
-    if (!hasLoadedRef.current) {
-      setLoading(true)
-    }
-
-    try {
-      // Build workloads array with resolved namespaces
-      const workloads = workloadItems.map(item => ({
-        kind: item.kind,
-        name: item.name,
-        namespace: item.namespace || namespace
-      }))
-
-      // Send all workloads in a single POST request
-      const response = await fetchWithMock({
-        endpoint: '/api/v1/workloads',
-        mockPath: '../mock/workload',
-        mockExport: 'getMockWorkloads',
-        method: 'POST',
-        body: { workloads }
-      })
-
-      // Build workloadsData map from response
-      const newWorkloadsData = {}
-      const returnedWorkloads = response.workloads || []
-      returnedWorkloads.forEach(workload => {
-        const key = `${workload.kind}/${workload.namespace}/${workload.name}`
-        newWorkloadsData[key] = workload
-      })
-      setWorkloadsData(newWorkloadsData)
-      hasLoadedRef.current = true
-
-      // Clean up pending deletions for pods that have disappeared
-      setPendingDeletions(prev => {
-        if (prev.size === 0) return prev
-        const allPodNames = new Set()
-        for (const w of returnedWorkloads) {
-          for (const pod of (w.pods || [])) {
-            allPodNames.add(pod.name)
-          }
-        }
-        const next = new Set([...prev].filter(name => allPodNames.has(name)))
-        return next.size === prev.size ? prev : next
-      })
-    } catch (err) {
-      console.error('Failed to fetch workloads:', err)
-    } finally {
-      setLoading(false)
-    }
-  }, [workloadItems, namespace])
-
-  // Initial fetch and polling
-  useEffect(() => {
-    fetchWorkloadsData()
-
-    const intervalId = window.setInterval(fetchWorkloadsData, pollInterval)
-    return () => window.clearInterval(intervalId)
-  }, [workloadItems, namespace, pollInterval])
-
-  // Cleanup fast poll timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (fastPollTimeoutRef.current) {
-        window.clearTimeout(fastPollTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  // Handler for when an action starts - speed up polling
-  const handleActionStart = useCallback(() => {
-    // Clear any existing fast poll timeout
-    if (fastPollTimeoutRef.current) {
-      window.clearTimeout(fastPollTimeoutRef.current)
-    }
-
-    // Switch to fast polling
-    setPollInterval(FAST_POLL_INTERVAL)
-
-    // Set timeout to return to normal polling
-    fastPollTimeoutRef.current = window.setTimeout(() => {
-      setPollInterval(NORMAL_POLL_INTERVAL)
-    }, FAST_POLL_DURATION)
-  }, [])
-
-  // Track pod deletion start - keeps spinner visible until the pod disappears
-  const handlePodDeleteStart = useCallback((podName) => {
-    setPendingDeletions(prev => new Set([...prev, podName]))
-  }, [])
-
-  // Remove pod from pending deletions on error so the error message is visible
-  const handlePodDeleteFailed = useCallback((podName) => {
-    setPendingDeletions(prev => {
-      const next = new Set(prev)
-      next.delete(podName)
-      return next
-    })
-  }, [])
-
-  // Toggle workload expansion
-  const toggleWorkloadExpansion = (key) => {
-    setExpandedWorkloads(prev => ({
-      ...prev,
-      [key]: !prev[key]
-    }))
-  }
-
-  // Show loading state
-  if (loading) {
-    return (
-      <div class="flex items-center justify-center p-8">
-        <FluxOperatorIcon className="animate-spin h-8 w-8 text-flux-blue" />
-        <span class="ml-3 text-gray-600 dark:text-gray-400">Loading workloads...</span>
-      </div>
-    )
-  }
-
-  // Render workload list
+export function WorkloadsTabContent({ workloadItems, namespace, workloadStatuses = {} }) {
+  // Render the workload list. Rows render immediately from props; the status
+  // badge and message fill in once statuses arrive (no blocking loader).
   return (
     <div class="space-y-4">
       {workloadItems.map((item) => {
-        const key = `${item.kind}/${item.namespace || namespace}/${item.name}`
-        const workload = workloadsData[key]
-        const isExpanded = expandedWorkloads[key]
-
-        // Get most recent pod timestamp
-        const mostRecentTimestamp = workload?.pods?.length > 0
-          ? workload.pods.reduce((latest, pod) => {
-            if (!pod.createdAt) return latest
-            if (!latest) return pod.createdAt
-            return new Date(pod.createdAt) > new Date(latest) ? pod.createdAt : latest
-          }, null)
-          : null
-
-        // Find the most recent triggered pod (has createdBy set)
-        const triggeredPod = workload?.pods?.length > 0
-          ? workload.pods.reduce((latest, pod) => {
-            if (!pod.createdBy || !pod.createdAt) return latest
-            if (!latest) return pod
-            return new Date(pod.createdAt) > new Date(latest.createdAt) ? pod : latest
-          }, null)
-          : null
+        const resolvedNamespace = item.namespace || namespace
+        const key = `${item.kind}/${resolvedNamespace}/${item.name}`
+        const status = workloadStatuses[key]
 
         return (
-          <div key={key} class="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
-            {/* Workload Header */}
-            <button
-              onClick={() => toggleWorkloadExpansion(key)}
-              class="w-full px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
-            >
-              <div class="flex items-center justify-between">
-                <div class="flex-grow min-w-0 mr-2">
-                  {/* Line 1: KIND (uppercase) with Status badge and timestamp */}
-                  <div class="flex items-center justify-between mb-1">
-                    <div class="flex items-center gap-3">
-                      <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
-                        {item.kind}
-                      </span>
-                      {workload && (
-                        <span class={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getWorkloadStatusBadgeClass(workload.status)}`}>
-                          {formatWorkloadStatus(workload.status)}
-                        </span>
-                      )}
-                    </div>
-                    {mostRecentTimestamp && (
-                      <span class="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap ml-4">
-                        {formatTimestamp(mostRecentTimestamp)}
-                      </span>
-                    )}
-                  </div>
-                  {/* Line 2: Namespace/Name */}
-                  <div class="text-sm mt-1">
-                    <span class="text-gray-500 dark:text-gray-400">{item.namespace || namespace}/</span>
-                    <span class="font-semibold text-gray-900 dark:text-gray-100">{item.name}</span>
-                  </div>
-                  {/* Line 3: StatusMessage */}
-                  {workload && workload.statusMessage && (
-                    <div class="text-sm text-gray-700 dark:text-gray-300 mt-1 break-all">
-                      {formatScheduleMessage(workload.statusMessage)}
-                    </div>
-                  )}
+          <a
+            key={key}
+            href={getDashboardUrl(item.kind, resolvedNamespace, item.name)}
+            class="group flex items-center gap-2 border border-gray-200 dark:border-gray-700 rounded-md px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+          >
+            <div class="flex-grow min-w-0">
+              {/* Line 1: KIND (uppercase) with status badge */}
+              <div class="flex items-center gap-3 mb-1">
+                <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
+                  {item.kind}
+                </span>
+                {status ? (
+                  <span class={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getWorkloadStatusBadgeClass(status.status)}`}>
+                    {formatWorkloadStatus(status.status)}
+                  </span>
+                ) : (
+                  // Placeholder until live status arrives, so the row keeps its
+                  // shape from first paint instead of flickering the badge in.
+                  <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400 animate-pulse" data-testid="workload-status-computing">
+                    computing...
+                  </span>
+                )}
+              </div>
+              {/* Line 2: Namespace/Name */}
+              <div class="text-sm truncate">
+                <span class="text-gray-500 dark:text-gray-400">{resolvedNamespace}/</span>
+                <span class="font-semibold text-gray-900 dark:text-gray-100">{item.name}</span>
+              </div>
+              {/* Line 3: StatusMessage */}
+              {status && status.statusMessage && (
+                <div class="text-sm text-gray-700 dark:text-gray-300 mt-1 break-all">
+                  {formatScheduleMessage(status.statusMessage)}
                 </div>
-                <svg
-                  class={`w-4 h-4 text-gray-400 dark:text-gray-500 transition-transform flex-shrink-0 ml-2 ${isExpanded ? 'rotate-180' : ''}`}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-                </svg>
-              </div>
-            </button>
-
-            {/* Workload Details (Expandable) */}
-            {isExpanded && workload && (
-              <div class="px-4 py-3 bg-gray-50 dark:bg-gray-800/30 border-t border-gray-200 dark:border-gray-700">
-                {/* Action Bar - Workload actions */}
-                {(item.kind === 'Deployment' || item.kind === 'StatefulSet' || item.kind === 'DaemonSet' || item.kind === 'CronJob') && workload.userActions?.includes('restart') && (
-                  <div class="mb-3 pb-3 border-b border-gray-200 dark:border-gray-700" onClick={(e) => e.stopPropagation()}>
-                    <WorkloadActionBar
-                      kind={item.kind}
-                      namespace={item.namespace || namespace}
-                      name={item.name}
-                      status={workload.status}
-                      restartedAt={workload.restartedAt}
-                      lastTriggeredAt={triggeredPod?.createdAt}
-                      lastTriggeredPodStatus={triggeredPod?.status}
-                      userActions={workload.userActions}
-                      onActionStart={handleActionStart}
-                      onActionComplete={fetchWorkloadsData}
-                    />
-                  </div>
-                )}
-
-                {/* Container Images */}
-                {workload.containerImages && workload.containerImages.length > 0 && (
-                  <div class="mb-3">
-                    <span class="text-xs font-medium text-gray-500 dark:text-gray-400">Images</span>
-                    <div class="mt-1 space-y-1">
-                      {workload.containerImages.map((image, idx) => (
-                        <div key={idx} class="text-xs text-gray-700 dark:text-gray-300 break-all bg-white dark:bg-gray-900 px-2 py-1 rounded">
-                          {image}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Pods */}
-                {workload.pods && workload.pods.length > 0 && (
-                  <div>
-                    <span class="text-xs font-medium text-gray-500 dark:text-gray-400">Pods</span>
-                    <div class="mt-2 space-y-2">
-                      {[...workload.pods].sort((a, b) => {
-                        // Sort by timestamp descending (most recent first)
-                        // Pods without timestamps go to the end
-                        if (!a.createdAt && !b.createdAt) return 0
-                        if (!a.createdAt) return 1
-                        if (!b.createdAt) return -1
-                        return new Date(b.createdAt) - new Date(a.createdAt)
-                      }).map((pod) => {
-                        const isRecent = isRecentTimestamp(pod.createdAt)
-                        const isPendingDeletion = pendingDeletions.has(pod.name)
-                        const displayStatus = isPendingDeletion ? 'Terminating' : pod.status
-                        return (
-                          <div
-                            key={pod.name}
-                            class={`bg-white dark:bg-gray-900 rounded px-3 py-2 ${
-                              isRecent
-                                ? 'ring-2 ring-blue-400 dark:ring-blue-500 ring-opacity-50'
-                                : ''
-                            }`}
-                            data-testid={isRecent ? 'recent-pod' : undefined}
-                          >
-                            <div class="flex items-center justify-between">
-                              <span class="text-xs text-gray-900 dark:text-white truncate flex-grow mr-2">
-                                {pod.name}
-                              </span>
-                              <div class="flex items-center gap-1.5 flex-shrink-0">
-                                <span class={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getWorkloadStatusBadgeClass(displayStatus)}`}>
-                                  {formatWorkloadStatus(displayStatus)}
-                                </span>
-                                {workload.userActions?.includes('deletePods') && (
-                                  <WorkloadDeleteAction
-                                    namespace={workload.namespace}
-                                    name={pod.name}
-                                    isPendingDeletion={pendingDeletions.has(pod.name)}
-                                    onActionStart={handleActionStart}
-                                    onActionComplete={fetchWorkloadsData}
-                                    onPodDeleteStart={handlePodDeleteStart}
-                                    onPodDeleteFailed={handlePodDeleteFailed}
-                                  />
-                                )}
-                              </div>
-                            </div>
-                            {pod.statusMessage && (
-                              <p class="text-xs text-gray-600 dark:text-gray-400 mt-1 break-all">
-                                {pod.statusMessage}
-                              </p>
-                            )}
-                            {pod.createdBy && (
-                              <p class="text-xs text-gray-500 dark:text-gray-400 mt-1" data-testid="pod-created-by">
-                                Triggered by {pod.createdBy}
-                              </p>
-                            )}
-                          </div>
-                        )})}
-                    </div>
-                  </div>
-                )}
-
-                {/* No Pods */}
-                {(!workload.pods || workload.pods.length === 0) && (
-                  <p class="text-xs text-gray-500 dark:text-gray-400">
-                    {item.kind === 'CronJob' ? 'No recent jobs' : 'No pods found'}
-                  </p>
-                )}
-              </div>
-            )}
-          </div>
+              )}
+            </div>
+            {/* Navigation chevron on the right */}
+            <svg class="w-4 h-4 text-gray-400 group-hover:text-flux-blue dark:group-hover:text-blue-400 transition-colors flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </a>
         )
       })}
     </div>

--- a/web/src/components/dashboards/resource/WorkloadsTabContent.test.jsx
+++ b/web/src/components/dashboards/resource/WorkloadsTabContent.test.jsx
@@ -1,1023 +1,159 @@
 // Copyright 2025 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/preact'
-import userEvent from '@testing-library/user-event'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/preact'
 import { WorkloadsTabContent } from './WorkloadsTabContent'
-import { fetchWithMock } from '../../../utils/fetch'
-
-// Mock the fetch utility
-vi.mock('../../../utils/fetch', () => ({
-  fetchWithMock: vi.fn()
-}))
 
 describe('WorkloadsTabContent component', () => {
   const mockWorkloadItems = [
-    {
-      kind: 'Deployment',
-      name: 'podinfo',
-      namespace: 'default'
-    },
-    {
-      kind: 'StatefulSet',
-      name: 'redis',
-      namespace: 'default'
-    }
+    { kind: 'Deployment', name: 'podinfo', namespace: 'default' },
+    { kind: 'StatefulSet', name: 'redis', namespace: 'default' }
   ]
 
-  const mockDeploymentWorkload = {
-    kind: 'Deployment',
-    name: 'podinfo',
-    namespace: 'default',
-    status: 'Current',
-    statusMessage: 'Deployment has minimum availability.',
-    containerImages: ['ghcr.io/stefanprodan/podinfo:6.0.0'],
-    pods: [
-      {
-        name: 'podinfo-7d8b9c4f5d-abc12',
-        status: 'Current',
-        statusMessage: 'Pod is running',
-        createdAt: '2025-01-15T10:30:00Z'
-      },
-      {
-        name: 'podinfo-7d8b9c4f5d-def34',
-        status: 'Current',
-        statusMessage: 'Pod is running',
-        createdAt: '2025-01-15T10:30:05Z'
-      }
-    ]
+  const mockStatuses = {
+    'Deployment/default/podinfo': {
+      status: 'Current',
+      statusMessage: 'Deployment has minimum availability.'
+    },
+    'StatefulSet/default/redis': {
+      status: 'InProgress',
+      statusMessage: 'Waiting for replicas to be ready'
+    }
   }
 
-  const mockStatefulSetWorkload = {
-    kind: 'StatefulSet',
-    name: 'redis',
-    namespace: 'default',
-    status: 'InProgress',
-    statusMessage: 'Waiting for replicas to be ready',
-    containerImages: ['redis:7.0'],
-    pods: [
-      {
-        name: 'redis-0',
-        status: 'Current',
-        statusMessage: 'Pod is running',
-        createdAt: '2025-01-15T10:25:00Z'
-      },
-      {
-        name: 'redis-1',
-        status: 'InProgress',
-        statusMessage: 'Container creating. Reason: ContainerCreating',
-        createdAt: '2025-01-15T10:35:00Z'
-      }
-    ]
-  }
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-    // Default mock response for batch endpoint
-    fetchWithMock.mockImplementation(({ body }) => {
-      const workloads = body?.workloads || []
-      const results = workloads.map(w => {
-        if (w.kind === 'Deployment' && w.name === 'podinfo') return mockDeploymentWorkload
-        if (w.kind === 'StatefulSet' && w.name === 'redis') return mockStatefulSetWorkload
-        return { ...w, status: 'NotFound', statusMessage: 'Workload not found' }
-      })
-      return Promise.resolve({ workloads: results })
-    })
-  })
-
-  it('should fetch workload data with single POST request', async () => {
+  it('should render a row for each workload with kind and namespace/name', () => {
     render(
       <WorkloadsTabContent
         workloadItems={mockWorkloadItems}
         namespace="default"
+        workloadStatuses={mockStatuses}
       />
     )
 
-    await waitFor(() => {
-      expect(fetchWithMock).toHaveBeenCalledTimes(1)
-      expect(fetchWithMock).toHaveBeenCalledWith({
-        endpoint: '/api/v1/workloads',
-        mockPath: '../mock/workload',
-        mockExport: 'getMockWorkloads',
-        method: 'POST',
-        body: {
-          workloads: [
-            { kind: 'Deployment', name: 'podinfo', namespace: 'default' },
-            { kind: 'StatefulSet', name: 'redis', namespace: 'default' }
-          ]
-        }
-      })
-    })
+    const textContent = document.body.textContent
+    expect(textContent).toContain('Deployment')
+    expect(textContent).toContain('default/podinfo')
+    expect(textContent).toContain('StatefulSet')
+    expect(textContent).toContain('default/redis')
   })
 
-  it('should show loading state while fetching workload data', async () => {
-    let resolvePromise
-    const promise = new Promise((resolve) => { resolvePromise = resolve })
-    fetchWithMock.mockReturnValue(promise)
+  it('should display status badges with correct colors from provided statuses', () => {
+    render(
+      <WorkloadsTabContent
+        workloadItems={mockWorkloadItems}
+        namespace="default"
+        workloadStatuses={mockStatuses}
+      />
+    )
+
+    const readyBadge = screen.getByText('Ready')
+    expect(readyBadge).toBeInTheDocument()
+    expect(readyBadge.className).toContain('bg-green-100')
+
+    const progressingBadge = screen.getByText('Progressing')
+    expect(progressingBadge).toBeInTheDocument()
+    expect(progressingBadge.className).toContain('bg-blue-100')
+  })
+
+  it('should display the workload status message', () => {
+    render(
+      <WorkloadsTabContent
+        workloadItems={[mockWorkloadItems[0]]}
+        namespace="default"
+        workloadStatuses={mockStatuses}
+      />
+    )
+
+    expect(screen.getByText('Deployment has minimum availability.')).toBeInTheDocument()
+  })
+
+  it('should show a computing placeholder for workloads with no status yet', () => {
+    // No statuses provided: every row shows the placeholder, keeping its shape
+    render(
+      <WorkloadsTabContent
+        workloadItems={mockWorkloadItems}
+        namespace="default"
+        workloadStatuses={{}}
+      />
+    )
+
+    expect(screen.getAllByTestId('workload-status-computing')).toHaveLength(2)
+    expect(screen.queryByText('Ready')).not.toBeInTheDocument()
+  })
+
+  it('should show a real badge for known workloads and a placeholder for unknown ones', () => {
+    const partial = { 'Deployment/default/podinfo': { status: 'Current', statusMessage: 'ok' } }
 
     render(
       <WorkloadsTabContent
         workloadItems={mockWorkloadItems}
         namespace="default"
+        workloadStatuses={partial}
       />
     )
 
-    // Should show loading spinner
-    expect(screen.getByText('Loading workloads...')).toBeInTheDocument()
-    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
-
-    // Resolve the promise
-    resolvePromise({ workloads: [mockDeploymentWorkload, mockStatefulSetWorkload] })
-
-    // Wait for loading to complete
-    await waitFor(() => {
-      expect(screen.queryByText('Loading workloads...')).not.toBeInTheDocument()
-    })
+    // podinfo has a status, redis does not
+    expect(screen.getByText('Ready')).toBeInTheDocument()
+    expect(screen.getAllByTestId('workload-status-computing')).toHaveLength(1)
   })
 
-  it('should display workload list after loading', async () => {
+  it('should link each row to the dedicated workload dashboard', () => {
     render(
       <WorkloadsTabContent
         workloadItems={mockWorkloadItems}
         namespace="default"
+        workloadStatuses={mockStatuses}
       />
     )
 
-    await waitFor(() => {
-      const textContent = document.body.textContent
-      expect(textContent).toContain('default/podinfo')
-      expect(textContent).toContain('default/redis')
-    })
+    const hrefs = Array.from(document.querySelectorAll('a[href]')).map(a => a.getAttribute('href'))
+    expect(hrefs).toContain('/workload/Deployment/default/podinfo')
+    expect(hrefs).toContain('/workload/StatefulSet/default/redis')
   })
 
-  it('should display workload details with status', async () => {
-    render(
-      <WorkloadsTabContent
-        workloadItems={mockWorkloadItems}
-        namespace="default"
-      />
-    )
-
-    await waitFor(() => {
-      const textContent = document.body.textContent
-      expect(textContent).toContain('podinfo')
-      expect(textContent).toContain('Deployment')
-      expect(textContent).toContain('Ready')
-      expect(textContent).toContain('redis')
-      expect(textContent).toContain('StatefulSet')
-      expect(textContent).toContain('Progressing')
-    })
-  })
-
-  it('should expand workload to show container images and pods', async () => {
-    const user = userEvent.setup()
+  it('should use fallback namespace in both the label and the link', () => {
+    const itemsWithoutNamespace = [{ kind: 'Deployment', name: 'podinfo' }]
+    const statuses = { 'Deployment/custom-namespace/podinfo': { status: 'Current', statusMessage: 'ok' } }
 
     render(
       <WorkloadsTabContent
-        workloadItems={mockWorkloadItems}
-        namespace="default"
-      />
-    )
-
-    await waitFor(() => {
-      const textContent = document.body.textContent
-      expect(textContent).toContain('default/podinfo')
-    })
-
-    // Find and click the podinfo workload to expand it
-    const workloadButtons = screen.getAllByRole('button')
-    const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo') && btn.textContent.includes('Deployment'))
-    await user.click(podinfoButton)
-
-    // Should show container images and pods
-    await waitFor(() => {
-      const textContent = document.body.textContent
-      expect(textContent).toContain('Images')
-      expect(textContent).toContain('ghcr.io/stefanprodan/podinfo:6.0.0')
-      expect(textContent).toContain('Pods')
-      expect(textContent).toContain('podinfo-7d8b9c4f5d-abc12')
-      expect(textContent).toContain('podinfo-7d8b9c4f5d-def34')
-    })
-  })
-
-  it('should display pod status and message', async () => {
-    const user = userEvent.setup()
-
-    render(
-      <WorkloadsTabContent
-        workloadItems={mockWorkloadItems}
-        namespace="default"
-      />
-    )
-
-    await waitFor(() => {
-      const textContent = document.body.textContent
-      expect(textContent).toContain('default/podinfo')
-    })
-
-    // Expand the podinfo workload
-    const workloadButtons = screen.getAllByRole('button')
-    const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo') && btn.textContent.includes('Deployment'))
-    await user.click(podinfoButton)
-
-    // Should show pod status messages
-    await waitFor(() => {
-      const textContent = document.body.textContent
-      expect(textContent).toContain('Pod is running')
-    })
-  })
-
-  it('should display status badges with correct colors', async () => {
-    render(
-      <WorkloadsTabContent
-        workloadItems={mockWorkloadItems}
-        namespace="default"
-      />
-    )
-
-    await waitFor(() => {
-      const readyBadge = screen.getAllByText('Ready')[0]
-      expect(readyBadge).toBeInTheDocument()
-      expect(readyBadge.className).toContain('bg-green-100')
-
-      const progressingBadge = screen.getByText('Progressing')
-      expect(progressingBadge).toBeInTheDocument()
-      expect(progressingBadge.className).toContain('bg-blue-100')
-    })
-  })
-
-  it('should handle fetch error gracefully', async () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    fetchWithMock.mockRejectedValue(new Error('Network error'))
-
-    render(
-      <WorkloadsTabContent
-        workloadItems={mockWorkloadItems}
-        namespace="default"
-      />
-    )
-
-    // Wait for fetch to complete
-    await waitFor(() => {
-      expect(fetchWithMock).toHaveBeenCalled()
-    })
-
-    // Component should still render, just without complete data
-    await waitFor(() => {
-      const textContent = document.body.textContent
-      expect(textContent).toContain('default/podinfo')
-    })
-
-    consoleErrorSpy.mockRestore()
-  })
-
-  it('should use fallback namespace when workload namespace is missing', async () => {
-    const workloadItemsWithoutNamespace = [
-      {
-        kind: 'Deployment',
-        name: 'podinfo'
-        // namespace missing
-      }
-    ]
-
-    render(
-      <WorkloadsTabContent
-        workloadItems={workloadItemsWithoutNamespace}
+        workloadItems={itemsWithoutNamespace}
         namespace="custom-namespace"
+        workloadStatuses={statuses}
       />
     )
 
-    await waitFor(() => {
-      expect(fetchWithMock).toHaveBeenCalledWith({
-        endpoint: '/api/v1/workloads',
-        mockPath: '../mock/workload',
-        mockExport: 'getMockWorkloads',
-        method: 'POST',
-        body: {
-          workloads: [
-            { kind: 'Deployment', name: 'podinfo', namespace: 'custom-namespace' }
-          ]
-        }
-      })
-    })
+    expect(document.body.textContent).toContain('custom-namespace/podinfo')
+    const link = document.querySelector('a[href]')
+    expect(link.getAttribute('href')).toBe('/workload/Deployment/custom-namespace/podinfo')
   })
 
-  it('should display status message in workload header', async () => {
-    const singleWorkloadItem = [{
-      kind: 'Deployment',
-      name: 'podinfo',
-      namespace: 'default'
-    }]
-
+  it('should not render an expandable drawer (no buttons, images, or action bar)', () => {
     render(
       <WorkloadsTabContent
-        workloadItems={singleWorkloadItem}
+        workloadItems={[mockWorkloadItems[0]]}
         namespace="default"
+        workloadStatuses={mockStatuses}
       />
     )
 
-    // Should show status message in header (no need to expand)
-    await waitFor(() => {
-      expect(screen.getByText('Deployment has minimum availability.')).toBeInTheDocument()
-    })
-
-    // Should NOT show "Status Message" label (it's not a section anymore)
-    expect(screen.queryByText('Status Message')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+    expect(screen.queryByTestId('workload-action-bar')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('delete-pod-button')).not.toBeInTheDocument()
+    expect(screen.queryByText('Images')).not.toBeInTheDocument()
+    expect(screen.queryByText('Pods')).not.toBeInTheDocument()
   })
 
-  it('should display workload header with uppercase kind, namespace/name, and status badge', async () => {
-    const singleWorkloadItem = [{
-      kind: 'Deployment',
-      name: 'podinfo',
-      namespace: 'default'
-    }]
-
-    render(
+  it('should render nothing when there are no workloads', () => {
+    const { container } = render(
       <WorkloadsTabContent
-        workloadItems={singleWorkloadItem}
+        workloadItems={[]}
         namespace="default"
+        workloadStatuses={{}}
       />
     )
 
-    await waitFor(() => {
-      const textContent = document.body.textContent
-      // Kind should be present
-      expect(textContent).toContain('Deployment')
-      // Namespace/Name format
-      expect(textContent).toContain('default/podinfo')
-      // Status badge
-      expect(screen.getByText('Ready')).toBeInTheDocument()
-      // Status message in header
-      expect(textContent).toContain('Deployment has minimum availability.')
-    })
-  })
-
-  it('should handle workload with no pods', async () => {
-    const workloadWithNoPods = {
-      ...mockDeploymentWorkload,
-      pods: []
-    }
-
-    fetchWithMock.mockImplementation(() =>
-      Promise.resolve({ workloads: [workloadWithNoPods] })
-    )
-    const user = userEvent.setup()
-
-    const singleWorkloadItem = [{
-      kind: 'Deployment',
-      name: 'podinfo',
-      namespace: 'default'
-    }]
-
-    render(
-      <WorkloadsTabContent
-        workloadItems={singleWorkloadItem}
-        namespace="default"
-      />
-    )
-
-    await waitFor(() => {
-      const textContent = document.body.textContent
-      expect(textContent).toContain('default/podinfo')
-    })
-
-    // Expand the workload
-    const workloadButtons = screen.getAllByRole('button')
-    const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-    await user.click(podinfoButton)
-
-    // Should show "No pods found"
-    await waitFor(() => {
-      expect(screen.getByText('No pods found')).toBeInTheDocument()
-    })
-  })
-
-  it('should show "No recent jobs" for CronJob with no pods', async () => {
-    const cronJobWorkload = {
-      kind: 'CronJob',
-      name: 'backup',
-      namespace: 'default',
-      status: 'Idle',
-      statusMessage: '0 */6 * * *',
-      containerImages: ['busybox:1.36'],
-      pods: []
-    }
-
-    fetchWithMock.mockImplementation(() =>
-      Promise.resolve({ workloads: [cronJobWorkload] })
-    )
-    const user = userEvent.setup()
-
-    const cronJobItem = [{
-      kind: 'CronJob',
-      name: 'backup',
-      namespace: 'default'
-    }]
-
-    render(
-      <WorkloadsTabContent
-        workloadItems={cronJobItem}
-        namespace="default"
-      />
-    )
-
-    await waitFor(() => {
-      const textContent = document.body.textContent
-      expect(textContent).toContain('default/backup')
-    })
-
-    // Expand the workload
-    const workloadButtons = screen.getAllByRole('button')
-    const backupButton = workloadButtons.find(btn => btn.textContent.includes('backup'))
-    await user.click(backupButton)
-
-    // Should show "No recent jobs" for CronJob
-    await waitFor(() => {
-      expect(screen.getByText('No recent jobs')).toBeInTheDocument()
-    })
-  })
-
-  it('should refetch workload data when workloadItems change', async () => {
-    const { rerender } = render(
-      <WorkloadsTabContent
-        workloadItems={mockWorkloadItems}
-        namespace="default"
-      />
-    )
-
-    // Wait for initial load
-    await waitFor(() => {
-      expect(fetchWithMock).toHaveBeenCalledTimes(1)
-    })
-
-    // Update with new workload
-    const updatedWorkloadItems = [
-      ...mockWorkloadItems,
-      {
-        kind: 'DaemonSet',
-        name: 'logger',
-        namespace: 'default'
-      }
-    ]
-
-    rerender(
-      <WorkloadsTabContent
-        workloadItems={updatedWorkloadItems}
-        namespace="default"
-      />
-    )
-
-    // Should refetch all workloads with single POST request
-    await waitFor(() => {
-      expect(fetchWithMock).toHaveBeenCalledTimes(2) // 1 initial + 1 after rerender
-    })
-  })
-
-  describe('Recent pod highlighting', () => {
-    it('should highlight pods with timestamps within the last 30 seconds', async () => {
-      const user = userEvent.setup()
-      const now = new Date()
-      const recentTimestamp = new Date(now.getTime() - 10000).toISOString() // 10 seconds ago
-
-      const workloadWithRecentPod = {
-        ...mockDeploymentWorkload,
-        pods: [
-          {
-            name: 'podinfo-recent-pod',
-            status: 'Current',
-            statusMessage: 'Pod is running',
-            createdAt: recentTimestamp
-          }
-        ]
-      }
-
-      fetchWithMock.mockImplementation(() =>
-        Promise.resolve({ workloads: [workloadWithRecentPod] })
-      )
-
-      const singleWorkloadItem = [{
-        kind: 'Deployment',
-        name: 'podinfo',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={singleWorkloadItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/podinfo')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-      await user.click(podinfoButton)
-
-      // Should have the recent-pod data-testid
-      await waitFor(() => {
-        expect(screen.getByTestId('recent-pod')).toBeInTheDocument()
-      })
-
-      // Should have the ring highlight class
-      const recentPod = screen.getByTestId('recent-pod')
-      expect(recentPod.className).toContain('ring-2')
-      expect(recentPod.className).toContain('ring-blue-400')
-    })
-
-    it('should not highlight pods with timestamps older than 30 seconds', async () => {
-      const user = userEvent.setup()
-      const oldTimestamp = new Date(Date.now() - 60000).toISOString() // 60 seconds ago
-
-      const workloadWithOldPod = {
-        ...mockDeploymentWorkload,
-        pods: [
-          {
-            name: 'podinfo-old-pod',
-            status: 'Current',
-            statusMessage: 'Pod is running',
-            createdAt: oldTimestamp
-          }
-        ]
-      }
-
-      fetchWithMock.mockImplementation(() =>
-        Promise.resolve({ workloads: [workloadWithOldPod] })
-      )
-
-      const singleWorkloadItem = [{
-        kind: 'Deployment',
-        name: 'podinfo',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={singleWorkloadItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/podinfo')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-      await user.click(podinfoButton)
-
-      // Should NOT have the recent-pod data-testid
-      await waitFor(() => {
-        expect(screen.getByText('podinfo-old-pod')).toBeInTheDocument()
-      })
-      expect(screen.queryByTestId('recent-pod')).not.toBeInTheDocument()
-    })
-
-    it('should not highlight pods without timestamps', async () => {
-      const user = userEvent.setup()
-
-      const workloadWithNoTimestampPod = {
-        ...mockDeploymentWorkload,
-        pods: [
-          {
-            name: 'podinfo-no-timestamp',
-            status: 'Current',
-            statusMessage: 'Pod is running'
-            // No timestamp
-          }
-        ]
-      }
-
-      fetchWithMock.mockImplementation(() =>
-        Promise.resolve({ workloads: [workloadWithNoTimestampPod] })
-      )
-
-      const singleWorkloadItem = [{
-        kind: 'Deployment',
-        name: 'podinfo',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={singleWorkloadItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/podinfo')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-      await user.click(podinfoButton)
-
-      // Should NOT have the recent-pod data-testid
-      await waitFor(() => {
-        expect(screen.getByText('podinfo-no-timestamp')).toBeInTheDocument()
-      })
-      expect(screen.queryByTestId('recent-pod')).not.toBeInTheDocument()
-    })
-  })
-
-  describe('Restart action bar', () => {
-    it('should show restart button when workload userActions contains restart', async () => {
-      const user = userEvent.setup()
-
-      const workloadWithRestart = {
-        ...mockDeploymentWorkload,
-        userActions: ['restart']
-      }
-
-      fetchWithMock.mockImplementation(() =>
-        Promise.resolve({ workloads: [workloadWithRestart] })
-      )
-
-      const singleWorkloadItem = [{
-        kind: 'Deployment',
-        name: 'podinfo',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={singleWorkloadItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/podinfo')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-      await user.click(podinfoButton)
-
-      await waitFor(() => {
-        expect(screen.getByTestId('workload-action-bar')).toBeInTheDocument()
-        expect(screen.getByTestId('restart-button')).toBeInTheDocument()
-      })
-    })
-
-    it('should not show restart button when workload userActions does not contain restart', async () => {
-      const user = userEvent.setup()
-
-      const workloadWithoutRestart = {
-        ...mockDeploymentWorkload,
-        userActions: ['deletePods']
-      }
-
-      fetchWithMock.mockImplementation(() =>
-        Promise.resolve({ workloads: [workloadWithoutRestart] })
-      )
-
-      const singleWorkloadItem = [{
-        kind: 'Deployment',
-        name: 'podinfo',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={singleWorkloadItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/podinfo')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-      await user.click(podinfoButton)
-
-      await waitFor(() => {
-        expect(screen.getByText('podinfo-7d8b9c4f5d-abc12')).toBeInTheDocument()
-      })
-      expect(screen.queryByTestId('workload-action-bar')).not.toBeInTheDocument()
-    })
-
-    it('should not show restart button when workload userActions is undefined', async () => {
-      const user = userEvent.setup()
-
-      // mockDeploymentWorkload has no userActions field
-      fetchWithMock.mockImplementation(() =>
-        Promise.resolve({ workloads: [mockDeploymentWorkload] })
-      )
-
-      const singleWorkloadItem = [{
-        kind: 'Deployment',
-        name: 'podinfo',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={singleWorkloadItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/podinfo')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-      await user.click(podinfoButton)
-
-      await waitFor(() => {
-        expect(screen.getByText('podinfo-7d8b9c4f5d-abc12')).toBeInTheDocument()
-      })
-      expect(screen.queryByTestId('workload-action-bar')).not.toBeInTheDocument()
-    })
-
-    it('should show both restart and delete pods when workload userActions contains both', async () => {
-      const user = userEvent.setup()
-
-      const workloadWithBoth = {
-        ...mockDeploymentWorkload,
-        userActions: ['restart', 'deletePods']
-      }
-
-      fetchWithMock.mockImplementation(() =>
-        Promise.resolve({ workloads: [workloadWithBoth] })
-      )
-
-      const singleWorkloadItem = [{
-        kind: 'Deployment',
-        name: 'podinfo',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={singleWorkloadItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/podinfo')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-      await user.click(podinfoButton)
-
-      await waitFor(() => {
-        expect(screen.getByTestId('workload-action-bar')).toBeInTheDocument()
-        expect(screen.getByTestId('restart-button')).toBeInTheDocument()
-        expect(screen.getAllByTestId('delete-pod-button').length).toBeGreaterThan(0)
-      })
-    })
-
-    it('should show run job button for CronJob when workload userActions contains restart', async () => {
-      const user = userEvent.setup()
-
-      const cronJobWorkload = {
-        kind: 'CronJob',
-        name: 'backup',
-        namespace: 'default',
-        status: 'Idle',
-        statusMessage: '*/5 * * * *',
-        containerImages: ['busybox:1.36'],
-        userActions: ['restart'],
-        pods: [
-          {
-            name: 'backup-28945678-xk9j2',
-            status: 'Succeeded',
-            statusMessage: 'Pod completed successfully',
-            createdAt: '2025-01-15T10:30:00Z'
-          }
-        ]
-      }
-
-      fetchWithMock.mockImplementation(() =>
-        Promise.resolve({ workloads: [cronJobWorkload] })
-      )
-
-      const cronJobItem = [{
-        kind: 'CronJob',
-        name: 'backup',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={cronJobItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/backup')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const backupButton = workloadButtons.find(btn => btn.textContent.includes('backup'))
-      await user.click(backupButton)
-
-      await waitFor(() => {
-        expect(screen.getByTestId('workload-action-bar')).toBeInTheDocument()
-        expect(screen.getByTestId('run-job-button')).toBeInTheDocument()
-      })
-    })
-  })
-
-  describe('Delete pod button', () => {
-    it('should show delete button when userActions contains deletePods', async () => {
-      const user = userEvent.setup()
-
-      const workloadWithDeletePods = {
-        ...mockDeploymentWorkload,
-        userActions: ['deletePods']
-      }
-
-      fetchWithMock.mockImplementation(() =>
-        Promise.resolve({ workloads: [workloadWithDeletePods] })
-      )
-
-      const singleWorkloadItem = [{
-        kind: 'Deployment',
-        name: 'podinfo',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={singleWorkloadItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/podinfo')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-      await user.click(podinfoButton)
-
-      await waitFor(() => {
-        expect(screen.getAllByTestId('delete-pod-button').length).toBeGreaterThan(0)
-      })
-    })
-
-    it('should not show delete button when userActions does not contain deletePods', async () => {
-      const user = userEvent.setup()
-
-      const workloadWithoutDeletePods = {
-        ...mockDeploymentWorkload,
-        userActions: []
-      }
-
-      fetchWithMock.mockImplementation(() =>
-        Promise.resolve({ workloads: [workloadWithoutDeletePods] })
-      )
-
-      const singleWorkloadItem = [{
-        kind: 'Deployment',
-        name: 'podinfo',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={singleWorkloadItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/podinfo')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-      await user.click(podinfoButton)
-
-      await waitFor(() => {
-        expect(screen.getByText('podinfo-7d8b9c4f5d-abc12')).toBeInTheDocument()
-      })
-      expect(screen.queryByTestId('delete-pod-button')).not.toBeInTheDocument()
-    })
-
-    it('should show Terminating badge when pod delete is pending', async () => {
-      const user = userEvent.setup()
-
-      const workloadWithDeletePods = {
-        ...mockDeploymentWorkload,
-        userActions: ['deletePods']
-      }
-
-      fetchWithMock.mockImplementation(({ endpoint, body }) => {
-        // Handle the workloads fetch
-        if (endpoint === '/api/v1/workloads' || body?.workloads) {
-          return Promise.resolve({ workloads: [workloadWithDeletePods] })
-        }
-        // Handle the delete action
-        return Promise.resolve({ success: true, message: 'Pod deleted' })
-      })
-
-      const singleWorkloadItem = [{
-        kind: 'Deployment',
-        name: 'podinfo',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={singleWorkloadItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/podinfo')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-      await user.click(podinfoButton)
-
-      await waitFor(() => {
-        expect(screen.getAllByTestId('delete-pod-button').length).toBeGreaterThan(0)
-      })
-
-      // Click the first delete button and confirm
-      vi.spyOn(window, 'confirm').mockReturnValue(true)
-      const deleteButtons = screen.getAllByTestId('delete-pod-button')
-      await user.click(deleteButtons[0])
-
-      // The pod badge should now show Terminating with yellow styling
-      await waitFor(() => {
-        const terminatingBadges = screen.getAllByText('Terminating')
-        expect(terminatingBadges.length).toBeGreaterThan(0)
-        expect(terminatingBadges[0].className).toContain('bg-yellow-100')
-      })
-
-      window.confirm.mockRestore()
-    })
-
-    it('should not show delete button when userActions does not contain deletePods', async () => {
-      const user = userEvent.setup()
-
-      const singleWorkloadItem = [{
-        kind: 'Deployment',
-        name: 'podinfo',
-        namespace: 'default'
-      }]
-
-      render(
-        <WorkloadsTabContent
-          workloadItems={singleWorkloadItem}
-          namespace="default"
-        />
-      )
-
-      await waitFor(() => {
-        const textContent = document.body.textContent
-        expect(textContent).toContain('default/podinfo')
-      })
-
-      // Expand the workload
-      const workloadButtons = screen.getAllByRole('button')
-      const podinfoButton = workloadButtons.find(btn => btn.textContent.includes('podinfo'))
-      await user.click(podinfoButton)
-
-      await waitFor(() => {
-        expect(screen.getByText('podinfo-7d8b9c4f5d-abc12')).toBeInTheDocument()
-      })
-      expect(screen.queryByTestId('delete-pod-button')).not.toBeInTheDocument()
-    })
+    expect(container.querySelectorAll('a[href]')).toHaveLength(0)
   })
 })

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
@@ -1,0 +1,559 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useMemo, useEffect, useRef, useState } from 'preact/hooks'
+import { fetchWithMock } from '../../../utils/fetch'
+import { formatTimestamp } from '../../../utils/time'
+import { getWorkloadStatusBadgeClass, formatWorkloadStatus, getEventBadgeClass, getContainerStateBadgeClass } from '../../../utils/status'
+import { formatScheduleMessage } from '../../../utils/cron'
+import { DashboardPanel, TabButton } from '../common/panel'
+import { YamlBlock } from '../common/yaml'
+import { WorkloadDeleteAction } from '../resource/WorkloadDeleteAction'
+import { FluxOperatorIcon } from '../../layout/Icons'
+import { useHashTab } from '../../../utils/hash'
+
+// Valid tabs for the WorkloadDetailPanel
+const WORKLOAD_TABS = ['overview', 'pods', 'events', 'spec', 'status']
+
+// Highlight threshold for recently changed pods
+const RECENT_POD_THRESHOLD = 30000  // 30 seconds
+
+/**
+ * Check if a timestamp is within the recent threshold
+ */
+function isRecentTimestamp(timestamp) {
+  if (!timestamp) return false
+  const podTime = new Date(timestamp).getTime()
+  const now = Date.now()
+  return (now - podTime) < RECENT_POD_THRESHOLD
+}
+
+/**
+ * Get a summary of container readiness and restart counts from podStatus.
+ * For completed pods (Succeeded phase), counts terminated containers with exit code 0.
+ * For running pods, counts containers with ready=true.
+ * @param {object} podStatus - The Kubernetes PodStatus object
+ * @returns {{ readyCount: number, totalCount: number, isCompleted: boolean }}
+ */
+function getContainerSummary(podStatus) {
+  const containers = podStatus.containerStatuses || []
+  const isCompleted = podStatus.phase === 'Succeeded'
+  let readyCount = 0
+  for (const cs of containers) {
+    if (isCompleted) {
+      if (cs.state?.terminated?.exitCode === 0) readyCount++
+    } else {
+      if (cs.ready) readyCount++
+    }
+  }
+  return { readyCount, totalCount: containers.length, isCompleted }
+}
+
+/**
+ * Get badge label and CSS class for a container's state.
+ * @param {object} state - The container state object with one of: waiting, running, terminated
+ * @returns {{ label: string, detail: string, badgeClass: string }}
+ */
+function getContainerStateBadge(state) {
+  if (!state) return { label: 'Unknown', detail: '', badgeClass: getContainerStateBadgeClass('Unknown') }
+
+  if (state.waiting) {
+    return {
+      label: 'Waiting',
+      detail: state.waiting.reason || '',
+      badgeClass: getContainerStateBadgeClass('Waiting')
+    }
+  }
+  if (state.terminated) {
+    const isSuccess = state.terminated.exitCode === 0
+    const label = isSuccess ? 'Completed' : 'Terminated'
+    let detail = ''
+    if (!isSuccess) {
+      detail = state.terminated.reason || ''
+      if (state.terminated.exitCode !== undefined) {
+        detail += ` (exit ${state.terminated.exitCode})`
+      }
+    }
+    return {
+      label,
+      detail: detail.trim(),
+      badgeClass: getContainerStateBadgeClass(isSuccess ? 'Completed' : 'Terminated')
+    }
+  }
+  if (state.running) {
+    return {
+      label: 'Running',
+      detail: '',
+      badgeClass: getContainerStateBadgeClass('Running')
+    }
+  }
+
+  return { label: 'Unknown', detail: '', badgeClass: getContainerStateBadgeClass('Unknown') }
+}
+
+/**
+ * WorkloadDetailPanel - Displays workload details including overview, pods, events, spec, and status.
+ * Owns tab state, events lazy-loading, and pod sorting/highlighting.
+ */
+export function WorkloadDetailPanel({
+  kind, namespace, workloadData, workloadInfo, workloadStatus,
+  pendingDeletions, onPodDeleteStart, onPodDeleteFailed,
+  onActionStart, onActionComplete
+}) {
+  // Tab state synced with URL hash
+  const [workloadTab, setWorkloadTab] = useHashTab('workload', 'overview', WORKLOAD_TABS, 'workload-panel')
+
+  // Expanded pods state (set of pod names)
+  const [expandedPods, setExpandedPods] = useState(new Set())
+
+  // Events data state (lazy-loaded)
+  const [eventsData, setEventsData] = useState([])
+  const [eventsLoading, setEventsLoading] = useState(false)
+  const [eventsLoaded, setEventsLoaded] = useState(false)
+
+  // Track initial mount to avoid refetching on first render
+  const isInitialMount = useRef(true)
+
+  // Sorted pods for display (most recent first)
+  const sortedPods = useMemo(() => {
+    const pods = workloadInfo?.pods || []
+    return [...pods].sort((a, b) => {
+      if (!a.createdAt && !b.createdAt) return 0
+      if (!a.createdAt) return 1
+      if (!b.createdAt) return -1
+      return new Date(b.createdAt) - new Date(a.createdAt)
+    })
+  }, [workloadInfo])
+
+  // Resolve the pod spec based on workload kind
+  const podSpec = useMemo(() => {
+    if (!workloadData?.spec) return null
+    return kind === 'CronJob'
+      ? workloadData.spec.jobTemplate?.spec?.template?.spec
+      : workloadData.spec.template?.spec
+  }, [workloadData, kind])
+
+  // Extract and sort unique container ports from the spec
+  const containerPorts = useMemo(() => {
+    if (!podSpec) return []
+    const containers = [...(podSpec.containers || []), ...(podSpec.initContainers || [])]
+    const ports = new Set()
+    for (const c of containers) {
+      for (const p of c.ports || []) {
+        if (p.containerPort) ports.add(p.containerPort)
+      }
+    }
+    return [...ports].sort((a, b) => a - b)
+  }, [podSpec])
+
+  // Last action timestamp: conditions for apps/v1, lastScheduleTime for CronJob
+  const lastActionTime = useMemo(() => {
+    if (!workloadData?.status) return null
+    // Find the most recent lastUpdateTime across all conditions
+    const conditions = workloadData.status.conditions || []
+    const lastUpdateTime = conditions.reduce((latest, c) => {
+      if (!c.lastUpdateTime) return latest
+      if (!latest) return c.lastUpdateTime
+      return new Date(c.lastUpdateTime) > new Date(latest) ? c.lastUpdateTime : latest
+    }, null)
+    if (lastUpdateTime) return lastUpdateTime
+    if (workloadData.status.lastScheduleTime) return workloadData.status.lastScheduleTime
+    return workloadInfo?.createdAt || null
+  }, [workloadData, workloadInfo])
+
+  // Memoized YAML data for workload
+  const workloadSpecYaml = useMemo(() => {
+    if (!workloadData) return null
+    return {
+      apiVersion: workloadData.apiVersion,
+      kind: workloadData.kind,
+      metadata: workloadData.metadata,
+      spec: workloadData.spec
+    }
+  }, [workloadData])
+
+  const workloadStatusYaml = useMemo(() => {
+    if (!workloadData?.status) return null
+    return {
+      apiVersion: workloadData.apiVersion,
+      kind: workloadData.kind,
+      metadata: { name: workloadData.metadata.name, namespace: workloadData.metadata.namespace },
+      status: workloadData.status
+    }
+  }, [workloadData])
+
+  // Fetch events on demand when Events tab is clicked
+  useEffect(() => {
+    if (workloadTab === 'events' && !eventsLoaded && !eventsLoading && workloadData?.metadata) {
+      const fetchEvents = async () => {
+        setEventsLoading(true)
+        const params = new URLSearchParams({
+          kind: workloadData.kind,
+          name: workloadData.metadata.name,
+          namespace: workloadData.metadata.namespace
+        })
+
+        try {
+          const eventsResp = await fetchWithMock({
+            endpoint: `/api/v1/events?${params.toString()}`,
+            mockPath: '../mock/events',
+            mockExport: 'getMockEvents'
+          })
+          setEventsData(eventsResp?.events || [])
+          setEventsLoaded(true)
+        } catch (err) {
+          console.error('Failed to fetch workload events:', err)
+        } finally {
+          setEventsLoading(false)
+        }
+      }
+
+      fetchEvents()
+    }
+  }, [workloadTab, eventsLoaded, eventsLoading, workloadData])
+
+  // Refetch events when workloadData changes (auto-refresh)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      if (workloadData) isInitialMount.current = false
+      return
+    }
+
+    if (workloadTab === 'events' && eventsLoaded && !eventsLoading && workloadData?.metadata) {
+      const refetchEvents = async () => {
+        const params = new URLSearchParams({
+          kind: workloadData.kind,
+          name: workloadData.metadata.name,
+          namespace: workloadData.metadata.namespace
+        })
+
+        try {
+          const eventsResp = await fetchWithMock({
+            endpoint: `/api/v1/events?${params.toString()}`,
+            mockPath: '../mock/events',
+            mockExport: 'getMockEvents'
+          })
+          setEventsData(eventsResp?.events || [])
+        } catch (err) {
+          console.error('Failed to refetch workload events:', err)
+        }
+      }
+
+      refetchEvents()
+    }
+  }, [workloadData])
+
+  return (
+    <DashboardPanel title={kind} id="workload-panel">
+      {/* Tab Navigation */}
+      <div class="border-b border-gray-200 dark:border-gray-700 mb-4">
+        <nav class="flex space-x-4">
+          <TabButton active={workloadTab === 'overview'} onClick={() => setWorkloadTab('overview')}>
+            <span class="sm:hidden">Info</span>
+            <span class="hidden sm:inline">Overview</span>
+          </TabButton>
+          <TabButton active={workloadTab === 'pods'} onClick={() => setWorkloadTab('pods')}>
+            Pods
+          </TabButton>
+          <TabButton active={workloadTab === 'events'} onClick={() => setWorkloadTab('events')}>
+            Events
+          </TabButton>
+          <TabButton active={workloadTab === 'spec'} onClick={() => setWorkloadTab('spec')}>
+            <span class="sm:hidden">Spec</span>
+            <span class="hidden sm:inline">Specification</span>
+          </TabButton>
+          <TabButton active={workloadTab === 'status'} onClick={() => setWorkloadTab('status')}>
+            Status
+          </TabButton>
+        </nav>
+      </div>
+
+      {/* Workload Overview Tab */}
+      {workloadTab === 'overview' && (
+        <div class="space-y-4">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* Left column: Status and metadata */}
+            <div class="space-y-4">
+              {/* Status Badge */}
+              <div class="text-sm">
+                <span class="text-gray-500 dark:text-gray-400">Status</span>
+                <span class={`ml-1 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getWorkloadStatusBadgeClass(workloadStatus)}`}>
+                  {formatWorkloadStatus(workloadStatus)}
+                </span>
+              </div>
+
+              {/* Created At */}
+              {workloadInfo?.createdAt && (
+                <div class="text-sm">
+                  <span class="text-gray-500 dark:text-gray-400">Created</span>
+                  <span class="ml-1 text-gray-900 dark:text-white">{new Date(workloadInfo.createdAt).toLocaleString().replace(',', '')}</span>
+                </div>
+              )}
+
+              {/* CronJob concurrency policy (spec.concurrencyPolicy) */}
+              {kind === 'CronJob' && workloadData?.spec?.concurrencyPolicy && (
+                <div class="text-sm">
+                  <span class="text-gray-500 dark:text-gray-400">Concurrency policy</span>
+                  <span class="ml-1 text-gray-900 dark:text-white">{workloadData.spec.concurrencyPolicy}</span>
+                </div>
+              )}
+
+              {/* Deployment rollout strategy (spec.strategy) */}
+              {kind === 'Deployment' && workloadData?.spec?.strategy?.type && (
+                <div class="text-sm">
+                  <span class="text-gray-500 dark:text-gray-400">Strategy</span>
+                  <span class="ml-1 text-gray-900 dark:text-white">
+                    {workloadData.spec.strategy.type}
+                    {workloadData.spec.strategy.rollingUpdate && (
+                      <span class="text-gray-500 dark:text-gray-400">
+                        {' '}(maxUnavailable: {workloadData.spec.strategy.rollingUpdate.maxUnavailable || 'N/A'}, maxSurge: {workloadData.spec.strategy.rollingUpdate.maxSurge || 'N/A'})
+                      </span>
+                    )}
+                  </span>
+                </div>
+              )}
+
+              {/* StatefulSet/DaemonSet update strategy (spec.updateStrategy) */}
+              {(kind === 'StatefulSet' || kind === 'DaemonSet') && workloadData?.spec?.updateStrategy?.type && (
+                <div class="text-sm">
+                  <span class="text-gray-500 dark:text-gray-400">Update strategy</span>
+                  <span class="ml-1 text-gray-900 dark:text-white">
+                    {workloadData.spec.updateStrategy.type}
+                    {workloadData.spec.updateStrategy.rollingUpdate && kind === 'DaemonSet' && (
+                      <span class="text-gray-500 dark:text-gray-400">
+                        {' '}(maxUnavailable: {workloadData.spec.updateStrategy.rollingUpdate.maxUnavailable || 'N/A'}, maxSurge: {workloadData.spec.updateStrategy.rollingUpdate.maxSurge || 'N/A'})
+                      </span>
+                    )}
+                    {workloadData.spec.updateStrategy.rollingUpdate && kind === 'StatefulSet' && (
+                      <span class="text-gray-500 dark:text-gray-400">
+                        {' '}(maxUnavailable: {workloadData.spec.updateStrategy.rollingUpdate.maxUnavailable || 'N/A'}, partition: {workloadData.spec.updateStrategy.rollingUpdate.partition ?? 'N/A'})
+                      </span>
+                    )}
+                  </span>
+                </div>
+              )}
+
+              {/* Service Account */}
+              {podSpec?.serviceAccountName && (
+                <div class="text-sm">
+                  <span class="text-gray-500 dark:text-gray-400">Service account</span>
+                  <span class="ml-1 text-gray-900 dark:text-white">{podSpec.serviceAccountName}</span>
+                </div>
+              )}
+
+              {/* Container Ports */}
+              {containerPorts.length > 0 && (
+                <div class="text-sm">
+                  <span class="text-gray-500 dark:text-gray-400">Ports</span>
+                  <span class="ml-1 text-gray-900 dark:text-white">{containerPorts.join(', ')}</span>
+                </div>
+              )}
+            </div>
+
+            {/* Right column: Last action and status message */}
+            {workloadInfo?.statusMessage && (
+              <div class="space-y-2 border-gray-200 dark:border-gray-700 border-t pt-4 md:border-t-0 md:border-l md:pt-0 md:pl-6">
+                {lastActionTime && (
+                  <div class="text-sm text-gray-500 dark:text-gray-400">
+                    Last action <span class="text-gray-900 dark:text-white">{new Date(lastActionTime).toLocaleString().replace(',', '')}</span>
+                  </div>
+                )}
+                <div class="text-sm text-gray-700 dark:text-gray-300">
+                  <pre class="whitespace-pre-wrap break-all font-sans">{formatScheduleMessage(workloadInfo.statusMessage)}</pre>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Workload Pods Tab */}
+      {workloadTab === 'pods' && (
+        <div class="space-y-4">
+          {/* Pods list */}
+          {sortedPods.length > 0 ? (
+            <div class="space-y-2">
+              {sortedPods.map((pod) => {
+                const isRecent = isRecentTimestamp(pod.createdAt)
+                const isPendingDeletion = pendingDeletions.has(pod.name)
+                const displayStatus = isPendingDeletion ? 'Terminating' : pod.status
+                const hasPodStatus = !!pod.podStatus
+                const isExpanded = expandedPods.has(pod.name)
+                const summary = hasPodStatus ? getContainerSummary(pod.podStatus) : null
+                return (
+                  <div
+                    key={pod.name}
+                    class={`rounded px-3 py-2 border border-gray-200 dark:border-gray-700 ${
+                      isRecent ? 'ring-2 ring-blue-400 dark:ring-blue-500 ring-opacity-50' : ''
+                    }`}
+                    data-testid={isRecent ? 'recent-pod' : undefined}
+                  >
+                    <div
+                      class={`flex items-center justify-between ${hasPodStatus ? 'cursor-pointer' : ''}`}
+                      onClick={(e) => {
+                        if (!hasPodStatus) return
+                        // Don't toggle when clicking the delete button
+                        if (e.target.closest('[data-testid="workload-delete-action"]')) return
+                        setExpandedPods(prev => {
+                          const next = new Set(prev)
+                          if (next.has(pod.name)) {
+                            next.delete(pod.name)
+                          } else {
+                            next.add(pod.name)
+                          }
+                          return next
+                        })
+                      }}
+                    >
+                      <div class="flex items-center flex-grow mr-2 min-w-0">
+                        {hasPodStatus && (
+                          <svg class={`w-3 h-3 mr-1.5 flex-shrink-0 text-gray-400 dark:text-gray-500 transition-transform ${isExpanded ? 'rotate-90' : ''}`} data-testid="pod-chevron" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                          </svg>
+                        )}
+                        <span class="text-sm text-gray-900 dark:text-white truncate">
+                          {pod.name}
+                        </span>
+                      </div>
+                      <div class="flex items-center gap-1.5 flex-shrink-0">
+                        <span class={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getWorkloadStatusBadgeClass(displayStatus)}`}>
+                          {formatWorkloadStatus(displayStatus)}
+                        </span>
+                        {workloadInfo?.userActions?.includes('deletePods') && (
+                          <WorkloadDeleteAction
+                            namespace={namespace}
+                            name={pod.name}
+                            isPendingDeletion={pendingDeletions.has(pod.name)}
+                            onActionStart={onActionStart}
+                            onActionComplete={onActionComplete}
+                            onPodDeleteStart={onPodDeleteStart}
+                            onPodDeleteFailed={onPodDeleteFailed}
+                          />
+                        )}
+                      </div>
+                    </div>
+                    {pod.statusMessage && (
+                      <div class="flex items-start gap-1.5 mt-1">
+                        <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0 mt-px" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        <span class="text-xs text-gray-600 dark:text-gray-400 break-all">{pod.statusMessage}</span>
+                      </div>
+                    )}
+                    {pod.createdBy && (
+                      <div class="flex items-center gap-1.5 mt-1" data-testid="pod-created-by">
+                        <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                        </svg>
+                        <span class="text-xs text-gray-500 dark:text-gray-400">Triggered by {pod.createdBy}</span>
+                      </div>
+                    )}
+                    {/* Container summary line */}
+                    {summary && (
+                      <div class="flex items-center gap-1.5 mt-1" data-testid="pod-container-summary">
+                        <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+                        </svg>
+                        <span class="text-xs text-gray-600 dark:text-gray-400">
+                          Containers: {summary.readyCount}/{summary.totalCount} {summary.isCompleted ? 'completed' : 'ready'}
+                        </span>
+                      </div>
+                    )}
+                    {/* Expanded container details */}
+                    {isExpanded && hasPodStatus && (
+                      <div class="mt-2 pt-2 border-t border-gray-100 dark:border-gray-700" data-testid="pod-expanded-details">
+                        {/* Container statuses */}
+                        <span class="text-xs font-medium text-gray-500 dark:text-gray-400">Containers</span>
+                        <div class="mt-1.5 space-y-2">
+                          {[
+                            ...(pod.podStatus.initContainerStatuses || []).map(cs => ({ ...cs, isInit: true })),
+                            ...(pod.podStatus.containerStatuses || [])
+                          ].map((cs) => {
+                            const stateInfo = getContainerStateBadge(cs.state)
+                            const rawImage = cs.image && !cs.image.startsWith('sha256:') ? cs.image : (cs.imageID || '').replace(/^docker-pullable:\/\//, '')
+                            return (
+                              <div key={cs.name} class="bg-white dark:bg-gray-900 rounded px-3 py-2 text-xs" data-testid="container-status">
+                                <div class="flex items-center justify-between">
+                                  <div class="flex items-center gap-1.5 min-w-0">
+                                    <span class="text-gray-900 dark:text-white font-medium truncate">
+                                      {cs.isInit ? `init:${cs.name}` : cs.name}
+                                    </span>
+                                    {(cs.restartCount || 0) > 0 && (
+                                      <span class="text-gray-500 dark:text-gray-500">({cs.restartCount} restarts)</span>
+                                    )}
+                                  </div>
+                                  <span class={`inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium ${stateInfo.badgeClass} ml-2 flex-shrink-0`}>
+                                    {stateInfo.label}
+                                  </span>
+                                </div>
+                                {rawImage && (
+                                  <p class="text-gray-500 dark:text-gray-400 mt-1 truncate">{rawImage}</p>
+                                )}
+                                {stateInfo.detail && (
+                                  <p class="text-gray-600 dark:text-gray-400 mt-0.5">{stateInfo.detail}</p>
+                                )}
+                                {cs.state?.waiting?.message && (
+                                  <p class="text-gray-500 dark:text-gray-400 mt-0.5 break-all">{cs.state.waiting.message}</p>
+                                )}
+                                {cs.state?.terminated?.message && (
+                                  <p class="text-gray-500 dark:text-gray-400 mt-0.5 break-all">{cs.state.terminated.message}</p>
+                                )}
+                              </div>
+                            )
+                          })}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+              {kind === 'CronJob' ? 'No recent jobs' : 'No pods found'}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Workload Events Tab */}
+      {workloadTab === 'events' && (
+        <div>
+          {eventsLoading ? (
+            <div class="flex items-center justify-center p-8">
+              <FluxOperatorIcon className="animate-spin h-8 w-8 text-flux-blue" />
+              <span class="ml-3 text-gray-600 dark:text-gray-400">Loading events...</span>
+            </div>
+          ) : eventsData.length === 0 ? (
+            <p class="text-sm text-gray-500 dark:text-gray-400">No events found</p>
+          ) : (
+            <div class="space-y-4">
+              {eventsData.map((event, idx) => {
+                const displayStatus = event.type === 'Normal' ? 'Info' : 'Warning'
+                return (
+                  <div key={idx} class="card p-4 hover:shadow-md transition-shadow">
+                    <div class="flex items-center justify-between mb-3">
+                      <span class={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getEventBadgeClass(event.type)}`}>
+                        {displayStatus}
+                      </span>
+                      <span class="text-xs text-gray-500 dark:text-gray-400">{formatTimestamp(event.lastTimestamp)}</span>
+                    </div>
+                    <div class="text-sm text-gray-700 dark:text-gray-300">
+                      <pre class="whitespace-pre-wrap break-all font-sans">{event.message}</pre>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Workload Specification Tab */}
+      {workloadTab === 'spec' && <YamlBlock data={workloadSpecYaml} />}
+
+      {/* Workload Status Tab */}
+      {workloadTab === 'status' && <YamlBlock data={workloadStatusYaml} />}
+    </DashboardPanel>
+  )
+}

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { useMemo, useEffect, useRef, useState } from 'preact/hooks'
+import { useMemo, useEffect, useRef, useState, useCallback } from 'preact/hooks'
 import { fetchWithMock } from '../../../utils/fetch'
 import { formatTimestamp } from '../../../utils/time'
 import { getWorkloadStatusBadgeClass, formatWorkloadStatus, getEventBadgeClass, getContainerStateBadgeClass } from '../../../utils/status'
@@ -10,8 +10,10 @@ import { DashboardPanel, TabButton } from '../common/panel'
 import { YamlBlock } from '../common/yaml'
 import { WorkloadDeleteAction } from '../resource/WorkloadDeleteAction'
 import { WorkloadLogsViewer } from './WorkloadLogsViewer'
+import { LOGS_QUERY_PARAM, ALL_PODS_VALUE } from './WorkloadLogsAction'
 import { FluxOperatorIcon } from '../../layout/Icons'
 import { useHashTab } from '../../../utils/hash'
+import { urlWithParam } from '../../../utils/routing'
 
 // Valid tabs for the WorkloadDetailPanel
 const WORKLOAD_TABS = ['overview', 'pods', 'events', 'spec', 'status']
@@ -107,23 +109,34 @@ export function WorkloadDetailPanel({
   // Expanded pods state (set of pod names)
   const [expandedPods, setExpandedPods] = useState(new Set())
 
-  // Open log-viewing session: { key, pod } where pod is a pod name to pre-select.
-  // key increments per open so the viewer remounts and re-initialises its pod
-  // selection. null when no viewer is open.
+  // Open session: { key, pod } where pod is a pod name to pre-select. key increments
+  // per open so the viewer remounts and re-inits its pod selection. null when closed.
   const [logsSession, setLogsSession] = useState(null)
   const logsSessionKeyRef = useRef(0)
+  // Keep the URL pointed at the pod shown (on open and every in-viewer switch via
+  // onPodChange) so the address bar is a shareable link. A null pod is "All pods".
+  // WorkloadLogsAction reads this param on load to re-open the viewer.
+  const syncLogFilterToUrl = useCallback((pod) => {
+    window.history.replaceState(null, '', urlWithParam(LOGS_QUERY_PARAM, pod || ALL_PODS_VALUE))
+  }, [])
+
   const openLogs = (podName) => {
     logsSessionKeyRef.current += 1
     setLogsSession({ key: logsSessionKeyRef.current, pod: podName })
+    syncLogFilterToUrl(podName)
+  }
+
+  const closeLogs = () => {
+    setLogsSession(null)
+    window.history.replaceState(null, '', urlWithParam(LOGS_QUERY_PARAM, null))
   }
 
   // Whether the user is allowed to view pod logs
   const canViewLogs = workloadInfo?.userActions?.includes('logs')
 
-  // The live pods passed to the viewer, each with its containers, so the viewer
-  // can build the "All pods" request and resolve a pod's containers (and restart
-  // counts) from the polled data while open. Only pods carrying container status
-  // can be inspected.
+  // Live pods passed to the viewer, each with its containers, so it can build the
+  // "All pods" request and resolve a pod's containers (and restart counts) from the
+  // polled data while open. Only pods carrying container status can be inspected.
   const logsPods = useMemo(
     () => (workloadInfo?.pods || [])
       .filter(p => p.podStatus)
@@ -599,8 +612,9 @@ export function WorkloadDetailPanel({
       {/* Workload Status Tab */}
       {workloadTab === 'status' && <YamlBlock data={workloadStatusYaml} />}
 
-      {/* Pod logs viewer */}
-      {logsSession && logsPods.length > 0 && (
+      {/* Pod logs viewer. Stays mounted even with no pods, showing an inline
+          notice instead of vanishing. */}
+      {logsSession && (
         <WorkloadLogsViewer
           key={logsSession.key}
           kind={kind}
@@ -608,7 +622,8 @@ export function WorkloadDetailPanel({
           workloadName={name}
           pods={logsPods}
           initialPodName={logsSession.pod}
-          onClose={() => setLogsSession(null)}
+          onClose={closeLogs}
+          onPodChange={syncLogFilterToUrl}
         />
       )}
     </DashboardPanel>

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
@@ -107,18 +107,26 @@ export function WorkloadDetailPanel({
   // Expanded pods state (set of pod names)
   const [expandedPods, setExpandedPods] = useState(new Set())
 
-  // Pod whose logs are currently displayed in the logs viewer (null when closed)
-  const [logsPod, setLogsPod] = useState(null)
+  // Name of the pod whose logs are displayed in the viewer (null when closed)
+  const [logsPodName, setLogsPodName] = useState(null)
 
   // Whether the user is allowed to view pod logs
   const canViewLogs = workloadInfo?.userActions?.includes('logs')
+
+  // Live pod whose logs are displayed; looked up from the polled workload data
+  // by name so its restart counts (and the viewer's "(previous)" options) stay
+  // current while open. Resolves to null if the pod is gone, closing the viewer.
+  const logsPod = useMemo(
+    () => (logsPodName ? (workloadInfo?.pods || []).find(p => p.name === logsPodName) || null : null),
+    [logsPodName, workloadInfo]
+  )
 
   // Containers of the pod selected for log viewing (init containers first)
   const logsContainers = useMemo(() => {
     if (!logsPod?.podStatus) return []
     return [
-      ...(logsPod.podStatus.initContainerStatuses || []).map(cs => ({ name: cs.name, isInit: true })),
-      ...(logsPod.podStatus.containerStatuses || []).map(cs => ({ name: cs.name, isInit: false }))
+      ...(logsPod.podStatus.initContainerStatuses || []).map(cs => ({ name: cs.name, isInit: true, restartCount: cs.restartCount || 0 })),
+      ...(logsPod.podStatus.containerStatuses || []).map(cs => ({ name: cs.name, isInit: false, restartCount: cs.restartCount || 0 }))
     ]
   }, [logsPod])
 
@@ -437,7 +445,7 @@ export function WorkloadDetailPanel({
                         </span>
                         {canViewLogs && hasPodStatus && (
                           <button
-                            onClick={(e) => { e.stopPropagation(); setLogsPod(pod) }}
+                            onClick={(e) => { e.stopPropagation(); setLogsPodName(pod.name) }}
                             class="inline-flex items-center p-1 rounded transition-colors focus:outline-none text-gray-400 hover:text-blue-500 dark:text-gray-500 dark:hover:text-blue-400"
                             data-testid="logs-pod-button"
                             title={`View logs for pod ${pod.name}`}
@@ -589,7 +597,7 @@ export function WorkloadDetailPanel({
           namespace={namespace}
           name={logsPod.name}
           containers={logsContainers}
-          onClose={() => setLogsPod(null)}
+          onClose={() => setLogsPodName(null)}
         />
       )}
     </DashboardPanel>

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
@@ -9,6 +9,7 @@ import { formatScheduleMessage } from '../../../utils/cron'
 import { DashboardPanel, TabButton } from '../common/panel'
 import { YamlBlock } from '../common/yaml'
 import { WorkloadDeleteAction } from '../resource/WorkloadDeleteAction'
+import { WorkloadLogsViewer } from './WorkloadLogsViewer'
 import { FluxOperatorIcon } from '../../layout/Icons'
 import { useHashTab } from '../../../utils/hash'
 
@@ -105,6 +106,21 @@ export function WorkloadDetailPanel({
 
   // Expanded pods state (set of pod names)
   const [expandedPods, setExpandedPods] = useState(new Set())
+
+  // Pod whose logs are currently displayed in the logs viewer (null when closed)
+  const [logsPod, setLogsPod] = useState(null)
+
+  // Whether the user is allowed to view pod logs
+  const canViewLogs = workloadInfo?.userActions?.includes('logs')
+
+  // Containers of the pod selected for log viewing (init containers first)
+  const logsContainers = useMemo(() => {
+    if (!logsPod?.podStatus) return []
+    return [
+      ...(logsPod.podStatus.initContainerStatuses || []).map(cs => ({ name: cs.name, isInit: true })),
+      ...(logsPod.podStatus.containerStatuses || []).map(cs => ({ name: cs.name, isInit: false }))
+    ]
+  }, [logsPod])
 
   // Events data state (lazy-loaded)
   const [eventsData, setEventsData] = useState([])
@@ -419,6 +435,18 @@ export function WorkloadDetailPanel({
                         <span class={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getWorkloadStatusBadgeClass(displayStatus)}`}>
                           {formatWorkloadStatus(displayStatus)}
                         </span>
+                        {canViewLogs && hasPodStatus && (
+                          <button
+                            onClick={(e) => { e.stopPropagation(); setLogsPod(pod) }}
+                            class="inline-flex items-center p-1 rounded transition-colors focus:outline-none text-gray-400 hover:text-blue-500 dark:text-gray-500 dark:hover:text-blue-400"
+                            data-testid="logs-pod-button"
+                            title={`View logs for pod ${pod.name}`}
+                          >
+                            <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                            </svg>
+                          </button>
+                        )}
                         {workloadInfo?.userActions?.includes('deletePods') && (
                           <WorkloadDeleteAction
                             namespace={namespace}
@@ -554,6 +582,16 @@ export function WorkloadDetailPanel({
 
       {/* Workload Status Tab */}
       {workloadTab === 'status' && <YamlBlock data={workloadStatusYaml} />}
+
+      {/* Pod logs viewer */}
+      {logsPod && (
+        <WorkloadLogsViewer
+          namespace={namespace}
+          name={logsPod.name}
+          containers={logsContainers}
+          onClose={() => setLogsPod(null)}
+        />
+      )}
     </DashboardPanel>
   )
 }

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
@@ -107,33 +107,34 @@ export function WorkloadDetailPanel({
   // Expanded pods state (set of pod names)
   const [expandedPods, setExpandedPods] = useState(new Set())
 
-  // Name of the pod whose logs are displayed in the viewer (null when closed)
-  const [logsPodName, setLogsPodName] = useState(null)
+  // Open log-viewing session: { key, pod } where pod is a pod name to pre-select.
+  // key increments per open so the viewer remounts and re-initialises its pod
+  // selection. null when no viewer is open.
+  const [logsSession, setLogsSession] = useState(null)
+  const logsSessionKeyRef = useRef(0)
+  const openLogs = (podName) => {
+    logsSessionKeyRef.current += 1
+    setLogsSession({ key: logsSessionKeyRef.current, pod: podName })
+  }
 
   // Whether the user is allowed to view pod logs
   const canViewLogs = workloadInfo?.userActions?.includes('logs')
 
-  // Live pod whose logs are displayed; looked up from the polled workload data
-  // by name so its restart counts (and the viewer's "(previous)" options) stay
-  // current while open. Resolves to null if the pod is gone, closing the viewer.
-  const logsPod = useMemo(
-    () => (logsPodName ? (workloadInfo?.pods || []).find(p => p.name === logsPodName) || null : null),
-    [logsPodName, workloadInfo]
-  )
-
-  // Containers of the pod selected for log viewing (init containers first)
-  const logsContainers = useMemo(() => {
-    if (!logsPod?.podStatus) return []
-    return [
-      ...(logsPod.podStatus.initContainerStatuses || []).map(cs => ({ name: cs.name, isInit: true, restartCount: cs.restartCount || 0 })),
-      ...(logsPod.podStatus.containerStatuses || []).map(cs => ({ name: cs.name, isInit: false, restartCount: cs.restartCount || 0 }))
-    ]
-  }, [logsPod])
-
-  // Pods that can be inspected in the viewer's pod dropdown: those carrying
-  // container status. Kept live so the dropdown tracks the polled workload data.
+  // The live pods passed to the viewer, each with its containers, so the viewer
+  // can build the "All pods" request and resolve a pod's containers (and restart
+  // counts) from the polled data while open. Only pods carrying container status
+  // can be inspected.
   const logsPods = useMemo(
-    () => (workloadInfo?.pods || []).filter(p => p.podStatus),
+    () => (workloadInfo?.pods || [])
+      .filter(p => p.podStatus)
+      .map(p => ({
+        name: p.name,
+        status: p.status,
+        containers: [
+          ...(p.podStatus.initContainerStatuses || []).map(cs => ({ name: cs.name, isInit: true, restartCount: cs.restartCount || 0 })),
+          ...(p.podStatus.containerStatuses || []).map(cs => ({ name: cs.name, isInit: false, restartCount: cs.restartCount || 0 }))
+        ]
+      })),
     [workloadInfo]
   )
 
@@ -452,7 +453,7 @@ export function WorkloadDetailPanel({
                         </span>
                         {canViewLogs && hasPodStatus && (
                           <button
-                            onClick={(e) => { e.stopPropagation(); setLogsPodName(pod.name) }}
+                            onClick={(e) => { e.stopPropagation(); openLogs(pod.name) }}
                             class="inline-flex items-center p-1 rounded transition-colors focus:outline-none text-gray-400 hover:text-blue-500 dark:text-gray-500 dark:hover:text-blue-400"
                             data-testid="logs-pod-button"
                             title={`View logs for pod ${pod.name}`}
@@ -599,16 +600,15 @@ export function WorkloadDetailPanel({
       {workloadTab === 'status' && <YamlBlock data={workloadStatusYaml} />}
 
       {/* Pod logs viewer */}
-      {logsPod && (
+      {logsSession && logsPods.length > 0 && (
         <WorkloadLogsViewer
+          key={logsSession.key}
           kind={kind}
           namespace={namespace}
-          name={logsPod.name}
           workloadName={name}
-          containers={logsContainers}
           pods={logsPods}
-          onSelectPod={setLogsPodName}
-          onClose={() => setLogsPodName(null)}
+          initialPodName={logsSession.pod}
+          onClose={() => setLogsSession(null)}
         />
       )}
     </DashboardPanel>

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
@@ -97,7 +97,7 @@ function getContainerStateBadge(state) {
  * Owns tab state, events lazy-loading, and pod sorting/highlighting.
  */
 export function WorkloadDetailPanel({
-  kind, namespace, workloadData, workloadInfo, workloadStatus,
+  kind, namespace, name, workloadData, workloadInfo, workloadStatus,
   pendingDeletions, onPodDeleteStart, onPodDeleteFailed,
   onActionStart, onActionComplete
 }) {
@@ -129,6 +129,13 @@ export function WorkloadDetailPanel({
       ...(logsPod.podStatus.containerStatuses || []).map(cs => ({ name: cs.name, isInit: false, restartCount: cs.restartCount || 0 }))
     ]
   }, [logsPod])
+
+  // Pods that can be inspected in the viewer's pod dropdown: those carrying
+  // container status. Kept live so the dropdown tracks the polled workload data.
+  const logsPods = useMemo(
+    () => (workloadInfo?.pods || []).filter(p => p.podStatus),
+    [workloadInfo]
+  )
 
   // Events data state (lazy-loaded)
   const [eventsData, setEventsData] = useState([])
@@ -594,9 +601,13 @@ export function WorkloadDetailPanel({
       {/* Pod logs viewer */}
       {logsPod && (
         <WorkloadLogsViewer
+          kind={kind}
           namespace={namespace}
           name={logsPod.name}
+          workloadName={name}
           containers={logsContainers}
+          pods={logsPods}
+          onSelectPod={setLogsPodName}
           onClose={() => setLogsPodName(null)}
         />
       )}

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.test.jsx
@@ -1,0 +1,975 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/preact'
+import userEvent from '@testing-library/user-event'
+import { WorkloadDetailPanel } from './WorkloadDetailPanel'
+import { fetchWithMock } from '../../../utils/fetch'
+
+// Mock fetchWithMock
+vi.mock('../../../utils/fetch', () => ({
+  fetchWithMock: vi.fn()
+}))
+
+// Mock useHashTab to use simple useState instead
+vi.mock('../../../utils/hash', async () => {
+  const { useState } = await import('preact/hooks')
+  return {
+    useHashTab: (panel, defaultTab) => useState(defaultTab)
+  }
+})
+
+vi.mock('../resource/WorkloadDeleteAction', () => ({
+  WorkloadDeleteAction: (props) => (
+    <div data-testid="workload-delete-action">Delete: {props.name}</div>
+  )
+}))
+
+describe('WorkloadDetailPanel component', () => {
+  const mockWorkloadData = {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: 'nginx',
+      namespace: 'default',
+      creationTimestamp: '2023-01-01T00:00:00Z'
+    },
+    spec: {
+      replicas: 3,
+      strategy: {
+        type: 'RollingUpdate',
+        rollingUpdate: { maxUnavailable: 1, maxSurge: 1 }
+      },
+      selector: { matchLabels: { app: 'nginx' } },
+      template: { spec: { containers: [{ name: 'nginx', image: 'nginx:1.25.0' }] } }
+    },
+    status: {
+      readyReplicas: 3,
+      conditions: [
+        { type: 'Available', status: 'True', message: 'Deployment has minimum availability' }
+      ]
+    }
+  }
+
+  const mockWorkloadInfo = {
+    status: 'Current',
+    statusMessage: 'Replicas: 3',
+    createdAt: '2023-01-01T00:00:00Z',
+    containerImages: ['nginx:1.25.0'],
+    userActions: ['restart', 'deletePods'],
+    pods: [
+      { name: 'nginx-abc-123', status: 'Running', statusMessage: 'Started at 2023-01-01 12:00:00 UTC', createdAt: '2023-01-01T12:00:00Z' },
+      { name: 'nginx-abc-456', status: 'Running', statusMessage: 'Started at 2023-01-01 12:00:00 UTC', createdAt: '2023-01-01T11:00:00Z' }
+    ]
+  }
+
+  const defaultProps = {
+    kind: 'Deployment',
+    namespace: 'default',
+    name: 'nginx',
+    workloadData: mockWorkloadData,
+    workloadInfo: mockWorkloadInfo,
+    workloadStatus: 'Current',
+    pendingDeletions: new Set(),
+    onPodDeleteStart: vi.fn(),
+    onPodDeleteFailed: vi.fn(),
+    onActionStart: vi.fn(),
+    onActionComplete: vi.fn()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render the panel title from kind', () => {
+    render(<WorkloadDetailPanel {...defaultProps} />)
+
+    expect(screen.getByText('Deployment')).toBeInTheDocument()
+  })
+
+  it('should render all tab buttons', () => {
+    render(<WorkloadDetailPanel {...defaultProps} />)
+
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+    expect(screen.getByText('Pods')).toBeInTheDocument()
+    expect(screen.getByText('Events')).toBeInTheDocument()
+    expect(screen.getByText('Specification')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument()
+  })
+
+  it('should toggle collapse/expand state', async () => {
+    const user = userEvent.setup()
+
+    render(<WorkloadDetailPanel {...defaultProps} />)
+
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+
+    const headerButton = screen.getByText('Deployment').closest('button')
+    await user.click(headerButton)
+
+    expect(screen.queryByText('Overview')).not.toBeInTheDocument()
+
+    await user.click(headerButton)
+
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+  })
+
+  describe('Overview tab', () => {
+    it('should display status badge', () => {
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      // formatWorkloadStatus('Current') returns 'Ready'
+      expect(screen.getByText('Ready')).toBeInTheDocument()
+    })
+
+    it('should display status message in right column', () => {
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      expect(screen.getByText('Replicas: 3')).toBeInTheDocument()
+    })
+
+    it('should display last action timestamp from conditions', () => {
+      const dataWithTransitionTime = {
+        ...mockWorkloadData,
+        status: {
+          ...mockWorkloadData.status,
+          conditions: [
+            { type: 'Available', status: 'True', message: 'Deployment has minimum availability', lastUpdateTime: '2023-06-15T10:30:00Z' }
+          ]
+        }
+      }
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          workloadData={dataWithTransitionTime}
+        />
+      )
+
+      expect(screen.getByText('Last action')).toBeInTheDocument()
+    })
+
+    it('should fall back to creation time for last action when conditions lack lastTransitionTime', () => {
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      // No lastTransitionTime in conditions, falls back to workloadInfo.createdAt
+      expect(screen.getByText('Last action')).toBeInTheDocument()
+    })
+
+    it('should display last action from lastScheduleTime for CronJob', () => {
+      const cronData = {
+        ...mockWorkloadData,
+        kind: 'CronJob',
+        spec: { ...mockWorkloadData.spec, schedule: '*/5 * * * *' },
+        status: {
+          lastScheduleTime: '2023-06-15T11:00:00Z'
+        }
+      }
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          kind="CronJob"
+          workloadData={cronData}
+        />
+      )
+
+      expect(screen.getByText('Last action')).toBeInTheDocument()
+    })
+
+    it('should display created timestamp', () => {
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      expect(screen.getByText('Created')).toBeInTheDocument()
+    })
+
+    it('should display rollout strategy', () => {
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      expect(screen.getByText('Strategy')).toBeInTheDocument()
+      expect(screen.getByText(/RollingUpdate/)).toBeInTheDocument()
+      expect(screen.getByText(/maxUnavailable: 1/)).toBeInTheDocument()
+    })
+
+    it('should display service account', () => {
+      const dataWithSA = {
+        ...mockWorkloadData,
+        spec: {
+          ...mockWorkloadData.spec,
+          template: {
+            spec: {
+              serviceAccountName: 'nginx-sa',
+              containers: [{ name: 'nginx', image: 'nginx:1.25.0' }]
+            }
+          }
+        }
+      }
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          workloadData={dataWithSA}
+        />
+      )
+
+      expect(screen.getByText('Service account')).toBeInTheDocument()
+      expect(screen.getByText('nginx-sa')).toBeInTheDocument()
+    })
+
+    it('should display sorted container ports', () => {
+      const dataWithPorts = {
+        ...mockWorkloadData,
+        spec: {
+          ...mockWorkloadData.spec,
+          template: {
+            spec: {
+              containers: [
+                { name: 'nginx', image: 'nginx:1.25.0', ports: [{ containerPort: 8080 }, { containerPort: 80 }] },
+                { name: 'sidecar', image: 'sidecar:1.0', ports: [{ containerPort: 9090 }] }
+              ]
+            }
+          }
+        }
+      }
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          workloadData={dataWithPorts}
+        />
+      )
+
+      expect(screen.getByText('Ports')).toBeInTheDocument()
+      expect(screen.getByText('80, 8080, 9090')).toBeInTheDocument()
+    })
+
+    it('should not display ports when containers have no ports', () => {
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      expect(screen.queryByText('Ports')).not.toBeInTheDocument()
+    })
+
+    it('should display concurrency policy for CronJob', () => {
+      const cronData = {
+        ...mockWorkloadData,
+        kind: 'CronJob',
+        spec: { ...mockWorkloadData.spec, schedule: '*/5 * * * *', concurrencyPolicy: 'Forbid' }
+      }
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          kind="CronJob"
+          workloadData={cronData}
+        />
+      )
+
+      expect(screen.getByText('Concurrency policy')).toBeInTheDocument()
+      expect(screen.getByText('Forbid')).toBeInTheDocument()
+    })
+
+    it('should display DaemonSet update strategy with rollingUpdate details', () => {
+      const daemonData = {
+        ...mockWorkloadData,
+        kind: 'DaemonSet',
+        spec: {
+          ...mockWorkloadData.spec,
+          updateStrategy: {
+            type: 'RollingUpdate',
+            rollingUpdate: { maxUnavailable: 1, maxSurge: 2 }
+          }
+        }
+      }
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          kind="DaemonSet"
+          workloadData={daemonData}
+        />
+      )
+
+      expect(screen.getByText('Update strategy')).toBeInTheDocument()
+      expect(screen.getByText(/maxUnavailable: 1/)).toBeInTheDocument()
+      expect(screen.getByText(/maxSurge: 2/)).toBeInTheDocument()
+    })
+
+    it('should display StatefulSet update strategy with rollingUpdate details', () => {
+      const stsData = {
+        ...mockWorkloadData,
+        kind: 'StatefulSet',
+        spec: {
+          ...mockWorkloadData.spec,
+          strategy: undefined,
+          updateStrategy: {
+            type: 'RollingUpdate',
+            rollingUpdate: { maxUnavailable: 1, partition: 0 }
+          }
+        }
+      }
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          kind="StatefulSet"
+          workloadData={stsData}
+        />
+      )
+
+      expect(screen.getByText('Update strategy')).toBeInTheDocument()
+      expect(screen.getByText(/maxUnavailable: 1/)).toBeInTheDocument()
+      expect(screen.getByText(/partition: 0/)).toBeInTheDocument()
+    })
+
+    it('should not display spec.strategy for non-Deployment kinds', () => {
+      const stsData = {
+        ...mockWorkloadData,
+        kind: 'StatefulSet',
+        spec: { ...mockWorkloadData.spec }
+      }
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          kind="StatefulSet"
+          workloadData={stsData}
+        />
+      )
+
+      // spec.strategy.type exists on mockWorkloadData but should not render for StatefulSet
+      expect(screen.queryByText('Strategy')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Pods tab', () => {
+    it('should display pods list', async () => {
+      const user = userEvent.setup()
+
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      await user.click(screen.getByText('Pods'))
+
+      expect(screen.getByText('nginx-abc-123')).toBeInTheDocument()
+      expect(screen.getByText('nginx-abc-456')).toBeInTheDocument()
+    })
+
+    it('should sort pods by creation time (most recent first)', async () => {
+      const user = userEvent.setup()
+
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      await user.click(screen.getByText('Pods'))
+
+      // Query pod name spans directly (exclude delete action text)
+      const podNameSpans = screen.getAllByText(/^nginx-abc-\d+$/)
+      // nginx-abc-123 has createdAt 12:00, nginx-abc-456 has 11:00
+      // Most recent first
+      expect(podNameSpans[0]).toHaveTextContent('nginx-abc-123')
+      expect(podNameSpans[1]).toHaveTextContent('nginx-abc-456')
+    })
+
+    it('should show "No pods found" when pods list is empty', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          workloadInfo={{ ...mockWorkloadInfo, pods: [] }}
+        />
+      )
+
+      await user.click(screen.getByText('Pods'))
+
+      expect(screen.getByText('No pods found')).toBeInTheDocument()
+    })
+
+    it('should show "No recent jobs" for CronJob with no pods', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          kind="CronJob"
+          workloadInfo={{ ...mockWorkloadInfo, pods: [] }}
+        />
+      )
+
+      await user.click(screen.getByText('Pods'))
+
+      expect(screen.getByText('No recent jobs')).toBeInTheDocument()
+    })
+
+    it('should render delete buttons when deletePods action is available', async () => {
+      const user = userEvent.setup()
+
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      await user.click(screen.getByText('Pods'))
+
+      const deleteActions = screen.getAllByTestId('workload-delete-action')
+      expect(deleteActions).toHaveLength(2)
+    })
+
+    it('should show Terminating status for pending deletions', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          pendingDeletions={new Set(['nginx-abc-123'])}
+        />
+      )
+
+      await user.click(screen.getByText('Pods'))
+
+      expect(screen.getByText('Terminating')).toBeInTheDocument()
+    })
+
+    it('should display triggered by info for pods with createdBy', async () => {
+      const user = userEvent.setup()
+      const infoWithTriggeredPod = {
+        ...mockWorkloadInfo,
+        pods: [
+          { name: 'pod-1', status: 'Running', createdAt: '2023-01-01T12:00:00Z', createdBy: 'admin@example.com' }
+        ]
+      }
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          workloadInfo={infoWithTriggeredPod}
+        />
+      )
+
+      await user.click(screen.getByText('Pods'))
+
+      expect(screen.getByTestId('pod-created-by')).toHaveTextContent('Triggered by admin@example.com')
+    })
+
+    it('should show container summary when podStatus has non-ready containers', async () => {
+      const user = userEvent.setup()
+      const infoWithPodStatus = {
+        ...mockWorkloadInfo,
+        pods: [{
+          name: 'pod-1',
+          status: 'Pending',
+          createdAt: '2023-01-01T12:00:00Z',
+          podStatus: {
+            phase: 'Pending',
+            containerStatuses: [
+              { name: 'app', ready: true, restartCount: 0, state: { running: {} } },
+              { name: 'sidecar', ready: false, restartCount: 0, state: { waiting: { reason: 'CrashLoopBackOff' } } }
+            ]
+          }
+        }]
+      }
+
+      render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoWithPodStatus} />)
+      await user.click(screen.getByText('Pods'))
+
+      const summary = screen.getByTestId('pod-container-summary')
+      expect(summary).toHaveTextContent('1/2 ready')
+    })
+
+    it('should show summary line for healthy pods with all containers ready', async () => {
+      const user = userEvent.setup()
+      const infoHealthy = {
+        ...mockWorkloadInfo,
+        pods: [{
+          name: 'pod-1',
+          status: 'Running',
+          createdAt: '2023-01-01T12:00:00Z',
+          podStatus: {
+            phase: 'Running',
+            containerStatuses: [
+              { name: 'app', ready: true, restartCount: 0, state: { running: {} } }
+            ]
+          }
+        }]
+      }
+
+      render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoHealthy} />)
+      await user.click(screen.getByText('Pods'))
+
+      const summary = screen.getByTestId('pod-container-summary')
+      expect(summary).toHaveTextContent('Containers: 1/1 ready')
+    })
+
+    it('should show completed instead of ready for succeeded pods', async () => {
+      const user = userEvent.setup()
+      const infoSucceeded = {
+        ...mockWorkloadInfo,
+        pods: [{
+          name: 'job-pod-1',
+          status: 'Succeeded',
+          createdAt: '2023-01-01T12:00:00Z',
+          podStatus: {
+            phase: 'Succeeded',
+            containerStatuses: [
+              { name: 'worker', ready: false, restartCount: 0, state: { terminated: { exitCode: 0, reason: 'Completed' } } }
+            ]
+          }
+        }]
+      }
+
+      render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoSucceeded} />)
+      await user.click(screen.getByText('Pods'))
+
+      const summary = screen.getByTestId('pod-container-summary')
+      expect(summary).toHaveTextContent('Containers: 1/1 completed')
+    })
+
+    it('should expand pod to show container statuses on click', async () => {
+      const user = userEvent.setup()
+      const infoWithPodStatus = {
+        ...mockWorkloadInfo,
+        pods: [{
+          name: 'pod-1',
+          status: 'Pending',
+          createdAt: '2023-01-01T12:00:00Z',
+          podStatus: {
+            phase: 'Pending',
+            containerStatuses: [
+              { name: 'manager', ready: false, restartCount: 3, state: { waiting: { reason: 'ImagePullBackOff' } } }
+            ]
+          }
+        }]
+      }
+
+      render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoWithPodStatus} />)
+      await user.click(screen.getByText('Pods'))
+
+      // Should not show expanded details initially
+      expect(screen.queryByTestId('pod-expanded-details')).not.toBeInTheDocument()
+
+      // Click on the pod row to expand
+      await user.click(screen.getByText('pod-1'))
+
+      // Should show expanded container details
+      expect(screen.getByTestId('pod-expanded-details')).toBeInTheDocument()
+      expect(screen.getByText('manager')).toBeInTheDocument()
+      expect(screen.getByText('Waiting')).toBeInTheDocument()
+      expect(screen.getByText('ImagePullBackOff')).toBeInTheDocument()
+    })
+
+    it('should collapse pod on second click', async () => {
+      const user = userEvent.setup()
+      const infoWithPodStatus = {
+        ...mockWorkloadInfo,
+        pods: [{
+          name: 'pod-1',
+          status: 'Running',
+          createdAt: '2023-01-01T12:00:00Z',
+          podStatus: {
+            phase: 'Running',
+            containerStatuses: [
+              { name: 'app', ready: true, restartCount: 0, state: { running: {} } }
+            ]
+          }
+        }]
+      }
+
+      render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoWithPodStatus} />)
+      await user.click(screen.getByText('Pods'))
+
+      // Click to expand
+      await user.click(screen.getByText('pod-1'))
+      expect(screen.getByTestId('pod-expanded-details')).toBeInTheDocument()
+
+      // Click again to collapse
+      await user.click(screen.getByText('pod-1'))
+      expect(screen.queryByTestId('pod-expanded-details')).not.toBeInTheDocument()
+    })
+
+    it('should show waiting reason and message for waiting containers', async () => {
+      const user = userEvent.setup()
+      const infoWithWaiting = {
+        ...mockWorkloadInfo,
+        pods: [{
+          name: 'pod-1',
+          status: 'Pending',
+          createdAt: '2023-01-01T12:00:00Z',
+          podStatus: {
+            phase: 'Pending',
+            containerStatuses: [
+              {
+                name: 'app',
+                ready: false,
+                restartCount: 0,
+                state: {
+                  waiting: {
+                    reason: 'ImagePullBackOff',
+                    message: 'Back-off pulling image "nginx:invalid"'
+                  }
+                }
+              }
+            ]
+          }
+        }]
+      }
+
+      render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoWithWaiting} />)
+      await user.click(screen.getByText('Pods'))
+      await user.click(screen.getByText('pod-1'))
+
+      expect(screen.getByText('ImagePullBackOff')).toBeInTheDocument()
+      expect(screen.getByText('Back-off pulling image "nginx:invalid"')).toBeInTheDocument()
+    })
+
+    it('should show terminated reason and exit code', async () => {
+      const user = userEvent.setup()
+      const infoWithTerminated = {
+        ...mockWorkloadInfo,
+        pods: [{
+          name: 'pod-1',
+          status: 'Failed',
+          createdAt: '2023-01-01T12:00:00Z',
+          podStatus: {
+            phase: 'Failed',
+            containerStatuses: [
+              {
+                name: 'app',
+                ready: false,
+                restartCount: 0,
+                state: {
+                  terminated: {
+                    reason: 'OOMKilled',
+                    exitCode: 137
+                  }
+                }
+              }
+            ]
+          }
+        }]
+      }
+
+      render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoWithTerminated} />)
+      await user.click(screen.getByText('Pods'))
+      await user.click(screen.getByText('pod-1'))
+
+      expect(screen.getByText('Terminated')).toBeInTheDocument()
+      expect(screen.getByText('OOMKilled (exit 137)')).toBeInTheDocument()
+    })
+
+    it('should display container image from image field when available', async () => {
+      const user = userEvent.setup()
+      const infoWithImage = {
+        ...mockWorkloadInfo,
+        pods: [{
+          name: 'pod-1',
+          status: 'Running',
+          createdAt: '2023-01-01T12:00:00Z',
+          podStatus: {
+            phase: 'Running',
+            containerStatuses: [
+              { name: 'app', ready: true, restartCount: 0, image: 'nginx:1.25.0', imageID: 'docker-pullable://nginx:1.25.0@sha256:abc123', state: { running: {} } }
+            ]
+          }
+        }]
+      }
+
+      render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoWithImage} />)
+      await user.click(screen.getByText('Pods'))
+      await user.click(screen.getByText('pod-1'))
+
+      expect(screen.getByText('nginx:1.25.0')).toBeInTheDocument()
+    })
+
+    it('should fall back to imageID when image is a bare digest', async () => {
+      const user = userEvent.setup()
+      const infoWithDigest = {
+        ...mockWorkloadInfo,
+        pods: [{
+          name: 'pod-1',
+          status: 'Running',
+          createdAt: '2023-01-01T12:00:00Z',
+          podStatus: {
+            phase: 'Running',
+            containerStatuses: [
+              { name: 'app', ready: true, restartCount: 0, image: 'sha256:abc123def456', imageID: 'docker-pullable://nginx:1.25.0@sha256:abc123def456', state: { running: {} } }
+            ]
+          }
+        }]
+      }
+
+      render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoWithDigest} />)
+      await user.click(screen.getByText('Pods'))
+      await user.click(screen.getByText('pod-1'))
+
+      expect(screen.getByText('nginx:1.25.0@sha256:abc123def456')).toBeInTheDocument()
+    })
+
+    it('should not render chevron or expand for pods without podStatus', async () => {
+      const user = userEvent.setup()
+      // Default mockWorkloadInfo has pods without podStatus
+      render(<WorkloadDetailPanel {...defaultProps} />)
+      await user.click(screen.getByText('Pods'))
+
+      expect(screen.queryByTestId('pod-chevron')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Events tab', () => {
+    it('should fetch and display events when Events tab is clicked', async () => {
+      const user = userEvent.setup()
+      const mockEvents = {
+        events: [
+          {
+            type: 'Normal',
+            reason: 'Scaled',
+            message: 'Scaled up replica set nginx-abc to 3',
+            lastTimestamp: '2023-01-01T12:05:00Z'
+          },
+          {
+            type: 'Warning',
+            reason: 'BackOff',
+            message: 'Back-off restarting failed container',
+            lastTimestamp: '2023-01-01T12:10:00Z'
+          }
+        ]
+      }
+
+      fetchWithMock.mockResolvedValueOnce(mockEvents)
+
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalledWith(expect.objectContaining({
+          endpoint: expect.stringContaining('/api/v1/events')
+        }))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Scaled up replica set nginx-abc to 3')).toBeInTheDocument()
+        expect(screen.getByText('Back-off restarting failed container')).toBeInTheDocument()
+      })
+
+      const infoBadges = screen.getAllByText('Info')
+      expect(infoBadges.length).toBeGreaterThan(0)
+      expect(screen.getByText('Warning')).toBeInTheDocument()
+    })
+
+    it('should display "No events found" when events list is empty', async () => {
+      const user = userEvent.setup()
+      fetchWithMock.mockResolvedValueOnce({ events: [] })
+
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(screen.getByText('No events found')).toBeInTheDocument()
+      })
+    })
+
+    it('should handle fetch error gracefully', async () => {
+      const user = userEvent.setup()
+      fetchWithMock.mockRejectedValueOnce(new Error('Network error'))
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalled()
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('No events found')).toBeInTheDocument()
+      })
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('Events auto-refresh', () => {
+    const mockEvents = {
+      events: [
+        {
+          type: 'Normal',
+          reason: 'Scaled',
+          message: 'Scaled up replica set',
+          lastTimestamp: '2023-01-01T12:05:00Z'
+        }
+      ]
+    }
+
+    it('should refetch events when workloadData changes if Events tab is open', async () => {
+      const user = userEvent.setup()
+
+      const { rerender } = render(<WorkloadDetailPanel {...defaultProps} />)
+
+      fetchWithMock.mockResolvedValueOnce(mockEvents)
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(screen.getByText('Scaled up replica set')).toBeInTheDocument()
+      })
+
+      fetchWithMock.mockResolvedValueOnce({
+        events: [
+          {
+            type: 'Normal',
+            reason: 'Scaled',
+            message: 'New event after refresh',
+            lastTimestamp: '2023-01-01T13:05:00Z'
+          }
+        ]
+      })
+
+      const updatedWorkloadData = {
+        ...mockWorkloadData,
+        status: { ...mockWorkloadData.status, readyReplicas: 4 }
+      }
+
+      rerender(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          workloadData={updatedWorkloadData}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('New event after refresh')).toBeInTheDocument()
+      })
+      expect(fetchWithMock.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('should NOT refetch events when workloadData changes if Events tab is not open', async () => {
+      const { rerender } = render(<WorkloadDetailPanel {...defaultProps} />)
+
+      expect(fetchWithMock).not.toHaveBeenCalled()
+
+      const updatedWorkloadData = {
+        ...mockWorkloadData,
+        status: { ...mockWorkloadData.status, readyReplicas: 4 }
+      }
+
+      rerender(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          workloadData={updatedWorkloadData}
+        />
+      )
+
+      await waitFor(() => {
+        expect(fetchWithMock).not.toHaveBeenCalled()
+      })
+    })
+
+    it('should NOT double-fetch events on initial mount', async () => {
+      const user = userEvent.setup()
+
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      fetchWithMock.mockResolvedValueOnce(mockEvents)
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('should preserve event data when refetch fails during auto-refresh', async () => {
+      const user = userEvent.setup()
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { rerender } = render(<WorkloadDetailPanel {...defaultProps} />)
+
+      fetchWithMock.mockResolvedValueOnce(mockEvents)
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(screen.getByText('Scaled up replica set')).toBeInTheDocument()
+      })
+
+      fetchWithMock.mockRejectedValueOnce(new Error('Network error'))
+
+      const updatedWorkloadData = {
+        ...mockWorkloadData,
+        status: { ...mockWorkloadData.status, readyReplicas: 4 }
+      }
+
+      rerender(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          workloadData={updatedWorkloadData}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Scaled up replica set')).toBeInTheDocument()
+      })
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('Specification tab', () => {
+    it('should switch to Specification tab and display yaml', async () => {
+      const user = userEvent.setup()
+
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      await user.click(screen.getByText('Specification'))
+
+      // YamlBlock uses Prism which splits text — check for key parts
+      expect(screen.getAllByText(/replicas/).length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('Status tab', () => {
+    it('should switch to Status tab and display yaml', async () => {
+      const user = userEvent.setup()
+
+      render(<WorkloadDetailPanel {...defaultProps} />)
+
+      await user.click(screen.getByRole('button', { name: 'Status' }))
+
+      expect(screen.getAllByText(/readyReplicas/).length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should handle null workloadInfo gracefully', () => {
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          workloadInfo={null}
+          workloadStatus="Unknown"
+        />
+      )
+
+      expect(screen.getByText('Unknown')).toBeInTheDocument()
+    })
+
+    it('should handle pods without createdAt in sorting', async () => {
+      const user = userEvent.setup()
+      const infoWithMissingDates = {
+        ...mockWorkloadInfo,
+        pods: [
+          { name: 'pod-no-date', status: 'Running' },
+          { name: 'pod-with-date', status: 'Running', createdAt: '2023-01-01T12:00:00Z' }
+        ]
+      }
+
+      render(
+        <WorkloadDetailPanel
+          {...defaultProps}
+          workloadInfo={infoWithMissingDates}
+        />
+      )
+
+      await user.click(screen.getByText('Pods'))
+
+      // Pod with date should come first (query exact pod name spans)
+      const pods = screen.getAllByText(/^pod-/)
+      expect(pods[0]).toHaveTextContent('pod-with-date')
+      expect(pods[1]).toHaveTextContent('pod-no-date')
+    })
+  })
+})

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.test.jsx
@@ -26,6 +26,12 @@ vi.mock('../resource/WorkloadDeleteAction', () => ({
   )
 }))
 
+vi.mock('./WorkloadLogsViewer', () => ({
+  WorkloadLogsViewer: (props) => (
+    <div data-testid="logs-viewer-mock">Logs: {props.name}</div>
+  )
+}))
+
 describe('WorkloadDetailPanel component', () => {
   const mockWorkloadData = {
     apiVersion: 'apps/v1',
@@ -409,6 +415,54 @@ describe('WorkloadDetailPanel component', () => {
 
       const deleteActions = screen.getAllByTestId('workload-delete-action')
       expect(deleteActions).toHaveLength(2)
+    })
+
+    it('should render logs buttons when logs action is available and pod has podStatus', async () => {
+      const user = userEvent.setup()
+      const infoWithLogs = {
+        ...mockWorkloadInfo,
+        userActions: ['restart', 'deletePods', 'logs'],
+        pods: [{
+          name: 'nginx-abc-123',
+          status: 'Running',
+          createdAt: '2023-01-01T12:00:00Z',
+          podStatus: {
+            phase: 'Running',
+            containerStatuses: [{ name: 'nginx', ready: true, restartCount: 0, state: { running: {} } }]
+          }
+        }]
+      }
+
+      render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoWithLogs} />)
+      await user.click(screen.getByText('Pods'))
+
+      const logsButton = screen.getByTestId('logs-pod-button')
+      expect(logsButton).toBeInTheDocument()
+
+      await user.click(logsButton)
+      expect(screen.getByTestId('logs-viewer-mock')).toHaveTextContent('Logs: nginx-abc-123')
+    })
+
+    it('should not render logs buttons when logs action is unavailable', async () => {
+      const user = userEvent.setup()
+      const infoWithPodStatus = {
+        ...mockWorkloadInfo,
+        userActions: ['restart', 'deletePods'],
+        pods: [{
+          name: 'nginx-abc-123',
+          status: 'Running',
+          createdAt: '2023-01-01T12:00:00Z',
+          podStatus: {
+            phase: 'Running',
+            containerStatuses: [{ name: 'nginx', ready: true, restartCount: 0, state: { running: {} } }]
+          }
+        }]
+      }
+
+      render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoWithPodStatus} />)
+      await user.click(screen.getByText('Pods'))
+
+      expect(screen.queryByTestId('logs-pod-button')).not.toBeInTheDocument()
     })
 
     it('should show Terminating status for pending deletions', async () => {

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.test.jsx
@@ -27,7 +27,10 @@ vi.mock('../resource/WorkloadDeleteAction', () => ({
 
 vi.mock('./WorkloadLogsViewer', () => ({
   WorkloadLogsViewer: (props) => (
-    <div data-testid="logs-viewer-mock">Logs: {props.initialPodName}</div>
+    <div data-testid="logs-viewer-mock">
+      Logs: {props.initialPodName}
+      <button data-testid="logs-viewer-close" onClick={props.onClose}>close</button>
+    </div>
   )
 }))
 
@@ -85,6 +88,9 @@ describe('WorkloadDetailPanel component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // The logs button writes a ?logs=<pod> share param to the URL; reset it so a
+    // session opened by one test does not leak into the next.
+    window.history.replaceState(null, '', '/')
   })
 
   it('should render the panel title from kind', () => {
@@ -440,6 +446,13 @@ describe('WorkloadDetailPanel component', () => {
 
       await user.click(logsButton)
       expect(screen.getByTestId('logs-viewer-mock')).toHaveTextContent('Logs: nginx-abc-123')
+      // The pod is written to the URL so the logs session is shareable.
+      expect(new URLSearchParams(window.location.search).get('logs')).toBe('nginx-abc-123')
+
+      // Closing the viewer clears the share param.
+      await user.click(screen.getByTestId('logs-viewer-close'))
+      expect(screen.queryByTestId('logs-viewer-mock')).not.toBeInTheDocument()
+      expect(new URLSearchParams(window.location.search).get('logs')).toBeNull()
     })
 
     it('should not render logs buttons when logs action is unavailable', async () => {

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.test.jsx
@@ -27,7 +27,7 @@ vi.mock('../resource/WorkloadDeleteAction', () => ({
 
 vi.mock('./WorkloadLogsViewer', () => ({
   WorkloadLogsViewer: (props) => (
-    <div data-testid="logs-viewer-mock">Logs: {props.name}</div>
+    <div data-testid="logs-viewer-mock">Logs: {props.initialPodName}</div>
   )
 }))
 

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.test.jsx
@@ -7,7 +7,6 @@ import userEvent from '@testing-library/user-event'
 import { WorkloadDetailPanel } from './WorkloadDetailPanel'
 import { fetchWithMock } from '../../../utils/fetch'
 
-// Mock fetchWithMock
 vi.mock('../../../utils/fetch', () => ({
   fetchWithMock: vi.fn()
 }))
@@ -594,13 +593,10 @@ describe('WorkloadDetailPanel component', () => {
       render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoWithPodStatus} />)
       await user.click(screen.getByText('Pods'))
 
-      // Should not show expanded details initially
       expect(screen.queryByTestId('pod-expanded-details')).not.toBeInTheDocument()
 
-      // Click on the pod row to expand
       await user.click(screen.getByText('pod-1'))
 
-      // Should show expanded container details
       expect(screen.getByTestId('pod-expanded-details')).toBeInTheDocument()
       expect(screen.getByText('manager')).toBeInTheDocument()
       expect(screen.getByText('Waiting')).toBeInTheDocument()
@@ -627,11 +623,9 @@ describe('WorkloadDetailPanel component', () => {
       render(<WorkloadDetailPanel {...defaultProps} workloadInfo={infoWithPodStatus} />)
       await user.click(screen.getByText('Pods'))
 
-      // Click to expand
       await user.click(screen.getByText('pod-1'))
       expect(screen.getByTestId('pod-expanded-details')).toBeInTheDocument()
 
-      // Click again to collapse
       await user.click(screen.getByText('pod-1'))
       expect(screen.queryByTestId('pod-expanded-details')).not.toBeInTheDocument()
     })

--- a/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
@@ -5,6 +5,14 @@ import { useState, useRef, useMemo } from 'preact/hooks'
 import { WorkloadLogsViewer } from './WorkloadLogsViewer'
 import { useDismiss } from '../../../utils/useDismiss'
 
+// containersOf builds the viewer's container list for a pod (init containers
+// first). The restart count lets the viewer offer a "(previous)" entry for
+// restarted containers.
+const containersOf = (pod) => [
+  ...(pod.podStatus.initContainerStatuses || []).map(cs => ({ name: cs.name, isInit: true, restartCount: cs.restartCount || 0 })),
+  ...(pod.podStatus.containerStatuses || []).map(cs => ({ name: cs.name, isInit: false, restartCount: cs.restartCount || 0 }))
+]
+
 /**
  * WorkloadLogsAction - "View logs" dropdown for the workload dashboard action bar.
  *
@@ -21,7 +29,11 @@ import { useDismiss } from '../../../utils/useDismiss'
  */
 export function WorkloadLogsAction({ kind, namespace, name, pods = [], userActions = [] }) {
   const [open, setOpen] = useState(false)
-  const [logsPodName, setLogsPodName] = useState(null)
+  // Open log-viewing session: { key, pod } where pod is a pod name or null for the
+  // "All pods" view. key increments per open so the viewer remounts (re-initialising
+  // its pod selection from the new session). null when no viewer is open.
+  const [session, setSession] = useState(null)
+  const sessionKeyRef = useRef(0)
   const dropdownRef = useRef(null)
 
   // Pods that can be inspected: the user is authorized to read logs and the pod
@@ -31,12 +43,12 @@ export function WorkloadLogsAction({ kind, namespace, name, pods = [], userActio
     [pods, userActions]
   )
 
-  // Live pod whose logs are displayed; looked up from the polled pods by name
-  // so its restart counts (and the viewer's "(previous)" options) stay current
-  // while the viewer is open. Resolves to null if the pod is gone, closing it.
-  const logsPod = useMemo(
-    () => (logsPodName ? logsPods.find(p => p.name === logsPodName) || null : null),
-    [logsPodName, logsPods]
+  // The live pods passed to the viewer, each with its containers, so the viewer
+  // can build the "All pods" request and resolve a pod's containers (and restart
+  // counts) from the polled data while it is open.
+  const viewerPods = useMemo(
+    () => logsPods.map(p => ({ name: p.name, status: p.status, containers: containersOf(p) })),
+    [logsPods]
   )
 
   // Close the dropdown on click outside or Escape.
@@ -46,16 +58,10 @@ export function WorkloadLogsAction({ kind, namespace, name, pods = [], userActio
     return null
   }
 
-  // Build the container list for a pod (init containers first). The restart
-  // count lets the viewer offer a "(previous)" entry for restarted containers.
-  const containersOf = (pod) => [
-    ...(pod.podStatus.initContainerStatuses || []).map(cs => ({ name: cs.name, isInit: true, restartCount: cs.restartCount || 0 })),
-    ...(pod.podStatus.containerStatuses || []).map(cs => ({ name: cs.name, isInit: false, restartCount: cs.restartCount || 0 }))
-  ]
-
-  const handleSelect = (pod) => {
+  const openSession = (pod) => {
     setOpen(false)
-    setLogsPodName(pod.name)
+    sessionKeyRef.current += 1
+    setSession({ key: sessionKeyRef.current, pod })
   }
 
   const baseButtonClass = 'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 dark:focus:ring-offset-gray-900'
@@ -87,10 +93,19 @@ export function WorkloadLogsAction({ kind, namespace, name, pods = [], userActio
           class="absolute left-0 mt-1 w-72 max-h-80 overflow-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50"
           data-testid="view-logs-dropdown-menu"
         >
+          {/* "All pods" leads: streams every pod merged, each line tagged with its
+              origin. The per-pod items open the viewer pre-selected on that pod. */}
+          <button
+            onClick={() => openSession(null)}
+            class="w-full px-3 py-2 text-left text-sm font-medium text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            data-testid="view-logs-all-pods"
+          >
+            All pods
+          </button>
           {logsPods.map((pod) => (
             <button
               key={pod.name}
-              onClick={() => handleSelect(pod)}
+              onClick={() => openSession(pod.name)}
               class="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
               data-testid={`view-logs-pod-${pod.name}`}
             >
@@ -103,16 +118,15 @@ export function WorkloadLogsAction({ kind, namespace, name, pods = [], userActio
         </div>
       )}
 
-      {logsPod && (
+      {session && (
         <WorkloadLogsViewer
+          key={session.key}
           kind={kind}
           namespace={namespace}
-          name={logsPod.name}
           workloadName={name}
-          containers={containersOf(logsPod)}
-          pods={logsPods}
-          onSelectPod={setLogsPodName}
-          onClose={() => setLogsPodName(null)}
+          pods={viewerPods}
+          initialPodName={session.pod || undefined}
+          onClose={() => setSession(null)}
         />
       )}
     </div>

--- a/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
@@ -1,9 +1,16 @@
 // Copyright 2026 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { useState, useRef, useMemo } from 'preact/hooks'
+import { useState, useRef, useMemo, useEffect, useCallback } from 'preact/hooks'
 import { WorkloadLogsViewer } from './WorkloadLogsViewer'
-import { useDismiss } from '../../../utils/useDismiss'
+import { urlWithParam } from '../../../utils/routing'
+
+// LOGS_QUERY_PARAM carries the open viewer in the URL so a session is shareable:
+// a pod name, or ALL_PODS_VALUE for "All pods". Shared with WorkloadDetailPanel,
+// which writes the same param. ALL_PODS_VALUE is `*`, not a valid pod name, so it
+// can never collide with a real pod.
+export const LOGS_QUERY_PARAM = 'logs'
+export const ALL_PODS_VALUE = '*'
 
 // containersOf builds the viewer's container list for a pod (init containers
 // first). The restart count lets the viewer offer a "(previous)" entry for
@@ -14,11 +21,12 @@ const containersOf = (pod) => [
 ]
 
 /**
- * WorkloadLogsAction - "View logs" dropdown for the workload dashboard action bar.
+ * WorkloadLogsAction - "View logs" button for the workload dashboard action bar.
  *
- * Lists the pods of the workload and opens the logs viewer for the selected one.
- * Renders nothing unless the user is authorized to read logs ('logs' user action)
- * and there is at least one pod with container status to view.
+ * Opens the viewer on "All pods"; its pod selector then narrows to one pod. Renders
+ * nothing without the 'logs' user action. With the action but no inspectable pods
+ * (e.g. scaled to zero), the button is shown disabled rather than hidden, so the
+ * capability stays visible.
  *
  * @param {Object} props
  * @param {string} props.kind - Workload kind (shown in the viewer title)
@@ -28,96 +36,92 @@ const containersOf = (pod) => [
  * @param {Array} props.userActions - Allowed user actions for the workload
  */
 export function WorkloadLogsAction({ kind, namespace, name, pods = [], userActions = [] }) {
-  const [open, setOpen] = useState(false)
-  // Open log-viewing session: { key, pod } where pod is a pod name or null for the
-  // "All pods" view. key increments per open so the viewer remounts (re-initialising
-  // its pod selection from the new session). null when no viewer is open.
+  // Open session: { key, pod } where pod is a pod name or null for "All pods". key
+  // increments per open so the viewer remounts and re-inits its pod selection. null
+  // when no viewer is open.
   const [session, setSession] = useState(null)
   const sessionKeyRef = useRef(0)
-  const dropdownRef = useRef(null)
 
-  // Pods that can be inspected: the user is authorized to read logs and the pod
-  // carries container status (needed to populate the viewer's container list).
+  // RBAC gate: only users authorized to read logs see the button at all.
+  const canViewLogs = userActions.includes('logs')
+
+  // Pods that can be inspected: those carrying container status (needed to populate
+  // the viewer's container list). Empty for a scaled-to-zero workload.
   const logsPods = useMemo(
-    () => (userActions.includes('logs') ? pods.filter(p => p.podStatus) : []),
-    [pods, userActions]
+    () => (canViewLogs ? pods.filter(p => p.podStatus) : []),
+    [pods, canViewLogs]
   )
 
-  // The live pods passed to the viewer, each with its containers, so the viewer
-  // can build the "All pods" request and resolve a pod's containers (and restart
-  // counts) from the polled data while it is open.
+  // Live pods passed to the viewer, each with its containers, so it can build the
+  // "All pods" request and resolve a pod's containers (and restart counts) from the
+  // polled data while open.
   const viewerPods = useMemo(
     () => logsPods.map(p => ({ name: p.name, status: p.status, containers: containersOf(p) })),
     [logsPods]
   )
 
-  // Close the dropdown on click outside or Escape.
-  useDismiss(dropdownRef, () => setOpen(false), open)
+  // Keep the URL pointed at the pod shown (on open and every in-viewer switch via
+  // onPodChange) so the address bar is a shareable link. A null pod is "All pods".
+  const syncLogFilterToUrl = useCallback((pod) => {
+    window.history.replaceState(null, '', urlWithParam(LOGS_QUERY_PARAM, pod || ALL_PODS_VALUE))
+  }, [])
 
-  if (logsPods.length === 0) {
+  // Deep link: a `?logs=<pod|*>` param opens the viewer on that pod (or "All pods")
+  // so a shared link lands in the logs. Runs once on mount. An unknown pod still
+  // opens the viewer, which falls back to "All pods" when the pod is gone.
+  const deepLinked = useRef(false)
+  useEffect(() => {
+    if (deepLinked.current) return
+    deepLinked.current = true
+    // Nothing to show for a workload with no inspectable pods, even with a ?logs link.
+    if (logsPods.length === 0) return
+    const logs = new URLSearchParams(window.location.search).get(LOGS_QUERY_PARAM)
+    if (!logs) return
+    sessionKeyRef.current += 1
+    setSession({ key: sessionKeyRef.current, pod: logs === ALL_PODS_VALUE ? null : logs })
+  }, [])
+
+  if (!canViewLogs) {
     return null
   }
 
-  const openSession = (pod) => {
-    setOpen(false)
+  // No pods to inspect (e.g. scaled to zero): the button is shown but disabled.
+  const hasPods = logsPods.length > 0
+
+  // Open the viewer on "All pods"; its pod selector narrows from there.
+  const openAllPods = () => {
     sessionKeyRef.current += 1
-    setSession({ key: sessionKeyRef.current, pod })
+    setSession({ key: sessionKeyRef.current, pod: null })
+    syncLogFilterToUrl(null)
   }
 
-  const baseButtonClass = 'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 dark:focus:ring-offset-gray-900'
+  const closeSession = () => {
+    setSession(null)
+    window.history.replaceState(null, '', urlWithParam(LOGS_QUERY_PARAM, null))
+  }
+
+  const baseButtonClass = 'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border transition-colors focus:outline-none'
+  const buttonClass = hasPods
+    ? `${baseButtonClass} border-teal-500 text-teal-600 hover:bg-teal-50 dark:border-teal-400 dark:text-teal-400 dark:hover:bg-teal-900/30 focus:ring-2 focus:ring-offset-1 dark:focus:ring-offset-gray-900 focus:ring-teal-500`
+    : `${baseButtonClass} border-gray-300 text-gray-400 cursor-not-allowed dark:border-gray-600 dark:text-gray-500`
 
   return (
-    <div class="relative" ref={dropdownRef} data-testid="workload-logs-action">
+    <div class="relative" data-testid="workload-logs-action">
       <button
-        onClick={() => setOpen(v => !v)}
-        class={`${baseButtonClass} ${
-          open
-            ? 'border-teal-500 text-teal-600 bg-teal-50 dark:border-teal-400 dark:text-teal-400 dark:bg-teal-900/30'
-            : 'border-teal-500 text-teal-600 hover:bg-teal-50 dark:border-teal-400 dark:text-teal-400 dark:hover:bg-teal-900/30 focus:ring-teal-500'
-        }`}
-        data-testid="view-logs-dropdown-button"
-        title="View pod logs"
-        aria-expanded={open}
+        onClick={hasPods ? openAllPods : undefined}
+        disabled={!hasPods}
+        class={buttonClass}
+        data-testid="view-logs-button"
+        title={hasPods ? 'View pod logs' : 'No running pods to view logs'}
       >
         <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
         </svg>
         View logs
-        <svg class="w-3 h-3 ml-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-        </svg>
       </button>
 
-      {open && (
-        <div
-          class="absolute left-0 mt-1 w-72 max-h-80 overflow-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50"
-          data-testid="view-logs-dropdown-menu"
-        >
-          {/* "All pods" leads: streams every pod merged, each line tagged with its
-              origin. The per-pod items open the viewer pre-selected on that pod. */}
-          <button
-            onClick={() => openSession(null)}
-            class="w-full px-3 py-2 text-left text-sm font-medium text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-            data-testid="view-logs-all-pods"
-          >
-            All pods
-          </button>
-          {logsPods.map((pod) => (
-            <button
-              key={pod.name}
-              onClick={() => openSession(pod.name)}
-              class="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-              data-testid={`view-logs-pod-${pod.name}`}
-            >
-              <div class="font-medium truncate text-gray-900 dark:text-gray-100">{pod.name}</div>
-              {pod.status && (
-                <div class="text-xs text-gray-500 dark:text-gray-400 truncate">{pod.status}</div>
-              )}
-            </button>
-          ))}
-        </div>
-      )}
-
+      {/* Stays mounted even with no pods, showing an inline notice instead of
+          vanishing; the button above still disables when there are no pods. */}
       {session && (
         <WorkloadLogsViewer
           key={session.key}
@@ -126,7 +130,8 @@ export function WorkloadLogsAction({ kind, namespace, name, pods = [], userActio
           workloadName={name}
           pods={viewerPods}
           initialPodName={session.pod || undefined}
-          onClose={() => setSession(null)}
+          onClose={closeSession}
+          onPodChange={syncLogFilterToUrl}
         />
       )}
     </div>

--- a/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
@@ -13,11 +13,13 @@ import { useDismiss } from '../../../utils/useDismiss'
  * and there is at least one pod with container status to view.
  *
  * @param {Object} props
+ * @param {string} props.kind - Workload kind (shown in the viewer title)
  * @param {string} props.namespace - Workload namespace
+ * @param {string} props.name - Workload name (shown in the viewer title)
  * @param {Array} props.pods - Pods of the workload (each with a podStatus)
  * @param {Array} props.userActions - Allowed user actions for the workload
  */
-export function WorkloadLogsAction({ namespace, pods = [], userActions = [] }) {
+export function WorkloadLogsAction({ kind, namespace, name, pods = [], userActions = [] }) {
   const [open, setOpen] = useState(false)
   const [logsPodName, setLogsPodName] = useState(null)
   const dropdownRef = useRef(null)
@@ -103,9 +105,13 @@ export function WorkloadLogsAction({ namespace, pods = [], userActions = [] }) {
 
       {logsPod && (
         <WorkloadLogsViewer
+          kind={kind}
           namespace={namespace}
           name={logsPod.name}
+          workloadName={name}
           containers={containersOf(logsPod)}
+          pods={logsPods}
+          onSelectPod={setLogsPodName}
           onClose={() => setLogsPodName(null)}
         />
       )}

--- a/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
@@ -1,8 +1,9 @@
 // Copyright 2026 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { useState, useEffect, useRef, useMemo } from 'preact/hooks'
+import { useState, useRef, useMemo } from 'preact/hooks'
 import { WorkloadLogsViewer } from './WorkloadLogsViewer'
+import { useDismiss } from '../../../utils/useDismiss'
 
 /**
  * WorkloadLogsAction - "View logs" dropdown for the workload dashboard action bar.
@@ -37,21 +38,7 @@ export function WorkloadLogsAction({ namespace, pods = [], userActions = [] }) {
   )
 
   // Close the dropdown on click outside or Escape.
-  useEffect(() => {
-    if (!open) return
-    const onClick = (e) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) setOpen(false)
-    }
-    const onKey = (e) => {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', onClick)
-    document.addEventListener('keydown', onKey)
-    return () => {
-      document.removeEventListener('mousedown', onClick)
-      document.removeEventListener('keydown', onKey)
-    }
-  }, [open])
+  useDismiss(dropdownRef, () => setOpen(false), open)
 
   if (logsPods.length === 0) {
     return null

--- a/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
@@ -18,7 +18,7 @@ import { WorkloadLogsViewer } from './WorkloadLogsViewer'
  */
 export function WorkloadLogsAction({ namespace, pods = [], userActions = [] }) {
   const [open, setOpen] = useState(false)
-  const [logsPod, setLogsPod] = useState(null)
+  const [logsPodName, setLogsPodName] = useState(null)
   const dropdownRef = useRef(null)
 
   // Pods that can be inspected: the user is authorized to read logs and the pod
@@ -26,6 +26,14 @@ export function WorkloadLogsAction({ namespace, pods = [], userActions = [] }) {
   const logsPods = useMemo(
     () => (userActions.includes('logs') ? pods.filter(p => p.podStatus) : []),
     [pods, userActions]
+  )
+
+  // Live pod whose logs are displayed; looked up from the polled pods by name
+  // so its restart counts (and the viewer's "(previous)" options) stay current
+  // while the viewer is open. Resolves to null if the pod is gone, closing it.
+  const logsPod = useMemo(
+    () => (logsPodName ? logsPods.find(p => p.name === logsPodName) || null : null),
+    [logsPodName, logsPods]
   )
 
   // Close the dropdown on click outside or Escape.
@@ -49,15 +57,16 @@ export function WorkloadLogsAction({ namespace, pods = [], userActions = [] }) {
     return null
   }
 
-  // Build the container list for a pod (init containers first).
+  // Build the container list for a pod (init containers first). The restart
+  // count lets the viewer offer a "(previous)" entry for restarted containers.
   const containersOf = (pod) => [
-    ...(pod.podStatus.initContainerStatuses || []).map(cs => ({ name: cs.name, isInit: true })),
-    ...(pod.podStatus.containerStatuses || []).map(cs => ({ name: cs.name, isInit: false }))
+    ...(pod.podStatus.initContainerStatuses || []).map(cs => ({ name: cs.name, isInit: true, restartCount: cs.restartCount || 0 })),
+    ...(pod.podStatus.containerStatuses || []).map(cs => ({ name: cs.name, isInit: false, restartCount: cs.restartCount || 0 }))
   ]
 
   const handleSelect = (pod) => {
     setOpen(false)
-    setLogsPod(pod)
+    setLogsPodName(pod.name)
   }
 
   const baseButtonClass = 'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 dark:focus:ring-offset-gray-900'
@@ -110,7 +119,7 @@ export function WorkloadLogsAction({ namespace, pods = [], userActions = [] }) {
           namespace={namespace}
           name={logsPod.name}
           containers={containersOf(logsPod)}
-          onClose={() => setLogsPod(null)}
+          onClose={() => setLogsPodName(null)}
         />
       )}
     </div>

--- a/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
@@ -1,0 +1,118 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useState, useEffect, useRef, useMemo } from 'preact/hooks'
+import { WorkloadLogsViewer } from './WorkloadLogsViewer'
+
+/**
+ * WorkloadLogsAction - "View logs" dropdown for the workload dashboard action bar.
+ *
+ * Lists the pods of the workload and opens the logs viewer for the selected one.
+ * Renders nothing unless the user is authorized to read logs ('logs' user action)
+ * and there is at least one pod with container status to view.
+ *
+ * @param {Object} props
+ * @param {string} props.namespace - Workload namespace
+ * @param {Array} props.pods - Pods of the workload (each with a podStatus)
+ * @param {Array} props.userActions - Allowed user actions for the workload
+ */
+export function WorkloadLogsAction({ namespace, pods = [], userActions = [] }) {
+  const [open, setOpen] = useState(false)
+  const [logsPod, setLogsPod] = useState(null)
+  const dropdownRef = useRef(null)
+
+  // Pods that can be inspected: the user is authorized to read logs and the pod
+  // carries container status (needed to populate the viewer's container list).
+  const logsPods = useMemo(
+    () => (userActions.includes('logs') ? pods.filter(p => p.podStatus) : []),
+    [pods, userActions]
+  )
+
+  // Close the dropdown on click outside or Escape.
+  useEffect(() => {
+    if (!open) return
+    const onClick = (e) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) setOpen(false)
+    }
+    const onKey = (e) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  if (logsPods.length === 0) {
+    return null
+  }
+
+  // Build the container list for a pod (init containers first).
+  const containersOf = (pod) => [
+    ...(pod.podStatus.initContainerStatuses || []).map(cs => ({ name: cs.name, isInit: true })),
+    ...(pod.podStatus.containerStatuses || []).map(cs => ({ name: cs.name, isInit: false }))
+  ]
+
+  const handleSelect = (pod) => {
+    setOpen(false)
+    setLogsPod(pod)
+  }
+
+  const baseButtonClass = 'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 dark:focus:ring-offset-gray-900'
+
+  return (
+    <div class="relative" ref={dropdownRef} data-testid="workload-logs-action">
+      <button
+        onClick={() => setOpen(v => !v)}
+        class={`${baseButtonClass} ${
+          open
+            ? 'border-teal-500 text-teal-600 bg-teal-50 dark:border-teal-400 dark:text-teal-400 dark:bg-teal-900/30'
+            : 'border-teal-500 text-teal-600 hover:bg-teal-50 dark:border-teal-400 dark:text-teal-400 dark:hover:bg-teal-900/30 focus:ring-teal-500'
+        }`}
+        data-testid="view-logs-dropdown-button"
+        title="View pod logs"
+        aria-expanded={open}
+      >
+        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        View logs
+        <svg class="w-3 h-3 ml-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          class="absolute left-0 mt-1 w-72 max-h-80 overflow-auto bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50"
+          data-testid="view-logs-dropdown-menu"
+        >
+          {logsPods.map((pod) => (
+            <button
+              key={pod.name}
+              onClick={() => handleSelect(pod)}
+              class="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              data-testid={`view-logs-pod-${pod.name}`}
+            >
+              <div class="font-medium truncate text-gray-900 dark:text-gray-100">{pod.name}</div>
+              {pod.status && (
+                <div class="text-xs text-gray-500 dark:text-gray-400 truncate">{pod.status}</div>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {logsPod && (
+        <WorkloadLogsViewer
+          namespace={namespace}
+          name={logsPod.name}
+          containers={containersOf(logsPod)}
+          onClose={() => setLogsPod(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/src/components/dashboards/workload/WorkloadLogsAction.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsAction.test.jsx
@@ -6,17 +6,25 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/preact'
 import userEvent from '@testing-library/user-event'
 import { WorkloadLogsAction } from './WorkloadLogsAction'
 
-// Mock the logs viewer so these tests stay focused on the dropdown.
+// Mock the logs viewer so these tests stay focused on the dropdown. It resolves
+// the pre-selected pod's containers from the live pods prop, mirroring how the
+// real viewer reads them (so a restart-count change flows through).
 vi.mock('./WorkloadLogsViewer', () => ({
-  WorkloadLogsViewer: ({ namespace, name, containers }) => (
-    <div
-      data-testid="logs-viewer-mock"
-      data-containers={(containers || []).map(c => c.name).join(',')}
-      data-restarts={(containers || []).map(c => c.restartCount).join(',')}
-    >
-      {namespace}/{name}
-    </div>
-  )
+  WorkloadLogsViewer: ({ namespace, workloadName, pods, initialPodName }) => {
+    const sel = (pods || []).find(p => p.name === initialPodName)
+    const containers = sel ? sel.containers : []
+    return (
+      <div
+        data-testid="logs-viewer-mock"
+        data-initialpod={initialPodName || ''}
+        data-pods={(pods || []).map(p => p.name).join(',')}
+        data-containers={containers.map(c => c.name).join(',')}
+        data-restarts={containers.map(c => c.restartCount).join(',')}
+      >
+        {namespace}/{workloadName}
+      </div>
+    )
+  }
 }))
 
 describe('WorkloadLogsAction component', () => {
@@ -34,7 +42,9 @@ describe('WorkloadLogsAction component', () => {
   ]
 
   const defaultProps = {
+    kind: 'Deployment',
     namespace: 'flux-system',
+    name: 'my-workload',
     pods,
     userActions: ['restart', 'logs']
   }
@@ -62,7 +72,7 @@ describe('WorkloadLogsAction component', () => {
     expect(screen.queryByTestId('view-logs-pod-app-pending')).not.toBeInTheDocument()
   })
 
-  it('opens the viewer for the selected pod with its containers (init first)', async () => {
+  it('opens the viewer pre-selected on the chosen pod, with its containers (init first)', async () => {
     const user = userEvent.setup()
     render(<WorkloadLogsAction {...defaultProps} />)
 
@@ -70,8 +80,22 @@ describe('WorkloadLogsAction component', () => {
     await user.click(screen.getByTestId('view-logs-pod-app-abc'))
 
     const viewer = screen.getByTestId('logs-viewer-mock')
-    expect(viewer).toHaveTextContent('flux-system/app-abc')
+    expect(viewer).toHaveTextContent('flux-system/my-workload')
+    expect(viewer).toHaveAttribute('data-initialpod', 'app-abc')
     expect(viewer).toHaveAttribute('data-containers', 'init,main')
+  })
+
+  it('opens the "All pods" view (no pre-selected pod) from the All pods item', async () => {
+    const user = userEvent.setup()
+    render(<WorkloadLogsAction {...defaultProps} />)
+
+    await user.click(screen.getByTestId('view-logs-dropdown-button'))
+    await user.click(screen.getByTestId('view-logs-all-pods'))
+
+    const viewer = screen.getByTestId('logs-viewer-mock')
+    expect(viewer).toHaveAttribute('data-initialpod', '')
+    // Only pods with container status are passed to the viewer.
+    expect(viewer).toHaveAttribute('data-pods', 'app-abc')
   })
 
   it('reflects live pod updates (e.g. a container restart) in the open viewer', async () => {
@@ -96,6 +120,21 @@ describe('WorkloadLogsAction component', () => {
     }]
     rerender(<WorkloadLogsAction {...defaultProps} pods={updated} />)
     expect(screen.getByTestId('logs-viewer-mock')).toHaveAttribute('data-restarts', '1')
+  })
+
+  it('re-initialises the viewer on each open (All pods, then a specific pod)', async () => {
+    const user = userEvent.setup()
+    render(<WorkloadLogsAction {...defaultProps} />)
+
+    await user.click(screen.getByTestId('view-logs-dropdown-button'))
+    await user.click(screen.getByTestId('view-logs-all-pods'))
+    expect(screen.getByTestId('logs-viewer-mock')).toHaveAttribute('data-initialpod', '')
+
+    // Reopening on a specific pod remounts the viewer pre-selected on that pod
+    // (the session key changes), rather than keeping the prior "All pods" session.
+    await user.click(screen.getByTestId('view-logs-dropdown-button'))
+    await user.click(screen.getByTestId('view-logs-pod-app-abc'))
+    expect(screen.getByTestId('logs-viewer-mock')).toHaveAttribute('data-initialpod', 'app-abc')
   })
 
   it('closes the dropdown on Escape', async () => {

--- a/web/src/components/dashboards/workload/WorkloadLogsAction.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsAction.test.jsx
@@ -9,7 +9,11 @@ import { WorkloadLogsAction } from './WorkloadLogsAction'
 // Mock the logs viewer so these tests stay focused on the dropdown.
 vi.mock('./WorkloadLogsViewer', () => ({
   WorkloadLogsViewer: ({ namespace, name, containers }) => (
-    <div data-testid="logs-viewer-mock" data-containers={(containers || []).map(c => c.name).join(',')}>
+    <div
+      data-testid="logs-viewer-mock"
+      data-containers={(containers || []).map(c => c.name).join(',')}
+      data-restarts={(containers || []).map(c => c.restartCount).join(',')}
+    >
       {namespace}/{name}
     </div>
   )
@@ -68,6 +72,30 @@ describe('WorkloadLogsAction component', () => {
     const viewer = screen.getByTestId('logs-viewer-mock')
     expect(viewer).toHaveTextContent('flux-system/app-abc')
     expect(viewer).toHaveAttribute('data-containers', 'init,main')
+  })
+
+  it('reflects live pod updates (e.g. a container restart) in the open viewer', async () => {
+    const user = userEvent.setup()
+    const initial = [{
+      name: 'app-abc',
+      status: 'Running',
+      podStatus: { containerStatuses: [{ name: 'main', restartCount: 0 }] }
+    }]
+    const { rerender } = render(<WorkloadLogsAction {...defaultProps} pods={initial} />)
+
+    await user.click(screen.getByTestId('view-logs-dropdown-button'))
+    await user.click(screen.getByTestId('view-logs-pod-app-abc'))
+    expect(screen.getByTestId('logs-viewer-mock')).toHaveAttribute('data-restarts', '0')
+
+    // The container restarts and the parent polls fresh pod data; the open
+    // viewer picks up the new restart count without being reopened.
+    const updated = [{
+      name: 'app-abc',
+      status: 'Running',
+      podStatus: { containerStatuses: [{ name: 'main', restartCount: 1 }] }
+    }]
+    rerender(<WorkloadLogsAction {...defaultProps} pods={updated} />)
+    expect(screen.getByTestId('logs-viewer-mock')).toHaveAttribute('data-restarts', '1')
   })
 
   it('closes the dropdown on Escape', async () => {

--- a/web/src/components/dashboards/workload/WorkloadLogsAction.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsAction.test.jsx
@@ -1,16 +1,17 @@
 // Copyright 2026 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/preact'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
 import userEvent from '@testing-library/user-event'
 import { WorkloadLogsAction } from './WorkloadLogsAction'
 
-// Mock the logs viewer so these tests stay focused on the dropdown. It resolves
-// the pre-selected pod's containers from the live pods prop, mirroring how the
-// real viewer reads them (so a restart-count change flows through).
+// Mock the logs viewer to keep these tests on the action button. It resolves the
+// pre-selected pod's containers from the live pods prop (mirroring the real viewer,
+// so a restart-count change flows through) and exposes buttons for onClose and
+// onPodChange.
 vi.mock('./WorkloadLogsViewer', () => ({
-  WorkloadLogsViewer: ({ namespace, workloadName, pods, initialPodName }) => {
+  WorkloadLogsViewer: ({ namespace, workloadName, pods, initialPodName, onClose, onPodChange }) => {
     const sel = (pods || []).find(p => p.name === initialPodName)
     const containers = sel ? sel.containers : []
     return (
@@ -22,10 +23,20 @@ vi.mock('./WorkloadLogsViewer', () => ({
         data-restarts={containers.map(c => c.restartCount).join(',')}
       >
         {namespace}/{workloadName}
+        <button data-testid="logs-viewer-close" onClick={onClose}>close</button>
+        {/* Simulate the viewer's own pod selector reporting a switch. */}
+        <button data-testid="logs-viewer-switch-pod" onClick={() => onPodChange && onPodChange('app-abc')}>switch</button>
+        <button data-testid="logs-viewer-switch-all" onClick={() => onPodChange && onPodChange(null)}>switch all</button>
       </div>
     )
   }
 }))
+
+// The deep-link/share-link tests drive window.location; reset it before each test
+// so a session opened by one test does not leak into the next via the URL.
+beforeEach(() => {
+  window.history.replaceState(null, '', '/')
+})
 
 describe('WorkloadLogsAction component', () => {
   const pods = [
@@ -37,7 +48,7 @@ describe('WorkloadLogsAction component', () => {
         containerStatuses: [{ name: 'main' }]
       }
     },
-    // No podStatus: cannot view logs, must be excluded from the list.
+    // No podStatus: cannot view logs, must be excluded from the viewer's pod list.
     { name: 'app-pending', status: 'Pending' }
   ]
 
@@ -49,70 +60,67 @@ describe('WorkloadLogsAction component', () => {
     userActions: ['restart', 'logs']
   }
 
-  it('renders nothing without the logs user action', () => {
+  it('renders nothing without the logs user action (no RBAC)', () => {
     const { container } = render(
       <WorkloadLogsAction {...defaultProps} userActions={['restart']} />
     )
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('renders nothing when no pod has container status', () => {
-    const { container } = render(
-      <WorkloadLogsAction {...defaultProps} pods={[{ name: 'p', status: 'Pending' }]} />
-    )
-    expect(container).toBeEmptyDOMElement()
+  it('shows the button disabled when there are no inspectable pods (scaled to zero)', () => {
+    // A pod without container status cannot be inspected.
+    const { unmount } = render(<WorkloadLogsAction {...defaultProps} pods={[{ name: 'p', status: 'Pending' }]} />)
+    expect(screen.getByTestId('view-logs-button')).toBeDisabled()
+    unmount()
+
+    // An empty pod list (scaled to zero) too.
+    render(<WorkloadLogsAction {...defaultProps} pods={[]} />)
+    expect(screen.getByTestId('view-logs-button')).toBeDisabled()
   })
 
-  it('lists only pods with container status', async () => {
+  it('does not open the viewer when the disabled button is clicked', () => {
+    render(<WorkloadLogsAction {...defaultProps} pods={[]} />)
+    fireEvent.click(screen.getByTestId('view-logs-button'))
+    expect(screen.queryByTestId('logs-viewer-mock')).not.toBeInTheDocument()
+  })
+
+  it('does not deep-link open when there are no pods, leaving the button disabled', () => {
+    window.history.replaceState(null, '', '/workload/Deployment/flux-system/my-workload?logs=*')
+    render(<WorkloadLogsAction {...defaultProps} pods={[]} />)
+    expect(screen.getByTestId('view-logs-button')).toBeDisabled()
+    expect(screen.queryByTestId('logs-viewer-mock')).not.toBeInTheDocument()
+  })
+
+  it('opens the viewer on the All pods view when the button is clicked', async () => {
     const user = userEvent.setup()
     render(<WorkloadLogsAction {...defaultProps} />)
 
-    await user.click(screen.getByTestId('view-logs-dropdown-button'))
-    expect(screen.getByTestId('view-logs-pod-app-abc')).toBeInTheDocument()
-    expect(screen.queryByTestId('view-logs-pod-app-pending')).not.toBeInTheDocument()
-  })
-
-  it('opens the viewer pre-selected on the chosen pod, with its containers (init first)', async () => {
-    const user = userEvent.setup()
-    render(<WorkloadLogsAction {...defaultProps} />)
-
-    await user.click(screen.getByTestId('view-logs-dropdown-button'))
-    await user.click(screen.getByTestId('view-logs-pod-app-abc'))
+    // No dropdown: the button opens the viewer directly.
+    expect(screen.queryByTestId('logs-viewer-mock')).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('view-logs-button'))
 
     const viewer = screen.getByTestId('logs-viewer-mock')
     expect(viewer).toHaveTextContent('flux-system/my-workload')
-    expect(viewer).toHaveAttribute('data-initialpod', 'app-abc')
-    expect(viewer).toHaveAttribute('data-containers', 'init,main')
-  })
-
-  it('opens the "All pods" view (no pre-selected pod) from the All pods item', async () => {
-    const user = userEvent.setup()
-    render(<WorkloadLogsAction {...defaultProps} />)
-
-    await user.click(screen.getByTestId('view-logs-dropdown-button'))
-    await user.click(screen.getByTestId('view-logs-all-pods'))
-
-    const viewer = screen.getByTestId('logs-viewer-mock')
+    // No pre-selected pod (All pods); only pods with container status are passed.
     expect(viewer).toHaveAttribute('data-initialpod', '')
-    // Only pods with container status are passed to the viewer.
     expect(viewer).toHaveAttribute('data-pods', 'app-abc')
+    // The All pods session is reflected in the URL.
+    expect(new URLSearchParams(window.location.search).get('logs')).toBe('*')
   })
 
   it('reflects live pod updates (e.g. a container restart) in the open viewer', async () => {
-    const user = userEvent.setup()
+    // Deep-link to a specific pod so the mock can surface its container restart count.
+    window.history.replaceState(null, '', '/workload/Deployment/flux-system/my-workload?logs=app-abc')
     const initial = [{
       name: 'app-abc',
       status: 'Running',
       podStatus: { containerStatuses: [{ name: 'main', restartCount: 0 }] }
     }]
     const { rerender } = render(<WorkloadLogsAction {...defaultProps} pods={initial} />)
+    expect(await screen.findByTestId('logs-viewer-mock')).toHaveAttribute('data-restarts', '0')
 
-    await user.click(screen.getByTestId('view-logs-dropdown-button'))
-    await user.click(screen.getByTestId('view-logs-pod-app-abc'))
-    expect(screen.getByTestId('logs-viewer-mock')).toHaveAttribute('data-restarts', '0')
-
-    // The container restarts and the parent polls fresh pod data; the open
-    // viewer picks up the new restart count without being reopened.
+    // The container restarts and the parent polls fresh pod data; the open viewer
+    // picks up the new restart count without being reopened.
     const updated = [{
       name: 'app-abc',
       status: 'Running',
@@ -122,28 +130,85 @@ describe('WorkloadLogsAction component', () => {
     expect(screen.getByTestId('logs-viewer-mock')).toHaveAttribute('data-restarts', '1')
   })
 
-  it('re-initialises the viewer on each open (All pods, then a specific pod)', async () => {
+  it('keeps the open viewer mounted and disables the button when the workload scales to zero', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<WorkloadLogsAction {...defaultProps} />)
+
+    await user.click(screen.getByTestId('view-logs-button'))
+    expect(screen.getByTestId('logs-viewer-mock')).toBeInTheDocument()
+
+    // Last pod goes away: viewer stays open (inline error), button disables.
+    rerender(<WorkloadLogsAction {...defaultProps} pods={[]} />)
+    expect(screen.getByTestId('logs-viewer-mock')).toBeInTheDocument()
+    expect(screen.getByTestId('view-logs-button')).toBeDisabled()
+  })
+
+  it('deep-links to a pod when loaded with ?logs=<pod>, without clicking the button', async () => {
+    window.history.replaceState(null, '', '/workload/Deployment/flux-system/my-workload?logs=app-abc')
+    render(<WorkloadLogsAction {...defaultProps} />)
+
+    const viewer = await screen.findByTestId('logs-viewer-mock')
+    expect(viewer).toHaveAttribute('data-initialpod', 'app-abc')
+  })
+
+  it('deep-links to the All pods view when loaded with ?logs=*', async () => {
+    window.history.replaceState(null, '', '/workload/Deployment/flux-system/my-workload?logs=*')
+    render(<WorkloadLogsAction {...defaultProps} />)
+
+    const viewer = await screen.findByTestId('logs-viewer-mock')
+    expect(viewer).toHaveAttribute('data-initialpod', '')
+  })
+
+  it('treats a deep-linked pod name as a pod, never the All pods sentinel', async () => {
+    // The All pods sentinel is `*`, which is not a valid pod name, so a real pod
+    // name in ?logs never collides with the merged view.
+    window.history.replaceState(null, '', '/workload/Deployment/flux-system/my-workload?logs=app-abc')
+    render(<WorkloadLogsAction {...defaultProps} />)
+    const viewer = await screen.findByTestId('logs-viewer-mock')
+    expect(viewer).toHaveAttribute('data-initialpod', 'app-abc')
+  })
+
+  it('does not open a viewer on mount without a ?logs param', () => {
+    render(<WorkloadLogsAction {...defaultProps} />)
+    expect(screen.queryByTestId('logs-viewer-mock')).not.toBeInTheDocument()
+  })
+
+  it('keeps the ?logs param in sync when the pod is switched inside the viewer', async () => {
     const user = userEvent.setup()
     render(<WorkloadLogsAction {...defaultProps} />)
 
-    await user.click(screen.getByTestId('view-logs-dropdown-button'))
-    await user.click(screen.getByTestId('view-logs-all-pods'))
-    expect(screen.getByTestId('logs-viewer-mock')).toHaveAttribute('data-initialpod', '')
+    await user.click(screen.getByTestId('view-logs-button'))
+    expect(new URLSearchParams(window.location.search).get('logs')).toBe('*')
 
-    // Reopening on a specific pod remounts the viewer pre-selected on that pod
-    // (the session key changes), rather than keeping the prior "All pods" session.
-    await user.click(screen.getByTestId('view-logs-dropdown-button'))
-    await user.click(screen.getByTestId('view-logs-pod-app-abc'))
-    expect(screen.getByTestId('logs-viewer-mock')).toHaveAttribute('data-initialpod', 'app-abc')
+    // Switching to a specific pod inside the viewer rewrites the share link.
+    await user.click(screen.getByTestId('logs-viewer-switch-pod'))
+    expect(new URLSearchParams(window.location.search).get('logs')).toBe('app-abc')
+
+    // Switching back to All pods rewrites it again.
+    await user.click(screen.getByTestId('logs-viewer-switch-all'))
+    expect(new URLSearchParams(window.location.search).get('logs')).toBe('*')
   })
 
-  it('closes the dropdown on Escape', async () => {
+  it('clears the ?logs param when the viewer is closed', async () => {
+    const user = userEvent.setup()
     render(<WorkloadLogsAction {...defaultProps} />)
 
-    fireEvent.click(screen.getByTestId('view-logs-dropdown-button'))
-    expect(screen.getByTestId('view-logs-dropdown-menu')).toBeInTheDocument()
+    await user.click(screen.getByTestId('view-logs-button'))
+    expect(new URLSearchParams(window.location.search).get('logs')).toBe('*')
 
-    fireEvent.keyDown(document, { key: 'Escape' })
-    await waitFor(() => expect(screen.queryByTestId('view-logs-dropdown-menu')).not.toBeInTheDocument())
+    await user.click(screen.getByTestId('logs-viewer-close'))
+    expect(screen.queryByTestId('logs-viewer-mock')).not.toBeInTheDocument()
+    expect(new URLSearchParams(window.location.search).get('logs')).toBeNull()
+  })
+
+  it('preserves other query params when writing the ?logs param', async () => {
+    const user = userEvent.setup()
+    window.history.replaceState(null, '', '/workload/Deployment/flux-system/my-workload?tab=pods')
+    render(<WorkloadLogsAction {...defaultProps} />)
+
+    await user.click(screen.getByTestId('view-logs-button'))
+    const params = new URLSearchParams(window.location.search)
+    expect(params.get('tab')).toBe('pods')
+    expect(params.get('logs')).toBe('*')
   })
 })

--- a/web/src/components/dashboards/workload/WorkloadLogsAction.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsAction.test.jsx
@@ -1,0 +1,82 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/preact'
+import userEvent from '@testing-library/user-event'
+import { WorkloadLogsAction } from './WorkloadLogsAction'
+
+// Mock the logs viewer so these tests stay focused on the dropdown.
+vi.mock('./WorkloadLogsViewer', () => ({
+  WorkloadLogsViewer: ({ namespace, name, containers }) => (
+    <div data-testid="logs-viewer-mock" data-containers={(containers || []).map(c => c.name).join(',')}>
+      {namespace}/{name}
+    </div>
+  )
+}))
+
+describe('WorkloadLogsAction component', () => {
+  const pods = [
+    {
+      name: 'app-abc',
+      status: 'Running',
+      podStatus: {
+        initContainerStatuses: [{ name: 'init' }],
+        containerStatuses: [{ name: 'main' }]
+      }
+    },
+    // No podStatus: cannot view logs, must be excluded from the list.
+    { name: 'app-pending', status: 'Pending' }
+  ]
+
+  const defaultProps = {
+    namespace: 'flux-system',
+    pods,
+    userActions: ['restart', 'logs']
+  }
+
+  it('renders nothing without the logs user action', () => {
+    const { container } = render(
+      <WorkloadLogsAction {...defaultProps} userActions={['restart']} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when no pod has container status', () => {
+    const { container } = render(
+      <WorkloadLogsAction {...defaultProps} pods={[{ name: 'p', status: 'Pending' }]} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('lists only pods with container status', async () => {
+    const user = userEvent.setup()
+    render(<WorkloadLogsAction {...defaultProps} />)
+
+    await user.click(screen.getByTestId('view-logs-dropdown-button'))
+    expect(screen.getByTestId('view-logs-pod-app-abc')).toBeInTheDocument()
+    expect(screen.queryByTestId('view-logs-pod-app-pending')).not.toBeInTheDocument()
+  })
+
+  it('opens the viewer for the selected pod with its containers (init first)', async () => {
+    const user = userEvent.setup()
+    render(<WorkloadLogsAction {...defaultProps} />)
+
+    await user.click(screen.getByTestId('view-logs-dropdown-button'))
+    await user.click(screen.getByTestId('view-logs-pod-app-abc'))
+
+    const viewer = screen.getByTestId('logs-viewer-mock')
+    expect(viewer).toHaveTextContent('flux-system/app-abc')
+    expect(viewer).toHaveAttribute('data-containers', 'init,main')
+  })
+
+  it('closes the dropdown on Escape', async () => {
+    render(<WorkloadLogsAction {...defaultProps} />)
+
+    fireEvent.click(screen.getByTestId('view-logs-dropdown-button'))
+    expect(screen.getByTestId('view-logs-dropdown-menu')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByTestId('view-logs-dropdown-menu')).not.toBeInTheDocument())
+  })
+})

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -23,6 +23,41 @@ const FOLLOW_INTERVAL = 5000
 // How long the most recent log line stays highlighted after new entries arrive.
 const HIGHLIGHT_DURATION = 2500
 
+// Distance in pixels from the bottom within which the view is still considered
+// pinned, so auto-scroll keeps following while allowing for sub-pixel rounding.
+const SCROLL_BOTTOM_THRESHOLD = 32
+
+// Upper bound on the number of accumulated log lines kept in the buffer while
+// following, so a long-running session does not grow without limit. Matches the
+// backend's maxLogTailLines cap.
+const MAX_BUFFER_LINES = 5000
+
+/**
+ * mergeLogs - appends incoming log lines to the accumulated buffer, dropping any
+ * that are already present and capping the result to MAX_BUFFER_LINES.
+ *
+ * Follow polls request everything since the last line's timestamp, which the
+ * API filters at second granularity, so the last second is re-sent on every
+ * poll. Each line carries a unique nanosecond timestamp prefix, so deduping by
+ * exact line text reliably drops those repeats. Returns the previous buffer
+ * unchanged when there is nothing new, so the state update is a no-op.
+ *
+ * @param {string} prev - The accumulated log payload
+ * @param {string} incoming - The newly fetched log payload
+ * @returns {string} The merged payload, newline-terminated
+ */
+function mergeLogs(prev, incoming) {
+  const add = incoming.split('\n').filter(Boolean)
+  if (add.length === 0) return prev
+  const prevLines = prev.split('\n').filter(Boolean)
+  const seen = new Set(prevLines)
+  const fresh = add.filter(line => !seen.has(line))
+  if (fresh.length === 0) return prev
+  const merged = prevLines.concat(fresh)
+  const capped = merged.length > MAX_BUFFER_LINES ? merged.slice(merged.length - MAX_BUFFER_LINES) : merged
+  return capped.join('\n') + '\n'
+}
+
 // Captures the leading RFC3339 timestamp the API prepends to each log line.
 // Anchored to a date so lines without a timestamp (e.g. stack-trace
 // continuations) are not mangled by splitting off their first token.
@@ -157,14 +192,19 @@ function LevelMenu({ value, onChange }) {
  * WorkloadLogsViewer - Modal that displays the logs of a pod container.
  *
  * Fetches logs from GET /api/v1/workload/logs for the selected container and
- * renders each log entry on its own row, with its timestamp shown as a pill on
- * the row separator. The pill border and rule are colored by the detected log
- * level (JSON/klog/logfmt/plain text), and the footer summarizes the per-level
- * counts. Supports following (live polling), pretty-printing JSON lines,
- * filtering by substring and minimum level, choosing the number of lines,
- * selecting a container (restarted containers also expose a "(previous)" entry
- * for the prior instance's logs), downloading the logs as a <pod>.log file, and
- * a fullscreen mode.
+ * renders each log entry on its own row. In the default formatted mode the
+ * timestamp is shown as a pill on the row separator, the pill border and rule
+ * are colored by the detected log level (JSON/klog/logfmt/plain text), and JSON
+ * lines are pretty-printed; the footer summarizes the per-level counts. The raw
+ * mode strips all of that styling, rendering each line as plain text without
+ * separators, timestamp pills, level coloring, or the new-entry highlight.
+ * Supports following (live polling, appending only new entries), toggling
+ * between formatted and raw output, filtering by substring and minimum level,
+ * choosing the number of lines, selecting a container (restarted containers
+ * also expose a "(previous)" entry for the prior instance's logs), downloading
+ * the logs as a <pod>.log file, and a fullscreen mode. A failed follow poll is
+ * shown inline at the tail of the feed, leaving the buffer on screen; an initial
+ * or post-reset failure (no buffer to keep) shows a full-pane error instead.
  *
  * @param {Object} props
  * @param {string} props.namespace - Pod namespace
@@ -185,15 +225,39 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
   const [follow, setFollow] = useState(true)
   const [filter, setFilter] = useState('')
   const [levelFilter, setLevelFilter] = useState('all')
-  const [prettyJson, setPrettyJson] = useState(false)
+  const [formatted, setFormatted] = useState(true)
   const [fullScreen, setFullScreen] = useState(false)
   const [logs, setLogs] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
+  // A failed follow poll, shown inline at the tail of the feed so the buffer
+  // stays visible. The full-pane `error` is used only when there is no buffer.
+  const [followError, setFollowError] = useState(null)
   const [flashLatest, setFlashLatest] = useState(false)
 
   const bodyRef = useRef(null)
   const prevLogsRef = useRef('')
+  // Identity (timestamp + text) of the most recent visible line, so the
+  // new-entry highlight fires only when that line actually changes.
+  const prevLatestKeyRef = useRef(null)
+  // Whether the log view is scrolled to the bottom; gates auto-follow scrolling.
+  const atBottomRef = useRef(true)
+  // Timestamp of the last buffered line, sent as sinceTime on follow polls so
+  // the server returns only newer entries to append.
+  const lastTsRef = useRef('')
+  // Monotonic id bumped by every reset (non-append) fetch. A fetch only applies
+  // its result if its id is still current, so an in-flight append poll from a
+  // previous container/params can't merge stale lines into a reset buffer.
+  const fetchGenRef = useRef(0)
+  // True while a reset (initial/param-change) fetch is in flight. Follow polls
+  // skip while it is set, so a poll started mid-reset can't append using the old
+  // buffer's cursor into the resetting buffer (the generation guard alone can't
+  // catch this, since a poll fired after the reset shares its generation).
+  const resettingRef = useRef(false)
+  // Memoizes the formatted (pretty-printed + Prism-highlighted) output per raw
+  // line text, so appends only format the new lines instead of re-highlighting
+  // the whole buffer on every poll. See displayLines for how it's pruned.
+  const formatCacheRef = useRef(new Map())
 
   // One option per container, plus a "(previous)" option for containers that
   // have restarted (a previous instance only has logs after a restart). The
@@ -213,29 +277,64 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
   // Fetch the logs. Background follow-polls pass { silent: true } so they don't
   // toggle the loading spinner, which would flicker on every poll; only the
   // initial load and user-driven changes (container, line count) show it.
-  const fetchLogs = useCallback(async ({ silent = false } = {}) => {
+  //
+  // Follow polls also pass { append: true }: once a buffer exists they request
+  // only the entries newer than the last line (sinceTime) and append them,
+  // instead of re-fetching the whole tail window and replacing it (which would
+  // make the visible lines shift on every poll). The initial load and any
+  // parameter change fetch the tail and replace the buffer.
+  const fetchLogs = useCallback(async ({ silent = false, append = false } = {}) => {
     if (!container) return
+    // Skip follow polls while a reset is in flight: appending now would use the
+    // old buffer's cursor (lastTsRef) and merge into the resetting buffer.
+    if (append && resettingRef.current) return
+    // A reset starts a new generation; appends ride on the current one. A fetch
+    // only applies its result if its generation is still current (checked on
+    // settle below), so an in-flight append poll from a previous container or
+    // a superseded reset can't write stale lines into the buffer.
+    const gen = append ? fetchGenRef.current : ++fetchGenRef.current
+    if (!append) resettingRef.current = true
     if (!silent) setLoading(true)
     try {
-      const params = new URLSearchParams({
-        namespace,
-        name,
-        container,
-        tailLines: String(tailLines),
-        previous: String(previous)
-      })
+      // tailLines is always sent so the backend caps every fetch (including a
+      // follow catch-up) to the user's selection; sinceTime narrows a follow
+      // poll to entries after the last buffered line.
+      const params = new URLSearchParams({ namespace, name, container, tailLines: String(tailLines), previous: String(previous) })
+      if (append && lastTsRef.current) {
+        params.set('sinceTime', lastTsRef.current)
+      }
       const resp = await fetchWithMock({
         endpoint: `/api/v1/workload/logs?${params.toString()}`,
         mockPath: '../mock/workload',
         mockExport: 'getMockWorkloadLogs'
       })
-      setLogs(resp?.logs || '')
+      if (fetchGenRef.current !== gen) return
+      const incoming = resp?.logs || ''
+      if (append) {
+        setLogs(prev => mergeLogs(prev, incoming))
+      } else {
+        setLogs(incoming)
+      }
       setError(null)
+      setFollowError(null)
     } catch (err) {
-      setError(err.message)
-      setLogs('')
+      if (fetchGenRef.current !== gen) return
+      if (append) {
+        // A follow poll failed: keep the buffer and surface the error inline at
+        // the tail of the feed rather than replacing the logs with a banner.
+        setFollowError(err.message)
+      } else {
+        setError(err.message)
+        setLogs('')
+        setFollowError(null)
+      }
     } finally {
-      if (!silent) setLoading(false)
+      // Only the still-current fetch clears the shared state, so a superseded
+      // reset settling first doesn't drop the loader or the resetting flag.
+      if (fetchGenRef.current === gen) {
+        if (!append) resettingRef.current = false
+        if (!silent) setLoading(false)
+      }
     }
   }, [namespace, name, container, tailLines, previous])
 
@@ -244,10 +343,15 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     fetchLogs()
   }, [fetchLogs])
 
-  // Poll for new logs while following, silently so the spinner doesn't flicker.
+  // Poll for new logs while following, silently so the spinner doesn't flicker
+  // and appending so the visible lines stay put instead of shifting each poll.
   useEffect(() => {
-    if (!follow) return
-    const id = setInterval(() => { fetchLogs({ silent: true }) }, FOLLOW_INTERVAL)
+    if (!follow) {
+      // No more polls, so drop any stale inline follow error.
+      setFollowError(null)
+      return
+    }
+    const id = setInterval(() => { fetchLogs({ silent: true, append: true }) }, FOLLOW_INTERVAL)
     return () => clearInterval(id)
   }, [follow, fetchLogs])
 
@@ -268,18 +372,6 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     return () => { document.body.style.overflow = previousOverflow }
   }, [])
 
-  // Briefly highlight the most recent line whenever a new batch of logs arrives
-  // (e.g. while following), skipping the very first load so the highlight only
-  // signals freshly appended entries.
-  useEffect(() => {
-    const prev = prevLogsRef.current
-    prevLogsRef.current = logs
-    if (prev === '' || logs === '' || prev === logs) return
-    setFlashLatest(true)
-    const id = setTimeout(() => setFlashLatest(false), HIGHLIGHT_DURATION)
-    return () => clearTimeout(id)
-  }, [logs])
-
   // Split the raw payload into entries once: strip the leading timestamp (shown
   // as a separator pill) and any ANSI escapes from the message, then detect the
   // log level. Only re-runs when the payload changes, not on every keystroke.
@@ -291,6 +383,20 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
       return { ts, text, level: detectLevel(text) }
     })
   }, [logs])
+
+  // Track the newest line's timestamp so the next follow poll can request only
+  // entries after it (sinceTime). This is authoritative over the current buffer:
+  // it clears to '' when the buffer has no timestamped lines (e.g. after a reset
+  // to a container with no logs yet), so a poll never reuses a stale timestamp
+  // from a previous stream. Trailing lines without a timestamp (stack-trace
+  // continuations) are skipped rather than clearing it.
+  useEffect(() => {
+    let ts = ''
+    for (let i = baseLines.length - 1; i >= 0; i--) {
+      if (baseLines[i].ts) { ts = baseLines[i].ts; break }
+    }
+    lastTsRef.current = ts
+  }, [baseLines])
 
   // Apply the substring filter on the message text; cheap pass over the
   // already-split entries. A leading "!" negates the match, keeping only lines
@@ -319,25 +425,80 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     return containsLines.filter(entry => entry.level === levelFilter)
   }, [containsLines, levelFilter])
 
-  // When the JSON toggle is on, every line renders as a code block sharing the
-  // same monospace font and size as the YAML blocks (`code: true`). Valid JSON
-  // gets indented and Prism-highlighted (`html`); other lines keep their plain
-  // text in the same styling. Filtering happens first on the raw text, so this
-  // only transforms what is actually shown.
+  // In formatted mode every line renders as a code block sharing the same
+  // monospace font and size as the YAML blocks (`code: true`). Valid JSON gets
+  // indented and Prism-highlighted (`html`); other lines keep their plain text
+  // in the same styling. In raw mode lines render as unstyled plain text
+  // (`code: false`). Filtering happens first on the raw text, so this only
+  // transforms what is actually shown.
+  //
+  // The formatted output is cached by raw line text (formatCacheRef): since the
+  // pretty-printed/highlighted form depends only on the line text, an append
+  // reuses the cached result for every existing line and only runs formatJson +
+  // Prism over the genuinely new lines, instead of re-highlighting the whole
+  // buffer on every poll. The cache is rebuilt to hold only the lines currently
+  // shown, so it can't outgrow the buffer; raw mode leaves it untouched so it
+  // survives a round-trip back to formatted. Returning the same html string for
+  // unchanged lines also lets Preact skip re-applying their innerHTML.
   const displayLines = useMemo(() => {
-    return logLines.map(entry => {
-      if (!prettyJson) return { ...entry, code: false, html: null }
-      const json = formatJson(entry.text)
-      if (json == null) return { ...entry, code: true, html: null }
-      return { ...entry, text: json, code: true, html: Prism.highlight(json, Prism.languages.json, 'json') }
+    if (!formatted) {
+      return logLines.map(entry => ({ ...entry, code: false, html: null }))
+    }
+    const prev = formatCacheRef.current
+    const next = new Map()
+    const result = logLines.map(entry => {
+      let formattedEntry = next.get(entry.text) || prev.get(entry.text)
+      if (!formattedEntry) {
+        const json = formatJson(entry.text)
+        formattedEntry = json == null
+          ? { text: entry.text, code: true, html: null }
+          : { text: json, code: true, html: Prism.highlight(json, Prism.languages.json, 'json') }
+      }
+      next.set(entry.text, formattedEntry)
+      return { ...entry, ...formattedEntry }
     })
-  }, [logLines, prettyJson])
+    formatCacheRef.current = next
+    return result
+  }, [logLines, formatted])
 
-  // Keep the most recent entry in view after each update.
+  // Briefly highlight the most recent visible line whenever genuinely new
+  // entries arrive (e.g. while following). The highlight is gated on two
+  // conditions so it only signals fresh logs: the raw buffer must have grown
+  // (prevLogs !== logs, skipping the very first load), and the newest displayed
+  // line must have changed. The second gate is what keeps a follow poll that
+  // appends only lines filtered out of the view — or a filter change that
+  // reshuffles the view — from re-pulsing an unchanged last line.
   useEffect(() => {
-    if (!bodyRef.current) return
+    const prevLogs = prevLogsRef.current
+    prevLogsRef.current = logs
+    const latest = displayLines.length > 0 ? displayLines[displayLines.length - 1] : null
+    const latestKey = latest ? `${latest.ts}\n${latest.text}` : null
+    const prevKey = prevLatestKeyRef.current
+    prevLatestKeyRef.current = latestKey
+    if (prevLogs === '' || logs === '' || prevLogs === logs) return
+    if (latestKey === null || latestKey === prevKey) return
+    setFlashLatest(true)
+    const id = setTimeout(() => setFlashLatest(false), HIGHLIGHT_DURATION)
+    return () => clearTimeout(id)
+  }, [logs, displayLines])
+
+  // Track whether the view is pinned to the bottom. Updated on every user
+  // scroll so the auto-scroll below only follows new entries when the user is
+  // already at the bottom; scrolling up to read older logs stops the next poll
+  // from yanking the view back down.
+  const handleScroll = useCallback(() => {
+    const el = bodyRef.current
+    if (!el) return
+    atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_BOTTOM_THRESHOLD
+  }, [])
+
+  // Keep the most recent entry (or the inline follow error) in view after each
+  // update, but only while pinned to the bottom, so following doesn't fight a
+  // user scrolling through history.
+  useEffect(() => {
+    if (!bodyRef.current || !atBottomRef.current) return
     bodyRef.current.scrollTop = bodyRef.current.scrollHeight
-  }, [displayLines])
+  }, [displayLines, followError])
 
   // Download the current logs as a <pod>.log text file.
   const handleDownload = useCallback(() => {
@@ -392,13 +553,15 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             </svg>
           </ToggleButton>
 
-          {/* Pretty-print JSON lines */}
+          {/* Toggle between formatted and raw output. Formatted (default)
+              pretty-prints structured lines and adds timestamp pills and
+              level coloring; raw strips all styling to plain text. */}
           <ToggleButton
-            active={prettyJson}
-            onClick={() => setPrettyJson(v => !v)}
-            label="Pretty-print JSON logs"
-            title="Format and syntax-highlight JSON log lines"
-            testid="logs-json-toggle"
+            active={formatted}
+            onClick={() => setFormatted(v => !v)}
+            label="Format logs"
+            title="Toggle between formatted and raw logs"
+            testid="logs-format-toggle"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1m8-18h1a2 2 0 0 1 2 2v5c0 1.1.9 2 2 2a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2h-1" />
@@ -493,21 +656,23 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
         </div>
 
         {/* Body */}
-        <div ref={bodyRef} class="flex-1 overflow-auto overscroll-contain bg-white dark:bg-gray-950" data-testid="logs-body">
+        <div ref={bodyRef} onScroll={handleScroll} class="flex-1 overflow-auto overscroll-contain bg-white dark:bg-gray-950" data-testid="logs-body">
           {error ? (
             <div class="m-3 p-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-xs text-red-800 dark:text-red-200" data-testid="logs-error">
               {error}
             </div>
           ) : loading && !logs ? (
             <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-loading">Loading logs...</p>
-          ) : displayLines.length > 0 ? (
+          ) : displayLines.length > 0 || followError ? (
             <div class="pb-2" data-testid="logs-content">
               {displayLines.map((entry, i) => {
-                const isLatest = flashLatest && i === displayLines.length - 1
+                // Raw mode strips all styling: no timestamp pill, no level
+                // coloring, and no highlight on the freshly appended entry.
+                const isLatest = formatted && flashLatest && i === displayLines.length - 1
                 const meta = LEVEL_META[entry.level] || LEVEL_META[DEFAULT_LEVEL]
                 return (
                   <Fragment key={i}>
-                    {entry.ts && (
+                    {formatted && entry.ts && (
                       <div
                         class="flex items-center gap-2 px-3 pt-2 select-none"
                         data-testid="logs-timestamp"
@@ -547,7 +712,7 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
                       </pre>
                     ) : (
                       <div
-                        class="px-3 py-1 text-sm font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-900"
+                        class="px-3 py-0.5 text-sm font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
                         data-testid="logs-line"
                       >
                         {entry.text}
@@ -556,6 +721,18 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
                   </Fragment>
                 )
               })}
+              {followError && (
+                <div
+                  class="flex items-start gap-2 mx-3 mt-2 p-2 rounded border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 text-xs text-red-800 dark:text-red-200"
+                  data-testid="logs-follow-error"
+                  role="alert"
+                >
+                  <svg class="w-4 h-4 flex-shrink-0 mt-px" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                  </svg>
+                  <span class="break-all">{followError}</span>
+                </div>
+              )}
             </div>
           ) : (
             <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-empty">

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -8,12 +8,7 @@ import { LEVELS, LEVEL_META, DEFAULT_LEVEL, detectLevel, stripAnsi } from '../..
 import { decorateLine, highlightJson } from '../../../utils/logFormat'
 import { groupEntries } from '../../../utils/logGroup'
 import { useDismiss } from '../../../utils/useDismiss'
-
-// Selectable limits for the number of log lines to fetch from the backend.
-const LINE_LIMITS = [100, 500, 1000, 5000]
-
-// Default number of log lines requested from the backend.
-const DEFAULT_TAIL_LINES = 100
+import { logSettings, LINE_LIMITS } from '../../../utils/logSettings'
 
 // Sentinel option key for the "All containers" view, which streams every
 // container (init and regular) and interleaves the lines chronologically.
@@ -272,7 +267,7 @@ function LevelMenu({ value, onChange }) {
   const current = LEVEL_OPTIONS.find(o => o.value === value) || LEVEL_OPTIONS[0]
 
   return (
-    <div class="relative w-full sm:w-auto" ref={ref}>
+    <div class="relative flex-1 min-w-0 sm:flex-none sm:w-auto" ref={ref}>
       <button
         type="button"
         onClick={() => setOpen(v => !v)}
@@ -601,11 +596,14 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   }, [containers, streamNames])
 
   const [containerKey, setContainerKey] = useState(defaultKey)
-  const [tailLines, setTailLines] = useState(DEFAULT_TAIL_LINES)
-  const [follow, setFollow] = useState(true)
+  // Follow, formatted and tailLines are seeded from the persisted log viewer
+  // settings (peek, so seeding doesn't subscribe the component) and written back
+  // by the effect below, so they carry across sessions.
+  const [tailLines, setTailLines] = useState(() => logSettings.peek().tail)
+  const [follow, setFollow] = useState(() => logSettings.peek().follow)
   const [filter, setFilter] = useState('')
   const [levelFilter, setLevelFilter] = useState('all')
-  const [formatted, setFormatted] = useState(true)
+  const [formatted, setFormatted] = useState(() => logSettings.peek().formatted)
   const [fullScreen, setFullScreen] = useState(false)
   const [logs, setLogs] = useState('')
   const [loading, setLoading] = useState(false)
@@ -809,6 +807,15 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   useEffect(() => {
     if (!formatted) setLevelFilter('all')
   }, [formatted])
+
+  // Persist the follow/formatted/tailLines settings so they carry across sessions.
+  // The signal's own effect writes them to localStorage. On mount this writes the
+  // seeded values back (a redundant but harmless write of identical content). The
+  // component seeds via peek() and never reads the signal reactively, so writing it
+  // here cannot re-render the viewer or feed back into this effect.
+  useEffect(() => {
+    logSettings.value = { follow, formatted, tail: tailLines }
+  }, [follow, formatted, tailLines])
 
   // Poll for new logs while following: silent (no spinner flicker) and appending
   // (visible lines stay put).
@@ -1139,12 +1146,12 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
           </button>
         </div>
 
-        {/* Toolbar. Mobile: a two-column grid of paired rows (the viewer is
-            full-screen there). From sm up: a single-row flex-wrap. */}
-        <div class="grid grid-cols-2 items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 sm:flex sm:flex-wrap">
-          {/* Toggles share the full-width top row on mobile; `sm:contents` dissolves
-              the wrapper on desktop so each toggle is a direct flex item. */}
-          <div class="col-span-2 flex items-center gap-2 sm:contents">
+        {/* Toolbar. Mobile: two stacked rows — controls+filter, then selectors
+            (the viewer is full-screen there). From sm up: a single-row flex-wrap.
+            Each row wrapper is `sm:contents` so it dissolves into that one row. */}
+        <div class="flex flex-col gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 sm:flex-row sm:flex-wrap sm:items-center">
+          {/* Row 1 (mobile): follow/format toggles, lines, and the contains filter. */}
+          <div class="flex items-center gap-2 sm:contents">
             {/* Follow logs */}
             <ToggleButton
               active={follow}
@@ -1170,75 +1177,83 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1m8-18h1a2 2 0 0 1 2 2v5c0 1.1.9 2 2 2a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2h-1" />
               </svg>
             </ToggleButton>
+
+            {/* Lines select — shares row 1 with the toggles and the filter. Sized to
+                its content (the contains filter takes the remaining width). */}
+            <select
+              value={tailLines}
+              onChange={(e) => setTailLines(Number(e.target.value))}
+              class={`${SELECT_CLASS} shrink-0 sm:w-auto`}
+              data-testid="logs-lines-select"
+              aria-label="Number of lines"
+              title="Number of log lines to fetch"
+            >
+              {LINE_LIMITS.map((n) => (
+                <option key={n} value={n}>{n} ln</option>
+              ))}
+            </select>
+
+            {/* Separator (desktop only) between the view controls and the filter. */}
+            <div class="hidden sm:block w-px h-5 bg-gray-300 dark:bg-gray-600" />
+
+            {/* Contains filter — takes the remaining width of row 1 on mobile. */}
+            <input
+              type="text"
+              value={filter}
+              onInput={(e) => setFilter(e.target.value)}
+              placeholder="contains…"
+              class={`${INPUT_CLASS} flex-1 min-w-0 sm:flex-none sm:w-40`}
+              data-testid="logs-filter-input"
+              aria-label="Filter log lines containing text"
+              title="Filter by keyword (prefix with ! to exclude e.g. !debug)"
+            />
           </div>
 
-          {/* Pod select. "All pods" leads (every pod merged, origin-tagged);
-              selecting one narrows the view and resets the container dropdown.
-              Fixed width so a long name is trimmed, not pushing the toolbar. */}
-          {pods.length > 0 && (
+          {/* Row 2 (mobile): the pod/container/level selectors, sharing the row in
+              equal parts. `sm:contents` dissolves the wrapper on desktop so they
+              rejoin the single wrapping toolbar row. */}
+          <div class="flex items-center gap-2 sm:contents">
+            {/* Pod select. "All pods" leads (every pod merged, origin-tagged);
+                selecting one narrows the view and resets the container dropdown. A
+                long name truncates instead of pushing the row. */}
+            {pods.length > 0 && (
+              <select
+                value={effectivePodKey}
+                onChange={(e) => setPodKey(e.target.value)}
+                class={`${SELECT_CLASS} flex-1 min-w-0 truncate sm:flex-none sm:w-40`}
+                data-testid="logs-pod-select"
+                aria-label="Pod"
+                title="Select pod"
+              >
+                {podOptions.map((o) => (
+                  <option key={o.key} value={o.key}>{o.label}</option>
+                ))}
+              </select>
+            )}
+
+            {/* Container select (always shown). Restarted containers also expose a
+                "(previous)" entry for the prior instance's logs. */}
             <select
-              value={effectivePodKey}
-              onChange={(e) => setPodKey(e.target.value)}
-              class={`${SELECT_CLASS} w-full truncate sm:w-40`}
-              data-testid="logs-pod-select"
-              aria-label="Pod"
-              title="Select pod"
+              value={containerKey}
+              onChange={(e) => setContainerKey(e.target.value)}
+              class={`${SELECT_CLASS} flex-1 min-w-0 truncate sm:flex-none sm:w-40`}
+              data-testid="logs-container-select"
+              aria-label="Container"
+              title="Select container (a previous entry reads the prior instance's logs)"
             >
-              {podOptions.map((o) => (
+              {containerOptions.map((o) => (
                 <option key={o.key} value={o.key}>{o.label}</option>
               ))}
             </select>
-          )}
 
-          {/* Container select (always shown). Restarted containers also expose a
-              "(previous)" entry for the prior instance's logs. Fixed width so a
-              long name is trimmed, not pushing the toolbar. */}
-          <select
-            value={containerKey}
-            onChange={(e) => setContainerKey(e.target.value)}
-            class={`${SELECT_CLASS} w-full truncate sm:w-40`}
-            data-testid="logs-container-select"
-            aria-label="Container"
-            title="Select container (a previous entry reads the prior instance's logs)"
-          >
-            {containerOptions.map((o) => (
-              <option key={o.key} value={o.key}>{o.label}</option>
-            ))}
-          </select>
+            {/* Minimum level filter. Formatted mode only — raw is verbatim with no
+                level semantics, so the filter is hidden (and reset to "all"). */}
+            {formatted && <LevelMenu value={levelFilter} onChange={setLevelFilter} />}
+          </div>
 
-          {/* Contains filter */}
-          <input
-            type="text"
-            value={filter}
-            onInput={(e) => setFilter(e.target.value)}
-            placeholder="contains…"
-            class={`${INPUT_CLASS} w-full sm:w-40`}
-            data-testid="logs-filter-input"
-            aria-label="Filter log lines containing text"
-            title="Filter by keyword (prefix with ! to exclude e.g. !debug)"
-          />
-
-          {/* Minimum level filter. Formatted mode only — raw is verbatim with no
-              level semantics, so the filter is hidden (and reset to "all"). */}
-          {formatted && <LevelMenu value={levelFilter} onChange={setLevelFilter} />}
-
-          {/* Lines select */}
-          <select
-            value={tailLines}
-            onChange={(e) => setTailLines(Number(e.target.value))}
-            class={`${SELECT_CLASS} w-full sm:w-auto`}
-            data-testid="logs-lines-select"
-            aria-label="Number of lines"
-            title="Number of log lines to fetch"
-          >
-            {LINE_LIMITS.map((n) => (
-              <option key={n} value={n}>{n} ln</option>
-            ))}
-          </select>
-
-          {/* Actions. Mobile: the last grid cell, right-aligned. Desktop: floats
-              to the far right of the row. */}
-          <div class="flex items-center justify-end gap-1 sm:ml-auto">
+          {/* Actions (desktop only): download + fullscreen are hidden on mobile,
+              where the viewer already fills the screen. */}
+          <div class="hidden sm:flex items-center justify-end gap-1 sm:ml-auto">
             <button
               onClick={handleDownload}
               disabled={!logs}

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -3,8 +3,11 @@
 
 import { Fragment } from 'preact'
 import { useState, useEffect, useCallback, useMemo, useRef } from 'preact/hooks'
+import Prism from 'prismjs'
+import 'prismjs/components/prism-json'
 import { fetchWithMock } from '../../../utils/fetch'
 import { downloadBlob } from '../../../utils/download'
+import { usePrismTheme } from '../common/yaml'
 
 // Selectable limits for the number of log lines to fetch from the backend.
 const LINE_LIMITS = [100, 500, 1000, 5000]
@@ -22,6 +25,24 @@ const HIGHLIGHT_DURATION = 2500
 // Anchored to a date so lines without a timestamp (e.g. stack-trace
 // continuations) are not mangled by splitting off their first token.
 const TIMESTAMP_PREFIX = /^(\d{4}-\d{2}-\d{2}T\S+)\s+/
+
+/**
+ * formatJson - indents a log line if it is a JSON object or array, otherwise
+ * returns null. The cheap first-character check avoids a try/catch on the
+ * common case of plain-text lines.
+ *
+ * @param {string} text - The log line text
+ * @returns {string|null} The indented JSON, or null if the line is not JSON
+ */
+function formatJson(text) {
+  const trimmed = text.trim()
+  if (trimmed[0] !== '{' && trimmed[0] !== '[') return null
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2)
+  } catch {
+    return null
+  }
+}
 
 // Shared styling for the toolbar controls. Selects deliberately omit a chevron
 // and right padding: those come from the global `select` rule in index.css.
@@ -66,10 +87,11 @@ function ToggleButton({ active, onClick, label, title, testid, children }) {
  *
  * Fetches logs from GET /api/v1/workload/logs for the selected container and
  * renders each log entry on its own row, with its timestamp shown as a pill on
- * the row separator. Supports following (live polling), filtering by substring,
- * choosing the number of lines, selecting a container (restarted containers
- * also expose a "(previous)" entry for the prior instance's logs), downloading
- * the logs as a <pod>.log file, and a fullscreen mode.
+ * the row separator. Supports following (live polling), pretty-printing JSON
+ * lines, filtering by substring, choosing the number of lines, selecting a
+ * container (restarted containers also expose a "(previous)" entry for the
+ * prior instance's logs), downloading the logs as a <pod>.log file, and a
+ * fullscreen mode.
  *
  * @param {Object} props
  * @param {string} props.namespace - Pod namespace
@@ -78,6 +100,9 @@ function ToggleButton({ active, onClick, label, title, testid, children }) {
  * @param {Function} props.onClose - Callback to close the viewer
  */
 export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }) {
+  // Load the Prism theme used to syntax-highlight JSON lines as code blocks.
+  usePrismTheme()
+
   // Default to the first regular container, falling back to the first entry.
   const defaultContainer = (containers.find(c => !c.isInit) || containers[0])?.name || ''
 
@@ -86,6 +111,7 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
   const [tailLines, setTailLines] = useState(DEFAULT_TAIL_LINES)
   const [follow, setFollow] = useState(true)
   const [filter, setFilter] = useState('')
+  const [prettyJson, setPrettyJson] = useState(false)
   const [fullScreen, setFullScreen] = useState(false)
   const [logs, setLogs] = useState('')
   const [loading, setLoading] = useState(false)
@@ -203,11 +229,25 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     return baseLines.filter(entry => entry.text.toLowerCase().includes(needle) !== negate)
   }, [baseLines, filter])
 
+  // When the JSON toggle is on, every line renders as a code block sharing the
+  // same monospace font and size as the YAML blocks (`code: true`). Valid JSON
+  // gets indented and Prism-highlighted (`html`); other lines keep their plain
+  // text in the same styling. Filtering happens first on the raw text, so this
+  // only transforms what is actually shown.
+  const displayLines = useMemo(() => {
+    if (!prettyJson) return logLines.map(entry => ({ ...entry, code: false, html: null }))
+    return logLines.map(entry => {
+      const json = formatJson(entry.text)
+      if (json == null) return { ...entry, code: true, html: null }
+      return { ...entry, text: json, code: true, html: Prism.highlight(json, Prism.languages.json, 'json') }
+    })
+  }, [logLines, prettyJson])
+
   // Keep the most recent entry in view after each update.
   useEffect(() => {
     if (!bodyRef.current) return
     bodyRef.current.scrollTop = bodyRef.current.scrollHeight
-  }, [logLines])
+  }, [displayLines])
 
   // Download the current logs as a <pod>.log text file.
   const handleDownload = useCallback(() => {
@@ -259,6 +299,19 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 13l-7 7-7-7m14-6l-7 7-7-7" />
+            </svg>
+          </ToggleButton>
+
+          {/* Pretty-print JSON lines */}
+          <ToggleButton
+            active={prettyJson}
+            onClick={() => setPrettyJson(v => !v)}
+            label="Pretty-print JSON logs"
+            title="Format and syntax-highlight JSON log lines"
+            testid="logs-json-toggle"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1m8-18h1a2 2 0 0 1 2 2v5c0 1.1.9 2 2 2a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2h-1" />
             </svg>
           </ToggleButton>
 
@@ -354,10 +407,10 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             </div>
           ) : loading && !logs ? (
             <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-loading">Loading logs...</p>
-          ) : logLines.length > 0 ? (
+          ) : displayLines.length > 0 ? (
             <div class="pb-2" data-testid="logs-content">
-              {logLines.map((entry, i) => {
-                const isLatest = flashLatest && i === logLines.length - 1
+              {displayLines.map((entry, i) => {
+                const isLatest = flashLatest && i === displayLines.length - 1
                 return (
                   <Fragment key={i}>
                     {entry.ts && (
@@ -374,12 +427,32 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
                         <span class="flex-1 border-t border-gray-200 dark:border-gray-800" />
                       </div>
                     )}
-                    <div
-                      class="px-3 py-1 text-sm font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-900"
-                      data-testid="logs-line"
-                    >
-                      {entry.text}
-                    </div>
+                    {entry.code ? (
+                      <pre
+                        class="overflow-x-auto language-json"
+                        style="margin: 0; padding: 0.25rem 0.75rem; background: transparent; text-shadow: none; font-size: 12px; line-height: 1.5;"
+                        data-testid="logs-line"
+                      >
+                        {entry.html != null ? (
+                          <code
+                            class="language-json"
+                            style="background: transparent; text-shadow: none;"
+                            dangerouslySetInnerHTML={{ __html: entry.html }}
+                          />
+                        ) : (
+                          <code class="language-json" style="background: transparent; text-shadow: none;">
+                            {entry.text}
+                          </code>
+                        )}
+                      </pre>
+                    ) : (
+                      <div
+                        class="px-3 py-1 text-sm font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-900"
+                        data-testid="logs-line"
+                      >
+                        {entry.text}
+                      </div>
+                    )}
                   </Fragment>
                 )
               })}

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'preact/hooks'
 import { fetchWithMock } from '../../../utils/fetch'
 import { downloadBlob } from '../../../utils/download'
 import { LEVELS, LEVEL_META, DEFAULT_LEVEL, detectLevel, stripAnsi } from '../../../utils/logLevel'
-import { decorateLine, highlightJson } from '../../../utils/logFormat'
+import { decorateLine, highlightJson, topLevelJsonKeys, fieldMatcher } from '../../../utils/logFormat'
 import { groupEntries } from '../../../utils/logGroup'
 import { logSettings, TAIL_LINES, FONT_SIZES } from '../../../utils/logSettings'
 
@@ -617,6 +617,10 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // Whether the settings panel (tail-lines slider, font size) is expanded below
   // the toolbar. Local to the session, not persisted.
   const [showSettings, setShowSettings] = useState(false)
+  // Field-selection expression for the formatted JSON body (e.g. "msg|error",
+  // "!level ts", "*id"). Seeded from and persisted to the log settings so it carries
+  // across sessions. See fieldMatcher for the syntax; empty = all fields.
+  const [fieldExpr, setFieldExpr] = useState(() => logSettings.peek().fields)
   const [fullScreen, setFullScreen] = useState(false)
   const [logs, setLogs] = useState('')
   const [loading, setLoading] = useState(false)
@@ -666,6 +670,10 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // Memoizes formatted output per raw line text, so appends format only the new
   // lines instead of the whole buffer each poll. See formattedLines for pruning.
   const formatCacheRef = useRef(new Map())
+  // Memoizes each line's top-level JSON keys (string[] | null) by text, so the field
+  // discovery pass parses each unique line once. Rebuilt over the buffer like
+  // formatCacheRef, so it can't outgrow it.
+  const jsonKeysCacheRef = useRef(new Map())
   // The parsed buffer, mirroring `logs` line-for-line in arrival order (pre-sort,
   // pre-format), so a follow poll re-parses only the appended lines instead of the
   // whole buffer. `key` is the tag regime and `gen` the reset-fetch id; a change in
@@ -777,6 +785,10 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
         // Count the new entries against the live buffer before merging, so the
         // "+N new" indicator reflects what this poll appended. It's set on every
         // poll (0 hides it), so the count persists until the next refresh replaces it.
+        // The merge itself stays exact via the functional update against the real
+        // prev; the count is computed against logsRef (a render-synced mirror) and is
+        // best-effort: if two follow polls overlap (a fetch slower than the interval),
+        // it may briefly over-report, never corrupting the deduped buffer.
         const added = countNewEntries(logsRef.current, incoming)
         setLogs(prev => mergeLogs(prev, incoming))
         setAppendedCount(added)
@@ -803,6 +815,8 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
         setError(err.message)
         setLogs('')
         setFollowError(null)
+        // The buffer is gone, so a leftover "+N new" from a prior poll is stale.
+        setAppendedCount(0)
       }
     } finally {
       // Only the still-current fetch clears shared state, so a superseded reset
@@ -834,14 +848,14 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     if (!formatted) setLevelFilter('all')
   }, [formatted])
 
-  // Persist the follow/formatted/tailLines/fontSize settings so they carry across
-  // sessions. The signal's own effect writes them to localStorage. On mount this
-  // writes the seeded values back (a redundant but harmless write of identical
+  // Persist the follow/formatted/tailLines/fontSize/fields settings so they carry
+  // across sessions. The signal's own effect writes them to localStorage. On mount
+  // this writes the seeded values back (a redundant but harmless write of identical
   // content). The component seeds via peek() and never reads the signal reactively,
   // so writing it here cannot re-render the viewer or feed back into this effect.
   useEffect(() => {
-    logSettings.value = { follow, formatted, tail: tailLines, fontSize }
-  }, [follow, formatted, tailLines, fontSize])
+    logSettings.value = { follow, formatted, tail: tailLines, fontSize, fields: fieldExpr }
+  }, [follow, formatted, tailLines, fontSize, fieldExpr])
 
   // Poll for new logs while following: silent (no spinner flicker) and appending
   // (visible lines stay put).
@@ -969,19 +983,62 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // only parses+formats the new lines. The cache is rebuilt over the whole base
   // buffer (≤ MAX_BUFFER_LINES), so it can't outgrow it; raw mode leaves it untouched
   // so it survives a round-trip back to formatted.
+  // Discover the JSON fields the buffer emits (union of top-level keys, in first-seen
+  // order), so the settings panel can offer a field picker. Independent of the field
+  // selection, so filtering never removes options. Scans every line that projection
+  // (highlightJson in formattedLines) sees — topLevelJsonKeys returns null for
+  // non-JSON lines, which contribute nothing — so a JSON line without a leading
+  // timestamp is still discovered, keeping the input visible and consistent with the
+  // projected body. Each unique line's keys are cached by text (jsonKeysCacheRef) to
+  // parse it once. Empty in raw mode (no field concept).
+  const availableFields = useMemo(() => {
+    if (!formatted) return []
+    const prev = jsonKeysCacheRef.current
+    const next = new Map()
+    const seen = new Set()
+    for (const entry of baseLines) {
+      let keys = next.get(entry.text)
+      if (keys === undefined) keys = prev.has(entry.text) ? prev.get(entry.text) : topLevelJsonKeys(entry.text)
+      next.set(entry.text, keys)
+      if (keys) for (const k of keys) seen.add(k)
+    }
+    jsonKeysCacheRef.current = next
+    return [...seen]
+  }, [baseLines, formatted])
+
+  // Resolve the field expression to the concrete set of top-level keys to show, or
+  // null for "all". Applying the matcher to the discovered fields (the union over the
+  // buffer) yields a stable set every JSON line is projected against; a pure-exclusion
+  // expression keeps newly seen fields once they enter availableFields.
+  const selectedFields = useMemo(() => {
+    const match = fieldMatcher(fieldExpr)
+    if (!match) return null
+    return new Set(availableFields.filter(match))
+  }, [fieldExpr, availableFields])
+
+  // Field-selection signature for the format cache key: 'all' when unfiltered, else a
+  // JSON-encoded array of the sorted selected keys (encoded so a key containing the
+  // delimiter can't make two different selections collide). A change busts only the
+  // JSON lines' cached formatting.
+  const fieldSig = useMemo(
+    () => (selectedFields === null ? 'all' : JSON.stringify([...selectedFields].sort())),
+    [selectedFields]
+  )
+
   const formattedLines = useMemo(() => {
     if (!formatted) return baseLines
     const prev = formatCacheRef.current
     const next = new Map()
     const result = baseLines.map(entry => {
       // The cache key carries the head flag since the same text can appear as both a
-      // head and a continuation line. JSON runs on every line; the klog/zap/logfmt
+      // head and a continuation line, and the field signature since the JSON body
+      // depends on the selected fields. JSON runs on every line; the klog/zap/logfmt
       // cascade only on a timestamped one (a frame's shape falls through to plain).
-      const key = `${entry.ts ? 1 : 0}\n${entry.text}`
+      const key = `${entry.ts ? 1 : 0}\n${fieldSig}\n${entry.text}`
       let f = next.get(key) || prev.get(key)
       if (!f) {
         const level = detectLevel(entry.text)
-        const json = highlightJson(entry.text)
+        const json = highlightJson(entry.text, selectedFields)
         const d = json || (entry.ts ? decorateLine(entry.text, level) : { kind: 'plain' })
         // `structured` (whether the burst grouper treats the line as a real log
         // entry vs structure-less noise) is true when the format layer decorates it,
@@ -1000,7 +1057,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     })
     formatCacheRef.current = next
     return result
-  }, [baseLines, formatted])
+  }, [baseLines, formatted, selectedFields, fieldSig])
 
   // Group recognized stack traces and unstructured bursts, one run per group (off →
   // one group per entry, keeping the chain uniform). When the stream is tagged (more
@@ -1361,6 +1418,30 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
               onChange={setFontSize}
               options={FONT_SIZES.map(f => ({ value: f.key, label: f.label, testid: `logs-fontsize-${f.key}` }))}
             />
+            {/* JSON field filter. Formatted mode only, and only when the buffer emits
+                structured JSON fields. A list of field names (space/comma/pipe
+                separated) with `*` globs and `!` to exclude; empty shows all. The
+                placeholder shows example syntax; the expression persists via the log
+                settings (see fieldExpr). */}
+            {formatted && availableFields.length > 0 && (
+              <div class="flex items-center gap-3">
+                <label for="logs-fields-input" class="text-xs font-medium text-gray-600 dark:text-gray-300 w-20 flex-shrink-0">Fields</label>
+                <input
+                  id="logs-fields-input"
+                  type="text"
+                  value={fieldExpr}
+                  onInput={(e) => setFieldExpr(e.target.value)}
+                  placeholder="msg error !level *id"
+                  class={`${INPUT_CLASS} w-60 max-w-full font-mono`}
+                  data-testid="logs-fields-input"
+                  aria-label="Show only these JSON fields"
+                  title="Field names separated by space, comma or pipe. Use * to glob and ! to exclude (e.g. msg|error, !level, *id). Empty shows all."
+                  autocomplete="off"
+                  autocapitalize="off"
+                  spellcheck={false}
+                />
+              </div>
+            )}
           </div>
         )}
 

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -17,9 +17,14 @@ const LINE_LIMITS = [100, 500, 1000, 5000]
 // Default number of log lines requested from the backend.
 const DEFAULT_TAIL_LINES = 100
 
-// Sentinel option key for the "All containers" view, which streams every regular
-// container and interleaves the lines chronologically.
+// Sentinel option key for the "All containers" view, which streams every
+// container (init and regular) and interleaves the lines chronologically.
 const ALL_CONTAINERS = 'all'
+
+// Sentinel option key for the "All pods" view, which streams every pod of the
+// workload and interleaves the lines chronologically, each tagged with its pod of
+// origin. Distinct from ALL_CONTAINERS so it can never collide with a pod name.
+const ALL_PODS = '__all_pods__'
 
 // Follow polling interval in milliseconds.
 const FOLLOW_INTERVAL = 5000
@@ -37,16 +42,19 @@ const SCROLL_BOTTOM_THRESHOLD = 32
 const MAX_BUFFER_LINES = 5000
 
 /**
- * mergeLogs - appends incoming log lines to the accumulated buffer, dropping any
- * that are already present and capping the result to MAX_BUFFER_LINES.
+ * mergeLogs - appends the entries of an incoming payload to the accumulated
+ * buffer, dropping whole entries already present and capping to MAX_BUFFER_LINES.
  *
- * Follow polls request everything since the last line's timestamp, which the
- * API filters at second granularity, so the last second is re-sent on every
- * poll. Each line carries a unique nanosecond timestamp prefix, so deduping by
- * exact line text reliably drops those repeats, including across the merged
- * "All containers" streams where the distinct timestamps keep containers' lines
- * apart. Returns the previous buffer unchanged when there is nothing new, so the
- * state update is a no-op.
+ * Follow polls request everything since the last line's timestamp, which the API
+ * filters at second granularity, so the last second of entries is re-sent on
+ * every poll. Dedup is by the entry's timestamped HEAD line, which is unique (a
+ * nanosecond timestamp, plus the pod tag in the all-pods view): a re-sent entry
+ * whose head already sits in the buffer is dropped whole — head and all the
+ * continuation lines under it. Continuation lines (stack frames, no timestamp)
+ * are never deduped on their own, so a genuinely new entry keeps its full stack
+ * even when a replica emitted a byte-identical frame earlier; deduping those by
+ * text (the previous behaviour) truncated the new trace. Returns the previous
+ * buffer unchanged when there is nothing new, so the state update is a no-op.
  *
  * @param {string} prev - The accumulated log payload
  * @param {string} incoming - The newly fetched log payload
@@ -57,7 +65,20 @@ function mergeLogs(prev, incoming) {
   if (add.length === 0) return prev
   const prevLines = prev.split('\n').filter(Boolean)
   const seen = new Set(prevLines)
-  const fresh = add.filter(line => !seen.has(line))
+  const fresh = []
+  let dropping = false
+  for (const line of add) {
+    if (entryTimestamp(line)) {
+      // Start of an entry: a re-send (head already buffered) is dropped whole, so
+      // its continuation lines are skipped until the next head arrives.
+      dropping = seen.has(line)
+      if (!dropping) { fresh.push(line); seen.add(line) }
+    } else if (!dropping) {
+      // A continuation line of a kept entry (or a leading orphan before any head):
+      // appended verbatim, never deduped against an identical frame elsewhere.
+      fresh.push(line)
+    }
+  }
   if (fresh.length === 0) return prev
   const merged = prevLines.concat(fresh)
   const capped = merged.length > MAX_BUFFER_LINES ? merged.slice(merged.length - MAX_BUFFER_LINES) : merged
@@ -68,6 +89,22 @@ function mergeLogs(prev, incoming) {
 // Anchored to a date so lines without a timestamp (e.g. stack-trace
 // continuations) are not mangled by splitting off their first token.
 const TIMESTAMP_PREFIX = /^(\d{4}-\d{2}-\d{2}T\S+)\s+/
+
+// entryTimestamp returns the RFC3339 timestamp that heads a log entry, or null
+// for a continuation line (a stack frame and the like) that carries none. A head
+// is either "<ts> msg" (single pod) or "<pod> <ts> msg" (all-pods, pod-tagged);
+// the timestamp must be a real instant, not merely date-shaped, so a frame
+// beginning with a word and a date-like token is not taken for a head.
+function entryTimestamp(line) {
+  const m = line.match(TIMESTAMP_PREFIX)
+  if (m && !Number.isNaN(Date.parse(m[1]))) return m[1]
+  const sp = line.indexOf(' ')
+  if (sp > 0) {
+    const am = line.slice(sp + 1).match(TIMESTAMP_PREFIX)
+    if (am && !Number.isNaN(Date.parse(am[1]))) return am[1]
+  }
+  return null
+}
 
 /**
  * formatJson - indents a log line if it is a JSON object or array, otherwise
@@ -197,62 +234,96 @@ function LevelMenu({ value, onChange }) {
 /**
  * WorkloadLogsViewer - Modal that displays the logs of a workload's pods.
  *
- * The header titles the modal "Log Viewer" over the workload's kind/namespace/name,
- * and a toolbar dropdown switches between the workload's pods. Selecting a pod
- * resets the container dropdown back to "All containers".
+ * The header titles the modal "Log Viewer" over the workload's kind/namespace/name.
+ * Two toolbar dropdowns scope the stream: a pod dropdown ("All pods" plus each
+ * pod) and a container dropdown ("All containers" plus each container). Switching
+ * pods resets the container dropdown back to "All containers".
  *
- * Fetches logs from GET /api/v1/workload/logs for the selected container and
- * renders each log entry on its own row. In the default formatted mode the
- * timestamp is shown as a pill on the row separator, the pill border and rule
- * are colored by the detected log level (JSON/klog/logfmt/plain text), and JSON
- * lines are pretty-printed; the footer summarizes the per-level counts. The raw
- * mode strips all of that styling, rendering each line as plain text without
- * separators, timestamp pills, level coloring, or the new-entry highlight.
- * Supports following (live polling, appending only new entries), toggling
- * between formatted and raw output, filtering by substring and minimum level,
- * choosing the number of lines, selecting a container (restarted containers
- * also expose a "(previous)" entry for the prior instance's logs), and an
- * "All containers" option (the default) that streams every regular container and
- * interleaves the lines chronologically. Init containers are excluded from
- * "All containers" but remain individually selectable. The viewer also supports
- * downloading the logs as a <pod>.log file and a fullscreen mode. A failed follow
- * poll is shown inline at the tail of the feed, leaving the buffer on screen; an
- * initial or post-reset failure (no buffer to keep) shows a full-pane error instead.
+ * Fetches logs from GET /api/v1/workload/logs and renders each log entry on its
+ * own row. In the default formatted mode the timestamp is shown as a pill on the
+ * row separator (prefixed with the pod id in the "All pods" view), the pill
+ * border and rule are colored by the detected log level (JSON/klog/logfmt/plain
+ * text), and JSON lines are pretty-printed; the footer summarizes the per-level
+ * counts. The raw mode strips all of that styling. Supports following (live
+ * polling, appending only new entries), toggling formatted/raw, filtering by
+ * substring and minimum level, choosing the number of lines, an "All containers"
+ * option (the default) and an "All pods" option (the default) that interleave the
+ * lines chronologically. In "All pods" the backend tags each line with its pod of
+ * origin; the row pill shows that pod's id. The viewer downloads the logs as a
+ * <pod>.log file and has a fullscreen mode. A failed follow poll is shown inline
+ * at the tail; an initial/post-reset failure (no buffer) shows a full-pane error.
  *
- * Pod selection is owned by the parent: switching pods invokes onSelectPod, which
- * re-renders the viewer with the new pod's name and containers.
+ * Pod selection is internal: the viewer is given every pod with its containers and
+ * keeps the current pod in local state, so it can build the "All pods" request
+ * (every pod's regular containers) and resolve the selected pod's containers live.
  *
  * @param {Object} props
  * @param {string} props.kind - Workload kind, shown in the title
  * @param {string} props.namespace - Workload namespace
- * @param {string} props.name - Name of the pod whose logs are shown
  * @param {string} props.workloadName - Workload name, shown in the title
- * @param {Array<{name: string, isInit: boolean, restartCount?: number}>} props.containers - Selected pod's containers
- * @param {Array<{name: string, status?: string}>} props.pods - Pods of the workload, for the pod dropdown
- * @param {Function} props.onSelectPod - Called with a pod name when the pod dropdown changes
+ * @param {Array<{name: string, status?: string, containers: Array<{name: string, isInit: boolean, restartCount?: number}>}>} props.pods - Pods of the workload, with their containers
+ * @param {string} [props.initialPodName] - Pod to pre-select; defaults to "All pods" when absent
  * @param {Function} props.onClose - Callback to close the viewer
  */
-export function WorkloadLogsViewer({ kind, namespace, name, workloadName, containers = [], pods = [], onSelectPod, onClose }) {
+export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], initialPodName, onClose }) {
   // Load the Prism theme used to syntax-highlight JSON lines as code blocks.
   usePrismTheme()
 
-  // Regular (non-init) container names, current instances only. These make up
-  // the "All containers" view; init containers are excluded from it but stay
-  // individually selectable.
-  const regularNames = useMemo(
-    () => containers.filter(c => !c.isInit).map(c => c.name),
+  // Selected pod: a specific pod name or ALL_PODS. Initialised from initialPodName
+  // (the parent remounts the viewer per open, so this re-inits on each open).
+  const [podKey, setPodKey] = useState(initialPodName || ALL_PODS)
+
+  // Resolve the selection against the live pod list. If the selected specific pod
+  // has disappeared, fall back to "All pods" so the view keeps working.
+  const effectivePodKey = (podKey === ALL_PODS || pods.some(p => p.name === podKey)) ? podKey : ALL_PODS
+  const allPods = effectivePodKey === ALL_PODS
+  const selectedPod = allPods ? null : (pods.find(p => p.name === effectivePodKey) || null)
+
+  // Commit the fallback when the selected pod disappears (scaled down, deleted).
+  // effectivePodKey already renders "All pods" in that case, but persisting it
+  // means a later pod that happens to reappear with the same name does not
+  // silently snap the view back to it without the user choosing it.
+  useEffect(() => {
+    if (podKey !== ALL_PODS && !pods.some(p => p.name === podKey)) {
+      setPodKey(ALL_PODS)
+    }
+  }, [podKey, pods])
+
+  // Sorted pod names: the request streams these (name = first, rest as repeated
+  // pod params) and the parser uses them as the set of valid pod tags. Sorting
+  // keeps the request stable if the backend returns the same pods reordered.
+  const podNames = useMemo(() => pods.map(p => p.name).sort(), [pods])
+
+  // Containers driving the container dropdown and the request. For "All pods" it
+  // is the union of containers across pods (pod templates are uniform, so this is
+  // just every container); for a specific pod it is that pod's live containers.
+  const containers = useMemo(() => {
+    if (!allPods) return selectedPod?.containers || []
+    const seen = new Set()
+    const out = []
+    for (const p of pods) {
+      for (const c of (p.containers || [])) {
+        if (!seen.has(c.name)) { seen.add(c.name); out.push(c) }
+      }
+    }
+    return out
+  }, [allPods, selectedPod, pods])
+
+  // Every container name (init and regular) — the set the "All containers" view
+  // streams and interleaves. Init containers run to completion before the app
+  // starts, so their lines sort to the front of the merged feed.
+  const streamNames = useMemo(
+    () => containers.map(c => c.name),
     [containers]
   )
 
-  // "All containers" is the default whenever the pod has at least one regular
-  // container (for a single one it streams just that container). It is omitted
-  // only for the degenerate case of no regular containers, where the default
-  // falls back to the first available container.
+  // "All containers" is the default whenever there is at least one container,
+  // falling back to the first available container otherwise.
   const defaultKey = useMemo(() => {
-    if (regularNames.length >= 1) return ALL_CONTAINERS
+    if (streamNames.length >= 1) return ALL_CONTAINERS
     const c = containers[0]
     return c ? `${c.name}::false` : ''
-  }, [containers, regularNames])
+  }, [containers, streamNames])
 
   const [containerKey, setContainerKey] = useState(defaultKey)
   const [tailLines, setTailLines] = useState(DEFAULT_TAIL_LINES)
@@ -268,6 +339,12 @@ export function WorkloadLogsViewer({ kind, namespace, name, workloadName, contai
   // stays visible. The full-pane `error` is used only when there is no buffer.
   const [followError, setFollowError] = useState(null)
   const [flashLatest, setFlashLatest] = useState(false)
+  // Whether the current buffer's lines are pod-tagged (set from the response, so
+  // the parser never has to guess the wire format). Reset with the buffer.
+  const [tagged, setTagged] = useState(false)
+  // Coverage of the "All pods" view: { streamed, total, forbidden } when the
+  // response did not cover every requested pod, else null.
+  const [partial, setPartial] = useState(null)
 
   const bodyRef = useRef(null)
   const prevLogsRef = useRef('')
@@ -276,9 +353,13 @@ export function WorkloadLogsViewer({ kind, namespace, name, workloadName, contai
   const prevLatestKeyRef = useRef(null)
   // Whether the log view is scrolled to the bottom; gates auto-follow scrolling.
   const atBottomRef = useRef(true)
-  // Timestamp of the last buffered line, sent as sinceTime on follow polls so
-  // the server returns only newer entries to append.
+  // Timestamp of the last buffered line, sent as sinceTime on single-pod follow
+  // polls so the server returns only newer entries to append.
   const lastTsRef = useRef('')
+  // Per-pod follow cursors (pod -> newest timestamp seen) for the "All pods" view,
+  // sent as repeated `since` params so each pod advances independently of clock
+  // skew between nodes. Kept in a ref so updating it doesn't re-create fetchLogs.
+  const cursorsRef = useRef(new Map())
   // Monotonic id bumped by every reset (non-append) fetch. A fetch only applies
   // its result if its id is still current, so an in-flight append poll from a
   // previous container/params can't merge stale lines into a reset buffer.
@@ -293,47 +374,65 @@ export function WorkloadLogsViewer({ kind, namespace, name, workloadName, contai
   // the whole buffer on every poll. See displayLines for how it's pruned.
   const formatCacheRef = useRef(new Map())
 
-  // The dropdown options. "All containers" leads whenever the pod has a regular
-  // container. Each container then has a base entry, and restarted containers
-  // additionally expose a "(previous)" option for the prior instance's logs. The
-  // value encodes the container and whether to read the previous instance.
+  // Pod dropdown options: "All pods" leads, then each pod.
+  const podOptions = useMemo(() => {
+    const opts = [{ key: ALL_PODS, label: 'All pods' }]
+    for (const p of pods) opts.push({ key: p.name, label: p.name })
+    return opts
+  }, [pods])
+
+  // Container dropdown options. "All containers" leads whenever there is at least
+  // one container, then every container (init ones prefixed "init:"). A
+  // "(previous)" entry for restarted containers is offered only for a single pod,
+  // since the previous instance is per-pod and meaningless aggregated over pods.
+  // The value encodes the container name and the previous flag.
   const containerOptions = useMemo(() => {
     const opts = []
-    if (regularNames.length >= 1) {
+    if (streamNames.length >= 1) {
       opts.push({ key: ALL_CONTAINERS, label: 'All containers' })
     }
     for (const c of containers) {
       const base = c.isInit ? `init:${c.name}` : c.name
       opts.push({ key: `${c.name}::false`, label: base })
-      if ((c.restartCount || 0) > 0) {
+      if (!allPods && (c.restartCount || 0) > 0) {
         opts.push({ key: `${c.name}::true`, label: `${base} (previous)` })
       }
     }
     return opts
-  }, [containers, regularNames])
+  }, [allPods, containers, streamNames])
 
-  // Resolve the selected option key into the request parameters: the container
-  // names to stream and whether to read the previous instance. "All containers"
-  // streams every regular container and never the previous instance; a specific
-  // selection encodes the container and previous flag in its key (name::previous).
-  // The container list is a comma-joined string (container names cannot contain
-  // commas) so the fetch dependencies stay primitive and value-stable across
-  // parent re-renders, preventing spurious buffer resets while following.
+  // The pods to stream as a stable comma-joined string: every pod for "All pods",
+  // or the single selected pod. Pod names cannot contain commas, so this stays a
+  // primitive, value-stable fetch dependency (a pod-set change resets the buffer;
+  // a backend reorder of the same set does not, because podNames is sorted).
+  const reqPodsStr = useMemo(
+    () => (allPods ? podNames : (selectedPod ? [selectedPod.name] : [])).join(','),
+    [allPods, podNames, selectedPod]
+  )
+
+  // Resolve the selected container option into the request parameters: the
+  // container names to stream and whether to read the previous instance. The
+  // previous flag applies only to a specific container of a single pod.
   const { reqContainersStr, reqPrevious } = useMemo(() => {
     if (containerKey === ALL_CONTAINERS) {
-      return { reqContainersStr: regularNames.join(','), reqPrevious: false }
+      // Sort the streamed container names (as reqPodsStr sorts pods) so a backend
+      // reorder of the same set keeps the fetch dependency value-stable and does
+      // not reset the follow buffer.
+      return { reqContainersStr: [...streamNames].sort().join(','), reqPrevious: false }
     }
     const sep = containerKey.lastIndexOf('::')
     const cname = sep >= 0 ? containerKey.slice(0, sep) : containerKey
-    const prev = sep >= 0 && containerKey.slice(sep + 2) === 'true'
+    const prev = !allPods && sep >= 0 && containerKey.slice(sep + 2) === 'true'
     // Guard the brief window after a pod switch where containerKey still holds the
     // previous pod's container (before the reset effect runs): if it names a
-    // container the current pod doesn't have, fall back to the regular containers.
+    // container the current set doesn't have, fall back to all containers. Sorted
+    // to match the ALL_CONTAINERS branch so the value stays stable and the
+    // fallback does not trigger an extra buffer reset.
     if (!containers.some(c => c.name === cname)) {
-      return { reqContainersStr: regularNames.join(','), reqPrevious: false }
+      return { reqContainersStr: [...streamNames].sort().join(','), reqPrevious: false }
     }
     return { reqContainersStr: cname, reqPrevious: prev }
-  }, [containerKey, containers, regularNames])
+  }, [containerKey, containers, streamNames, allPods])
 
   // Fetch the logs. Background follow-polls pass { silent: true } so they don't
   // toggle the loading spinner, which would flicker on every poll; only the
@@ -345,29 +444,41 @@ export function WorkloadLogsViewer({ kind, namespace, name, workloadName, contai
   // make the visible lines shift on every poll). The initial load and any
   // parameter change fetch the tail and replace the buffer.
   const fetchLogs = useCallback(async ({ silent = false, append = false } = {}) => {
+    const reqPodsList = reqPodsStr ? reqPodsStr.split(',') : []
     const reqContainers = reqContainersStr ? reqContainersStr.split(',') : []
-    if (reqContainers.length === 0) return
+    if (reqPodsList.length === 0 || reqContainers.length === 0) return
     // Skip follow polls while a reset is in flight: appending now would use the
-    // old buffer's cursor (lastTsRef) and merge into the resetting buffer.
+    // old buffer's cursor and merge into the resetting buffer.
     if (append && resettingRef.current) return
     // A reset starts a new generation; appends ride on the current one. A fetch
     // only applies its result if its generation is still current (checked on
-    // settle below), so an in-flight append poll from a previous container or
+    // settle below), so an in-flight append poll from a previous pod/container or
     // a superseded reset can't write stale lines into the buffer.
     const gen = append ? fetchGenRef.current : ++fetchGenRef.current
     if (!append) resettingRef.current = true
     if (!silent) setLoading(true)
     try {
-      // tailLines is always sent so the backend caps every fetch (including a
-      // follow catch-up) to the user's selection; sinceTime narrows a follow
-      // poll to entries after the last buffered line. A repeated container param
-      // requests the merged "All containers" view.
-      const params = new URLSearchParams({ namespace, name, tailLines: String(tailLines), previous: String(reqPrevious) })
+      // The required name is the first pod; additional pods are repeated `pod`
+      // params (the "All pods" view) and containers repeated `container` params.
+      // tailLines is always sent so the backend bounds every fetch to the user's
+      // selection. On a follow poll, single-pod mode narrows by a global sinceTime
+      // while all-pods mode narrows by a per-pod `since` cursor.
+      const params = new URLSearchParams({ namespace, name: reqPodsList[0], tailLines: String(tailLines), previous: String(reqPrevious) })
+      for (let i = 1; i < reqPodsList.length; i++) {
+        params.append('pod', reqPodsList[i])
+      }
       for (const c of reqContainers) {
         params.append('container', c)
       }
-      if (append && lastTsRef.current) {
-        params.set('sinceTime', lastTsRef.current)
+      if (append) {
+        if (reqPodsList.length > 1) {
+          for (const p of reqPodsList) {
+            const cur = cursorsRef.current.get(p)
+            if (cur) params.append('since', `${p}=${cur}`)
+          }
+        } else if (lastTsRef.current) {
+          params.set('sinceTime', lastTsRef.current)
+        }
       }
       const resp = await fetchWithMock({
         endpoint: `/api/v1/workload/logs?${params.toString()}`,
@@ -381,6 +492,12 @@ export function WorkloadLogsViewer({ kind, namespace, name, workloadName, contai
       } else {
         setLogs(incoming)
       }
+      // The response states whether its lines are pod-tagged and how many of the
+      // requested pods it covered, so the parser and the footer never have to
+      // guess. Both are refreshed on every fetch (they stay constant for a given
+      // pod set, but a pod becoming readable can clear a partial result).
+      setTagged(!!resp?.tagged)
+      setPartial(resp?.partial ? { streamed: resp.streamed || 0, total: resp.total || 0, forbidden: resp.forbidden || 0 } : null)
       setError(null)
       setFollowError(null)
     } catch (err) {
@@ -402,21 +519,21 @@ export function WorkloadLogsViewer({ kind, namespace, name, workloadName, contai
         if (!silent) setLoading(false)
       }
     }
-  }, [namespace, name, reqContainersStr, reqPrevious, tailLines])
+  }, [namespace, reqPodsStr, reqContainersStr, reqPrevious, tailLines])
 
   // Re-fetch whenever the selected container(s), previous flag or line count changes.
   useEffect(() => {
     fetchLogs()
   }, [fetchLogs])
 
-  // Reset the container selection to the pod's default ("All containers") whenever
-  // the pod changes, so a container picked for the previous pod doesn't carry over.
-  // Keyed on the pod name only: poll-driven re-renders keep the same name and leave
-  // the selection untouched. On the initial mount this re-sets the already-default
+  // Reset the container selection to the default ("All containers") whenever the
+  // selected pod changes, so a container picked for the previous pod doesn't carry
+  // over. Keyed on the pod selection only: poll-driven re-renders keep the same
+  // selection untouched. On the initial mount this re-sets the already-default
   // value, which Preact bails out of as a no-op.
   useEffect(() => {
     setContainerKey(defaultKey)
-  }, [name])
+  }, [effectivePodKey])
 
   // Poll for new logs while following, silently so the spinner doesn't flicker
   // and appending so the visible lines stay put instead of shifting each poll.
@@ -447,36 +564,87 @@ export function WorkloadLogsViewer({ kind, namespace, name, workloadName, contai
     return () => { document.body.style.overflow = previousOverflow }
   }, [])
 
-  // Split the raw payload into entries once: strip the leading timestamp (shown
-  // as a separator pill) and any ANSI escapes from the message, then detect the
-  // log level. Only re-runs when the payload changes, not on every keystroke.
+  // Split the raw payload into entries once. In the "All pods" view each
+  // timestamped line is prefixed with its pod of origin ("<pod> <ts> <msg>"); a
+  // token is only treated as a pod tag when it is one of the pods we requested AND
+  // the next token parses as a timestamp, so a message that merely starts with a
+  // word + timestamp is never mistaken for a tag. The leading timestamp (shown as
+  // a separator pill) and any ANSI escapes are then stripped and the level
+  // detected. Only re-runs when the payload (or tagging regime) changes.
   const baseLines = useMemo(() => {
-    return logs.split('\n').filter(line => line.length > 0).map(line => {
-      const m = line.match(TIMESTAMP_PREFIX)
-      const ts = m ? m[1] : ''
-      const text = stripAnsi(m ? line.slice(m[0].length) : line)
-      return { ts, text, level: detectLevel(text) }
+    const podSet = tagged ? new Set(reqPodsStr ? reqPodsStr.split(',') : []) : null
+    const entries = logs.split('\n').filter(line => line.length > 0).map(line => {
+      let rest = line
+      let pod = ''
+      if (podSet) {
+        const sp = line.indexOf(' ')
+        if (sp > 0) {
+          const first = line.slice(0, sp)
+          const after = line.slice(sp + 1)
+          // Require a real timestamp, not merely a date-shaped token, so a message
+          // that happens to begin "<known-pod> 2026-13-45T.." is not mistaken for
+          // a tag and split apart.
+          const am = after.match(TIMESTAMP_PREFIX)
+          if (podSet.has(first) && am && !Number.isNaN(Date.parse(am[1]))) {
+            pod = first
+            rest = after
+          }
+        }
+      }
+      const m = rest.match(TIMESTAMP_PREFIX)
+      const tsMs = m ? Date.parse(m[1]) : NaN
+      const hasTs = !Number.isNaN(tsMs)
+      const ts = hasTs ? m[1] : ''
+      const text = stripAnsi(hasTs ? rest.slice(m[0].length) : rest)
+      const podId = pod ? pod.slice(pod.lastIndexOf('-') + 1) : ''
+      return { ts, tsMs, text, level: detectLevel(text), pod, podId }
     })
-  }, [logs])
 
-  // Track the newest line's timestamp so the next follow poll can request only
-  // entries after it (sinceTime). This is authoritative over the current buffer:
-  // it clears to '' when the buffer has no timestamped lines (e.g. after a reset
-  // to a container with no logs yet), so a poll never reuses a stale timestamp
-  // from a previous stream. Trailing lines without a timestamp (stack-trace
-  // continuations) are skipped rather than clearing it.
-  //
-  // For "All containers" this is a single global high-watermark across the merged
-  // streams, not a per-container cursor. The second-granular sinceTime re-sends
-  // the overlap so a lagging container's recent lines are still picked up; a line
-  // landing more than a second behind the watermark is only reconciled on the
-  // next full (non-append) refetch.
+    // In the all-pods view each pod advances its own `since` cursor, so a pod
+    // that lags (slow or clock-skewed) can deliver a line older than another
+    // pod's already-buffered tail; appended in arrival order the buffer would no
+    // longer be chronological. Regroup each timestamped line with the
+    // continuation lines that follow it and stable-sort the groups by timestamp,
+    // so the merged view stays ordered while a multi-line entry and same-instant
+    // lines keep their original (backend-merged) order. The single-pod and
+    // all-containers paths arrive pre-merged from one cursor, so they are left
+    // untouched.
+    if (!tagged) return entries
+    const groups = []
+    for (const entry of entries) {
+      if (groups.length === 0 || entry.ts) groups.push([entry])
+      else groups[groups.length - 1].push(entry)
+    }
+    groups.sort((a, b) => {
+      const ta = a[0].tsMs, tb = b[0].tsMs
+      if (Number.isNaN(ta)) return Number.isNaN(tb) ? 0 : -1
+      if (Number.isNaN(tb)) return 1
+      return ta - tb
+    })
+    return groups.flat()
+  }, [logs, tagged, reqPodsStr])
+
+  // Track the follow cursors from the current buffer so the next poll requests
+  // only newer entries. lastTsRef is the global high-watermark for the single-pod
+  // path (sinceTime); cursorsRef holds the newest timestamp per pod for the
+  // all-pods path (repeated `since`). Both are authoritative over the buffer: they
+  // clear when it has no timestamped lines, so a poll never reuses a stale cursor
+  // from a previous stream. The second-granular cursor re-sends the last second of
+  // overlap, deduped on append; a per-pod cursor keeps a clock-skewed pod from
+  // being starved by another pod's faster-advancing watermark.
   useEffect(() => {
     let ts = ''
     for (let i = baseLines.length - 1; i >= 0; i--) {
       if (baseLines[i].ts) { ts = baseLines[i].ts; break }
     }
     lastTsRef.current = ts
+    // Newest timestamp per pod. The buffer is chronological, so the last occurrence
+    // of each pod is its newest; second-granular cursors make exact ordering moot.
+    const cursors = new Map()
+    for (const entry of baseLines) {
+      if (entry.pod && entry.ts) cursors.set(entry.pod, entry.ts)
+    }
+    cursorsRef.current = cursors
   }, [baseLines])
 
   // Apply the substring filter on the message text; cheap pass over the
@@ -590,25 +758,27 @@ export function WorkloadLogsViewer({ kind, namespace, name, workloadName, contai
     bodyRef.current.scrollTop = bodyRef.current.scrollHeight
   }, [displayLines, followError])
 
-  // Download the current logs as a <pod>.log text file.
+  // Download the current logs as a text file, named after the pod for a single
+  // pod or the workload for the all-pods view.
+  const downloadName = allPods ? (workloadName || 'workload') : effectivePodKey
   const handleDownload = useCallback(() => {
-    downloadBlob(new window.Blob([logs], { type: 'text/plain' }), `${name}.log`)
-  }, [logs, name])
+    downloadBlob(new window.Blob([logs], { type: 'text/plain' }), `${downloadName}.log`)
+  }, [logs, downloadName])
 
   return (
     <div
-      class={`fixed inset-0 z-50 flex justify-center bg-black/50 ${fullScreen ? 'items-center p-0' : 'items-start pt-16 px-4 sm:px-6 lg:px-8 pb-4'}`}
+      class={`fixed inset-0 z-50 flex justify-center bg-black/50 ${fullScreen ? 'items-center p-0' : 'items-center px-4 sm:px-6 lg:px-8 py-16'}`}
       onClick={onClose}
       data-testid="logs-viewer-overlay"
     >
       <div
         class={`bg-white dark:bg-gray-900 shadow-xl flex flex-col overflow-hidden border border-gray-200 dark:border-gray-700 ${
-          fullScreen ? 'w-full h-full max-w-full max-h-full rounded-none' : 'w-full max-w-7xl h-[calc(100vh-5rem)] rounded-lg'
+          fullScreen ? 'w-full h-full max-w-full max-h-full rounded-none' : 'w-full max-w-7xl h-[calc(100vh-8rem)] rounded-lg'
         }`}
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
-        aria-label={`Logs for pod ${name}`}
+        aria-label={`Logs for ${[kind, workloadName].filter(Boolean).join(' ')}`}
         data-testid="logs-viewer"
       >
         {/* Header */}
@@ -660,21 +830,21 @@ export function WorkloadLogsViewer({ kind, namespace, name, workloadName, contai
             </svg>
           </ToggleButton>
 
-          {/* Pod select. Shown only when there is more than one pod (nothing to
-              switch otherwise); switching pods resets the container dropdown to
-              "All containers". Fixed width so a long pod name is trimmed instead
-              of pushing the rest of the toolbar. */}
-          {pods.length > 1 && (
+          {/* Pod select. "All pods" leads and streams every pod merged, tagged
+              with its origin; selecting a specific pod narrows the view and
+              resets the container dropdown to "All containers". Fixed width so a
+              long pod name is trimmed instead of pushing the rest of the toolbar. */}
+          {pods.length > 0 && (
             <select
-              value={name}
-              onChange={(e) => onSelectPod?.(e.target.value)}
+              value={effectivePodKey}
+              onChange={(e) => setPodKey(e.target.value)}
               class={`${SELECT_CLASS} w-28 sm:w-40 truncate`}
               data-testid="logs-pod-select"
               aria-label="Pod"
               title="Select pod"
             >
-              {pods.map((p) => (
-                <option key={p.name} value={p.name}>{p.name}</option>
+              {podOptions.map((o) => (
+                <option key={o.key} value={o.key}>{o.label}</option>
               ))}
             </select>
           )}
@@ -787,8 +957,9 @@ export function WorkloadLogsViewer({ kind, namespace, name, workloadName, contai
                         <span
                           class={`text-[10px] font-mono px-1.5 py-0.5 rounded-full border bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 ${meta.border} ${isLatest ? 'log-glow' : ''}`}
                           style={isLatest ? `--glow-color: ${meta.glow}` : undefined}
-                          title={`${meta.label} level`}
+                          title={entry.pod ? `${entry.pod} · ${meta.label} level` : `${meta.label} level`}
                         >
+                          {entry.podId && <span class="font-semibold text-gray-700 dark:text-gray-300" data-testid="logs-pod-id">{entry.podId} · </span>}
                           {entry.ts}
                         </span>
                         <span
@@ -853,13 +1024,36 @@ export function WorkloadLogsViewer({ kind, namespace, name, workloadName, contai
           class="flex items-center justify-between gap-3 px-4 py-2 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800"
           data-testid="logs-footer"
         >
-          <div class="flex items-center gap-3 text-xs text-gray-600 dark:text-gray-400" data-testid="logs-level-summary">
-            {LEVELS.filter(l => levelCounts[l]).map((l) => (
-              <span key={l} class="inline-flex items-center gap-1" title={`${LEVEL_META[l].label}: ${levelCounts[l]}`}>
-                <span class={`w-2 h-2 rounded-full ${LEVEL_META[l].swatch}`} />
-                {LEVEL_META[l].label} {levelCounts[l]}
+          <div class="flex items-center gap-3 min-w-0">
+            <div class="flex items-center gap-3 text-xs text-gray-600 dark:text-gray-400" data-testid="logs-level-summary">
+              {LEVELS.filter(l => levelCounts[l]).map((l) => (
+                <span key={l} class="inline-flex items-center gap-1" title={`${LEVEL_META[l].label}: ${levelCounts[l]}`}>
+                  <span class={`w-2 h-2 rounded-full ${LEVEL_META[l].swatch}`} />
+                  {LEVEL_META[l].label} {levelCounts[l]}
+                </span>
+              ))}
+            </div>
+            {/* Partial-coverage note: the all-pods view did not cover every pod
+                (forbidden, missing) or the fan-out was capped. The pod-count
+                phrasing is shown only when pods were actually dropped; a pure cap
+                (every pod streamed, but the stream count was capped) reads as
+                "results truncated" instead, to avoid a misleading "N of N". */}
+            {partial && (
+              <span
+                class="inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400 flex-shrink-0"
+                data-testid="logs-partial"
+                title={partial.forbidden > 0
+                  ? `${partial.forbidden} pod(s) not readable with your permissions`
+                  : 'Some streams could not be shown'}
+              >
+                <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                </svg>
+                {partial.streamed < partial.total
+                  ? `showing ${partial.streamed} of ${partial.total} pods`
+                  : 'results truncated'}
               </span>
-            ))}
+            )}
           </div>
           {loading ? (
             <div

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -17,6 +17,10 @@ const LINE_LIMITS = [100, 500, 1000, 5000]
 // Default number of log lines requested from the backend.
 const DEFAULT_TAIL_LINES = 100
 
+// Sentinel option key for the "All containers" view, which streams every regular
+// container and interleaves the lines chronologically.
+const ALL_CONTAINERS = 'all'
+
 // Follow polling interval in milliseconds.
 const FOLLOW_INTERVAL = 5000
 
@@ -39,8 +43,10 @@ const MAX_BUFFER_LINES = 5000
  * Follow polls request everything since the last line's timestamp, which the
  * API filters at second granularity, so the last second is re-sent on every
  * poll. Each line carries a unique nanosecond timestamp prefix, so deduping by
- * exact line text reliably drops those repeats. Returns the previous buffer
- * unchanged when there is nothing new, so the state update is a no-op.
+ * exact line text reliably drops those repeats, including across the merged
+ * "All containers" streams where the distinct timestamps keep containers' lines
+ * apart. Returns the previous buffer unchanged when there is nothing new, so the
+ * state update is a no-op.
  *
  * @param {string} prev - The accumulated log payload
  * @param {string} incoming - The newly fetched log payload
@@ -83,11 +89,11 @@ function formatJson(text) {
 
 // Shared styling for the toolbar controls. Selects deliberately omit a chevron
 // and right padding: those come from the global `select` rule in index.css.
-const FIELD_CLASS = 'text-xs py-1 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-flux-blue'
+const FIELD_CLASS = 'text-xs py-1 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue'
 const SELECT_CLASS = `${FIELD_CLASS} pl-2`
 const INPUT_CLASS = `${FIELD_CLASS} px-2 placeholder-gray-400 dark:placeholder-gray-500`
 // p-1 keeps the icon buttons the same height as the text-xs py-1 selects.
-const ICON_TOGGLE_CLASS = 'inline-flex items-center justify-center p-1 rounded-md border transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue'
+const ICON_TOGGLE_CLASS = 'inline-flex items-center justify-center p-1 rounded-md border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue'
 const INACTIVE_CLASS = 'border-gray-300 text-gray-600 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700'
 const ACTIVE_CLASS = 'border-flux-blue text-flux-blue bg-blue-50 dark:bg-blue-900/30'
 const ACTION_CLASS = 'inline-flex items-center p-1 rounded-md text-gray-400 hover:text-flux-blue dark:text-gray-500 dark:hover:text-flux-blue disabled:cursor-not-allowed'
@@ -189,7 +195,11 @@ function LevelMenu({ value, onChange }) {
 }
 
 /**
- * WorkloadLogsViewer - Modal that displays the logs of a pod container.
+ * WorkloadLogsViewer - Modal that displays the logs of a workload's pods.
+ *
+ * The header titles the modal "Log Viewer" over the workload's kind/namespace/name,
+ * and a toolbar dropdown switches between the workload's pods. Selecting a pod
+ * resets the container dropdown back to "All containers".
  *
  * Fetches logs from GET /api/v1/workload/logs for the selected container and
  * renders each log entry on its own row. In the default formatted mode the
@@ -201,26 +211,50 @@ function LevelMenu({ value, onChange }) {
  * Supports following (live polling, appending only new entries), toggling
  * between formatted and raw output, filtering by substring and minimum level,
  * choosing the number of lines, selecting a container (restarted containers
- * also expose a "(previous)" entry for the prior instance's logs), downloading
- * the logs as a <pod>.log file, and a fullscreen mode. A failed follow poll is
- * shown inline at the tail of the feed, leaving the buffer on screen; an initial
- * or post-reset failure (no buffer to keep) shows a full-pane error instead.
+ * also expose a "(previous)" entry for the prior instance's logs), and an
+ * "All containers" option (the default) that streams every regular container and
+ * interleaves the lines chronologically. Init containers are excluded from
+ * "All containers" but remain individually selectable. The viewer also supports
+ * downloading the logs as a <pod>.log file and a fullscreen mode. A failed follow
+ * poll is shown inline at the tail of the feed, leaving the buffer on screen; an
+ * initial or post-reset failure (no buffer to keep) shows a full-pane error instead.
+ *
+ * Pod selection is owned by the parent: switching pods invokes onSelectPod, which
+ * re-renders the viewer with the new pod's name and containers.
  *
  * @param {Object} props
- * @param {string} props.namespace - Pod namespace
- * @param {string} props.name - Pod name
- * @param {Array<{name: string, isInit: boolean, restartCount?: number}>} props.containers - Pod containers
+ * @param {string} props.kind - Workload kind, shown in the title
+ * @param {string} props.namespace - Workload namespace
+ * @param {string} props.name - Name of the pod whose logs are shown
+ * @param {string} props.workloadName - Workload name, shown in the title
+ * @param {Array<{name: string, isInit: boolean, restartCount?: number}>} props.containers - Selected pod's containers
+ * @param {Array<{name: string, status?: string}>} props.pods - Pods of the workload, for the pod dropdown
+ * @param {Function} props.onSelectPod - Called with a pod name when the pod dropdown changes
  * @param {Function} props.onClose - Callback to close the viewer
  */
-export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }) {
+export function WorkloadLogsViewer({ kind, namespace, name, workloadName, containers = [], pods = [], onSelectPod, onClose }) {
   // Load the Prism theme used to syntax-highlight JSON lines as code blocks.
   usePrismTheme()
 
-  // Default to the first regular container, falling back to the first entry.
-  const defaultContainer = (containers.find(c => !c.isInit) || containers[0])?.name || ''
+  // Regular (non-init) container names, current instances only. These make up
+  // the "All containers" view; init containers are excluded from it but stay
+  // individually selectable.
+  const regularNames = useMemo(
+    () => containers.filter(c => !c.isInit).map(c => c.name),
+    [containers]
+  )
 
-  const [container, setContainer] = useState(defaultContainer)
-  const [previous, setPrevious] = useState(false)
+  // "All containers" is the default whenever the pod has at least one regular
+  // container (for a single one it streams just that container). It is omitted
+  // only for the degenerate case of no regular containers, where the default
+  // falls back to the first available container.
+  const defaultKey = useMemo(() => {
+    if (regularNames.length >= 1) return ALL_CONTAINERS
+    const c = containers[0]
+    return c ? `${c.name}::false` : ''
+  }, [containers, regularNames])
+
+  const [containerKey, setContainerKey] = useState(defaultKey)
   const [tailLines, setTailLines] = useState(DEFAULT_TAIL_LINES)
   const [follow, setFollow] = useState(true)
   const [filter, setFilter] = useState('')
@@ -259,20 +293,47 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
   // the whole buffer on every poll. See displayLines for how it's pruned.
   const formatCacheRef = useRef(new Map())
 
-  // One option per container, plus a "(previous)" option for containers that
-  // have restarted (a previous instance only has logs after a restart). The
-  // value encodes both the container and whether to read the previous instance.
+  // The dropdown options. "All containers" leads whenever the pod has a regular
+  // container. Each container then has a base entry, and restarted containers
+  // additionally expose a "(previous)" option for the prior instance's logs. The
+  // value encodes the container and whether to read the previous instance.
   const containerOptions = useMemo(() => {
     const opts = []
+    if (regularNames.length >= 1) {
+      opts.push({ key: ALL_CONTAINERS, label: 'All containers' })
+    }
     for (const c of containers) {
       const base = c.isInit ? `init:${c.name}` : c.name
-      opts.push({ key: `${c.name}::false`, label: base, container: c.name, previous: false })
+      opts.push({ key: `${c.name}::false`, label: base })
       if ((c.restartCount || 0) > 0) {
-        opts.push({ key: `${c.name}::true`, label: `${base} (previous)`, container: c.name, previous: true })
+        opts.push({ key: `${c.name}::true`, label: `${base} (previous)` })
       }
     }
     return opts
-  }, [containers])
+  }, [containers, regularNames])
+
+  // Resolve the selected option key into the request parameters: the container
+  // names to stream and whether to read the previous instance. "All containers"
+  // streams every regular container and never the previous instance; a specific
+  // selection encodes the container and previous flag in its key (name::previous).
+  // The container list is a comma-joined string (container names cannot contain
+  // commas) so the fetch dependencies stay primitive and value-stable across
+  // parent re-renders, preventing spurious buffer resets while following.
+  const { reqContainersStr, reqPrevious } = useMemo(() => {
+    if (containerKey === ALL_CONTAINERS) {
+      return { reqContainersStr: regularNames.join(','), reqPrevious: false }
+    }
+    const sep = containerKey.lastIndexOf('::')
+    const cname = sep >= 0 ? containerKey.slice(0, sep) : containerKey
+    const prev = sep >= 0 && containerKey.slice(sep + 2) === 'true'
+    // Guard the brief window after a pod switch where containerKey still holds the
+    // previous pod's container (before the reset effect runs): if it names a
+    // container the current pod doesn't have, fall back to the regular containers.
+    if (!containers.some(c => c.name === cname)) {
+      return { reqContainersStr: regularNames.join(','), reqPrevious: false }
+    }
+    return { reqContainersStr: cname, reqPrevious: prev }
+  }, [containerKey, containers, regularNames])
 
   // Fetch the logs. Background follow-polls pass { silent: true } so they don't
   // toggle the loading spinner, which would flicker on every poll; only the
@@ -284,7 +345,8 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
   // make the visible lines shift on every poll). The initial load and any
   // parameter change fetch the tail and replace the buffer.
   const fetchLogs = useCallback(async ({ silent = false, append = false } = {}) => {
-    if (!container) return
+    const reqContainers = reqContainersStr ? reqContainersStr.split(',') : []
+    if (reqContainers.length === 0) return
     // Skip follow polls while a reset is in flight: appending now would use the
     // old buffer's cursor (lastTsRef) and merge into the resetting buffer.
     if (append && resettingRef.current) return
@@ -298,8 +360,12 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     try {
       // tailLines is always sent so the backend caps every fetch (including a
       // follow catch-up) to the user's selection; sinceTime narrows a follow
-      // poll to entries after the last buffered line.
-      const params = new URLSearchParams({ namespace, name, container, tailLines: String(tailLines), previous: String(previous) })
+      // poll to entries after the last buffered line. A repeated container param
+      // requests the merged "All containers" view.
+      const params = new URLSearchParams({ namespace, name, tailLines: String(tailLines), previous: String(reqPrevious) })
+      for (const c of reqContainers) {
+        params.append('container', c)
+      }
       if (append && lastTsRef.current) {
         params.set('sinceTime', lastTsRef.current)
       }
@@ -336,12 +402,21 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
         if (!silent) setLoading(false)
       }
     }
-  }, [namespace, name, container, tailLines, previous])
+  }, [namespace, name, reqContainersStr, reqPrevious, tailLines])
 
-  // Fetch logs whenever the container, line count or previous toggle changes.
+  // Re-fetch whenever the selected container(s), previous flag or line count changes.
   useEffect(() => {
     fetchLogs()
   }, [fetchLogs])
+
+  // Reset the container selection to the pod's default ("All containers") whenever
+  // the pod changes, so a container picked for the previous pod doesn't carry over.
+  // Keyed on the pod name only: poll-driven re-renders keep the same name and leave
+  // the selection untouched. On the initial mount this re-sets the already-default
+  // value, which Preact bails out of as a no-op.
+  useEffect(() => {
+    setContainerKey(defaultKey)
+  }, [name])
 
   // Poll for new logs while following, silently so the spinner doesn't flicker
   // and appending so the visible lines stay put instead of shifting each poll.
@@ -390,6 +465,12 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
   // to a container with no logs yet), so a poll never reuses a stale timestamp
   // from a previous stream. Trailing lines without a timestamp (stack-trace
   // continuations) are skipped rather than clearing it.
+  //
+  // For "All containers" this is a single global high-watermark across the merged
+  // streams, not a per-container cursor. The second-granular sinceTime re-sends
+  // the overlap so a lagging container's recent lines are still picked up; a line
+  // landing more than a second behind the watermark is only reconciled on the
+  // next full (non-append) refetch.
   useEffect(() => {
     let ts = ''
     for (let i = baseLines.length - 1; i >= 0; i--) {
@@ -492,6 +573,15 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_BOTTOM_THRESHOLD
   }, [])
 
+  // Jump to the latest log line and re-pin to the bottom so following resumes
+  // auto-scrolling. Wired to the footer mode indicator.
+  const scrollToBottom = useCallback(() => {
+    const el = bodyRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+    atBottomRef.current = true
+  }, [])
+
   // Keep the most recent entry (or the inline follow error) in view after each
   // update, but only while pinned to the bottom, so following doesn't fight a
   // user scrolling through history.
@@ -507,7 +597,7 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
 
   return (
     <div
-      class={`fixed inset-0 z-50 flex justify-center bg-black/50 ${fullScreen ? 'items-center p-0' : 'items-start pt-16 px-4 pb-4'}`}
+      class={`fixed inset-0 z-50 flex justify-center bg-black/50 ${fullScreen ? 'items-center p-0' : 'items-start pt-16 px-4 sm:px-6 lg:px-8 pb-4'}`}
       onClick={onClose}
       data-testid="logs-viewer-overlay"
     >
@@ -524,8 +614,10 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
         {/* Header */}
         <div class="flex items-center justify-between gap-2 px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
           <div class="min-w-0">
-            <h2 class="text-sm font-semibold text-gray-900 dark:text-white truncate">Logs</h2>
-            <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{namespace}/{name}</p>
+            <h2 class="text-sm font-semibold text-gray-900 dark:text-white truncate">Log Viewer</h2>
+            <p class="text-xs text-gray-500 dark:text-gray-400 truncate" data-testid="logs-title">
+              {[kind, namespace, workloadName].filter(Boolean).join('/')}
+            </p>
           </div>
           <button
             onClick={onClose}
@@ -568,19 +660,32 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             </svg>
           </ToggleButton>
 
+          {/* Pod select. Shown only when there is more than one pod (nothing to
+              switch otherwise); switching pods resets the container dropdown to
+              "All containers". Fixed width so a long pod name is trimmed instead
+              of pushing the rest of the toolbar. */}
+          {pods.length > 1 && (
+            <select
+              value={name}
+              onChange={(e) => onSelectPod?.(e.target.value)}
+              class={`${SELECT_CLASS} w-28 sm:w-40 truncate`}
+              data-testid="logs-pod-select"
+              aria-label="Pod"
+              title="Select pod"
+            >
+              {pods.map((p) => (
+                <option key={p.name} value={p.name}>{p.name}</option>
+              ))}
+            </select>
+          )}
+
           {/* Container select (always shown). Containers that have restarted
               also expose a "(previous)" entry for the prior instance's logs.
               Fixed width so a long container name is trimmed instead of pushing
               the rest of the toolbar. */}
           <select
-            value={`${container}::${previous}`}
-            onChange={(e) => {
-              const opt = containerOptions.find(o => o.key === e.target.value)
-              if (opt) {
-                setContainer(opt.container)
-                setPrevious(opt.previous)
-              }
-            }}
+            value={containerKey}
+            onChange={(e) => setContainerKey(e.target.value)}
             class={`${SELECT_CLASS} w-28 sm:w-40 truncate`}
             data-testid="logs-container-select"
             aria-label="Container"
@@ -741,8 +846,9 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
           )}
         </div>
 
-        {/* Footer: a per-level count summary that doubles as the color legend,
-            with the loader trailing it while a fetch is in flight. */}
+        {/* Footer: a per-level count summary that doubles as the color legend.
+            The trailing corner shows the fetch loader while a request is in
+            flight, otherwise the live/snapshot mode reflecting the follow state. */}
         <div
           class="flex items-center justify-between gap-3 px-4 py-2 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800"
           data-testid="logs-footer"
@@ -755,12 +861,42 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
               </span>
             ))}
           </div>
-          {loading && (
+          {loading ? (
             <div
-              class="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-400 flex-shrink-0"
+              class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 flex-shrink-0"
               data-testid="logs-loader"
+              role="status"
               aria-label="Loading logs"
-            />
+            >
+              <div class="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-400" />
+              <span>Loading…</span>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={scrollToBottom}
+              class="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 hover:text-flux-blue dark:hover:text-flux-blue flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue rounded"
+              data-testid="logs-mode"
+              title={`${follow ? 'Following live logs' : 'Snapshot'} — click to scroll to latest`}
+              aria-label="Scroll to latest logs"
+            >
+              {follow ? (
+                <>
+                  <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 13l-7 7-7-7m14-6l-7 7-7-7" />
+                  </svg>
+                  <span>Following</span>
+                </>
+              ) : (
+                <>
+                  <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6.827 6.175A2.31 2.31 0 0 1 5.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 0 0-1.134-.175 2.31 2.31 0 0 1-1.64-1.055l-.822-1.316a2.192 2.192 0 0 0-1.736-1.039 48.774 48.774 0 0 0-5.232 0 2.192 2.192 0 0 0-1.736 1.039l-.821 1.316Z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16.5 12.75a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0ZM18.75 10.5h.008v.008h-.008V10.5Z" />
+                  </svg>
+                  <span>Snapshot</span>
+                </>
+              )}
+            </button>
           )}
         </div>
       </div>

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -9,6 +9,7 @@ import { fetchWithMock } from '../../../utils/fetch'
 import { downloadBlob } from '../../../utils/download'
 import { usePrismTheme } from '../common/yaml'
 import { LEVELS, LEVEL_META, DEFAULT_LEVEL, detectLevel, stripAnsi } from '../../../utils/logLevel'
+import { decorateLine } from '../../../utils/logFormat'
 import { useDismiss } from '../../../utils/useDismiss'
 
 // Selectable limits for the number of log lines to fetch from the backend.
@@ -573,7 +574,10 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // detected. Only re-runs when the payload (or tagging regime) changes.
   const baseLines = useMemo(() => {
     const podSet = tagged ? new Set(reqPodsStr ? reqPodsStr.split(',') : []) : null
-    const entries = logs.split('\n').filter(line => line.length > 0).map(line => {
+    // Strip a trailing CR up front so a CRLF stream doesn't leak `\r` into the
+    // message text, the decorated field values, or the filter. (The download uses
+    // the raw payload, so it stays byte-verbatim.)
+    const entries = logs.split('\n').map(line => line.replace(/\r$/, '')).filter(line => line.length > 0).map(line => {
       let rest = line
       let pod = ''
       if (podSet) {
@@ -691,19 +695,33 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // unchanged lines also lets Preact skip re-applying their innerHTML.
   const displayLines = useMemo(() => {
     if (!formatted) {
-      return logLines.map(entry => ({ ...entry, code: false, html: null }))
+      return logLines.map(entry => ({ ...entry, code: false, html: null, fmt: null }))
     }
     const prev = formatCacheRef.current
     const next = new Map()
     const result = logLines.map(entry => {
-      let formattedEntry = next.get(entry.text) || prev.get(entry.text)
+      // JSON formatting runs on every line (unchanged from before). Only the
+      // klog/zap/logfmt cascade is gated on a parsed timestamp, so a continuation
+      // line (stack frame, no timestamp) can never be mistaken for a structured
+      // entry. The cache key carries the head flag because the same stripped text
+      // may appear both as a head and as a continuation line.
+      const key = `${entry.ts ? 1 : 0} ${entry.text}`
+      let formattedEntry = next.get(key) || prev.get(key)
       if (!formattedEntry) {
         const json = formatJson(entry.text)
-        formattedEntry = json == null
-          ? { text: entry.text, code: true, html: null }
-          : { text: json, code: true, html: Prism.highlight(json, Prism.languages.json, 'json') }
+        if (json != null) {
+          formattedEntry = { text: json, code: true, html: Prism.highlight(json, Prism.languages.json, 'json'), fmt: null }
+        } else {
+          // klog → zap → logfmt → plain. The block/spans kinds render as decorated
+          // multi-line / single highlighted rows; plain keeps the existing code
+          // path so its output is byte-for-byte unchanged.
+          const d = entry.ts ? decorateLine(entry.text, entry.level) : { kind: 'plain' }
+          formattedEntry = d.kind === 'plain'
+            ? { text: entry.text, code: true, html: null, fmt: null }
+            : { text: entry.text, code: false, html: null, fmt: d }
+        }
       }
-      next.set(entry.text, formattedEntry)
+      next.set(key, formattedEntry)
       return { ...entry, ...formattedEntry }
     })
     formatCacheRef.current = next
@@ -968,7 +986,31 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
                         />
                       </div>
                     )}
-                    {entry.code ? (
+                    {entry.fmt && entry.fmt.kind === 'block' ? (
+                      // Structured entry: one container per entry (keeping the
+                      // per-entry logs-line invariant), one inner row per visual
+                      // line, all flush-left at full width.
+                      <div
+                        class="overflow-x-auto font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
+                        style="padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;"
+                        data-testid="logs-line"
+                      >
+                        {entry.fmt.rows.map((row, r) => (
+                          <div key={r} data-testid="logs-line-row">
+                            {row.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
+                          </div>
+                        ))}
+                      </div>
+                    ) : entry.fmt && entry.fmt.kind === 'spans' ? (
+                      // Unstructured entry highlighted in place: a single row.
+                      <div
+                        class="overflow-x-auto font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
+                        style="padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;"
+                        data-testid="logs-line"
+                      >
+                        {entry.fmt.spans.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
+                      </div>
+                    ) : entry.code ? (
                       <pre
                         class="overflow-x-auto language-json"
                         style="margin: 0; padding: 0.25rem 0.75rem; background: transparent; text-shadow: none; font-size: 12px; line-height: 1.5;"

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'preact/hooks'
 import { fetchWithMock } from '../../../utils/fetch'
+import { downloadBlob } from '../../../utils/download'
 
 // Selectable limits for the number of log lines to fetch from the backend.
 const LINE_LIMITS = [100, 500, 1000, 5000]
@@ -13,8 +14,51 @@ const DEFAULT_TAIL_LINES = 100
 // Follow polling interval in milliseconds.
 const FOLLOW_INTERVAL = 5000
 
+// How long the most recent log line stays highlighted after new entries arrive.
+const HIGHLIGHT_DURATION = 2500
+
 // Matches the leading RFC3339 timestamp the API prepends to each log line.
-const TIMESTAMP_PREFIX = /^\S+\s+/
+// Anchored to a date so lines without a timestamp (e.g. stack-trace
+// continuations) are not mangled by stripping their first token.
+const TIMESTAMP_PREFIX = /^\d{4}-\d{2}-\d{2}T\S+\s+/
+
+// Shared styling for the toolbar controls. Selects deliberately omit a chevron
+// and right padding: those come from the global `select` rule in index.css.
+const FIELD_CLASS = 'text-xs py-1 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-flux-blue'
+const SELECT_CLASS = `${FIELD_CLASS} pl-2`
+const INPUT_CLASS = `${FIELD_CLASS} px-2 placeholder-gray-400 dark:placeholder-gray-500`
+// p-1 keeps the icon buttons the same height as the text-xs py-1 selects.
+const ICON_TOGGLE_CLASS = 'inline-flex items-center justify-center p-1 rounded-md border transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue'
+const INACTIVE_CLASS = 'border-gray-300 text-gray-600 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700'
+const ACTIVE_CLASS = 'border-flux-blue text-flux-blue bg-blue-50 dark:bg-blue-900/30'
+const ACTION_CLASS = 'inline-flex items-center p-1 rounded-md text-gray-400 hover:text-flux-blue dark:text-gray-500 dark:hover:text-flux-blue disabled:cursor-not-allowed'
+
+/**
+ * ToggleButton - square icon button in the logs toolbar that reflects an
+ * on/off state via aria-pressed and active styling.
+ *
+ * @param {Object} props
+ * @param {boolean} props.active - Whether the toggle is on
+ * @param {Function} props.onClick - Click handler
+ * @param {string} props.label - Accessible label (also the default tooltip)
+ * @param {string} [props.title] - Optional tooltip text, defaults to label
+ * @param {string} props.testid - data-testid value
+ * @param {any} props.children - The button icon
+ */
+function ToggleButton({ active, onClick, label, title, testid, children }) {
+  return (
+    <button
+      onClick={onClick}
+      class={`${ICON_TOGGLE_CLASS} ${active ? ACTIVE_CLASS : INACTIVE_CLASS}`}
+      data-testid={testid}
+      aria-pressed={active}
+      aria-label={label}
+      title={title || label}
+    >
+      {children}
+    </button>
+  )
+}
 
 /**
  * WorkloadLogsViewer - Modal that displays the logs of a pod container.
@@ -22,7 +66,8 @@ const TIMESTAMP_PREFIX = /^\S+\s+/
  * Fetches logs from GET /api/v1/workload/logs for the selected container and
  * renders each log entry on its own separated row. Supports following (live
  * polling), filtering by substring, choosing the number of lines, viewing the
- * previous container instance, toggling timestamps, and a fullscreen mode.
+ * previous container instance, toggling timestamps, downloading the logs as a
+ * <pod>.log file, and a fullscreen mode.
  *
  * @param {Object} props
  * @param {string} props.namespace - Pod namespace
@@ -37,16 +82,17 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
   const [container, setContainer] = useState(defaultContainer)
   const [previous, setPrevious] = useState(false)
   const [tailLines, setTailLines] = useState(DEFAULT_TAIL_LINES)
-  const [follow, setFollow] = useState(false)
+  const [follow, setFollow] = useState(true)
   const [filter, setFilter] = useState('')
   const [showTimestamps, setShowTimestamps] = useState(false)
   const [fullScreen, setFullScreen] = useState(false)
   const [logs, setLogs] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
-  const [copied, setCopied] = useState(false)
+  const [flashLatest, setFlashLatest] = useState(false)
 
   const bodyRef = useRef(null)
+  const prevLogsRef = useRef('')
 
   const fetchLogs = useCallback(async () => {
     if (!container) return
@@ -95,16 +141,40 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [onClose])
 
-  // Split the raw log payload into entries, apply the substring filter and
-  // optionally strip the leading timestamp for display.
-  const logLines = useMemo(() => {
-    let lines = logs.split('\n').filter(line => line.length > 0)
-    const needle = filter.trim().toLowerCase()
-    if (needle) {
-      lines = lines.filter(line => line.toLowerCase().includes(needle))
-    }
+  // Lock the background page scroll while the viewer is open so scrolling the
+  // logs does not bleed through to the dashboard behind the modal.
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = previousOverflow }
+  }, [])
+
+  // Briefly highlight the most recent line whenever a new batch of logs arrives
+  // (e.g. while following), skipping the very first load so the highlight only
+  // signals freshly appended entries.
+  useEffect(() => {
+    const prev = prevLogsRef.current
+    prevLogsRef.current = logs
+    if (prev === '' || logs === '' || prev === logs) return
+    setFlashLatest(true)
+    const id = setTimeout(() => setFlashLatest(false), HIGHLIGHT_DURATION)
+    return () => clearTimeout(id)
+  }, [logs])
+
+  // Split the raw payload into entries once, stripping timestamps for display
+  // unless they are shown. This only re-runs when the payload or the timestamp
+  // toggle changes, not on every filter keystroke.
+  const baseLines = useMemo(() => {
+    const lines = logs.split('\n').filter(line => line.length > 0)
     return showTimestamps ? lines : lines.map(line => line.replace(TIMESTAMP_PREFIX, ''))
-  }, [logs, filter, showTimestamps])
+  }, [logs, showTimestamps])
+
+  // Apply the substring filter; cheap pass over the already-split lines.
+  const logLines = useMemo(() => {
+    const needle = filter.trim().toLowerCase()
+    if (!needle) return baseLines
+    return baseLines.filter(line => line.toLowerCase().includes(needle))
+  }, [baseLines, filter])
 
   // Keep the most recent entry in view after each update.
   useEffect(() => {
@@ -112,38 +182,20 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     bodyRef.current.scrollTop = bodyRef.current.scrollHeight
   }, [logLines])
 
-  const handleCopy = useCallback(async () => {
-    try {
-      await window.navigator.clipboard.writeText(logs)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // Clipboard access can fail in insecure contexts; ignore silently.
-    }
-  }, [logs])
-
-  const fieldClass = 'text-xs px-2 py-1 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-flux-blue'
-  // appearance-none removes the native caret; the @tailwindcss/forms plugin
-  // also injects a chevron via background-image which is suppressed with an
-  // inline style on each select (see noFormsChevron). pr-6 leaves room for the
-  // single custom chevron rendered alongside.
-  const selectClass = `${fieldClass} appearance-none pr-6`
-  const noFormsChevron = { backgroundImage: 'none' }
-  const inputClass = `${fieldClass} placeholder-gray-400 dark:placeholder-gray-500`
-  const iconToggleClass = 'inline-flex items-center justify-center p-1.5 rounded-md border transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue'
-  const inactiveClass = 'border-gray-300 text-gray-600 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700'
-  const activeClass = 'border-flux-blue text-flux-blue bg-blue-50 dark:bg-blue-900/30'
-  const actionClass = 'inline-flex items-center p-1.5 rounded-md text-gray-400 hover:text-flux-blue dark:text-gray-500 dark:hover:text-flux-blue disabled:cursor-not-allowed'
+  // Download the current logs as a <pod>.log text file.
+  const handleDownload = useCallback(() => {
+    downloadBlob(new window.Blob([logs], { type: 'text/plain' }), `${name}.log`)
+  }, [logs, name])
 
   return (
     <div
-      class={`fixed inset-0 z-50 flex items-center justify-center bg-black/50 ${fullScreen ? 'p-0' : 'p-4'}`}
+      class={`fixed inset-0 z-50 flex justify-center bg-black/50 ${fullScreen ? 'items-center p-0' : 'items-start pt-16 px-4 pb-4'}`}
       onClick={onClose}
       data-testid="logs-viewer-overlay"
     >
       <div
-        class={`bg-white dark:bg-gray-900 shadow-xl flex flex-col border border-gray-200 dark:border-gray-700 ${
-          fullScreen ? 'w-full h-full max-w-full max-h-full rounded-none' : 'w-full max-w-4xl h-[85vh] rounded-lg'
+        class={`bg-white dark:bg-gray-900 shadow-xl flex flex-col overflow-hidden border border-gray-200 dark:border-gray-700 ${
+          fullScreen ? 'w-full h-full max-w-full max-h-full rounded-none' : 'w-full max-w-7xl h-[calc(100vh-5rem)] rounded-lg'
         }`}
         onClick={(e) => e.stopPropagation()}
         role="dialog"
@@ -172,37 +224,30 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
         {/* Toolbar */}
         <div class="flex items-center flex-wrap gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700">
           {/* Follow logs */}
-          <button
+          <ToggleButton
+            active={follow}
             onClick={() => setFollow(v => !v)}
-            class={`${iconToggleClass} ${follow ? activeClass : inactiveClass}`}
-            data-testid="logs-follow-toggle"
-            aria-pressed={follow}
-            aria-label="Follow logs"
-            title="Follow logs"
+            label="Follow logs"
+            testid="logs-follow-toggle"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 13l-7 7-7-7m14-6l-7 7-7-7" />
             </svg>
-          </button>
+          </ToggleButton>
 
-          {/* Container select (always shown) */}
-          <div class="relative inline-flex">
-            <select
-              value={container}
-              onChange={(e) => setContainer(e.target.value)}
-              class={selectClass}
-              style={noFormsChevron}
-              data-testid="logs-container-select"
-              aria-label="Container"
-            >
-              {containers.map((c) => (
-                <option key={c.name} value={c.name}>{c.isInit ? `init:${c.name}` : c.name}</option>
-              ))}
-            </select>
-            <svg class="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
+          {/* Container select (always shown). Fixed width so a long container
+              name is trimmed instead of pushing the rest of the toolbar. */}
+          <select
+            value={container}
+            onChange={(e) => setContainer(e.target.value)}
+            class={`${SELECT_CLASS} w-28 sm:w-40 truncate`}
+            data-testid="logs-container-select"
+            aria-label="Container"
+          >
+            {containers.map((c) => (
+              <option key={c.name} value={c.name}>{c.isInit ? `init:${c.name}` : c.name}</option>
+            ))}
+          </select>
 
           {/* Contains filter */}
           <input
@@ -210,64 +255,55 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             value={filter}
             onInput={(e) => setFilter(e.target.value)}
             placeholder="contains…"
-            class={`${inputClass} w-28 sm:w-44`}
+            class={`${INPUT_CLASS} w-28 sm:w-40`}
             data-testid="logs-filter-input"
             aria-label="Filter log lines containing text"
           />
 
           {/* Previous container instance */}
-          <button
+          <ToggleButton
+            active={previous}
             onClick={() => setPrevious(v => !v)}
-            class={`${iconToggleClass} ${previous ? activeClass : inactiveClass}`}
-            data-testid="logs-previous-toggle"
-            aria-pressed={previous}
-            aria-label="Previous container instance"
+            label="Previous container instance"
             title="Show logs from the previous container instance"
+            testid="logs-previous-toggle"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
             </svg>
-          </button>
+          </ToggleButton>
 
           {/* Lines select */}
-          <div class="relative inline-flex">
-            <select
-              value={tailLines}
-              onChange={(e) => setTailLines(Number(e.target.value))}
-              class={selectClass}
-              style={noFormsChevron}
-              data-testid="logs-lines-select"
-              aria-label="Number of lines"
-            >
-              {LINE_LIMITS.map((n) => (
-                <option key={n} value={n}>{n} ln</option>
-              ))}
-            </select>
-            <svg class="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
+          <select
+            value={tailLines}
+            onChange={(e) => setTailLines(Number(e.target.value))}
+            class={SELECT_CLASS}
+            data-testid="logs-lines-select"
+            aria-label="Number of lines"
+          >
+            {LINE_LIMITS.map((n) => (
+              <option key={n} value={n}>{n} ln</option>
+            ))}
+          </select>
 
           {/* Timestamps show/hide */}
-          <button
+          <ToggleButton
+            active={showTimestamps}
             onClick={() => setShowTimestamps(v => !v)}
-            class={`${iconToggleClass} ${showTimestamps ? activeClass : inactiveClass}`}
-            data-testid="logs-timestamps-toggle"
-            aria-pressed={showTimestamps}
-            aria-label="Show or hide timestamps"
-            title="Show or hide timestamps"
+            label="Show or hide timestamps"
+            testid="logs-timestamps-toggle"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-          </button>
+          </ToggleButton>
 
           {/* Actions */}
           <div class="flex items-center gap-1 ml-auto">
             <button
               onClick={fetchLogs}
               disabled={loading}
-              class={actionClass}
+              class={ACTION_CLASS}
               title="Refresh logs"
               aria-label="Refresh logs"
               data-testid="logs-refresh-button"
@@ -277,25 +313,20 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
               </svg>
             </button>
             <button
-              onClick={handleCopy}
-              class={actionClass}
-              title="Copy logs to clipboard"
-              aria-label="Copy logs to clipboard"
-              data-testid="logs-copy-button"
+              onClick={handleDownload}
+              disabled={!logs}
+              class={ACTION_CLASS}
+              title="Download logs"
+              aria-label="Download logs"
+              data-testid="logs-download-button"
             >
-              {copied ? (
-                <svg class="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-                </svg>
-              ) : (
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                </svg>
-              )}
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+              </svg>
             </button>
             <button
               onClick={() => setFullScreen(v => !v)}
-              class={actionClass}
+              class={ACTION_CLASS}
               aria-pressed={fullScreen}
               title={fullScreen ? 'Exit fullscreen' : 'Fullscreen'}
               aria-label={fullScreen ? 'Exit fullscreen' : 'Fullscreen'}
@@ -315,7 +346,7 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
         </div>
 
         {/* Body */}
-        <div ref={bodyRef} class="flex-1 overflow-auto bg-gray-50 dark:bg-gray-950" data-testid="logs-body">
+        <div ref={bodyRef} class="flex-1 overflow-auto overscroll-contain bg-gray-50 dark:bg-gray-950" data-testid="logs-body">
           {error ? (
             <div class="m-3 p-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-xs text-red-800 dark:text-red-200" data-testid="logs-error">
               {error}
@@ -324,15 +355,23 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-loading">Loading logs...</p>
           ) : logLines.length > 0 ? (
             <div class="divide-y divide-gray-200 dark:divide-gray-800" data-testid="logs-content">
-              {logLines.map((line, i) => (
-                <div
-                  key={i}
-                  class="px-3 py-1 text-sm font-mono text-gray-800 dark:text-gray-200 whitespace-pre-wrap break-all hover:bg-gray-100 dark:hover:bg-gray-900"
-                  data-testid="logs-line"
-                >
-                  {line}
-                </div>
-              ))}
+              {logLines.map((line, i) => {
+                const isLatest = flashLatest && i === logLines.length - 1
+                return (
+                  <div
+                    key={i}
+                    class={`px-3 py-1 text-sm font-mono whitespace-pre-wrap break-all transition-colors duration-1000 ${
+                      isLatest
+                        ? 'bg-blue-100 dark:bg-blue-900/40 text-gray-900 dark:text-gray-100'
+                        : 'text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-900'
+                    }`}
+                    data-testid="logs-line"
+                    data-latest={isLatest ? 'true' : undefined}
+                  >
+                    {line}
+                  </div>
+                )
+              })}
             </div>
           ) : (
             <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-empty">

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -3,13 +3,10 @@
 
 import { Fragment } from 'preact'
 import { useState, useEffect, useCallback, useMemo, useRef } from 'preact/hooks'
-import Prism from 'prismjs'
-import 'prismjs/components/prism-json'
 import { fetchWithMock } from '../../../utils/fetch'
 import { downloadBlob } from '../../../utils/download'
-import { usePrismTheme } from '../common/yaml'
 import { LEVELS, LEVEL_META, DEFAULT_LEVEL, detectLevel, stripAnsi } from '../../../utils/logLevel'
-import { decorateLine } from '../../../utils/logFormat'
+import { decorateLine, highlightJson } from '../../../utils/logFormat'
 import { useDismiss } from '../../../utils/useDismiss'
 
 // Selectable limits for the number of log lines to fetch from the backend.
@@ -105,24 +102,6 @@ function entryTimestamp(line) {
     if (am && !Number.isNaN(Date.parse(am[1]))) return am[1]
   }
   return null
-}
-
-/**
- * formatJson - indents a log line if it is a JSON object or array, otherwise
- * returns null. The cheap first-character check avoids a try/catch on the
- * common case of plain-text lines.
- *
- * @param {string} text - The log line text
- * @returns {string|null} The indented JSON, or null if the line is not JSON
- */
-function formatJson(text) {
-  const trimmed = text.trim()
-  if (trimmed[0] !== '{' && trimmed[0] !== '[') return null
-  try {
-    return JSON.stringify(JSON.parse(trimmed), null, 2)
-  } catch {
-    return null
-  }
 }
 
 // Shared styling for the toolbar controls. Selects deliberately omit a chevron
@@ -267,9 +246,6 @@ function LevelMenu({ value, onChange }) {
  * @param {Function} props.onClose - Callback to close the viewer
  */
 export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], initialPodName, onClose }) {
-  // Load the Prism theme used to syntax-highlight JSON lines as code blocks.
-  usePrismTheme()
-
   // Selected pod: a specific pod name or ALL_PODS. Initialised from initialPodName
   // (the parent remounts the viewer per open, so this re-inits on each open).
   const [podKey, setPodKey] = useState(initialPodName || ALL_PODS)
@@ -370,9 +346,9 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // buffer's cursor into the resetting buffer (the generation guard alone can't
   // catch this, since a poll fired after the reset shares its generation).
   const resettingRef = useRef(false)
-  // Memoizes the formatted (pretty-printed + Prism-highlighted) output per raw
-  // line text, so appends only format the new lines instead of re-highlighting
-  // the whole buffer on every poll. See displayLines for how it's pruned.
+  // Memoizes the formatted (pretty-printed, colored-span) output per raw line text,
+  // so appends only format the new lines instead of re-formatting the whole buffer
+  // on every poll. See displayLines for how it's pruned.
   const formatCacheRef = useRef(new Map())
 
   // Pod dropdown options: "All pods" leads, then each pod.
@@ -678,24 +654,22 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     return containsLines.filter(entry => entry.level === levelFilter)
   }, [containsLines, levelFilter])
 
-  // In formatted mode every line renders as a code block sharing the same
-  // monospace font and size as the YAML blocks (`code: true`). Valid JSON gets
-  // indented and Prism-highlighted (`html`); other lines keep their plain text
-  // in the same styling. In raw mode lines render as unstyled plain text
+  // In formatted mode every line carries a descriptor (`fmt`) of colored spans:
+  // valid JSON is pretty-printed (`fmt.kind === 'json'`), structured loggers reflow
+  // to `block`/`spans`, and an unmatched line falls back to plain wrapping text
+  // (`code: true`). In raw mode lines render as unstyled plain text
   // (`code: false`). Filtering happens first on the raw text, so this only
   // transforms what is actually shown.
   //
   // The formatted output is cached by raw line text (formatCacheRef): since the
-  // pretty-printed/highlighted form depends only on the line text, an append
-  // reuses the cached result for every existing line and only runs formatJson +
-  // Prism over the genuinely new lines, instead of re-highlighting the whole
-  // buffer on every poll. The cache is rebuilt to hold only the lines currently
-  // shown, so it can't outgrow the buffer; raw mode leaves it untouched so it
-  // survives a round-trip back to formatted. Returning the same html string for
-  // unchanged lines also lets Preact skip re-applying their innerHTML.
+  // formatted form depends only on the line text, an append reuses the cached
+  // result for every existing line and only formats the genuinely new lines,
+  // instead of re-formatting the whole buffer on every poll. The cache is rebuilt
+  // to hold only the lines currently shown, so it can't outgrow the buffer; raw
+  // mode leaves it untouched so it survives a round-trip back to formatted.
   const displayLines = useMemo(() => {
     if (!formatted) {
-      return logLines.map(entry => ({ ...entry, code: false, html: null, fmt: null }))
+      return logLines.map(entry => ({ ...entry, code: false, fmt: null }))
     }
     const prev = formatCacheRef.current
     const next = new Map()
@@ -705,21 +679,16 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
       // line (stack frame, no timestamp) can never be mistaken for a structured
       // entry. The cache key carries the head flag because the same stripped text
       // may appear both as a head and as a continuation line.
-      const key = `${entry.ts ? 1 : 0} ${entry.text}`
+      const key = `${entry.ts ? 1 : 0}\n${entry.text}`
       let formattedEntry = next.get(key) || prev.get(key)
       if (!formattedEntry) {
-        const json = formatJson(entry.text)
-        if (json != null) {
-          formattedEntry = { text: json, code: true, html: Prism.highlight(json, Prism.languages.json, 'json'), fmt: null }
-        } else {
-          // klog → zap → logfmt → plain. The block/spans kinds render as decorated
-          // multi-line / single highlighted rows; plain keeps the existing code
-          // path so its output is byte-for-byte unchanged.
-          const d = entry.ts ? decorateLine(entry.text, entry.level) : { kind: 'plain' }
-          formattedEntry = d.kind === 'plain'
-            ? { text: entry.text, code: true, html: null, fmt: null }
-            : { text: entry.text, code: false, html: null, fmt: d }
-        }
+        // json then klog/zap/logfmt then plain. The json/block/spans kinds render as
+        // decorated rows; plain keeps a wrapping text div.
+        const json = highlightJson(entry.text)
+        const d = json || (entry.ts ? decorateLine(entry.text, entry.level) : { kind: 'plain' })
+        formattedEntry = d.kind === 'plain'
+          ? { text: entry.text, code: true, fmt: null }
+          : { text: entry.text, code: false, fmt: d }
       }
       next.set(key, formattedEntry)
       return { ...entry, ...formattedEntry }
@@ -1010,24 +979,28 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
                       >
                         {entry.fmt.spans.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
                       </div>
-                    ) : entry.code ? (
+                    ) : entry.fmt && entry.fmt.kind === 'json' ? (
+                      // Pretty-printed JSON: a <pre> preserves the indentation/newlines
+                      // baked into the spans and scrolls long values horizontally,
+                      // keeping nested structures intact.
                       <pre
-                        class="overflow-x-auto language-json"
-                        style="margin: 0; padding: 0.25rem 0.75rem; background: transparent; text-shadow: none; font-size: 12px; line-height: 1.5;"
+                        class="overflow-x-auto font-mono text-gray-800 dark:text-gray-200"
+                        style="margin: 0; padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;"
                         data-testid="logs-line"
                       >
-                        {entry.html != null ? (
-                          <code
-                            class="language-json"
-                            style="background: transparent; text-shadow: none;"
-                            dangerouslySetInnerHTML={{ __html: entry.html }}
-                          />
-                        ) : (
-                          <code class="language-json" style="background: transparent; text-shadow: none;">
-                            {entry.text}
-                          </code>
-                        )}
+                        {entry.fmt.spans.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
                       </pre>
+                    ) : entry.code ? (
+                      // Plain line that matched no formatter (or a continuation line
+                      // such as a stack frame): wrap it like the decorated rows rather
+                      // than the JSON <pre>, which scrolls horizontally and never wraps.
+                      <div
+                        class="overflow-x-auto font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
+                        style="padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;"
+                        data-testid="logs-line"
+                      >
+                        {entry.text}
+                      </div>
                     ) : (
                       <div
                         class="px-3 py-0.5 text-sm font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -19,9 +19,9 @@ const DEFAULT_TAIL_LINES = 100
 // container (init and regular) and interleaves the lines chronologically.
 const ALL_CONTAINERS = 'all'
 
-// Sentinel option key for the "All pods" view, which streams every pod of the
-// workload and interleaves the lines chronologically, each tagged with its pod of
-// origin. Distinct from ALL_CONTAINERS so it can never collide with a pod name.
+// Sentinel option key for the "All pods" view: every pod streamed and interleaved
+// chronologically, each line tagged with its pod. Distinct from ALL_CONTAINERS so
+// it can never collide with a pod name.
 const ALL_PODS = '__all_pods__'
 
 // Follow polling interval in milliseconds.
@@ -39,20 +39,20 @@ const SCROLL_BOTTOM_THRESHOLD = 32
 // backend's maxLogTailLines cap.
 const MAX_BUFFER_LINES = 5000
 
+// Shown inline when the workload has lost every pod while the viewer is open.
+const NO_PODS_MESSAGE = 'The workload has no running pods to stream logs from.'
+
 /**
  * mergeLogs - appends the entries of an incoming payload to the accumulated
  * buffer, dropping whole entries already present and capping to MAX_BUFFER_LINES.
  *
- * Follow polls request everything since the last line's timestamp, which the API
- * filters at second granularity, so the last second of entries is re-sent on
- * every poll. Dedup is by the entry's timestamped HEAD line, which is unique (a
- * nanosecond timestamp, plus the pod tag in the all-pods view): a re-sent entry
- * whose head already sits in the buffer is dropped whole — head and all the
- * continuation lines under it. Continuation lines (stack frames, no timestamp)
- * are never deduped on their own, so a genuinely new entry keeps its full stack
- * even when a replica emitted a byte-identical frame earlier; deduping those by
- * text (the previous behaviour) truncated the new trace. Returns the previous
- * buffer unchanged when there is nothing new, so the state update is a no-op.
+ * Follow polls re-send the last second of entries (the API filters at second
+ * granularity). Dedup is by the timestamped HEAD line, unique per entry (nanosecond
+ * ts, plus pod tag in the all-pods view): a re-sent head already buffered drops the
+ * whole entry — head and its continuation lines. Continuation lines (stack frames,
+ * no ts) are never deduped alone, so a new entry keeps its full stack even when a
+ * replica emitted an identical frame earlier. Returns prev unchanged when nothing
+ * is new, so the state update is a no-op.
  *
  * @param {string} prev - The accumulated log payload
  * @param {string} incoming - The newly fetched log payload
@@ -67,13 +67,12 @@ function mergeLogs(prev, incoming) {
   let dropping = false
   for (const line of add) {
     if (entryTimestamp(line)) {
-      // Start of an entry: a re-send (head already buffered) is dropped whole, so
-      // its continuation lines are skipped until the next head arrives.
+      // Entry head: a re-send already buffered drops the entry and its
+      // continuation lines until the next head.
       dropping = seen.has(line)
       if (!dropping) { fresh.push(line); seen.add(line) }
     } else if (!dropping) {
-      // A continuation line of a kept entry (or a leading orphan before any head):
-      // appended verbatim, never deduped against an identical frame elsewhere.
+      // Continuation line of a kept entry (or a leading orphan): appended verbatim.
       fresh.push(line)
     }
   }
@@ -88,11 +87,10 @@ function mergeLogs(prev, incoming) {
 // continuations) are not mangled by splitting off their first token.
 const TIMESTAMP_PREFIX = /^(\d{4}-\d{2}-\d{2}T\S+)\s+/
 
-// entryTimestamp returns the RFC3339 timestamp that heads a log entry, or null
-// for a continuation line (a stack frame and the like) that carries none. A head
-// is either "<ts> msg" (single pod) or "<pod> <ts> msg" (all-pods, pod-tagged);
-// the timestamp must be a real instant, not merely date-shaped, so a frame
-// beginning with a word and a date-like token is not taken for a head.
+// entryTimestamp returns the RFC3339 timestamp heading a log entry, or null for a
+// continuation line (stack frame) that carries none. A head is "<ts> msg" (single
+// pod) or "<pod> <ts> msg" (all-pods); the ts must be a real instant, not merely
+// date-shaped, so a frame beginning with a word and date-like token isn't a head.
 function entryTimestamp(line) {
   const m = line.match(TIMESTAMP_PREFIX)
   if (m && !Number.isNaN(Date.parse(m[1]))) return m[1]
@@ -170,25 +168,25 @@ function LevelMenu({ value, onChange }) {
   const current = LEVEL_OPTIONS.find(o => o.value === value) || LEVEL_OPTIONS[0]
 
   return (
-    <div class="relative" ref={ref}>
+    <div class="relative w-full sm:w-auto" ref={ref}>
       <button
         type="button"
         onClick={() => setOpen(v => !v)}
-        class={LEVEL_BUTTON_CLASS}
+        class={`${LEVEL_BUTTON_CLASS} w-full justify-between sm:w-auto`}
         data-testid="logs-level-filter"
         aria-label="Log level"
         aria-expanded={open}
         title="Show only logs of this level"
       >
         {current.swatch && <span class={`w-2 h-2 rounded-full ${current.swatch}`} />}
-        <span>{current.label}</span>
+        <span class="flex-1 text-left sm:flex-none">{current.label}</span>
         <svg class="w-3 h-3 ml-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
         </svg>
       </button>
       {open && (
         <div
-          class="absolute left-0 mt-1 w-36 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50"
+          class="absolute left-0 mt-1 w-full sm:w-36 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50"
           data-testid="logs-level-menu"
         >
           {LEVEL_OPTIONS.map((o) => (
@@ -214,28 +212,25 @@ function LevelMenu({ value, onChange }) {
 /**
  * WorkloadLogsViewer - Modal that displays the logs of a workload's pods.
  *
- * The header titles the modal "Log Viewer" over the workload's kind/namespace/name.
- * Two toolbar dropdowns scope the stream: a pod dropdown ("All pods" plus each
- * pod) and a container dropdown ("All containers" plus each container). Switching
- * pods resets the container dropdown back to "All containers".
+ * Two toolbar dropdowns scope the stream: pods ("All pods" plus each pod) and
+ * containers ("All containers" plus each). Switching pods resets the container
+ * dropdown to "All containers".
  *
- * Fetches logs from GET /api/v1/workload/logs and renders each log entry on its
- * own row. In the default formatted mode the timestamp is shown as a pill on the
- * row separator (prefixed with the pod id in the "All pods" view), the pill
- * border and rule are colored by the detected log level (JSON/klog/logfmt/plain
- * text), and JSON lines are pretty-printed; the footer summarizes the per-level
- * counts. The raw mode strips all of that styling. Supports following (live
- * polling, appending only new entries), toggling formatted/raw, filtering by
- * substring and minimum level, choosing the number of lines, an "All containers"
- * option (the default) and an "All pods" option (the default) that interleave the
- * lines chronologically. In "All pods" the backend tags each line with its pod of
- * origin; the row pill shows that pod's id. The viewer downloads the logs as a
- * <pod>.log file and has a fullscreen mode. A failed follow poll is shown inline
- * at the tail; an initial/post-reset failure (no buffer) shows a full-pane error.
+ * Fetches from GET /api/v1/workload/logs, one entry per row. Formatted mode (the
+ * default) shows the timestamp as a level-colored pill on the row separator
+ * (prefixed with the pod id in "All pods"), pretty-prints JSON, and summarizes
+ * per-level counts in the footer; raw mode strips all styling. Supports following
+ * (live polling, appending only new entries), formatted/raw toggle, substring and
+ * minimum-level filters, line count, and the chronologically-interleaved "All
+ * containers" and "All pods" views (the latter tags each line with its pod id).
+ * Downloads as a <pod>.log file and has a fullscreen mode. A failed follow poll
+ * shows inline at the tail; an initial/post-reset failure (no buffer) shows a
+ * full-pane error. If all pods vanish while open (scaled to zero, deleted), the
+ * viewer stays open showing buffered logs and an inline notice, rather than closing.
  *
- * Pod selection is internal: the viewer is given every pod with its containers and
- * keeps the current pod in local state, so it can build the "All pods" request
- * (every pod's regular containers) and resolve the selected pod's containers live.
+ * Pod selection is internal: given every pod with its containers, the viewer keeps
+ * the current pod in local state to build the "All pods" request and resolve the
+ * selected pod's containers live.
  *
  * @param {Object} props
  * @param {string} props.kind - Workload kind, shown in the title
@@ -244,36 +239,53 @@ function LevelMenu({ value, onChange }) {
  * @param {Array<{name: string, status?: string, containers: Array<{name: string, isInit: boolean, restartCount?: number}>}>} props.pods - Pods of the workload, with their containers
  * @param {string} [props.initialPodName] - Pod to pre-select; defaults to "All pods" when absent
  * @param {Function} props.onClose - Callback to close the viewer
+ * @param {Function} [props.onPodChange] - Called with the selected pod name (or null
+ *   for the "All pods" view) whenever the selection changes, so the parent can keep
+ *   a shareable URL in sync with the pod currently shown.
  */
-export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], initialPodName, onClose }) {
-  // Selected pod: a specific pod name or ALL_PODS. Initialised from initialPodName
-  // (the parent remounts the viewer per open, so this re-inits on each open).
+export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], initialPodName, onClose, onPodChange }) {
+  // Selected pod: a specific pod name or ALL_PODS. Initialised from initialPodName;
+  // the parent remounts the viewer per open, so this re-inits on each open.
   const [podKey, setPodKey] = useState(initialPodName || ALL_PODS)
 
-  // Resolve the selection against the live pod list. If the selected specific pod
-  // has disappeared, fall back to "All pods" so the view keeps working.
+  // Resolve against the live pod list, falling back to "All pods" if the selected
+  // pod has disappeared.
   const effectivePodKey = (podKey === ALL_PODS || pods.some(p => p.name === podKey)) ? podKey : ALL_PODS
   const allPods = effectivePodKey === ALL_PODS
   const selectedPod = allPods ? null : (pods.find(p => p.name === effectivePodKey) || null)
 
-  // Commit the fallback when the selected pod disappears (scaled down, deleted).
-  // effectivePodKey already renders "All pods" in that case, but persisting it
-  // means a later pod that happens to reappear with the same name does not
-  // silently snap the view back to it without the user choosing it.
+  // No pods left to stream (scaled to zero, deleted): show an inline notice
+  // instead of closing.
+  const podsGone = pods.length === 0
+
+  // Commit the fallback when the selected pod disappears. effectivePodKey already
+  // renders "All pods", but persisting it stops a later pod reappearing with the
+  // same name from silently snapping the view back without the user choosing it.
   useEffect(() => {
     if (podKey !== ALL_PODS && !pods.some(p => p.name === podKey)) {
       setPodKey(ALL_PODS)
     }
   }, [podKey, pods])
 
-  // Sorted pod names: the request streams these (name = first, rest as repeated
-  // pod params) and the parser uses them as the set of valid pod tags. Sorting
-  // keeps the request stable if the backend returns the same pods reordered.
+  // Report the effective pod selection to the parent so it can keep the shareable
+  // URL pointed at the pod shown. Guarded by a ref so an unstable onPodChange
+  // identity doesn't trigger redundant writes.
+  const reportedPodRef = useRef(undefined)
+  useEffect(() => {
+    const pod = allPods ? null : effectivePodKey
+    if (onPodChange && reportedPodRef.current !== pod) {
+      reportedPodRef.current = pod
+      onPodChange(pod)
+    }
+  }, [allPods, effectivePodKey, onPodChange])
+
+  // Sorted pod names: streamed in the request (first as name, rest as repeated pod
+  // params) and used as the set of valid pod tags. Sorting keeps the request stable
+  // when the backend reorders the same pods.
   const podNames = useMemo(() => pods.map(p => p.name).sort(), [pods])
 
-  // Containers driving the container dropdown and the request. For "All pods" it
-  // is the union of containers across pods (pod templates are uniform, so this is
-  // just every container); for a specific pod it is that pod's live containers.
+  // Containers for the dropdown and request: the union across pods for "All pods"
+  // (templates are uniform, so every container), else the selected pod's live ones.
   const containers = useMemo(() => {
     if (!allPods) return selectedPod?.containers || []
     const seen = new Set()
@@ -286,9 +298,8 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     return out
   }, [allPods, selectedPod, pods])
 
-  // Every container name (init and regular) — the set the "All containers" view
-  // streams and interleaves. Init containers run to completion before the app
-  // starts, so their lines sort to the front of the merged feed.
+  // Every container name (init and regular) streamed by "All containers". Init
+  // containers run to completion first, so their lines sort to the front.
   const streamNames = useMemo(
     () => containers.map(c => c.name),
     [containers]
@@ -333,22 +344,20 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // Timestamp of the last buffered line, sent as sinceTime on single-pod follow
   // polls so the server returns only newer entries to append.
   const lastTsRef = useRef('')
-  // Per-pod follow cursors (pod -> newest timestamp seen) for the "All pods" view,
-  // sent as repeated `since` params so each pod advances independently of clock
-  // skew between nodes. Kept in a ref so updating it doesn't re-create fetchLogs.
+  // Per-pod follow cursors (pod -> newest ts) for "All pods", sent as repeated
+  // `since` params so each pod advances independently of node clock skew. In a ref
+  // so updating it doesn't re-create fetchLogs.
   const cursorsRef = useRef(new Map())
-  // Monotonic id bumped by every reset (non-append) fetch. A fetch only applies
-  // its result if its id is still current, so an in-flight append poll from a
-  // previous container/params can't merge stale lines into a reset buffer.
+  // Monotonic id bumped by every reset (non-append) fetch. A fetch applies its
+  // result only if its id is still current, so an in-flight append poll from
+  // previous params can't merge stale lines into a reset buffer.
   const fetchGenRef = useRef(0)
-  // True while a reset (initial/param-change) fetch is in flight. Follow polls
-  // skip while it is set, so a poll started mid-reset can't append using the old
-  // buffer's cursor into the resetting buffer (the generation guard alone can't
-  // catch this, since a poll fired after the reset shares its generation).
+  // True while a reset fetch is in flight; follow polls skip so a poll started
+  // mid-reset can't append the old buffer's cursor into the resetting buffer (a
+  // poll fired after the reset shares its generation, so the guard alone misses it).
   const resettingRef = useRef(false)
-  // Memoizes the formatted (pretty-printed, colored-span) output per raw line text,
-  // so appends only format the new lines instead of re-formatting the whole buffer
-  // on every poll. See displayLines for how it's pruned.
+  // Memoizes formatted output per raw line text, so appends format only the new
+  // lines instead of the whole buffer each poll. See displayLines for pruning.
   const formatCacheRef = useRef(new Map())
 
   // Pod dropdown options: "All pods" leads, then each pod.
@@ -378,48 +387,38 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     return opts
   }, [allPods, containers, streamNames])
 
-  // The pods to stream as a stable comma-joined string: every pod for "All pods",
-  // or the single selected pod. Pod names cannot contain commas, so this stays a
-  // primitive, value-stable fetch dependency (a pod-set change resets the buffer;
-  // a backend reorder of the same set does not, because podNames is sorted).
+  // Pods to stream as a comma-joined string: every pod for "All pods", else the
+  // selected one. Pod names hold no commas, so this is a value-stable fetch
+  // dependency (a pod-set change resets the buffer; a sorted-stable reorder doesn't).
   const reqPodsStr = useMemo(
     () => (allPods ? podNames : (selectedPod ? [selectedPod.name] : [])).join(','),
     [allPods, podNames, selectedPod]
   )
 
-  // Resolve the selected container option into the request parameters: the
-  // container names to stream and whether to read the previous instance. The
-  // previous flag applies only to a specific container of a single pod.
+  // Resolve the container option into request params: names to stream and whether
+  // to read the previous instance (only for a specific container of a single pod).
   const { reqContainersStr, reqPrevious } = useMemo(() => {
     if (containerKey === ALL_CONTAINERS) {
-      // Sort the streamed container names (as reqPodsStr sorts pods) so a backend
-      // reorder of the same set keeps the fetch dependency value-stable and does
-      // not reset the follow buffer.
+      // Sorted (like reqPodsStr) so a backend reorder of the same set keeps the
+      // fetch dependency stable and doesn't reset the follow buffer.
       return { reqContainersStr: [...streamNames].sort().join(','), reqPrevious: false }
     }
     const sep = containerKey.lastIndexOf('::')
     const cname = sep >= 0 ? containerKey.slice(0, sep) : containerKey
     const prev = !allPods && sep >= 0 && containerKey.slice(sep + 2) === 'true'
-    // Guard the brief window after a pod switch where containerKey still holds the
-    // previous pod's container (before the reset effect runs): if it names a
-    // container the current set doesn't have, fall back to all containers. Sorted
-    // to match the ALL_CONTAINERS branch so the value stays stable and the
-    // fallback does not trigger an extra buffer reset.
+    // Brief window after a pod switch where containerKey still holds the previous
+    // pod's container (before the reset effect runs): if absent from the current
+    // set, fall back to all containers. Sorted to match the ALL_CONTAINERS branch.
     if (!containers.some(c => c.name === cname)) {
       return { reqContainersStr: [...streamNames].sort().join(','), reqPrevious: false }
     }
     return { reqContainersStr: cname, reqPrevious: prev }
   }, [containerKey, containers, streamNames, allPods])
 
-  // Fetch the logs. Background follow-polls pass { silent: true } so they don't
-  // toggle the loading spinner, which would flicker on every poll; only the
-  // initial load and user-driven changes (container, line count) show it.
-  //
-  // Follow polls also pass { append: true }: once a buffer exists they request
-  // only the entries newer than the last line (sinceTime) and append them,
-  // instead of re-fetching the whole tail window and replacing it (which would
-  // make the visible lines shift on every poll). The initial load and any
-  // parameter change fetch the tail and replace the buffer.
+  // Fetch the logs. Follow polls pass { silent: true } to avoid spinner flicker and
+  // { append: true } to request only entries newer than the last line (sinceTime)
+  // and append them, so the visible lines don't shift each poll. The initial load
+  // and any parameter change fetch the tail and replace the buffer.
   const fetchLogs = useCallback(async ({ silent = false, append = false } = {}) => {
     const reqPodsList = reqPodsStr ? reqPodsStr.split(',') : []
     const reqContainers = reqContainersStr ? reqContainersStr.split(',') : []
@@ -428,18 +427,15 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     // old buffer's cursor and merge into the resetting buffer.
     if (append && resettingRef.current) return
     // A reset starts a new generation; appends ride on the current one. A fetch
-    // only applies its result if its generation is still current (checked on
-    // settle below), so an in-flight append poll from a previous pod/container or
-    // a superseded reset can't write stale lines into the buffer.
+    // applies its result only if its generation is still current (checked on settle),
+    // so a stale append poll or superseded reset can't write into the buffer.
     const gen = append ? fetchGenRef.current : ++fetchGenRef.current
     if (!append) resettingRef.current = true
     if (!silent) setLoading(true)
     try {
-      // The required name is the first pod; additional pods are repeated `pod`
-      // params (the "All pods" view) and containers repeated `container` params.
-      // tailLines is always sent so the backend bounds every fetch to the user's
-      // selection. On a follow poll, single-pod mode narrows by a global sinceTime
-      // while all-pods mode narrows by a per-pod `since` cursor.
+      // First pod is `name`, the rest repeated `pod` params; containers repeated
+      // `container` params. tailLines always bounds the fetch. On a follow poll,
+      // single-pod narrows by a global sinceTime, all-pods by per-pod `since`.
       const params = new URLSearchParams({ namespace, name: reqPodsList[0], tailLines: String(tailLines), previous: String(reqPrevious) })
       for (let i = 1; i < reqPodsList.length; i++) {
         params.append('pod', reqPodsList[i])
@@ -469,10 +465,9 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
       } else {
         setLogs(incoming)
       }
-      // The response states whether its lines are pod-tagged and how many of the
-      // requested pods it covered, so the parser and the footer never have to
-      // guess. Both are refreshed on every fetch (they stay constant for a given
-      // pod set, but a pod becoming readable can clear a partial result).
+      // The response states whether its lines are pod-tagged and how many requested
+      // pods it covered, so the parser and footer don't guess. Refreshed every fetch
+      // (a pod becoming readable can clear a partial result).
       setTagged(!!resp?.tagged)
       setPartial(resp?.partial ? { streamed: resp.streamed || 0, total: resp.total || 0, forbidden: resp.forbidden || 0 } : null)
       setError(null)
@@ -480,8 +475,8 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     } catch (err) {
       if (fetchGenRef.current !== gen) return
       if (append) {
-        // A follow poll failed: keep the buffer and surface the error inline at
-        // the tail of the feed rather than replacing the logs with a banner.
+        // Follow poll failed: keep the buffer, show the error inline at the tail
+        // rather than replacing the logs with a banner.
         setFollowError(err.message)
       } else {
         setError(err.message)
@@ -489,8 +484,8 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
         setFollowError(null)
       }
     } finally {
-      // Only the still-current fetch clears the shared state, so a superseded
-      // reset settling first doesn't drop the loader or the resetting flag.
+      // Only the still-current fetch clears shared state, so a superseded reset
+      // settling first doesn't drop the loader or the resetting flag.
       if (fetchGenRef.current === gen) {
         if (!append) resettingRef.current = false
         if (!silent) setLoading(false)
@@ -503,17 +498,15 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     fetchLogs()
   }, [fetchLogs])
 
-  // Reset the container selection to the default ("All containers") whenever the
-  // selected pod changes, so a container picked for the previous pod doesn't carry
-  // over. Keyed on the pod selection only: poll-driven re-renders keep the same
-  // selection untouched. On the initial mount this re-sets the already-default
-  // value, which Preact bails out of as a no-op.
+  // Reset the container selection to "All containers" when the pod changes, so a
+  // container picked for the previous pod doesn't carry over. Keyed on the pod only;
+  // on mount this re-sets the already-default value, which Preact treats as a no-op.
   useEffect(() => {
     setContainerKey(defaultKey)
   }, [effectivePodKey])
 
-  // Poll for new logs while following, silently so the spinner doesn't flicker
-  // and appending so the visible lines stay put instead of shifting each poll.
+  // Poll for new logs while following: silent (no spinner flicker) and appending
+  // (visible lines stay put).
   useEffect(() => {
     if (!follow) {
       // No more polls, so drop any stale inline follow error.
@@ -550,9 +543,8 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // detected. Only re-runs when the payload (or tagging regime) changes.
   const baseLines = useMemo(() => {
     const podSet = tagged ? new Set(reqPodsStr ? reqPodsStr.split(',') : []) : null
-    // Strip a trailing CR up front so a CRLF stream doesn't leak `\r` into the
-    // message text, the decorated field values, or the filter. (The download uses
-    // the raw payload, so it stays byte-verbatim.)
+    // Strip a trailing CR so a CRLF stream doesn't leak `\r` into the text, fields,
+    // or filter. (Download uses the raw payload, so it stays byte-verbatim.)
     const entries = logs.split('\n').map(line => line.replace(/\r$/, '')).filter(line => line.length > 0).map(line => {
       let rest = line
       let pod = ''
@@ -561,9 +553,8 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
         if (sp > 0) {
           const first = line.slice(0, sp)
           const after = line.slice(sp + 1)
-          // Require a real timestamp, not merely a date-shaped token, so a message
-          // that happens to begin "<known-pod> 2026-13-45T.." is not mistaken for
-          // a tag and split apart.
+          // Require a real timestamp, not a date-shaped token, so a message
+          // beginning "<known-pod> 2026-13-45T.." isn't mistaken for a tag.
           const am = after.match(TIMESTAMP_PREFIX)
           if (podSet.has(first) && am && !Number.isNaN(Date.parse(am[1]))) {
             pod = first
@@ -580,15 +571,12 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
       return { ts, tsMs, text, level: detectLevel(text), pod, podId }
     })
 
-    // In the all-pods view each pod advances its own `since` cursor, so a pod
-    // that lags (slow or clock-skewed) can deliver a line older than another
-    // pod's already-buffered tail; appended in arrival order the buffer would no
-    // longer be chronological. Regroup each timestamped line with the
-    // continuation lines that follow it and stable-sort the groups by timestamp,
-    // so the merged view stays ordered while a multi-line entry and same-instant
-    // lines keep their original (backend-merged) order. The single-pod and
-    // all-containers paths arrive pre-merged from one cursor, so they are left
-    // untouched.
+    // In all-pods each pod advances its own `since` cursor, so a lagging pod can
+    // deliver a line older than another's buffered tail; in arrival order the buffer
+    // would lose chronology. Group each timestamped line with its continuation lines
+    // and stable-sort the groups by timestamp, keeping multi-line entries and
+    // same-instant lines in backend-merged order. Single-pod/all-containers arrive
+    // pre-merged from one cursor, so they're left untouched.
     if (!tagged) return entries
     const groups = []
     for (const entry of entries) {
@@ -604,22 +592,19 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     return groups.flat()
   }, [logs, tagged, reqPodsStr])
 
-  // Track the follow cursors from the current buffer so the next poll requests
-  // only newer entries. lastTsRef is the global high-watermark for the single-pod
-  // path (sinceTime); cursorsRef holds the newest timestamp per pod for the
-  // all-pods path (repeated `since`). Both are authoritative over the buffer: they
-  // clear when it has no timestamped lines, so a poll never reuses a stale cursor
-  // from a previous stream. The second-granular cursor re-sends the last second of
-  // overlap, deduped on append; a per-pod cursor keeps a clock-skewed pod from
-  // being starved by another pod's faster-advancing watermark.
+  // Track the follow cursors from the buffer so the next poll requests only newer
+  // entries: lastTsRef is the single-pod high-watermark (sinceTime), cursorsRef the
+  // newest ts per pod for all-pods (repeated `since`). Both clear when the buffer
+  // has no timestamped lines, so a poll never reuses a stale cursor. A per-pod
+  // cursor keeps a clock-skewed pod from being starved by a faster watermark.
   useEffect(() => {
     let ts = ''
     for (let i = baseLines.length - 1; i >= 0; i--) {
       if (baseLines[i].ts) { ts = baseLines[i].ts; break }
     }
     lastTsRef.current = ts
-    // Newest timestamp per pod. The buffer is chronological, so the last occurrence
-    // of each pod is its newest; second-granular cursors make exact ordering moot.
+    // Newest ts per pod. The buffer is chronological, so each pod's last occurrence
+    // is its newest.
     const cursors = new Map()
     for (const entry of baseLines) {
       if (entry.pod && entry.ts) cursors.set(entry.pod, entry.ts)
@@ -627,8 +612,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     cursorsRef.current = cursors
   }, [baseLines])
 
-  // Apply the substring filter on the message text; cheap pass over the
-  // already-split entries. A leading "!" negates the match, keeping only lines
+  // Substring filter on the message text. A leading "!" negates, keeping only lines
   // that do NOT contain the text (e.g. "!debug" hides every line mentioning debug).
   const containsLines = useMemo(() => {
     const raw = filter.trim()
@@ -639,9 +623,9 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     return baseLines.filter(entry => entry.text.toLowerCase().includes(needle) !== negate)
   }, [baseLines, filter])
 
-  // Per-level counts over the contains-filtered set, before the minimum-level
-  // threshold (so the footer summary shows how many errors exist even while
-  // viewing "error and above"). Doubles as the footer legend.
+  // Per-level counts over the contains-filtered set, before the level filter (so the
+  // footer shows how many errors exist even while viewing one level). Doubles as the
+  // footer legend.
   const levelCounts = useMemo(() => {
     const counts = {}
     for (const entry of containsLines) counts[entry.level] = (counts[entry.level] || 0) + 1
@@ -654,19 +638,16 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     return containsLines.filter(entry => entry.level === levelFilter)
   }, [containsLines, levelFilter])
 
-  // In formatted mode every line carries a descriptor (`fmt`) of colored spans:
-  // valid JSON is pretty-printed (`fmt.kind === 'json'`), structured loggers reflow
-  // to `block`/`spans`, and an unmatched line falls back to plain wrapping text
-  // (`code: true`). In raw mode lines render as unstyled plain text
-  // (`code: false`). Filtering happens first on the raw text, so this only
-  // transforms what is actually shown.
+  // In formatted mode every line carries a `fmt` descriptor of colored spans: JSON
+  // pretty-printed (`kind: 'json'`), structured loggers reflowed to `block`/`spans`,
+  // unmatched lines plain wrapping text (`code: true`). Raw mode renders unstyled
+  // (`code: false`). Filtering runs first on raw text, so this only transforms what
+  // is shown.
   //
-  // The formatted output is cached by raw line text (formatCacheRef): since the
-  // formatted form depends only on the line text, an append reuses the cached
-  // result for every existing line and only formats the genuinely new lines,
-  // instead of re-formatting the whole buffer on every poll. The cache is rebuilt
-  // to hold only the lines currently shown, so it can't outgrow the buffer; raw
-  // mode leaves it untouched so it survives a round-trip back to formatted.
+  // Formatted output is cached by raw line text (formatCacheRef): an append reuses
+  // cached results and only formats the new lines, not the whole buffer each poll.
+  // The cache is rebuilt to the shown lines so it can't outgrow the buffer; raw mode
+  // leaves it untouched so it survives a round-trip back to formatted.
   const displayLines = useMemo(() => {
     if (!formatted) {
       return logLines.map(entry => ({ ...entry, code: false, fmt: null }))
@@ -674,15 +655,14 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     const prev = formatCacheRef.current
     const next = new Map()
     const result = logLines.map(entry => {
-      // JSON formatting runs on every line (unchanged from before). Only the
-      // klog/zap/logfmt cascade is gated on a parsed timestamp, so a continuation
-      // line (stack frame, no timestamp) can never be mistaken for a structured
-      // entry. The cache key carries the head flag because the same stripped text
-      // may appear both as a head and as a continuation line.
+      // JSON formatting runs on every line; the klog/zap/logfmt cascade is gated on
+      // a parsed timestamp, so a continuation line (no ts) can't be mistaken for a
+      // structured entry. The cache key carries the head flag since the same text
+      // may appear as both a head and a continuation line.
       const key = `${entry.ts ? 1 : 0}\n${entry.text}`
       let formattedEntry = next.get(key) || prev.get(key)
       if (!formattedEntry) {
-        // json then klog/zap/logfmt then plain. The json/block/spans kinds render as
+        // json, then klog/zap/logfmt, then plain. json/block/spans render as
         // decorated rows; plain keeps a wrapping text div.
         const json = highlightJson(entry.text)
         const d = json || (entry.ts ? decorateLine(entry.text, entry.level) : { kind: 'plain' })
@@ -697,13 +677,11 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     return result
   }, [logLines, formatted])
 
-  // Briefly highlight the most recent visible line whenever genuinely new
-  // entries arrive (e.g. while following). The highlight is gated on two
-  // conditions so it only signals fresh logs: the raw buffer must have grown
-  // (prevLogs !== logs, skipping the very first load), and the newest displayed
-  // line must have changed. The second gate is what keeps a follow poll that
-  // appends only lines filtered out of the view — or a filter change that
-  // reshuffles the view — from re-pulsing an unchanged last line.
+  // Briefly highlight the most recent visible line when new entries arrive (e.g.
+  // while following). Gated on two conditions so it only signals fresh logs: the raw
+  // buffer grew (prevLogs !== logs, skipping the first load) and the newest displayed
+  // line changed. The second gate stops a poll that appends only filtered-out lines,
+  // or a filter change reshuffling the view, from re-pulsing an unchanged last line.
   useEffect(() => {
     const prevLogs = prevLogsRef.current
     prevLogsRef.current = logs
@@ -738,8 +716,8 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   }, [])
 
   // Keep the most recent entry (or the inline follow error) in view after each
-  // update, but only while pinned to the bottom, so following doesn't fight a
-  // user scrolling through history.
+  // update, but only while pinned to the bottom, so following doesn't fight a user
+  // scrolling through history.
   useEffect(() => {
     if (!bodyRef.current || !atBottomRef.current) return
     bodyRef.current.scrollTop = bodyRef.current.scrollHeight
@@ -754,13 +732,15 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
 
   return (
     <div
-      class={`fixed inset-0 z-50 flex justify-center bg-black/50 ${fullScreen ? 'items-center p-0' : 'items-center px-4 sm:px-6 lg:px-8 py-16'}`}
+      class={`fixed inset-0 z-50 flex items-center justify-center bg-black/50 ${fullScreen ? 'p-0' : 'p-0 sm:px-6 sm:py-16 lg:px-8'}`}
       onClick={onClose}
       data-testid="logs-viewer-overlay"
     >
       <div
         class={`bg-white dark:bg-gray-900 shadow-xl flex flex-col overflow-hidden border border-gray-200 dark:border-gray-700 ${
-          fullScreen ? 'w-full h-full max-w-full max-h-full rounded-none' : 'w-full max-w-7xl h-[calc(100vh-8rem)] rounded-lg'
+          fullScreen
+            ? 'w-full h-full max-w-full max-h-full rounded-none'
+            : 'w-full h-full max-w-full rounded-none sm:max-w-7xl sm:h-[calc(100vh-8rem)] sm:rounded-lg'
         }`}
         onClick={(e) => e.stopPropagation()}
         role="dialog"
@@ -788,44 +768,47 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
           </button>
         </div>
 
-        {/* Toolbar */}
-        <div class="flex items-center flex-wrap gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
-          {/* Follow logs */}
-          <ToggleButton
-            active={follow}
-            onClick={() => setFollow(v => !v)}
-            label="Follow logs"
-            testid="logs-follow-toggle"
-          >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 13l-7 7-7-7m14-6l-7 7-7-7" />
-            </svg>
-          </ToggleButton>
+        {/* Toolbar. Mobile: a two-column grid of paired rows (the viewer is
+            full-screen there). From sm up: a single-row flex-wrap. */}
+        <div class="grid grid-cols-2 items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 sm:flex sm:flex-wrap">
+          {/* Toggles share the full-width top row on mobile; `sm:contents` dissolves
+              the wrapper on desktop so each toggle is a direct flex item. */}
+          <div class="col-span-2 flex items-center gap-2 sm:contents">
+            {/* Follow logs */}
+            <ToggleButton
+              active={follow}
+              onClick={() => setFollow(v => !v)}
+              label="Follow logs"
+              testid="logs-follow-toggle"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 13l-7 7-7-7m14-6l-7 7-7-7" />
+              </svg>
+            </ToggleButton>
 
-          {/* Toggle between formatted and raw output. Formatted (default)
-              pretty-prints structured lines and adds timestamp pills and
-              level coloring; raw strips all styling to plain text. */}
-          <ToggleButton
-            active={formatted}
-            onClick={() => setFormatted(v => !v)}
-            label="Format logs"
-            title="Toggle between formatted and raw logs"
-            testid="logs-format-toggle"
-          >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1m8-18h1a2 2 0 0 1 2 2v5c0 1.1.9 2 2 2a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2h-1" />
-            </svg>
-          </ToggleButton>
+            {/* Formatted (default) pretty-prints structured lines and adds
+                timestamp pills and level coloring; raw strips all styling. */}
+            <ToggleButton
+              active={formatted}
+              onClick={() => setFormatted(v => !v)}
+              label="Format logs"
+              title="Toggle between formatted and raw logs"
+              testid="logs-format-toggle"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1m8-18h1a2 2 0 0 1 2 2v5c0 1.1.9 2 2 2a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2h-1" />
+              </svg>
+            </ToggleButton>
+          </div>
 
-          {/* Pod select. "All pods" leads and streams every pod merged, tagged
-              with its origin; selecting a specific pod narrows the view and
-              resets the container dropdown to "All containers". Fixed width so a
-              long pod name is trimmed instead of pushing the rest of the toolbar. */}
+          {/* Pod select. "All pods" leads (every pod merged, origin-tagged);
+              selecting one narrows the view and resets the container dropdown.
+              Fixed width so a long name is trimmed, not pushing the toolbar. */}
           {pods.length > 0 && (
             <select
               value={effectivePodKey}
               onChange={(e) => setPodKey(e.target.value)}
-              class={`${SELECT_CLASS} w-28 sm:w-40 truncate`}
+              class={`${SELECT_CLASS} w-full truncate sm:w-40`}
               data-testid="logs-pod-select"
               aria-label="Pod"
               title="Select pod"
@@ -836,14 +819,13 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
             </select>
           )}
 
-          {/* Container select (always shown). Containers that have restarted
-              also expose a "(previous)" entry for the prior instance's logs.
-              Fixed width so a long container name is trimmed instead of pushing
-              the rest of the toolbar. */}
+          {/* Container select (always shown). Restarted containers also expose a
+              "(previous)" entry for the prior instance's logs. Fixed width so a
+              long name is trimmed, not pushing the toolbar. */}
           <select
             value={containerKey}
             onChange={(e) => setContainerKey(e.target.value)}
-            class={`${SELECT_CLASS} w-28 sm:w-40 truncate`}
+            class={`${SELECT_CLASS} w-full truncate sm:w-40`}
             data-testid="logs-container-select"
             aria-label="Container"
             title="Select container (a previous entry reads the prior instance's logs)"
@@ -859,10 +841,10 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
             value={filter}
             onInput={(e) => setFilter(e.target.value)}
             placeholder="contains…"
-            class={`${INPUT_CLASS} w-28 sm:w-40`}
+            class={`${INPUT_CLASS} w-full sm:w-40`}
             data-testid="logs-filter-input"
             aria-label="Filter log lines containing text"
-            title="Keep lines containing this text; prefix with ! to exclude (e.g. !debug)"
+            title="Filter by keyword (prefix with ! to exclude e.g. !debug)"
           />
 
           {/* Minimum level filter */}
@@ -872,7 +854,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
           <select
             value={tailLines}
             onChange={(e) => setTailLines(Number(e.target.value))}
-            class={SELECT_CLASS}
+            class={`${SELECT_CLASS} w-full sm:w-auto`}
             data-testid="logs-lines-select"
             aria-label="Number of lines"
             title="Number of log lines to fetch"
@@ -882,8 +864,9 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
             ))}
           </select>
 
-          {/* Actions */}
-          <div class="flex items-center gap-1 ml-auto">
+          {/* Actions. Mobile: the last grid cell, right-aligned. Desktop: floats
+              to the far right of the row. */}
+          <div class="flex items-center justify-end gap-1 sm:ml-auto">
             <button
               onClick={handleDownload}
               disabled={!logs}
@@ -896,9 +879,11 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
               </svg>
             </button>
+            {/* Fullscreen hidden on mobile, where the viewer already fills the
+                screen. */}
             <button
               onClick={() => setFullScreen(v => !v)}
-              class={ACTION_CLASS}
+              class={`${ACTION_CLASS} hidden sm:inline-flex`}
               aria-pressed={fullScreen}
               title={fullScreen ? 'Exit fullscreen' : 'Fullscreen'}
               aria-label={fullScreen ? 'Exit fullscreen' : 'Fullscreen'}
@@ -925,11 +910,11 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
             </div>
           ) : loading && !logs ? (
             <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-loading">Loading logs...</p>
-          ) : displayLines.length > 0 || followError ? (
+          ) : displayLines.length > 0 || followError || podsGone ? (
             <div class="pb-2" data-testid="logs-content">
               {displayLines.map((entry, i) => {
-                // Raw mode strips all styling: no timestamp pill, no level
-                // coloring, and no highlight on the freshly appended entry.
+                // Raw mode strips styling: no timestamp pill, level coloring, or
+                // highlight on the freshly appended entry.
                 const isLatest = formatted && flashLatest && i === displayLines.length - 1
                 const meta = LEVEL_META[entry.level] || LEVEL_META[DEFAULT_LEVEL]
                 return (
@@ -956,9 +941,8 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
                       </div>
                     )}
                     {entry.fmt && entry.fmt.kind === 'block' ? (
-                      // Structured entry: one container per entry (keeping the
-                      // per-entry logs-line invariant), one inner row per visual
-                      // line, all flush-left at full width.
+                      // Structured entry: one container per entry (the per-entry
+                      // logs-line invariant), one inner row per visual line.
                       <div
                         class="overflow-x-auto font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
                         style="padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;"
@@ -980,9 +964,8 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
                         {entry.fmt.spans.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
                       </div>
                     ) : entry.fmt && entry.fmt.kind === 'json' ? (
-                      // Pretty-printed JSON: a <pre> preserves the indentation/newlines
-                      // baked into the spans and scrolls long values horizontally,
-                      // keeping nested structures intact.
+                      // Pretty-printed JSON: a <pre> preserves the baked-in
+                      // indentation/newlines and scrolls long values horizontally.
                       <pre
                         class="overflow-x-auto font-mono text-gray-800 dark:text-gray-200"
                         style="margin: 0; padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;"
@@ -991,9 +974,9 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
                         {entry.fmt.spans.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
                       </pre>
                     ) : entry.code ? (
-                      // Plain line that matched no formatter (or a continuation line
-                      // such as a stack frame): wrap it like the decorated rows rather
-                      // than the JSON <pre>, which scrolls horizontally and never wraps.
+                      // Plain line (no formatter match, or a continuation line such
+                      // as a stack frame): wrap like the decorated rows, not the
+                      // non-wrapping JSON <pre>.
                       <div
                         class="overflow-x-auto font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
                         style="padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;"
@@ -1024,6 +1007,18 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
                   <span class="break-all">{followError}</span>
                 </div>
               )}
+              {podsGone && (
+                <div
+                  class="flex items-start gap-2 mx-3 mt-2 p-2 rounded border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 text-xs text-red-800 dark:text-red-200"
+                  data-testid="logs-no-pods"
+                  role="alert"
+                >
+                  <svg class="w-4 h-4 flex-shrink-0 mt-px" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                  </svg>
+                  <span class="break-all">{NO_PODS_MESSAGE}</span>
+                </div>
+              )}
             </div>
           ) : (
             <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-empty">
@@ -1032,15 +1027,15 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
           )}
         </div>
 
-        {/* Footer: a per-level count summary that doubles as the color legend.
-            The trailing corner shows the fetch loader while a request is in
-            flight, otherwise the live/snapshot mode reflecting the follow state. */}
+        {/* Footer: a per-level count summary doubling as the color legend. The
+            trailing corner shows the fetch loader while a request is in flight,
+            else the live/snapshot mode. */}
         <div
           class="flex items-center justify-between gap-3 px-4 py-2 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800"
           data-testid="logs-footer"
         >
-          <div class="flex items-center gap-3 min-w-0">
-            <div class="flex items-center gap-3 text-xs text-gray-600 dark:text-gray-400" data-testid="logs-level-summary">
+          <div class="flex flex-wrap items-center gap-x-3 gap-y-1 min-w-0">
+            <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-600 dark:text-gray-400" data-testid="logs-level-summary">
               {LEVELS.filter(l => levelCounts[l]).map((l) => (
                 <span key={l} class="inline-flex items-center gap-1" title={`${LEVEL_META[l].label}: ${levelCounts[l]}`}>
                   <span class={`w-2 h-2 rounded-full ${LEVEL_META[l].swatch}`} />
@@ -1048,11 +1043,10 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
                 </span>
               ))}
             </div>
-            {/* Partial-coverage note: the all-pods view did not cover every pod
-                (forbidden, missing) or the fan-out was capped. The pod-count
-                phrasing is shown only when pods were actually dropped; a pure cap
-                (every pod streamed, but the stream count was capped) reads as
-                "results truncated" instead, to avoid a misleading "N of N". */}
+            {/* Partial-coverage note: all-pods didn't cover every pod (forbidden,
+                missing) or the fan-out was capped. The pod-count phrasing shows only
+                when pods were dropped; a pure cap reads as "results truncated" to
+                avoid a misleading "N of N". */}
             {partial && (
               <span
                 class="inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400 flex-shrink-0"

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -1,12 +1,12 @@
 // Copyright 2026 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { Fragment } from 'preact'
 import { useState, useEffect, useCallback, useMemo, useRef } from 'preact/hooks'
 import { fetchWithMock } from '../../../utils/fetch'
 import { downloadBlob } from '../../../utils/download'
 import { LEVELS, LEVEL_META, DEFAULT_LEVEL, detectLevel, stripAnsi } from '../../../utils/logLevel'
 import { decorateLine, highlightJson } from '../../../utils/logFormat'
+import { groupEntries } from '../../../utils/logGroup'
 import { useDismiss } from '../../../utils/useDismiss'
 
 // Selectable limits for the number of log lines to fetch from the backend.
@@ -83,9 +83,10 @@ function mergeLogs(prev, incoming) {
 }
 
 // Captures the leading RFC3339 timestamp the API prepends to each log line.
-// Anchored to a date so lines without a timestamp (e.g. stack-trace
-// continuations) are not mangled by splitting off their first token.
-const TIMESTAMP_PREFIX = /^(\d{4}-\d{2}-\d{2}T\S+)\s+/
+// Anchored to a date so an untimestamped line (a stack frame) isn't mangled. The
+// separator is a single space (kubelet emits exactly one), not greedy `\s+`, so a
+// frame's own indentation (`\tat …`, `  File …`) survives to drive trace folding.
+const TIMESTAMP_PREFIX = /^(\d{4}-\d{2}-\d{2}T\S+) /
 
 // entryTimestamp returns the RFC3339 timestamp heading a log entry, or null for a
 // continuation line (stack frame) that carries none. A head is "<ts> msg" (single
@@ -100,6 +101,44 @@ function entryTimestamp(line) {
     if (am && !Number.isNaN(Date.parse(am[1]))) return am[1]
   }
   return null
+}
+
+/**
+ * parseLogLine - parse one raw payload line into a log entry. In the all-pods
+ * (tagged) view a line is "<pod> <ts> <msg>"; the leading token is a pod tag only
+ * when it is a requested pod AND the next token is a real timestamp (so a message
+ * starting "<word> <date>" isn't mistaken for one). The timestamp and ANSI are
+ * stripped and the level detected; a continuation line (no ts) keeps its
+ * indentation (see TIMESTAMP_PREFIX). Exported so tests hit the real parse path.
+ *
+ * @param {string} line - One raw payload line (CR already stripped, non-empty)
+ * @param {Set<string>|null} podSet - Requested pods in the tagged view, else null
+ * @returns {{ts: string, tsMs: number, text: string, level: string, pod: string, podId: string}}
+ */
+export function parseLogLine(line, podSet) {
+  let rest = line
+  let pod = ''
+  if (podSet) {
+    const sp = line.indexOf(' ')
+    if (sp > 0) {
+      const first = line.slice(0, sp)
+      const after = line.slice(sp + 1)
+      // Require a real timestamp, not a date-shaped token, so a message
+      // beginning "<known-pod> 2026-13-45T.." isn't mistaken for a tag.
+      const am = after.match(TIMESTAMP_PREFIX)
+      if (podSet.has(first) && am && !Number.isNaN(Date.parse(am[1]))) {
+        pod = first
+        rest = after
+      }
+    }
+  }
+  const m = rest.match(TIMESTAMP_PREFIX)
+  const tsMs = m ? Date.parse(m[1]) : NaN
+  const hasTs = !Number.isNaN(tsMs)
+  const ts = hasTs ? m[1] : ''
+  const text = stripAnsi(hasTs ? rest.slice(m[0].length) : rest)
+  const podId = pod ? pod.slice(pod.lastIndexOf('-') + 1) : ''
+  return { ts, tsMs, text, level: detectLevel(text), pod, podId }
 }
 
 // Shared styling for the toolbar controls. Selects deliberately omit a chevron
@@ -123,13 +162,15 @@ const ACTION_CLASS = 'inline-flex items-center p-1 rounded-md text-gray-400 hove
  * @param {string} props.label - Accessible label (also the default tooltip)
  * @param {string} [props.title] - Optional tooltip text, defaults to label
  * @param {string} props.testid - data-testid value
+ * @param {boolean} [props.disabled] - When set, the button is non-interactive and dimmed
  * @param {any} props.children - The button icon
  */
-function ToggleButton({ active, onClick, label, title, testid, children }) {
+function ToggleButton({ active, onClick, label, title, testid, disabled, children }) {
   return (
     <button
       onClick={onClick}
-      class={`${ICON_TOGGLE_CLASS} ${active ? ACTIVE_CLASS : INACTIVE_CLASS}`}
+      disabled={disabled}
+      class={`${ICON_TOGGLE_CLASS} ${active ? ACTIVE_CLASS : INACTIVE_CLASS} ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
       data-testid={testid}
       aria-pressed={active}
       aria-label={label}
@@ -206,6 +247,177 @@ function LevelMenu({ value, onChange }) {
         </div>
       )}
     </div>
+  )
+}
+
+// Shared monospace body styling for a formatted log line: a horizontally
+// scrollable, wrapping row. The block/spans/plain-code variants share it; the
+// JSON <pre> reuses the style with a margin reset.
+const LINE_CLASS = 'overflow-x-auto font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200'
+const LINE_STYLE = 'padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;'
+
+/**
+ * LogLineBody - renders the formatted body of one log line: a structured block,
+ * highlighted spans, pretty-printed JSON, or plain wrapping text. Shared by a
+ * single-line entry, a folded group's head, and its expanded frames so all three
+ * render identically.
+ *
+ * @param {Object} props
+ * @param {{text: string, code: boolean, fmt: Object|null}} props.entry - A formatted line
+ */
+function LogLineBody({ entry }) {
+  if (entry.fmt && entry.fmt.kind === 'block') {
+    // Structured entry: one container per entry (the per-entry logs-line
+    // invariant), one inner row per visual line.
+    return (
+      <div class={LINE_CLASS} style={LINE_STYLE} data-testid="logs-line">
+        {entry.fmt.rows.map((row, r) => (
+          <div key={r} data-testid="logs-line-row">
+            {row.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
+          </div>
+        ))}
+      </div>
+    )
+  }
+  if (entry.fmt && entry.fmt.kind === 'spans') {
+    // Unstructured entry highlighted in place: a single row.
+    return (
+      <div class={LINE_CLASS} style={LINE_STYLE} data-testid="logs-line">
+        {entry.fmt.spans.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
+      </div>
+    )
+  }
+  if (entry.fmt && entry.fmt.kind === 'json') {
+    // Pretty-printed JSON: a <pre> preserves the baked-in indentation/newlines
+    // and scrolls long values horizontally.
+    return (
+      <pre
+        class="overflow-x-auto font-mono text-gray-800 dark:text-gray-200"
+        style={`margin: 0; ${LINE_STYLE}`}
+        data-testid="logs-line"
+      >
+        {entry.fmt.spans.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
+      </pre>
+    )
+  }
+  if (entry.code) {
+    // Plain line (no formatter match, or a continuation line such as a stack
+    // frame): wrap like the decorated rows, not the non-wrapping JSON <pre>.
+    return (
+      <div class={LINE_CLASS} style={LINE_STYLE} data-testid="logs-line">
+        {entry.text}
+      </div>
+    )
+  }
+  return (
+    <div
+      class="px-3 py-0.5 text-sm font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
+      data-testid="logs-line"
+    >
+      {entry.text}
+    </div>
+  )
+}
+
+/**
+ * LogSeparator - the level-colored timestamp pill on a logical entry's separator
+ * row. Shows the pod id in the all-pods view and glows when this is the freshly
+ * appended entry. `level` is the group level (a recognized trace head is bumped to
+ * error), so the pill matches the level filter and footer counts.
+ *
+ * @param {Object} props
+ * @param {{ts: string, pod: string, podId: string}} props.entry - The head entry
+ * @param {string} props.level - The group's normalized level
+ * @param {boolean} props.isLatest - Whether to glow as the freshly appended entry
+ */
+function LogSeparator({ entry, level, isLatest }) {
+  const meta = LEVEL_META[level] || LEVEL_META[DEFAULT_LEVEL]
+  return (
+    <div
+      class="flex items-center gap-2 px-3 pt-2 select-none"
+      data-testid="logs-timestamp"
+      data-level={level}
+      data-latest={isLatest ? 'true' : undefined}
+    >
+      <span
+        class={`text-[10px] font-mono px-1.5 py-0.5 rounded-full border bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 ${meta.border} ${isLatest ? 'log-glow' : ''}`}
+        style={isLatest ? `--glow-color: ${meta.glow}` : undefined}
+        title={entry.pod ? `${entry.pod} · ${meta.label} level` : `${meta.label} level`}
+      >
+        {entry.podId && <span class="font-semibold text-gray-700 dark:text-gray-300" data-testid="logs-pod-id">{entry.podId} · </span>}
+        {entry.ts}
+      </span>
+      <span
+        class={`flex-1 border-t ${meta.border} ${isLatest ? 'log-glow' : ''}`}
+        style={isLatest ? `--glow-color: ${meta.glow}` : undefined}
+      />
+    </div>
+  )
+}
+
+// Folded lines shown when a group is expanded before a "show all" link, so a
+// pathological multi-thousand-frame trace doesn't render all at once.
+const EXPANDED_LINE_CAP = 500
+
+/**
+ * LogGroup - one logical log entry: a single line, or a folded trace that starts
+ * collapsed (head + frame count), expands on click, and caps a long expansion with
+ * a "show all" link. A headless group (head === null, a buffer opened mid-trace)
+ * skips the separator pill and renders its lines through the same path.
+ *
+ * @param {Object} props
+ * @param {Object} props.group - A display group: head, formatted lines, and metadata
+ * @param {boolean} props.formatted - Whether formatted mode is on (renders the pill)
+ * @param {boolean} props.isLatest - Whether to glow as the freshly appended entry
+ */
+function LogGroup({ group, formatted, isLatest }) {
+  const [expanded, setExpanded] = useState(false)
+  const [showAll, setShowAll] = useState(false)
+  const lines = group.lines
+
+  const folded = lines.length > 1
+  // Frames exclude folded blank lines (a Go panic's blank, a trailing Node blank)
+  // so the "N frames" count isn't inflated.
+  const frameCount = lines.slice(1).filter(l => l.text !== '').length
+  const hiddenCount = lines.length - 1
+  const shown = showAll ? lines.length : Math.min(lines.length, EXPANDED_LINE_CAP + 1)
+
+  return (
+    <>
+      {formatted && group.head && <LogSeparator entry={group.head} level={group.level} isLatest={isLatest} />}
+      <LogLineBody entry={lines[0]} />
+      {folded && (
+        <>
+          <button
+            type="button"
+            onClick={() => setExpanded(v => !v)}
+            class="flex items-center gap-1 px-3 py-0.5 text-[11px] font-mono text-gray-500 hover:text-flux-blue dark:text-gray-400 dark:hover:text-flux-blue select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue rounded"
+            data-testid="logs-group-fold"
+            aria-expanded={expanded}
+          >
+            <span aria-hidden="true">{expanded ? '▾' : '▸'}</span>
+            {group.isTrace && frameCount > 0
+              ? `${frameCount} frame${frameCount === 1 ? '' : 's'}`
+              : `+${hiddenCount} line${hiddenCount === 1 ? '' : 's'}`}
+          </button>
+          {expanded && (
+            <div class="border-l-2 border-gray-200 dark:border-gray-700 ml-3" data-testid="logs-group-frames">
+              {lines.slice(1, shown).map((l, j) => <LogLineBody key={j} entry={l} />)}
+              {shown < lines.length && (
+                <button
+                  type="button"
+                  onClick={() => setShowAll(true)}
+                  class="px-3 py-0.5 text-[11px] font-mono text-flux-blue hover:underline select-none"
+                  data-testid="logs-group-showall"
+                >
+                  show all {hiddenCount} lines
+                </button>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </>
   )
 }
 
@@ -319,6 +531,9 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   const [filter, setFilter] = useState('')
   const [levelFilter, setLevelFilter] = useState('all')
   const [formatted, setFormatted] = useState(true)
+  // Fold recognized multi-line stack traces under their head into one collapsible
+  // entry. On by default; a formatted-mode-only affordance (raw renders flat).
+  const [grouped, setGrouped] = useState(true)
   const [fullScreen, setFullScreen] = useState(false)
   const [logs, setLogs] = useState('')
   const [loading, setLoading] = useState(false)
@@ -357,7 +572,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // poll fired after the reset shares its generation, so the guard alone misses it).
   const resettingRef = useRef(false)
   // Memoizes formatted output per raw line text, so appends format only the new
-  // lines instead of the whole buffer each poll. See displayLines for pruning.
+  // lines instead of the whole buffer each poll. See displayGroups for pruning.
   const formatCacheRef = useRef(new Map())
 
   // Pod dropdown options: "All pods" leads, then each pod.
@@ -545,31 +760,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     const podSet = tagged ? new Set(reqPodsStr ? reqPodsStr.split(',') : []) : null
     // Strip a trailing CR so a CRLF stream doesn't leak `\r` into the text, fields,
     // or filter. (Download uses the raw payload, so it stays byte-verbatim.)
-    const entries = logs.split('\n').map(line => line.replace(/\r$/, '')).filter(line => line.length > 0).map(line => {
-      let rest = line
-      let pod = ''
-      if (podSet) {
-        const sp = line.indexOf(' ')
-        if (sp > 0) {
-          const first = line.slice(0, sp)
-          const after = line.slice(sp + 1)
-          // Require a real timestamp, not a date-shaped token, so a message
-          // beginning "<known-pod> 2026-13-45T.." isn't mistaken for a tag.
-          const am = after.match(TIMESTAMP_PREFIX)
-          if (podSet.has(first) && am && !Number.isNaN(Date.parse(am[1]))) {
-            pod = first
-            rest = after
-          }
-        }
-      }
-      const m = rest.match(TIMESTAMP_PREFIX)
-      const tsMs = m ? Date.parse(m[1]) : NaN
-      const hasTs = !Number.isNaN(tsMs)
-      const ts = hasTs ? m[1] : ''
-      const text = stripAnsi(hasTs ? rest.slice(m[0].length) : rest)
-      const podId = pod ? pod.slice(pod.lastIndexOf('-') + 1) : ''
-      return { ts, tsMs, text, level: detectLevel(text), pod, podId }
-    })
+    const entries = logs.split('\n').map(line => line.replace(/\r$/, '')).filter(line => line.length > 0).map(line => parseLogLine(line, podSet))
 
     // In all-pods each pod advances its own `since` cursor, so a lagging pod can
     // deliver a line older than another's buffered tail; in arrival order the buffer
@@ -612,53 +803,92 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     cursorsRef.current = cursors
   }, [baseLines])
 
-  // Substring filter on the message text. A leading "!" negates, keeping only lines
-  // that do NOT contain the text (e.g. "!debug" hides every line mentioning debug).
-  const containsLines = useMemo(() => {
+  // Grouping is a formatted-mode affordance: raw mode renders every line flat, so
+  // it is bypassed when not formatted.
+  const grouping = grouped && formatted
+
+  // Fold recognized stack traces into one collapsible entry each (off → one group
+  // per entry, keeping the chain uniform). In the all-pods view fold per pod then
+  // order groups by head ts: frames are timestamped, so two pods crashing together
+  // interleave frame-by-frame and folding the flat list would fragment each trace.
+  // A ts==='' orphan inherits the previous line's pod, so it buckets with its head.
+  const groups = useMemo(() => {
+    if (!tagged) return groupEntries(baseLines, grouping)
+    const byPod = new Map()
+    let lastPod = ''
+    for (const e of baseLines) {
+      const pod = e.pod || lastPod
+      if (e.pod) lastPod = e.pod
+      let bucket = byPod.get(pod)
+      if (!bucket) { bucket = []; byPod.set(pod, bucket) }
+      bucket.push(e)
+    }
+    // A group with no timestamped head inherits the previous group's ts so it stays
+    // adjacent instead of floating to the front; a leading orphan keeps NaN (first).
+    const ordered = [...byPod.values()].flatMap(es => {
+      const gs = groupEntries(es, grouping)
+      let sortTs = NaN
+      for (const g of gs) {
+        if (!Number.isNaN(g.tsMs)) sortTs = g.tsMs
+        g.sortTs = sortTs
+      }
+      return gs
+    })
+    return ordered.sort((a, b) => {
+      if (Number.isNaN(a.sortTs)) return Number.isNaN(b.sortTs) ? 0 : -1
+      if (Number.isNaN(b.sortTs)) return 1
+      return a.sortTs - b.sortTs
+    })
+  }, [baseLines, tagged, grouping])
+
+  // Substring filter over each group's whole block. Positive: keep if any line has
+  // the needle (a match keeps the whole trace). "!needle": keep only if no line has
+  // it (the exact complement — a buried frame drops the trace).
+  const containsGroups = useMemo(() => {
     const raw = filter.trim()
-    if (!raw) return baseLines
+    if (!raw) return groups
     const negate = raw.startsWith('!')
     const needle = (negate ? raw.slice(1) : raw).trim().toLowerCase()
-    if (!needle) return baseLines
-    return baseLines.filter(entry => entry.text.toLowerCase().includes(needle) !== negate)
-  }, [baseLines, filter])
+    if (!needle) return groups
+    return groups.filter(g => g.lines.some(l => l.text.toLowerCase().includes(needle)) !== negate)
+  }, [groups, filter])
 
-  // Per-level counts over the contains-filtered set, before the level filter (so the
-  // footer shows how many errors exist even while viewing one level). Doubles as the
-  // footer legend.
+  // Per-level tally over the contains-filtered groups, before the level filter (so
+  // the footer shows error counts while viewing one level). One per logical entry,
+  // so the legend matches the rendered list.
   const levelCounts = useMemo(() => {
     const counts = {}
-    for (const entry of containsLines) counts[entry.level] = (counts[entry.level] || 0) + 1
+    for (const g of containsGroups) counts[g.level] = (counts[g.level] || 0) + 1
     return counts
-  }, [containsLines])
+  }, [containsGroups])
 
-  // Apply the level filter on top of the contains filter (exact level match).
-  const logLines = useMemo(() => {
-    if (levelFilter === 'all') return containsLines
-    return containsLines.filter(entry => entry.level === levelFilter)
-  }, [containsLines, levelFilter])
+  // Apply the level filter on top of the contains filter (exact group-level match).
+  const logGroups = useMemo(() => {
+    if (levelFilter === 'all') return containsGroups
+    return containsGroups.filter(g => g.level === levelFilter)
+  }, [containsGroups, levelFilter])
 
-  // In formatted mode every line carries a `fmt` descriptor of colored spans: JSON
-  // pretty-printed (`kind: 'json'`), structured loggers reflowed to `block`/`spans`,
-  // unmatched lines plain wrapping text (`code: true`). Raw mode renders unstyled
-  // (`code: false`). Filtering runs first on raw text, so this only transforms what
-  // is shown.
+  // Format every line of every kept group. In formatted mode each line carries a
+  // `fmt` descriptor of colored spans: JSON pretty-printed (`kind: 'json'`),
+  // structured loggers reflowed to `block`/`spans`, unmatched lines plain wrapping
+  // text (`code: true`). Raw mode renders unstyled (`code: false`).
   //
   // Formatted output is cached by raw line text (formatCacheRef): an append reuses
   // cached results and only formats the new lines, not the whole buffer each poll.
   // The cache is rebuilt to the shown lines so it can't outgrow the buffer; raw mode
   // leaves it untouched so it survives a round-trip back to formatted.
-  const displayLines = useMemo(() => {
-    if (!formatted) {
-      return logLines.map(entry => ({ ...entry, code: false, fmt: null }))
-    }
+  const displayGroups = useMemo(() => {
+    // Raw mode renders unstyled: each line has no fmt/code, so LogLineBody falls
+    // through to its plain branch. No per-line transform is needed, so the groups
+    // pass straight through (avoids spread-copying every line each poll).
+    if (!formatted) return logGroups
     const prev = formatCacheRef.current
     const next = new Map()
-    const result = logLines.map(entry => {
-      // JSON formatting runs on every line; the klog/zap/logfmt cascade is gated on
-      // a parsed timestamp, so a continuation line (no ts) can't be mistaken for a
-      // structured entry. The cache key carries the head flag since the same text
-      // may appear as both a head and a continuation line.
+    const formatLine = (entry) => {
+      // JSON runs on every line; the klog/zap/logfmt cascade only on a timestamped
+      // one. A CRI frame has a ts so it reaches the cascade, but its shape (leading
+      // indent, no anchor) falls through to plain. The cache key carries the head
+      // flag since the same text can appear as both a head and a continuation.
       const key = `${entry.ts ? 1 : 0}\n${entry.text}`
       let formattedEntry = next.get(key) || prev.get(key)
       if (!formattedEntry) {
@@ -672,20 +902,24 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
       }
       next.set(key, formattedEntry)
       return { ...entry, ...formattedEntry }
-    })
+    }
+    const result = logGroups.map(g => ({ ...g, lines: g.lines.map(formatLine) }))
     formatCacheRef.current = next
     return result
-  }, [logLines, formatted])
+  }, [logGroups, formatted])
 
-  // Briefly highlight the most recent visible line when new entries arrive (e.g.
+  // Briefly highlight the most recent visible entry when new entries arrive (e.g.
   // while following). Gated on two conditions so it only signals fresh logs: the raw
   // buffer grew (prevLogs !== logs, skipping the first load) and the newest displayed
   // line changed. The second gate stops a poll that appends only filtered-out lines,
-  // or a filter change reshuffling the view, from re-pulsing an unchanged last line.
+  // or a filter change reshuffling the view, from re-pulsing an unchanged last entry.
+  // Keys off the last group's last line, so a frame appended to an open trace (which
+  // folds into the group rather than adding a row) still triggers the highlight.
   useEffect(() => {
     const prevLogs = prevLogsRef.current
     prevLogsRef.current = logs
-    const latest = displayLines.length > 0 ? displayLines[displayLines.length - 1] : null
+    const lastGroup = displayGroups.length > 0 ? displayGroups[displayGroups.length - 1] : null
+    const latest = lastGroup ? lastGroup.lines[lastGroup.lines.length - 1] : null
     const latestKey = latest ? `${latest.ts}\n${latest.text}` : null
     const prevKey = prevLatestKeyRef.current
     prevLatestKeyRef.current = latestKey
@@ -694,7 +928,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     setFlashLatest(true)
     const id = setTimeout(() => setFlashLatest(false), HIGHLIGHT_DURATION)
     return () => clearTimeout(id)
-  }, [logs, displayLines])
+  }, [logs, displayGroups])
 
   // Track whether the view is pinned to the bottom. Updated on every user
   // scroll so the auto-scroll below only follows new entries when the user is
@@ -721,7 +955,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   useEffect(() => {
     if (!bodyRef.current || !atBottomRef.current) return
     bodyRef.current.scrollTop = bodyRef.current.scrollHeight
-  }, [displayLines, followError])
+  }, [displayGroups, followError])
 
   // Download the current logs as a text file, named after the pod for a single
   // pod or the workload for the all-pods view.
@@ -797,6 +1031,22 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
             >
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1m8-18h1a2 2 0 0 1 2 2v5c0 1.1.9 2 2 2a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2h-1" />
+              </svg>
+            </ToggleButton>
+
+            {/* Fold a recognized multi-line trace into one collapsible entry.
+                Formatted mode only, so the toggle is disabled in raw mode rather
+                than silently flipping hidden state with no visible effect. */}
+            <ToggleButton
+              active={grouping}
+              onClick={() => setGrouped(v => !v)}
+              label="Group stack traces"
+              title={formatted ? 'Fold multi-line stack traces into collapsible entries' : 'Available in formatted mode'}
+              testid="logs-group-toggle"
+              disabled={!formatted}
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.75 5.25h16.5M3.75 9.75h16.5M7.5 14.25h12.75M7.5 18.75h12.75M3.75 14.25h.008v.008H3.75v-.008zm0 4.5h.008v.008H3.75v-.008z" />
               </svg>
             </ToggleButton>
           </div>
@@ -910,89 +1160,24 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
             </div>
           ) : loading && !logs ? (
             <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-loading">Loading logs...</p>
-          ) : displayLines.length > 0 || followError || podsGone ? (
+          ) : displayGroups.length > 0 || followError || podsGone ? (
             <div class="pb-2" data-testid="logs-content">
-              {displayLines.map((entry, i) => {
-                // Raw mode strips styling: no timestamp pill, level coloring, or
-                // highlight on the freshly appended entry.
-                const isLatest = formatted && flashLatest && i === displayLines.length - 1
-                const meta = LEVEL_META[entry.level] || LEVEL_META[DEFAULT_LEVEL]
+              {displayGroups.map((group, i) => {
+                // Content-identity key, not index: front-eviction and the all-pods
+                // re-sort shift indices, which would bleed a folded group's expand
+                // state onto another. Head text disambiguates a shared pod+ts; a
+                // headless run falls back to the index.
+                const key = group.head ? `${group.pod} ${group.ts} ${group.head.text}` : `orphan ${i}`
+                // Raw mode strips styling: the highlight on the freshly appended
+                // entry only fires in formatted mode.
+                const isLatest = formatted && flashLatest && i === displayGroups.length - 1
                 return (
-                  <Fragment key={i}>
-                    {formatted && entry.ts && (
-                      <div
-                        class="flex items-center gap-2 px-3 pt-2 select-none"
-                        data-testid="logs-timestamp"
-                        data-level={entry.level}
-                        data-latest={isLatest ? 'true' : undefined}
-                      >
-                        <span
-                          class={`text-[10px] font-mono px-1.5 py-0.5 rounded-full border bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 ${meta.border} ${isLatest ? 'log-glow' : ''}`}
-                          style={isLatest ? `--glow-color: ${meta.glow}` : undefined}
-                          title={entry.pod ? `${entry.pod} · ${meta.label} level` : `${meta.label} level`}
-                        >
-                          {entry.podId && <span class="font-semibold text-gray-700 dark:text-gray-300" data-testid="logs-pod-id">{entry.podId} · </span>}
-                          {entry.ts}
-                        </span>
-                        <span
-                          class={`flex-1 border-t ${meta.border} ${isLatest ? 'log-glow' : ''}`}
-                          style={isLatest ? `--glow-color: ${meta.glow}` : undefined}
-                        />
-                      </div>
-                    )}
-                    {entry.fmt && entry.fmt.kind === 'block' ? (
-                      // Structured entry: one container per entry (the per-entry
-                      // logs-line invariant), one inner row per visual line.
-                      <div
-                        class="overflow-x-auto font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
-                        style="padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;"
-                        data-testid="logs-line"
-                      >
-                        {entry.fmt.rows.map((row, r) => (
-                          <div key={r} data-testid="logs-line-row">
-                            {row.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
-                          </div>
-                        ))}
-                      </div>
-                    ) : entry.fmt && entry.fmt.kind === 'spans' ? (
-                      // Unstructured entry highlighted in place: a single row.
-                      <div
-                        class="overflow-x-auto font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
-                        style="padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;"
-                        data-testid="logs-line"
-                      >
-                        {entry.fmt.spans.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
-                      </div>
-                    ) : entry.fmt && entry.fmt.kind === 'json' ? (
-                      // Pretty-printed JSON: a <pre> preserves the baked-in
-                      // indentation/newlines and scrolls long values horizontally.
-                      <pre
-                        class="overflow-x-auto font-mono text-gray-800 dark:text-gray-200"
-                        style="margin: 0; padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;"
-                        data-testid="logs-line"
-                      >
-                        {entry.fmt.spans.map((s, j) => (s.cls ? <span key={j} class={s.cls}>{s.text}</span> : s.text))}
-                      </pre>
-                    ) : entry.code ? (
-                      // Plain line (no formatter match, or a continuation line such
-                      // as a stack frame): wrap like the decorated rows, not the
-                      // non-wrapping JSON <pre>.
-                      <div
-                        class="overflow-x-auto font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
-                        style="padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;"
-                        data-testid="logs-line"
-                      >
-                        {entry.text}
-                      </div>
-                    ) : (
-                      <div
-                        class="px-3 py-0.5 text-sm font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
-                        data-testid="logs-line"
-                      >
-                        {entry.text}
-                      </div>
-                    )}
-                  </Fragment>
+                  <LogGroup
+                    key={key}
+                    group={group}
+                    formatted={formatted}
+                    isLatest={isLatest}
+                  />
                 )
               })}
               {followError && (

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -1,0 +1,346 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useState, useEffect, useCallback, useMemo, useRef } from 'preact/hooks'
+import { fetchWithMock } from '../../../utils/fetch'
+
+// Selectable limits for the number of log lines to fetch from the backend.
+const LINE_LIMITS = [100, 500, 1000, 5000]
+
+// Default number of log lines requested from the backend.
+const DEFAULT_TAIL_LINES = 100
+
+// Follow polling interval in milliseconds.
+const FOLLOW_INTERVAL = 5000
+
+// Matches the leading RFC3339 timestamp the API prepends to each log line.
+const TIMESTAMP_PREFIX = /^\S+\s+/
+
+/**
+ * WorkloadLogsViewer - Modal that displays the logs of a pod container.
+ *
+ * Fetches logs from GET /api/v1/workload/logs for the selected container and
+ * renders each log entry on its own separated row. Supports following (live
+ * polling), filtering by substring, choosing the number of lines, viewing the
+ * previous container instance, toggling timestamps, and a fullscreen mode.
+ *
+ * @param {Object} props
+ * @param {string} props.namespace - Pod namespace
+ * @param {string} props.name - Pod name
+ * @param {Array<{name: string, isInit: boolean}>} props.containers - Pod containers
+ * @param {Function} props.onClose - Callback to close the viewer
+ */
+export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }) {
+  // Default to the first regular container, falling back to the first entry.
+  const defaultContainer = (containers.find(c => !c.isInit) || containers[0])?.name || ''
+
+  const [container, setContainer] = useState(defaultContainer)
+  const [previous, setPrevious] = useState(false)
+  const [tailLines, setTailLines] = useState(DEFAULT_TAIL_LINES)
+  const [follow, setFollow] = useState(false)
+  const [filter, setFilter] = useState('')
+  const [showTimestamps, setShowTimestamps] = useState(false)
+  const [fullScreen, setFullScreen] = useState(false)
+  const [logs, setLogs] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [copied, setCopied] = useState(false)
+
+  const bodyRef = useRef(null)
+
+  const fetchLogs = useCallback(async () => {
+    if (!container) return
+    setLoading(true)
+    setError(null)
+    try {
+      const params = new URLSearchParams({
+        namespace,
+        name,
+        container,
+        tailLines: String(tailLines),
+        previous: String(previous)
+      })
+      const resp = await fetchWithMock({
+        endpoint: `/api/v1/workload/logs?${params.toString()}`,
+        mockPath: '../mock/workload',
+        mockExport: 'getMockWorkloadLogs'
+      })
+      setLogs(resp?.logs || '')
+    } catch (err) {
+      setError(err.message)
+      setLogs('')
+    } finally {
+      setLoading(false)
+    }
+  }, [namespace, name, container, tailLines, previous])
+
+  // Fetch logs whenever the container, line count or previous toggle changes.
+  useEffect(() => {
+    fetchLogs()
+  }, [fetchLogs])
+
+  // Poll for new logs while following.
+  useEffect(() => {
+    if (!follow) return
+    const id = setInterval(() => { fetchLogs() }, FOLLOW_INTERVAL)
+    return () => clearInterval(id)
+  }, [follow, fetchLogs])
+
+  // Close the viewer on Escape.
+  useEffect(() => {
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  // Split the raw log payload into entries, apply the substring filter and
+  // optionally strip the leading timestamp for display.
+  const logLines = useMemo(() => {
+    let lines = logs.split('\n').filter(line => line.length > 0)
+    const needle = filter.trim().toLowerCase()
+    if (needle) {
+      lines = lines.filter(line => line.toLowerCase().includes(needle))
+    }
+    return showTimestamps ? lines : lines.map(line => line.replace(TIMESTAMP_PREFIX, ''))
+  }, [logs, filter, showTimestamps])
+
+  // Keep the most recent entry in view after each update.
+  useEffect(() => {
+    if (!bodyRef.current) return
+    bodyRef.current.scrollTop = bodyRef.current.scrollHeight
+  }, [logLines])
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await window.navigator.clipboard.writeText(logs)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard access can fail in insecure contexts; ignore silently.
+    }
+  }, [logs])
+
+  const fieldClass = 'text-xs px-2 py-1 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-flux-blue'
+  // appearance-none removes the native caret; the @tailwindcss/forms plugin
+  // also injects a chevron via background-image which is suppressed with an
+  // inline style on each select (see noFormsChevron). pr-6 leaves room for the
+  // single custom chevron rendered alongside.
+  const selectClass = `${fieldClass} appearance-none pr-6`
+  const noFormsChevron = { backgroundImage: 'none' }
+  const inputClass = `${fieldClass} placeholder-gray-400 dark:placeholder-gray-500`
+  const iconToggleClass = 'inline-flex items-center justify-center p-1.5 rounded-md border transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue'
+  const inactiveClass = 'border-gray-300 text-gray-600 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700'
+  const activeClass = 'border-flux-blue text-flux-blue bg-blue-50 dark:bg-blue-900/30'
+  const actionClass = 'inline-flex items-center p-1.5 rounded-md text-gray-400 hover:text-flux-blue dark:text-gray-500 dark:hover:text-flux-blue disabled:cursor-not-allowed'
+
+  return (
+    <div
+      class={`fixed inset-0 z-50 flex items-center justify-center bg-black/50 ${fullScreen ? 'p-0' : 'p-4'}`}
+      onClick={onClose}
+      data-testid="logs-viewer-overlay"
+    >
+      <div
+        class={`bg-white dark:bg-gray-900 shadow-xl flex flex-col border border-gray-200 dark:border-gray-700 ${
+          fullScreen ? 'w-full h-full max-w-full max-h-full rounded-none' : 'w-full max-w-4xl h-[85vh] rounded-lg'
+        }`}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Logs for pod ${name}`}
+        data-testid="logs-viewer"
+      >
+        {/* Header */}
+        <div class="flex items-center justify-between gap-2 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+          <div class="min-w-0">
+            <h2 class="text-sm font-semibold text-gray-900 dark:text-white truncate">Logs</h2>
+            <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{namespace}/{name}</p>
+          </div>
+          <button
+            onClick={onClose}
+            class="inline-flex items-center p-1 rounded text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200 flex-shrink-0"
+            aria-label="Close logs viewer"
+            data-testid="logs-close-button"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Toolbar */}
+        <div class="flex items-center flex-wrap gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+          {/* Follow logs */}
+          <button
+            onClick={() => setFollow(v => !v)}
+            class={`${iconToggleClass} ${follow ? activeClass : inactiveClass}`}
+            data-testid="logs-follow-toggle"
+            aria-pressed={follow}
+            aria-label="Follow logs"
+            title="Follow logs"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 13l-7 7-7-7m14-6l-7 7-7-7" />
+            </svg>
+          </button>
+
+          {/* Container select (always shown) */}
+          <div class="relative inline-flex">
+            <select
+              value={container}
+              onChange={(e) => setContainer(e.target.value)}
+              class={selectClass}
+              style={noFormsChevron}
+              data-testid="logs-container-select"
+              aria-label="Container"
+            >
+              {containers.map((c) => (
+                <option key={c.name} value={c.name}>{c.isInit ? `init:${c.name}` : c.name}</option>
+              ))}
+            </select>
+            <svg class="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </div>
+
+          {/* Contains filter */}
+          <input
+            type="text"
+            value={filter}
+            onInput={(e) => setFilter(e.target.value)}
+            placeholder="contains…"
+            class={`${inputClass} w-28 sm:w-44`}
+            data-testid="logs-filter-input"
+            aria-label="Filter log lines containing text"
+          />
+
+          {/* Previous container instance */}
+          <button
+            onClick={() => setPrevious(v => !v)}
+            class={`${iconToggleClass} ${previous ? activeClass : inactiveClass}`}
+            data-testid="logs-previous-toggle"
+            aria-pressed={previous}
+            aria-label="Previous container instance"
+            title="Show logs from the previous container instance"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+            </svg>
+          </button>
+
+          {/* Lines select */}
+          <div class="relative inline-flex">
+            <select
+              value={tailLines}
+              onChange={(e) => setTailLines(Number(e.target.value))}
+              class={selectClass}
+              style={noFormsChevron}
+              data-testid="logs-lines-select"
+              aria-label="Number of lines"
+            >
+              {LINE_LIMITS.map((n) => (
+                <option key={n} value={n}>{n} ln</option>
+              ))}
+            </select>
+            <svg class="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </div>
+
+          {/* Timestamps show/hide */}
+          <button
+            onClick={() => setShowTimestamps(v => !v)}
+            class={`${iconToggleClass} ${showTimestamps ? activeClass : inactiveClass}`}
+            data-testid="logs-timestamps-toggle"
+            aria-pressed={showTimestamps}
+            aria-label="Show or hide timestamps"
+            title="Show or hide timestamps"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </button>
+
+          {/* Actions */}
+          <div class="flex items-center gap-1 ml-auto">
+            <button
+              onClick={fetchLogs}
+              disabled={loading}
+              class={actionClass}
+              title="Refresh logs"
+              aria-label="Refresh logs"
+              data-testid="logs-refresh-button"
+            >
+              <svg class={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+            <button
+              onClick={handleCopy}
+              class={actionClass}
+              title="Copy logs to clipboard"
+              aria-label="Copy logs to clipboard"
+              data-testid="logs-copy-button"
+            >
+              {copied ? (
+                <svg class="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                </svg>
+              ) : (
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+              )}
+            </button>
+            <button
+              onClick={() => setFullScreen(v => !v)}
+              class={actionClass}
+              aria-pressed={fullScreen}
+              title={fullScreen ? 'Exit fullscreen' : 'Fullscreen'}
+              aria-label={fullScreen ? 'Exit fullscreen' : 'Fullscreen'}
+              data-testid="logs-fullscreen-toggle"
+            >
+              {fullScreen ? (
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 9V4.5M9 9H4.5M9 9 3.75 3.75M15 9h4.5M15 9V4.5M15 9l5.25-5.25M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 15h4.5M15 15v4.5m0-4.5 5.25 5.25" />
+                </svg>
+              ) : (
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
+                </svg>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div ref={bodyRef} class="flex-1 overflow-auto bg-gray-50 dark:bg-gray-950" data-testid="logs-body">
+          {error ? (
+            <div class="m-3 p-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-xs text-red-800 dark:text-red-200" data-testid="logs-error">
+              {error}
+            </div>
+          ) : loading && !logs ? (
+            <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-loading">Loading logs...</p>
+          ) : logLines.length > 0 ? (
+            <div class="divide-y divide-gray-200 dark:divide-gray-800" data-testid="logs-content">
+              {logLines.map((line, i) => (
+                <div
+                  key={i}
+                  class="px-3 py-1 text-sm font-mono text-gray-800 dark:text-gray-200 whitespace-pre-wrap break-all hover:bg-gray-100 dark:hover:bg-gray-900"
+                  data-testid="logs-line"
+                >
+                  {line}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-empty">
+              {filter.trim() ? 'No matching log entries' : 'No logs available'}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -89,56 +89,66 @@ function mergeLogs(prev, incoming) {
 const TIMESTAMP_PREFIX = /^(\d{4}-\d{2}-\d{2}T\S+) /
 
 // entryTimestamp returns the RFC3339 timestamp heading a log entry, or null for a
-// continuation line (stack frame) that carries none. A head is "<ts> msg" (single
-// pod) or "<pod> <ts> msg" (all-pods); the ts must be a real instant, not merely
-// date-shaped, so a frame beginning with a word and date-like token isn't a head.
+// continuation line (stack frame) that carries none. A head is "<ts> msg" or
+// carries up to two leading origin tags before the ts ("<pod> <ts> msg", "<container>
+// <ts> msg", or "<pod> <container> <ts> msg"), so the ts may sit after 0, 1, or 2
+// tokens. The ts must be a real instant, not merely date-shaped, so a frame
+// beginning with words and a date-like token isn't a head. The two-token cap bounds
+// misdetection; an indented continuation breaks on its leading space.
 function entryTimestamp(line) {
-  const m = line.match(TIMESTAMP_PREFIX)
-  if (m && !Number.isNaN(Date.parse(m[1]))) return m[1]
-  const sp = line.indexOf(' ')
-  if (sp > 0) {
-    const am = line.slice(sp + 1).match(TIMESTAMP_PREFIX)
-    if (am && !Number.isNaN(Date.parse(am[1]))) return am[1]
+  let s = line
+  for (let i = 0; i < 3; i++) {
+    const m = s.match(TIMESTAMP_PREFIX)
+    if (m && !Number.isNaN(Date.parse(m[1]))) return m[1]
+    const sp = s.indexOf(' ')
+    if (sp <= 0) break
+    s = s.slice(sp + 1)
   }
   return null
 }
 
 /**
- * parseLogLine - parse one raw payload line into a log entry. In the all-pods
- * (tagged) view a line is "<pod> <ts> <msg>"; the leading token is a pod tag only
- * when it is a requested pod AND the next token is a real timestamp (so a message
- * starting "<word> <date>" isn't mistaken for one). The timestamp and ANSI are
- * stripped and the level detected; a continuation line (no ts) keeps its
- * indentation (see TIMESTAMP_PREFIX). Exported so tests hit the real parse path.
+ * parseLogLine - parse one raw payload line into a log entry. A multi-stream line
+ * carries its origin tags before the timestamp: "<pod> <ts> <msg>" (all-pods),
+ * "<container> <ts> <msg>" (all-containers, one pod), or "<pod> <container> <ts>
+ * <msg>" (both). Each tag is peeled only when its token is one of the requested
+ * names AND a real timestamp follows the peels (so a message starting "<word>
+ * <date>" isn't mistaken for a tag, and a continuation line keeps its full text).
+ * The timestamp and ANSI are then stripped and the level detected; a continuation
+ * line (no ts) keeps its indentation (see TIMESTAMP_PREFIX). Exported so tests hit
+ * the real parse path.
  *
  * @param {string} line - One raw payload line (CR already stripped, non-empty)
- * @param {Set<string>|null} podSet - Requested pods in the tagged view, else null
- * @returns {{ts: string, tsMs: number, text: string, level: string, pod: string, podId: string}}
+ * @param {Set<string>|null} podSet - Requested pods in the pod-tagged view, else null
+ * @param {Set<string>|null} containerSet - Requested containers in the container-tagged view, else null
+ * @returns {{ts: string, tsMs: number, text: string, level: string, pod: string, podId: string, container: string}}
  */
-export function parseLogLine(line, podSet) {
-  let rest = line
-  let pod = ''
-  if (podSet) {
-    const sp = line.indexOf(' ')
-    if (sp > 0) {
-      const first = line.slice(0, sp)
-      const after = line.slice(sp + 1)
-      // Require a real timestamp, not a date-shaped token, so a message
-      // beginning "<known-pod> 2026-13-45T.." isn't mistaken for a tag.
-      const am = after.match(TIMESTAMP_PREFIX)
-      if (podSet.has(first) && am && !Number.isNaN(Date.parse(am[1]))) {
-        pod = first
-        rest = after
-      }
-    }
+export function parseLogLine(line, podSet, containerSet) {
+  // Peel pod then container, but commit the peel only if a real timestamp follows:
+  // a name-shaped first token is a tag only on an actual entry head.
+  const peel = (s, set) => {
+    const sp = s.indexOf(' ')
+    if (sp > 0 && set.has(s.slice(0, sp))) return [s.slice(0, sp), s.slice(sp + 1)]
+    return null
   }
+  let cursor = line
+  let pod = ''
+  let container = ''
+  if (podSet) { const r = peel(cursor, podSet); if (r) { pod = r[0]; cursor = r[1] } }
+  if (containerSet) { const r = peel(cursor, containerSet); if (r) { container = r[0]; cursor = r[1] } }
+  const am = cursor.match(TIMESTAMP_PREFIX)
+  // Require a real timestamp, not a date-shaped token, after the peels; otherwise
+  // the tokens weren't tags — restore the original line and drop the peeled names.
+  const tagged = !!am && !Number.isNaN(Date.parse(am[1]))
+  const rest = tagged ? cursor : line
+  if (!tagged) { pod = ''; container = '' }
   const m = rest.match(TIMESTAMP_PREFIX)
   const tsMs = m ? Date.parse(m[1]) : NaN
   const hasTs = !Number.isNaN(tsMs)
   const ts = hasTs ? m[1] : ''
   const text = stripAnsi(hasTs ? rest.slice(m[0].length) : rest)
   const podId = pod ? pod.slice(pod.lastIndexOf('-') + 1) : ''
-  return { ts, tsMs, text, level: detectLevel(text), pod, podId }
+  return { ts, tsMs, text, level: detectLevel(text), pod, podId, container }
 }
 
 // Shared styling for the toolbar controls. Selects deliberately omit a chevron
@@ -360,10 +370,18 @@ function LogSeparator({ entry, level, isLatest }) {
 const EXPANDED_LINE_CAP = 500
 
 /**
- * LogGroup - one logical log entry: a single line, or a folded trace that starts
- * collapsed (head + frame count), expands on click, and caps a long expansion with
- * a "show all" link. A headless group (head === null, a buffer opened mid-trace)
- * skips the separator pill and renders its lines through the same path.
+ * LogGroup - one logical log entry. Two multi-line shapes render differently:
+ *
+ *  - **stack trace** (`group.isTrace`) is *folded*: head visible, frames hidden
+ *    behind a click-to-expand control that caps a long expansion with a "show all"
+ *    link, so a multi-thousand-frame trace doesn't render at once.
+ *  - **unstructured burst** is *grouped but not folded*: every line renders under
+ *    the one timestamp pill, nothing hidden — a curl -v dump reads as a single
+ *    timestamped block.
+ *
+ * A single-line entry renders just its head. A headless group (head === null, a
+ * buffer opened mid-trace) skips the separator pill and renders its lines through
+ * the same path.
  *
  * @param {Object} props
  * @param {Object} props.group - A display group: head, formatted lines, and metadata
@@ -375,7 +393,9 @@ function LogGroup({ group, formatted, isLatest }) {
   const [showAll, setShowAll] = useState(false)
   const lines = group.lines
 
-  const folded = lines.length > 1
+  const multi = lines.length > 1
+  // A trace folds (head + click-to-expand); a burst groups without folding.
+  const foldable = group.isTrace && multi
   // Frames exclude folded blank lines (a Go panic's blank, a trailing Node blank)
   // so the "N frames" count isn't inflated.
   const frameCount = lines.slice(1).filter(l => l.text !== '').length
@@ -386,7 +406,7 @@ function LogGroup({ group, formatted, isLatest }) {
     <>
       {formatted && group.head && <LogSeparator entry={group.head} level={group.level} isLatest={isLatest} />}
       <LogLineBody entry={lines[0]} />
-      {folded && (
+      {foldable && (
         <>
           <button
             type="button"
@@ -396,7 +416,7 @@ function LogGroup({ group, formatted, isLatest }) {
             aria-expanded={expanded}
           >
             <span aria-hidden="true">{expanded ? '▾' : '▸'}</span>
-            {group.isTrace && frameCount > 0
+            {frameCount > 0
               ? `${frameCount} frame${frameCount === 1 ? '' : 's'}`
               : `+${hiddenCount} line${hiddenCount === 1 ? '' : 's'}`}
           </button>
@@ -417,6 +437,8 @@ function LogGroup({ group, formatted, isLatest }) {
           )}
         </>
       )}
+      {/* Burst: not folded — render every remaining line under the one pill. */}
+      {!group.isTrace && multi && lines.slice(1).map((l, j) => <LogLineBody key={j} entry={l} />)}
     </>
   )
 }
@@ -531,9 +553,6 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   const [filter, setFilter] = useState('')
   const [levelFilter, setLevelFilter] = useState('all')
   const [formatted, setFormatted] = useState(true)
-  // Fold recognized multi-line stack traces under their head into one collapsible
-  // entry. On by default; a formatted-mode-only affordance (raw renders flat).
-  const [grouped, setGrouped] = useState(true)
   const [fullScreen, setFullScreen] = useState(false)
   const [logs, setLogs] = useState('')
   const [loading, setLoading] = useState(false)
@@ -542,9 +561,12 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // stays visible. The full-pane `error` is used only when there is no buffer.
   const [followError, setFollowError] = useState(null)
   const [flashLatest, setFlashLatest] = useState(false)
-  // Whether the current buffer's lines are pod-tagged (set from the response, so
-  // the parser never has to guess the wire format). Reset with the buffer.
+  // Whether the current buffer's lines are pod-tagged and/or container-tagged (set
+  // from the response, so the parser never has to guess the wire format). Pod
+  // tagging marks the all-pods view, container tagging the all-containers view;
+  // both can be set in the combined view. Reset with the buffer.
   const [tagged, setTagged] = useState(false)
+  const [containerTagged, setContainerTagged] = useState(false)
   // Coverage of the "All pods" view: { streamed, total, forbidden } when the
   // response did not cover every requested pod, else null.
   const [partial, setPartial] = useState(null)
@@ -572,7 +594,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // poll fired after the reset shares its generation, so the guard alone misses it).
   const resettingRef = useRef(false)
   // Memoizes formatted output per raw line text, so appends format only the new
-  // lines instead of the whole buffer each poll. See displayGroups for pruning.
+  // lines instead of the whole buffer each poll. See formattedLines for pruning.
   const formatCacheRef = useRef(new Map())
 
   // Pod dropdown options: "All pods" leads, then each pod.
@@ -684,6 +706,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
       // pods it covered, so the parser and footer don't guess. Refreshed every fetch
       // (a pod becoming readable can clear a partial result).
       setTagged(!!resp?.tagged)
+      setContainerTagged(!!resp?.containerTagged)
       setPartial(resp?.partial ? { streamed: resp.streamed || 0, total: resp.total || 0, forbidden: resp.forbidden || 0 } : null)
       setError(null)
       setFollowError(null)
@@ -758,9 +781,10 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // detected. Only re-runs when the payload (or tagging regime) changes.
   const baseLines = useMemo(() => {
     const podSet = tagged ? new Set(reqPodsStr ? reqPodsStr.split(',') : []) : null
+    const containerSet = containerTagged ? new Set(reqContainersStr ? reqContainersStr.split(',') : []) : null
     // Strip a trailing CR so a CRLF stream doesn't leak `\r` into the text, fields,
     // or filter. (Download uses the raw payload, so it stays byte-verbatim.)
-    const entries = logs.split('\n').map(line => line.replace(/\r$/, '')).filter(line => line.length > 0).map(line => parseLogLine(line, podSet))
+    const entries = logs.split('\n').map(line => line.replace(/\r$/, '')).filter(line => line.length > 0).map(line => parseLogLine(line, podSet, containerSet))
 
     // In all-pods each pod advances its own `since` cursor, so a lagging pod can
     // deliver a line older than another's buffered tail; in arrival order the buffer
@@ -781,7 +805,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
       return ta - tb
     })
     return groups.flat()
-  }, [logs, tagged, reqPodsStr])
+  }, [logs, tagged, reqPodsStr, containerTagged, reqContainersStr])
 
   // Track the follow cursors from the buffer so the next poll requests only newer
   // entries: lastTsRef is the single-pod high-watermark (sinceTime), cursorsRef the
@@ -803,29 +827,79 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     cursorsRef.current = cursors
   }, [baseLines])
 
-  // Grouping is a formatted-mode affordance: raw mode renders every line flat, so
-  // it is bypassed when not formatted.
-  const grouping = grouped && formatted
+  // Grouping is a formatted-mode affordance: raw mode renders every line flat, so it
+  // is bypassed when not formatted. There is no separate toggle — a trace starts
+  // folded (click to expand), a burst renders all its lines under one timestamp pill.
+  const grouping = formatted
 
-  // Fold recognized stack traces into one collapsible entry each (off → one group
-  // per entry, keeping the chain uniform). In the all-pods view fold per pod then
-  // order groups by head ts: frames are timestamped, so two pods crashing together
-  // interleave frame-by-frame and folding the flat list would fragment each trace.
-  // A ts==='' orphan inherits the previous line's pod, so it buckets with its head.
+  // Format each base line once, before grouping, so a line's `fmt` descriptor and
+  // its `structured` flag (whether the format layer recognizes it) are known when
+  // groupEntries decides whether to join an unstructured burst. In formatted mode a
+  // line gains { code, fmt, structured }; raw mode passes baseLines through (no fmt,
+  // structured irrelevant — grouping is off, LogLineBody falls through to plain).
+  //
+  // Cached by raw line text (formatCacheRef): an append reuses cached results and
+  // only formats the new lines. The cache is rebuilt over the whole base buffer
+  // (≤ MAX_BUFFER_LINES), so it can't outgrow it; raw mode leaves it untouched so it
+  // survives a round-trip back to formatted.
+  const formattedLines = useMemo(() => {
+    if (!formatted) return baseLines
+    const prev = formatCacheRef.current
+    const next = new Map()
+    const result = baseLines.map(entry => {
+      // The cache key carries the head flag since the same text can appear as both a
+      // head and a continuation line. JSON runs on every line; the klog/zap/logfmt
+      // cascade only on a timestamped one (a frame's shape falls through to plain).
+      const key = `${entry.ts ? 1 : 0}\n${entry.text}`
+      let f = next.get(key) || prev.get(key)
+      if (!f) {
+        const json = highlightJson(entry.text)
+        const d = json || (entry.ts ? decorateLine(entry.text, entry.level) : { kind: 'plain' })
+        // `structured` (whether the burst grouper treats the line as a real log
+        // entry vs structure-less noise) is true when the format layer decorates it,
+        // OR when a level was detected even though decorateLine fell through to
+        // plain. The level catch closes the decorateLine gap: a date-less console
+        // line like `[main] DEBUG com.x - msg` renders plain (no leading digit for
+        // parseJava) but detectLevel finds `debug`, so it is not swept into a burst.
+        // A curl -v dump carries no level (default info), so it still groups.
+        const leveled = entry.level !== DEFAULT_LEVEL
+        f = d.kind === 'plain'
+          ? { code: true, fmt: null, structured: leveled }
+          : { code: false, fmt: d, structured: true }
+      }
+      next.set(key, f)
+      return { ...entry, ...f }
+    })
+    formatCacheRef.current = next
+    return result
+  }, [baseLines, formatted])
+
+  // Group recognized stack traces and unstructured bursts, one run per group (off →
+  // one group per entry, keeping the chain uniform). When the stream is tagged (more
+  // than one pod and/or container), partition by origin (pod + container) then order
+  // groups by head ts: every line is timestamped, so two streams crashing together
+  // interleave frame-by-frame and grouping the flat list would fragment each run. The
+  // partition keeps each origin's trace intact; groupEntries' samePod/sameContainer
+  // guard is then a backstop. A ts==='' orphan inherits the previous line's origin,
+  // so it buckets with its head. A single untagged stream skips the partition.
   const groups = useMemo(() => {
-    if (!tagged) return groupEntries(baseLines, grouping)
-    const byPod = new Map()
+    if (!tagged && !containerTagged) return groupEntries(formattedLines, grouping)
+    const byOrigin = new Map()
     let lastPod = ''
-    for (const e of baseLines) {
+    let lastContainer = ''
+    for (const e of formattedLines) {
       const pod = e.pod || lastPod
+      const container = e.container || lastContainer
       if (e.pod) lastPod = e.pod
-      let bucket = byPod.get(pod)
-      if (!bucket) { bucket = []; byPod.set(pod, bucket) }
+      if (e.container) lastContainer = e.container
+      const origin = `${pod}\n${container}`
+      let bucket = byOrigin.get(origin)
+      if (!bucket) { bucket = []; byOrigin.set(origin, bucket) }
       bucket.push(e)
     }
     // A group with no timestamped head inherits the previous group's ts so it stays
     // adjacent instead of floating to the front; a leading orphan keeps NaN (first).
-    const ordered = [...byPod.values()].flatMap(es => {
+    const ordered = [...byOrigin.values()].flatMap(es => {
       const gs = groupEntries(es, grouping)
       let sortTs = NaN
       for (const g of gs) {
@@ -839,7 +913,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
       if (Number.isNaN(b.sortTs)) return 1
       return a.sortTs - b.sortTs
     })
-  }, [baseLines, tagged, grouping])
+  }, [formattedLines, tagged, containerTagged, grouping])
 
   // Substring filter over each group's whole block. Positive: keep if any line has
   // the needle (a match keeps the whole trace). "!needle": keep only if no line has
@@ -863,50 +937,12 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   }, [containsGroups])
 
   // Apply the level filter on top of the contains filter (exact group-level match).
+  // Lines already carry their fmt/code from formattedLines, so this is the final set
+  // the render maps — no separate formatting pass.
   const logGroups = useMemo(() => {
     if (levelFilter === 'all') return containsGroups
     return containsGroups.filter(g => g.level === levelFilter)
   }, [containsGroups, levelFilter])
-
-  // Format every line of every kept group. In formatted mode each line carries a
-  // `fmt` descriptor of colored spans: JSON pretty-printed (`kind: 'json'`),
-  // structured loggers reflowed to `block`/`spans`, unmatched lines plain wrapping
-  // text (`code: true`). Raw mode renders unstyled (`code: false`).
-  //
-  // Formatted output is cached by raw line text (formatCacheRef): an append reuses
-  // cached results and only formats the new lines, not the whole buffer each poll.
-  // The cache is rebuilt to the shown lines so it can't outgrow the buffer; raw mode
-  // leaves it untouched so it survives a round-trip back to formatted.
-  const displayGroups = useMemo(() => {
-    // Raw mode renders unstyled: each line has no fmt/code, so LogLineBody falls
-    // through to its plain branch. No per-line transform is needed, so the groups
-    // pass straight through (avoids spread-copying every line each poll).
-    if (!formatted) return logGroups
-    const prev = formatCacheRef.current
-    const next = new Map()
-    const formatLine = (entry) => {
-      // JSON runs on every line; the klog/zap/logfmt cascade only on a timestamped
-      // one. A CRI frame has a ts so it reaches the cascade, but its shape (leading
-      // indent, no anchor) falls through to plain. The cache key carries the head
-      // flag since the same text can appear as both a head and a continuation.
-      const key = `${entry.ts ? 1 : 0}\n${entry.text}`
-      let formattedEntry = next.get(key) || prev.get(key)
-      if (!formattedEntry) {
-        // json, then klog/zap/logfmt, then plain. json/block/spans render as
-        // decorated rows; plain keeps a wrapping text div.
-        const json = highlightJson(entry.text)
-        const d = json || (entry.ts ? decorateLine(entry.text, entry.level) : { kind: 'plain' })
-        formattedEntry = d.kind === 'plain'
-          ? { text: entry.text, code: true, fmt: null }
-          : { text: entry.text, code: false, fmt: d }
-      }
-      next.set(key, formattedEntry)
-      return { ...entry, ...formattedEntry }
-    }
-    const result = logGroups.map(g => ({ ...g, lines: g.lines.map(formatLine) }))
-    formatCacheRef.current = next
-    return result
-  }, [logGroups, formatted])
 
   // Briefly highlight the most recent visible entry when new entries arrive (e.g.
   // while following). Gated on two conditions so it only signals fresh logs: the raw
@@ -918,7 +954,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   useEffect(() => {
     const prevLogs = prevLogsRef.current
     prevLogsRef.current = logs
-    const lastGroup = displayGroups.length > 0 ? displayGroups[displayGroups.length - 1] : null
+    const lastGroup = logGroups.length > 0 ? logGroups[logGroups.length - 1] : null
     const latest = lastGroup ? lastGroup.lines[lastGroup.lines.length - 1] : null
     const latestKey = latest ? `${latest.ts}\n${latest.text}` : null
     const prevKey = prevLatestKeyRef.current
@@ -928,7 +964,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     setFlashLatest(true)
     const id = setTimeout(() => setFlashLatest(false), HIGHLIGHT_DURATION)
     return () => clearTimeout(id)
-  }, [logs, displayGroups])
+  }, [logs, logGroups])
 
   // Track whether the view is pinned to the bottom. Updated on every user
   // scroll so the auto-scroll below only follows new entries when the user is
@@ -955,7 +991,7 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   useEffect(() => {
     if (!bodyRef.current || !atBottomRef.current) return
     bodyRef.current.scrollTop = bodyRef.current.scrollHeight
-  }, [displayGroups, followError])
+  }, [logGroups, followError])
 
   // Download the current logs as a text file, named after the pod for a single
   // pod or the workload for the all-pods view.
@@ -1031,22 +1067,6 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
             >
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1m8-18h1a2 2 0 0 1 2 2v5c0 1.1.9 2 2 2a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2h-1" />
-              </svg>
-            </ToggleButton>
-
-            {/* Fold a recognized multi-line trace into one collapsible entry.
-                Formatted mode only, so the toggle is disabled in raw mode rather
-                than silently flipping hidden state with no visible effect. */}
-            <ToggleButton
-              active={grouping}
-              onClick={() => setGrouped(v => !v)}
-              label="Group stack traces"
-              title={formatted ? 'Fold multi-line stack traces into collapsible entries' : 'Available in formatted mode'}
-              testid="logs-group-toggle"
-              disabled={!formatted}
-            >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.75 5.25h16.5M3.75 9.75h16.5M7.5 14.25h12.75M7.5 18.75h12.75M3.75 14.25h.008v.008H3.75v-.008zm0 4.5h.008v.008H3.75v-.008z" />
               </svg>
             </ToggleButton>
           </div>
@@ -1160,17 +1180,18 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
             </div>
           ) : loading && !logs ? (
             <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-loading">Loading logs...</p>
-          ) : displayGroups.length > 0 || followError || podsGone ? (
+          ) : logGroups.length > 0 || followError || podsGone ? (
             <div class="pb-2" data-testid="logs-content">
-              {displayGroups.map((group, i) => {
+              {logGroups.map((group, i) => {
                 // Content-identity key, not index: front-eviction and the all-pods
                 // re-sort shift indices, which would bleed a folded group's expand
-                // state onto another. Head text disambiguates a shared pod+ts; a
-                // headless run falls back to the index.
-                const key = group.head ? `${group.pod} ${group.ts} ${group.head.text}` : `orphan ${i}`
+                // state onto another. Container + head text disambiguate a shared
+                // pod+ts (two containers in one pod can emit the same line at the
+                // same instant); a headless run falls back to the index.
+                const key = group.head ? `${group.pod} ${group.container} ${group.ts} ${group.head.text}` : `orphan ${i}`
                 // Raw mode strips styling: the highlight on the freshly appended
                 // entry only fires in formatted mode.
-                const isLatest = formatted && flashLatest && i === displayGroups.length - 1
+                const isLatest = formatted && flashLatest && i === logGroups.length - 1
                 return (
                   <LogGroup
                     key={key}

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -116,12 +116,13 @@ function entryTimestamp(line) {
  * <date>" isn't mistaken for a tag, and a continuation line keeps its full text).
  * The timestamp and ANSI are then stripped and the level detected; a continuation
  * line (no ts) keeps its indentation (see TIMESTAMP_PREFIX). Exported so tests hit
- * the real parse path.
+ * the real parse path. Level is NOT detected here — it is formatted-mode only and
+ * computed lazily in formattedLines (raw mode is verbatim with no level semantics).
  *
  * @param {string} line - One raw payload line (CR already stripped, non-empty)
  * @param {Set<string>|null} podSet - Requested pods in the pod-tagged view, else null
  * @param {Set<string>|null} containerSet - Requested containers in the container-tagged view, else null
- * @returns {{ts: string, tsMs: number, text: string, level: string, pod: string, podId: string, container: string}}
+ * @returns {{ts: string, tsMs: number, text: string, pod: string, podId: string, container: string}}
  */
 export function parseLogLine(line, podSet, containerSet) {
   // Peel pod then container, but commit the peel only if a real timestamp follows:
@@ -148,7 +149,59 @@ export function parseLogLine(line, podSet, containerSet) {
   const ts = hasTs ? m[1] : ''
   const text = stripAnsi(hasTs ? rest.slice(m[0].length) : rest)
   const podId = pod ? pod.slice(pod.lastIndexOf('-') + 1) : ''
-  return { ts, tsMs, text, level: detectLevel(text), pod, podId, container }
+  return { ts, tsMs, text, pod, podId, container }
+}
+
+/**
+ * reconcileEntries - incrementally parse `lines` against the previously parsed
+ * buffer, reusing the cached entry objects for lines unchanged since the last
+ * poll and calling `parse` only on the appended tail. mergeLogs only appends and
+ * front-evicts, so `prevLines` is either an exact prefix of `lines` (the buffer
+ * grew) or, once the buffer is capped, a suffix of `prevLines` equals the head of
+ * `lines` (front-eviction dropped some heads).
+ *
+ * Two paths:
+ * - No eviction: `lines` starts with all of `prevLines`. The endpoint check is a
+ *   cheap guard, not the correctness basis — it is sound only because the caller
+ *   guarantees an append (mergeLogs is append-only and every non-append fetch
+ *   bumps fetchGenRef, which forces a full re-parse before this is ever reached).
+ * - Eviction: scan for the drop offset, then VERIFY the whole overlap and fall
+ *   back to a full parse on any divergence, so the result always equals
+ *   `lines.map(parse)` and the parsed mirror can never drift from the buffer.
+ *
+ * Exported so tests can prove the reuse mechanism (parse call count + object
+ * identity) directly, not just the end-to-end output.
+ *
+ * @param {string[]} prevLines - the previously parsed lines, in arrival order
+ * @param {Array} prevEntries - their parsed entries, 1:1 with prevLines
+ * @param {string[]} lines - the current buffer lines, in arrival order
+ * @param {(line: string) => object} parse - parses one raw line into an entry
+ * @returns {Array} entries, 1:1 with lines
+ */
+export function reconcileEntries(prevLines, prevEntries, lines, parse) {
+  const p = prevLines.length
+  if (p === 0) return lines.map(parse)
+  // No eviction: the buffer grew (or is unchanged), so prevLines is an exact
+  // prefix. Reuse every cached entry, parse only the appended tail.
+  if (lines.length >= p && lines[0] === prevLines[0] && lines[p - 1] === prevLines[p - 1]) {
+    return prevEntries.concat(lines.slice(p).map(parse))
+  }
+  // Front-eviction at the buffer cap dropped some head lines. Find the eviction
+  // offset (prevLines.slice(drop) == lines head), verify the overlap, then reuse
+  // the surviving entries and parse the appended tail. The verify loop (not just
+  // the offset match) makes this correct even when lines[0] also appears earlier
+  // as a duplicate; any divergence falls through to a full parse.
+  let drop = 1
+  while (drop < p && prevLines[drop] !== lines[0]) drop++
+  const reuse = p - drop
+  if (lines.length >= reuse) {
+    let ok = true
+    for (let i = 0; ok && i < reuse; i++) {
+      if (prevLines[drop + i] !== lines[i]) ok = false
+    }
+    if (ok) return prevEntries.slice(drop).concat(lines.slice(reuse).map(parse))
+  }
+  return lines.map(parse)
 }
 
 // Shared styling for the toolbar controls. Selects deliberately omit a chevron
@@ -596,6 +649,12 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // Memoizes formatted output per raw line text, so appends format only the new
   // lines instead of the whole buffer each poll. See formattedLines for pruning.
   const formatCacheRef = useRef(new Map())
+  // The parsed buffer, mirroring `logs` line-for-line in arrival order (pre-sort,
+  // pre-format), so a follow poll re-parses only the appended lines instead of the
+  // whole buffer. `key` is the tag regime and `gen` the reset-fetch id; a change in
+  // either forces a full re-parse (see baseLines). `logs` (the string) stays
+  // authoritative — this is a derived mirror that must never diverge from it.
+  const parsedRef = useRef({ key: null, gen: -1, lines: [], entries: [] })
 
   // Pod dropdown options: "All pods" leads, then each pod.
   const podOptions = useMemo(() => {
@@ -743,6 +802,14 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     setContainerKey(defaultKey)
   }, [effectivePodKey])
 
+  // Raw mode is verbatim text with no level semantics: the level filter is hidden
+  // and reset to "all" so a filter set in formatted mode doesn't silently narrow the
+  // raw view (where the level pills/legend are gone). On mount formatted is true, so
+  // this is a no-op until the user switches to raw.
+  useEffect(() => {
+    if (!formatted) setLevelFilter('all')
+  }, [formatted])
+
   // Poll for new logs while following: silent (no spinner flicker) and appending
   // (visible lines stay put).
   useEffect(() => {
@@ -772,19 +839,44 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     return () => { document.body.style.overflow = previousOverflow }
   }, [])
 
-  // Split the raw payload into entries once. In the "All pods" view each
-  // timestamped line is prefixed with its pod of origin ("<pod> <ts> <msg>"); a
-  // token is only treated as a pod tag when it is one of the pods we requested AND
-  // the next token parses as a timestamp, so a message that merely starts with a
-  // word + timestamp is never mistaken for a tag. The leading timestamp (shown as
-  // a separator pill) and any ANSI escapes are then stripped and the level
-  // detected. Only re-runs when the payload (or tagging regime) changes.
+  // Split the raw payload into entries. In the "All pods" view each timestamped
+  // line is prefixed with its pod of origin ("<pod> <ts> <msg>"); a token is only
+  // treated as a pod tag when it is one of the pods we requested AND the next token
+  // parses as a timestamp, so a message that merely starts with a word + timestamp
+  // is never mistaken for a tag. The leading timestamp (shown as a separator pill)
+  // and any ANSI escapes are then stripped.
+  //
+  // Parsing is incremental: a follow poll re-parses only the lines mergeLogs
+  // appended, reusing the cached entry objects for lines already parsed (parsedRef).
+  // A full re-parse is forced only when the tag regime changes (peeling differs) or
+  // a reset fetch replaced the buffer (fetchGenRef bumps on every non-append fetch).
+  // mergeLogs only appends and front-evicts, so on an append the surviving cached
+  // lines are a suffix of the previous buffer equal to the head of the new one.
   const baseLines = useMemo(() => {
     const podSet = tagged ? new Set(reqPodsStr ? reqPodsStr.split(',') : []) : null
     const containerSet = containerTagged ? new Set(reqContainersStr ? reqContainersStr.split(',') : []) : null
     // Strip a trailing CR so a CRLF stream doesn't leak `\r` into the text, fields,
     // or filter. (Download uses the raw payload, so it stays byte-verbatim.)
-    const entries = logs.split('\n').map(line => line.replace(/\r$/, '')).filter(line => line.length > 0).map(line => parseLogLine(line, podSet, containerSet))
+    const lines = logs.split('\n').map(line => line.replace(/\r$/, '')).filter(line => line.length > 0)
+    const parse = (line) => parseLogLine(line, podSet, containerSet)
+
+    // The parse regime is keyed by the tagging signals; `gen` (fetchGenRef, bumped
+    // only on a non-append fetch) is the replace signal. A change in either means
+    // the buffer was rebuilt, not appended, so the prior mirror can't be trusted
+    // and every line re-parses. Otherwise reconcileEntries reuses the cached
+    // entries for unchanged lines and parses only the appended tail. Reading the
+    // ref here (not via deps) is safe because Preact's useMemo recomputes only on a
+    // dep change, and an append is the only same-gen/same-key mutation of `logs`.
+    const cache = parsedRef.current
+    const gen = fetchGenRef.current
+    const key = `${tagged}|${reqPodsStr}|${containerTagged}|${reqContainersStr}`
+    const entries = (cache.key !== key || cache.gen !== gen)
+      ? lines.map(parse)
+      : reconcileEntries(cache.lines, cache.entries, lines, parse)
+    // Mirror the arrival-order parse before the derived sort below, so the next poll
+    // diffs against the unsorted buffer. The sort returns a fresh array and never
+    // mutates these entries.
+    parsedRef.current = { key, gen, lines, entries }
 
     // In all-pods each pod advances its own `since` cursor, so a lagging pod can
     // deliver a line older than another's buffered tail; in arrival order the buffer
@@ -832,16 +924,18 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // folded (click to expand), a burst renders all its lines under one timestamp pill.
   const grouping = formatted
 
-  // Format each base line once, before grouping, so a line's `fmt` descriptor and
-  // its `structured` flag (whether the format layer recognizes it) are known when
-  // groupEntries decides whether to join an unstructured burst. In formatted mode a
-  // line gains { code, fmt, structured }; raw mode passes baseLines through (no fmt,
-  // structured irrelevant — grouping is off, LogLineBody falls through to plain).
+  // Format each base line once, before grouping, so a line's `level`, `fmt`
+  // descriptor, and `structured` flag are known when groupEntries decides whether to
+  // join an unstructured burst. Level is detected HERE (formatted mode only), not in
+  // parseLogLine: raw mode is verbatim with no level semantics, so it skips
+  // detectLevel entirely. In formatted mode a line gains { level, code, fmt,
+  // structured }; raw mode passes baseLines through (no level/fmt — grouping is off,
+  // the level filter/legend are hidden, LogLineBody falls through to plain).
   //
   // Cached by raw line text (formatCacheRef): an append reuses cached results and
-  // only formats the new lines. The cache is rebuilt over the whole base buffer
-  // (≤ MAX_BUFFER_LINES), so it can't outgrow it; raw mode leaves it untouched so it
-  // survives a round-trip back to formatted.
+  // only parses+formats the new lines. The cache is rebuilt over the whole base
+  // buffer (≤ MAX_BUFFER_LINES), so it can't outgrow it; raw mode leaves it untouched
+  // so it survives a round-trip back to formatted.
   const formattedLines = useMemo(() => {
     if (!formatted) return baseLines
     const prev = formatCacheRef.current
@@ -853,8 +947,9 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
       const key = `${entry.ts ? 1 : 0}\n${entry.text}`
       let f = next.get(key) || prev.get(key)
       if (!f) {
+        const level = detectLevel(entry.text)
         const json = highlightJson(entry.text)
-        const d = json || (entry.ts ? decorateLine(entry.text, entry.level) : { kind: 'plain' })
+        const d = json || (entry.ts ? decorateLine(entry.text, level) : { kind: 'plain' })
         // `structured` (whether the burst grouper treats the line as a real log
         // entry vs structure-less noise) is true when the format layer decorates it,
         // OR when a level was detected even though decorateLine fell through to
@@ -862,10 +957,10 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
         // line like `[main] DEBUG com.x - msg` renders plain (no leading digit for
         // parseJava) but detectLevel finds `debug`, so it is not swept into a burst.
         // A curl -v dump carries no level (default info), so it still groups.
-        const leveled = entry.level !== DEFAULT_LEVEL
+        const leveled = level !== DEFAULT_LEVEL
         f = d.kind === 'plain'
-          ? { code: true, fmt: null, structured: leveled }
-          : { code: false, fmt: d, structured: true }
+          ? { level, code: true, fmt: null, structured: leveled }
+          : { level, code: false, fmt: d, structured: true }
       }
       next.set(key, f)
       return { ...entry, ...f }
@@ -938,11 +1033,17 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
 
   // Apply the level filter on top of the contains filter (exact group-level match).
   // Lines already carry their fmt/code from formattedLines, so this is the final set
-  // the render maps — no separate formatting pass.
+  // the render maps — no separate formatting pass. The filter is forced to "all" in
+  // raw mode (which carries no level): a setLevelFilter('all') effect resets the
+  // state, but deriving the effective level here too closes the one-frame window
+  // where the toggle has flipped to raw before that effect runs — otherwise a
+  // lingering 'warn' filter would blank the raw list for a frame (no group has a
+  // level), flashing "No matching log entries".
+  const effectiveLevel = formatted ? levelFilter : 'all'
   const logGroups = useMemo(() => {
-    if (levelFilter === 'all') return containsGroups
-    return containsGroups.filter(g => g.level === levelFilter)
-  }, [containsGroups, levelFilter])
+    if (effectiveLevel === 'all') return containsGroups
+    return containsGroups.filter(g => g.level === effectiveLevel)
+  }, [containsGroups, effectiveLevel])
 
   // Briefly highlight the most recent visible entry when new entries arrive (e.g.
   // while following). Gated on two conditions so it only signals fresh logs: the raw
@@ -1117,8 +1218,9 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
             title="Filter by keyword (prefix with ! to exclude e.g. !debug)"
           />
 
-          {/* Minimum level filter */}
-          <LevelMenu value={levelFilter} onChange={setLevelFilter} />
+          {/* Minimum level filter. Formatted mode only — raw is verbatim with no
+              level semantics, so the filter is hidden (and reset to "all"). */}
+          {formatted && <LevelMenu value={levelFilter} onChange={setLevelFilter} />}
 
           {/* Lines select */}
           <select
@@ -1233,7 +1335,8 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
           )}
         </div>
 
-        {/* Footer: a per-level count summary doubling as the color legend. The
+        {/* Footer: in formatted mode a per-level count summary doubling as the
+            color legend; in raw mode (no level semantics) a plain line count. The
             trailing corner shows the fetch loader while a request is in flight,
             else the live/snapshot mode. */}
         <div
@@ -1241,14 +1344,20 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
           data-testid="logs-footer"
         >
           <div class="flex flex-wrap items-center gap-x-3 gap-y-1 min-w-0">
-            <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-600 dark:text-gray-400" data-testid="logs-level-summary">
-              {LEVELS.filter(l => levelCounts[l]).map((l) => (
-                <span key={l} class="inline-flex items-center gap-1" title={`${LEVEL_META[l].label}: ${levelCounts[l]}`}>
-                  <span class={`w-2 h-2 rounded-full ${LEVEL_META[l].swatch}`} />
-                  {LEVEL_META[l].label} {levelCounts[l]}
-                </span>
-              ))}
-            </div>
+            {formatted ? (
+              <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-600 dark:text-gray-400" data-testid="logs-level-summary">
+                {LEVELS.filter(l => levelCounts[l]).map((l) => (
+                  <span key={l} class="inline-flex items-center gap-1" title={`${LEVEL_META[l].label}: ${levelCounts[l]}`}>
+                    <span class={`w-2 h-2 rounded-full ${LEVEL_META[l].swatch}`} />
+                    {LEVEL_META[l].label} {levelCounts[l]}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <span class="text-xs text-gray-600 dark:text-gray-400" data-testid="logs-line-count">
+                {logGroups.length} log line{logGroups.length === 1 ? '' : 's'}
+              </span>
+            )}
             {/* Partial-coverage note: all-pods didn't cover every pod (forbidden,
                 missing) or the fan-out was capped. The pod-count phrasing shows only
                 when pods were dropped; a pure cap reads as "results truncated" to

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -1,6 +1,7 @@
 // Copyright 2026 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
+import { Fragment } from 'preact'
 import { useState, useEffect, useCallback, useMemo, useRef } from 'preact/hooks'
 import { fetchWithMock } from '../../../utils/fetch'
 import { downloadBlob } from '../../../utils/download'
@@ -17,10 +18,10 @@ const FOLLOW_INTERVAL = 5000
 // How long the most recent log line stays highlighted after new entries arrive.
 const HIGHLIGHT_DURATION = 2500
 
-// Matches the leading RFC3339 timestamp the API prepends to each log line.
+// Captures the leading RFC3339 timestamp the API prepends to each log line.
 // Anchored to a date so lines without a timestamp (e.g. stack-trace
-// continuations) are not mangled by stripping their first token.
-const TIMESTAMP_PREFIX = /^\d{4}-\d{2}-\d{2}T\S+\s+/
+// continuations) are not mangled by splitting off their first token.
+const TIMESTAMP_PREFIX = /^(\d{4}-\d{2}-\d{2}T\S+)\s+/
 
 // Shared styling for the toolbar controls. Selects deliberately omit a chevron
 // and right padding: those come from the global `select` rule in index.css.
@@ -64,15 +65,16 @@ function ToggleButton({ active, onClick, label, title, testid, children }) {
  * WorkloadLogsViewer - Modal that displays the logs of a pod container.
  *
  * Fetches logs from GET /api/v1/workload/logs for the selected container and
- * renders each log entry on its own separated row. Supports following (live
- * polling), filtering by substring, choosing the number of lines, viewing the
- * previous container instance, toggling timestamps, downloading the logs as a
- * <pod>.log file, and a fullscreen mode.
+ * renders each log entry on its own row, with its timestamp shown as a pill on
+ * the row separator. Supports following (live polling), filtering by substring,
+ * choosing the number of lines, selecting a container (restarted containers
+ * also expose a "(previous)" entry for the prior instance's logs), downloading
+ * the logs as a <pod>.log file, and a fullscreen mode.
  *
  * @param {Object} props
  * @param {string} props.namespace - Pod namespace
  * @param {string} props.name - Pod name
- * @param {Array<{name: string, isInit: boolean}>} props.containers - Pod containers
+ * @param {Array<{name: string, isInit: boolean, restartCount?: number}>} props.containers - Pod containers
  * @param {Function} props.onClose - Callback to close the viewer
  */
 export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }) {
@@ -84,7 +86,6 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
   const [tailLines, setTailLines] = useState(DEFAULT_TAIL_LINES)
   const [follow, setFollow] = useState(true)
   const [filter, setFilter] = useState('')
-  const [showTimestamps, setShowTimestamps] = useState(false)
   const [fullScreen, setFullScreen] = useState(false)
   const [logs, setLogs] = useState('')
   const [loading, setLoading] = useState(false)
@@ -94,10 +95,27 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
   const bodyRef = useRef(null)
   const prevLogsRef = useRef('')
 
-  const fetchLogs = useCallback(async () => {
+  // One option per container, plus a "(previous)" option for containers that
+  // have restarted (a previous instance only has logs after a restart). The
+  // value encodes both the container and whether to read the previous instance.
+  const containerOptions = useMemo(() => {
+    const opts = []
+    for (const c of containers) {
+      const base = c.isInit ? `init:${c.name}` : c.name
+      opts.push({ key: `${c.name}::false`, label: base, container: c.name, previous: false })
+      if ((c.restartCount || 0) > 0) {
+        opts.push({ key: `${c.name}::true`, label: `${base} (previous)`, container: c.name, previous: true })
+      }
+    }
+    return opts
+  }, [containers])
+
+  // Fetch the logs. Background follow-polls pass { silent: true } so they don't
+  // toggle the loading spinner, which would flicker on every poll; only the
+  // initial load and user-driven changes (container, line count) show it.
+  const fetchLogs = useCallback(async ({ silent = false } = {}) => {
     if (!container) return
-    setLoading(true)
-    setError(null)
+    if (!silent) setLoading(true)
     try {
       const params = new URLSearchParams({
         namespace,
@@ -112,11 +130,12 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
         mockExport: 'getMockWorkloadLogs'
       })
       setLogs(resp?.logs || '')
+      setError(null)
     } catch (err) {
       setError(err.message)
       setLogs('')
     } finally {
-      setLoading(false)
+      if (!silent) setLoading(false)
     }
   }, [namespace, name, container, tailLines, previous])
 
@@ -125,10 +144,10 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     fetchLogs()
   }, [fetchLogs])
 
-  // Poll for new logs while following.
+  // Poll for new logs while following, silently so the spinner doesn't flicker.
   useEffect(() => {
     if (!follow) return
-    const id = setInterval(() => { fetchLogs() }, FOLLOW_INTERVAL)
+    const id = setInterval(() => { fetchLogs({ silent: true }) }, FOLLOW_INTERVAL)
     return () => clearInterval(id)
   }, [follow, fetchLogs])
 
@@ -161,24 +180,27 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     return () => clearTimeout(id)
   }, [logs])
 
-  // Split the raw payload into entries once, stripping timestamps for display
-  // unless they are shown. This only re-runs when the payload or the timestamp
-  // toggle changes, not on every filter keystroke.
+  // Split the raw payload into entries once, separating the leading timestamp
+  // from the message so the timestamp can be shown as a separator pill while
+  // the message occupies the row. Only re-runs when the payload changes, not on
+  // every filter keystroke.
   const baseLines = useMemo(() => {
-    const lines = logs.split('\n').filter(line => line.length > 0)
-    return showTimestamps ? lines : lines.map(line => line.replace(TIMESTAMP_PREFIX, ''))
-  }, [logs, showTimestamps])
+    return logs.split('\n').filter(line => line.length > 0).map(line => {
+      const m = line.match(TIMESTAMP_PREFIX)
+      return m ? { ts: m[1], text: line.slice(m[0].length) } : { ts: '', text: line }
+    })
+  }, [logs])
 
-  // Apply the substring filter; cheap pass over the already-split lines. A
-  // leading "!" negates the match, keeping only lines that do NOT contain the
-  // text (e.g. "!debug" hides every line mentioning debug).
+  // Apply the substring filter on the message text; cheap pass over the
+  // already-split entries. A leading "!" negates the match, keeping only lines
+  // that do NOT contain the text (e.g. "!debug" hides every line mentioning debug).
   const logLines = useMemo(() => {
     const raw = filter.trim()
     if (!raw) return baseLines
     const negate = raw.startsWith('!')
     const needle = (negate ? raw.slice(1) : raw).trim().toLowerCase()
     if (!needle) return baseLines
-    return baseLines.filter(line => line.toLowerCase().includes(needle) !== negate)
+    return baseLines.filter(entry => entry.text.toLowerCase().includes(needle) !== negate)
   }, [baseLines, filter])
 
   // Keep the most recent entry in view after each update.
@@ -209,7 +231,7 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
         data-testid="logs-viewer"
       >
         {/* Header */}
-        <div class="flex items-center justify-between gap-2 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <div class="flex items-center justify-between gap-2 px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
           <div class="min-w-0">
             <h2 class="text-sm font-semibold text-gray-900 dark:text-white truncate">Logs</h2>
             <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{namespace}/{name}</p>
@@ -227,7 +249,7 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
         </div>
 
         {/* Toolbar */}
-        <div class="flex items-center flex-wrap gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+        <div class="flex items-center flex-wrap gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
           {/* Follow logs */}
           <ToggleButton
             active={follow}
@@ -240,18 +262,26 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             </svg>
           </ToggleButton>
 
-          {/* Container select (always shown). Fixed width so a long container
-              name is trimmed instead of pushing the rest of the toolbar. */}
+          {/* Container select (always shown). Containers that have restarted
+              also expose a "(previous)" entry for the prior instance's logs.
+              Fixed width so a long container name is trimmed instead of pushing
+              the rest of the toolbar. */}
           <select
-            value={container}
-            onChange={(e) => setContainer(e.target.value)}
+            value={`${container}::${previous}`}
+            onChange={(e) => {
+              const opt = containerOptions.find(o => o.key === e.target.value)
+              if (opt) {
+                setContainer(opt.container)
+                setPrevious(opt.previous)
+              }
+            }}
             class={`${SELECT_CLASS} w-28 sm:w-40 truncate`}
             data-testid="logs-container-select"
             aria-label="Container"
-            title="Select container"
+            title="Select container (a previous entry reads the prior instance's logs)"
           >
-            {containers.map((c) => (
-              <option key={c.name} value={c.name}>{c.isInit ? `init:${c.name}` : c.name}</option>
+            {containerOptions.map((o) => (
+              <option key={o.key} value={o.key}>{o.label}</option>
             ))}
           </select>
 
@@ -267,19 +297,6 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             title="Keep lines containing this text; prefix with ! to exclude (e.g. !debug)"
           />
 
-          {/* Previous container instance */}
-          <ToggleButton
-            active={previous}
-            onClick={() => setPrevious(v => !v)}
-            label="Previous container instance"
-            title="Show logs from the previous container instance"
-            testid="logs-previous-toggle"
-          >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
-            </svg>
-          </ToggleButton>
-
           {/* Lines select */}
           <select
             value={tailLines}
@@ -293,18 +310,6 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
               <option key={n} value={n}>{n} ln</option>
             ))}
           </select>
-
-          {/* Timestamps show/hide */}
-          <ToggleButton
-            active={showTimestamps}
-            onClick={() => setShowTimestamps(v => !v)}
-            label="Show or hide timestamps"
-            testid="logs-timestamps-toggle"
-          >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          </ToggleButton>
 
           {/* Actions */}
           <div class="flex items-center gap-1 ml-auto">
@@ -342,7 +347,7 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
         </div>
 
         {/* Body */}
-        <div ref={bodyRef} class="flex-1 overflow-auto overscroll-contain bg-gray-50 dark:bg-gray-950" data-testid="logs-body">
+        <div ref={bodyRef} class="flex-1 overflow-auto overscroll-contain bg-white dark:bg-gray-950" data-testid="logs-body">
           {error ? (
             <div class="m-3 p-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-xs text-red-800 dark:text-red-200" data-testid="logs-error">
               {error}
@@ -350,22 +355,32 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
           ) : loading && !logs ? (
             <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-loading">Loading logs...</p>
           ) : logLines.length > 0 ? (
-            <div class="divide-y divide-gray-200 dark:divide-gray-800" data-testid="logs-content">
-              {logLines.map((line, i) => {
+            <div class="pb-2" data-testid="logs-content">
+              {logLines.map((entry, i) => {
                 const isLatest = flashLatest && i === logLines.length - 1
                 return (
-                  <div
-                    key={i}
-                    class={`px-3 py-1 text-sm font-mono whitespace-pre-wrap break-all transition-colors duration-1000 ${
-                      isLatest
-                        ? 'bg-blue-100 dark:bg-blue-900/40 text-gray-900 dark:text-gray-100'
-                        : 'text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-900'
-                    }`}
-                    data-testid="logs-line"
-                    data-latest={isLatest ? 'true' : undefined}
-                  >
-                    {line}
-                  </div>
+                  <Fragment key={i}>
+                    {entry.ts && (
+                      <div class="flex items-center gap-2 px-3 pt-2 select-none" data-testid="logs-timestamp" data-latest={isLatest ? 'true' : undefined}>
+                        <span
+                          class={`text-[10px] font-mono px-1.5 py-0.5 rounded-full transition-colors duration-1000 ${
+                            isLatest
+                              ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+                              : 'bg-gray-200 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+                          }`}
+                        >
+                          {entry.ts}
+                        </span>
+                        <span class="flex-1 border-t border-gray-200 dark:border-gray-800" />
+                      </div>
+                    )}
+                    <div
+                      class="px-3 py-1 text-sm font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-900"
+                      data-testid="logs-line"
+                    >
+                      {entry.text}
+                    </div>
+                  </Fragment>
                 )
               })}
             </div>
@@ -374,6 +389,22 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
               {filter.trim() ? 'No matching log entries' : 'No logs available'}
             </p>
           )}
+        </div>
+
+        {/* Footer showing the current line count, with a loader to its left
+            while a fetch is in flight. */}
+        <div
+          class="flex items-center justify-center gap-2 px-4 py-2 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800"
+          data-testid="logs-footer"
+        >
+          {loading && (
+            <div
+              class="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-400"
+              data-testid="logs-loader"
+              aria-label="Loading logs"
+            />
+          )}
+          <span class="text-xs text-gray-500 dark:text-gray-400">{logLines.length} lines</span>
         </div>
       </div>
     </div>

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -169,11 +169,16 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     return showTimestamps ? lines : lines.map(line => line.replace(TIMESTAMP_PREFIX, ''))
   }, [logs, showTimestamps])
 
-  // Apply the substring filter; cheap pass over the already-split lines.
+  // Apply the substring filter; cheap pass over the already-split lines. A
+  // leading "!" negates the match, keeping only lines that do NOT contain the
+  // text (e.g. "!debug" hides every line mentioning debug).
   const logLines = useMemo(() => {
-    const needle = filter.trim().toLowerCase()
+    const raw = filter.trim()
+    if (!raw) return baseLines
+    const negate = raw.startsWith('!')
+    const needle = (negate ? raw.slice(1) : raw).trim().toLowerCase()
     if (!needle) return baseLines
-    return baseLines.filter(line => line.toLowerCase().includes(needle))
+    return baseLines.filter(line => line.toLowerCase().includes(needle) !== negate)
   }, [baseLines, filter])
 
   // Keep the most recent entry in view after each update.
@@ -243,6 +248,7 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             class={`${SELECT_CLASS} w-28 sm:w-40 truncate`}
             data-testid="logs-container-select"
             aria-label="Container"
+            title="Select container"
           >
             {containers.map((c) => (
               <option key={c.name} value={c.name}>{c.isInit ? `init:${c.name}` : c.name}</option>
@@ -258,6 +264,7 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             class={`${INPUT_CLASS} w-28 sm:w-40`}
             data-testid="logs-filter-input"
             aria-label="Filter log lines containing text"
+            title="Keep lines containing this text; prefix with ! to exclude (e.g. !debug)"
           />
 
           {/* Previous container instance */}
@@ -280,6 +287,7 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             class={SELECT_CLASS}
             data-testid="logs-lines-select"
             aria-label="Number of lines"
+            title="Number of log lines to fetch"
           >
             {LINE_LIMITS.map((n) => (
               <option key={n} value={n}>{n} ln</option>
@@ -300,18 +308,6 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
 
           {/* Actions */}
           <div class="flex items-center gap-1 ml-auto">
-            <button
-              onClick={fetchLogs}
-              disabled={loading}
-              class={ACTION_CLASS}
-              title="Refresh logs"
-              aria-label="Refresh logs"
-              data-testid="logs-refresh-button"
-            >
-              <svg class={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-              </svg>
-            </button>
             <button
               onClick={handleDownload}
               disabled={!logs}

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -7,8 +7,7 @@ import { downloadBlob } from '../../../utils/download'
 import { LEVELS, LEVEL_META, DEFAULT_LEVEL, detectLevel, stripAnsi } from '../../../utils/logLevel'
 import { decorateLine, highlightJson } from '../../../utils/logFormat'
 import { groupEntries } from '../../../utils/logGroup'
-import { useDismiss } from '../../../utils/useDismiss'
-import { logSettings, LINE_LIMITS } from '../../../utils/logSettings'
+import { logSettings, TAIL_LINES, FONT_SIZES } from '../../../utils/logSettings'
 
 // Sentinel option key for the "All containers" view, which streams every
 // container (init and regular) and interleaves the lines chronologically.
@@ -75,6 +74,28 @@ function mergeLogs(prev, incoming) {
   const merged = prevLines.concat(fresh)
   const capped = merged.length > MAX_BUFFER_LINES ? merged.slice(merged.length - MAX_BUFFER_LINES) : merged
   return capped.join('\n') + '\n'
+}
+
+/**
+ * countNewEntries - counts how many logical log entries an incoming follow payload
+ * adds to the buffer. An entry is a timestamped HEAD line (continuation lines such
+ * as stack frames carry no timestamp and fold into their head, so they aren't
+ * counted). Dedup mirrors mergeLogs: a head already buffered is a re-send, not a
+ * new entry. Used to show a transient "+N new" indicator after a poll appends.
+ *
+ * @param {string} prev - The accumulated log payload before the append
+ * @param {string} incoming - The newly fetched log payload
+ * @returns {number} The number of new entries the append introduces
+ */
+function countNewEntries(prev, incoming) {
+  const add = incoming.split('\n').filter(Boolean)
+  if (add.length === 0) return 0
+  const seen = new Set(prev.split('\n').filter(Boolean))
+  let count = 0
+  for (const line of add) {
+    if (entryTimestamp(line) && !seen.has(line)) count++
+  }
+  return count
 }
 
 // Captures the leading RFC3339 timestamp the API prepends to each log line.
@@ -239,80 +260,65 @@ function ToggleButton({ active, onClick, label, title, testid, disabled, childre
   )
 }
 
-// Button styled like the toolbar selects, but for a custom dropdown (a native
-// <select> can't render the per-level color swatches).
-const LEVEL_BUTTON_CLASS = `${FIELD_CLASS} px-2 inline-flex items-center gap-1.5`
-
-// Level filter options: "All levels" plus one entry per level. Constant.
-const LEVEL_OPTIONS = [
-  { value: 'all', label: 'All levels', swatch: null },
-  ...LEVELS.map((l) => ({ value: l, label: LEVEL_META[l].label, swatch: LEVEL_META[l].swatch }))
-]
-
 /**
- * LevelMenu - log-level filter. A custom dropdown (not a native select) so each
- * option can show its level color swatch. Selecting a level shows only entries
- * of that exact level; "All levels" disables the filter.
+ * ToggleGroup - a labelled segmented control in the settings panel. One button
+ * per option, the selected one highlighted; clicking calls onChange with its
+ * value. Used for both the tail-lines and font-size settings.
  *
  * @param {Object} props
- * @param {string} props.value - Current level, or 'all'
+ * @param {string} props.label - Row label and group aria-label
+ * @param {Array<{value: any, label: string, testid: string}>} props.options - The choices
+ * @param {any} props.value - The currently selected option value
  * @param {Function} props.onChange - Called with the chosen value
+ * @param {string} props.testid - data-testid for the group container
  */
-function LevelMenu({ value, onChange }) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef(null)
-
-  useDismiss(ref, () => setOpen(false), open)
-
-  const current = LEVEL_OPTIONS.find(o => o.value === value) || LEVEL_OPTIONS[0]
-
+function ToggleGroup({ label, options, value, onChange, testid }) {
   return (
-    <div class="relative flex-1 min-w-0 sm:flex-none sm:w-auto" ref={ref}>
-      <button
-        type="button"
-        onClick={() => setOpen(v => !v)}
-        class={`${LEVEL_BUTTON_CLASS} w-full justify-between sm:w-auto`}
-        data-testid="logs-level-filter"
-        aria-label="Log level"
-        aria-expanded={open}
-        title="Show only logs of this level"
+    <div class="flex items-center gap-3">
+      <span class="text-xs font-medium text-gray-600 dark:text-gray-300 w-20 flex-shrink-0">{label}</span>
+      <div
+        class="flex w-60 max-w-full rounded-md border border-gray-300 dark:border-gray-600 overflow-hidden"
+        role="group"
+        aria-label={label}
+        data-testid={testid}
       >
-        {current.swatch && <span class={`w-2 h-2 rounded-full ${current.swatch}`} />}
-        <span class="flex-1 text-left sm:flex-none">{current.label}</span>
-        <svg class="w-3 h-3 ml-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
-      {open && (
-        <div
-          class="absolute left-0 mt-1 w-full sm:w-36 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50"
-          data-testid="logs-level-menu"
-        >
-          {LEVEL_OPTIONS.map((o) => (
-            <button
-              key={o.value}
-              type="button"
-              onClick={() => { onChange(o.value); setOpen(false) }}
-              class={`w-full px-2 py-1 text-left text-xs inline-flex items-center gap-2 hover:bg-gray-100 dark:hover:bg-gray-700 ${
-                o.value === value ? 'font-semibold text-gray-900 dark:text-gray-100' : 'text-gray-700 dark:text-gray-300'
-              }`}
-              data-testid={`logs-level-option-${o.value}`}
-            >
-              <span class={`w-2 h-2 rounded-full flex-shrink-0 ${o.swatch || 'border border-gray-400 dark:border-gray-500'}`} />
-              {o.label}
-            </button>
-          ))}
-        </div>
-      )}
+        {options.map((o, i) => (
+          <button
+            key={o.value}
+            type="button"
+            onClick={() => onChange(o.value)}
+            class={`flex-1 px-3 py-1 text-xs text-center focus:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue focus-visible:ring-inset ${
+              i > 0 ? 'border-l border-gray-300 dark:border-gray-600' : ''
+            } ${
+              value === o.value
+                ? 'bg-flux-blue text-white'
+                : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600'
+            }`}
+            data-testid={o.testid}
+            aria-pressed={value === o.value}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
     </div>
   )
 }
+
+// Level filter options for the native select: "All levels" plus one entry per
+// level. Constant.
+const LEVEL_OPTIONS = [
+  { value: 'all', label: 'All levels' },
+  ...LEVELS.map((l) => ({ value: l, label: LEVEL_META[l].label }))
+]
 
 // Shared monospace body styling for a formatted log line: a horizontally
 // scrollable, wrapping row. The block/spans/plain-code variants share it; the
 // JSON <pre> reuses the style with a margin reset.
 const LINE_CLASS = 'overflow-x-auto font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200'
-const LINE_STYLE = 'padding: 0.25rem 0.75rem; font-size: 12px; line-height: 1.5;'
+// font-size is driven by the --logs-font-size CSS variable set on the log body
+// container from the persisted font-size setting, falling back to 12px.
+const LINE_STYLE = 'padding: 0.25rem 0.75rem; font-size: var(--logs-font-size, 12px); line-height: 1.5;'
 
 /**
  * LogLineBody - renders the formatted body of one log line: a structured block,
@@ -369,7 +375,8 @@ function LogLineBody({ entry }) {
   }
   return (
     <div
-      class="px-3 py-0.5 text-sm font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
+      class="px-3 py-0.5 font-mono whitespace-pre-wrap break-all text-gray-800 dark:text-gray-200"
+      style="font-size: var(--logs-font-size, 12px); line-height: 1.5;"
       data-testid="logs-line"
     >
       {entry.text}
@@ -604,6 +611,12 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   const [filter, setFilter] = useState('')
   const [levelFilter, setLevelFilter] = useState('all')
   const [formatted, setFormatted] = useState(() => logSettings.peek().formatted)
+  // Monospace font size for the log body, seeded from the persisted setting and
+  // applied via the --logs-font-size CSS variable on the body container.
+  const [fontSize, setFontSize] = useState(() => logSettings.peek().fontSize)
+  // Whether the settings panel (tail-lines slider, font size) is expanded below
+  // the toolbar. Local to the session, not persisted.
+  const [showSettings, setShowSettings] = useState(false)
   const [fullScreen, setFullScreen] = useState(false)
   const [logs, setLogs] = useState('')
   const [loading, setLoading] = useState(false)
@@ -612,6 +625,9 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
   // stays visible. The full-pane `error` is used only when there is no buffer.
   const [followError, setFollowError] = useState(null)
   const [flashLatest, setFlashLatest] = useState(false)
+  // Number of entries the most recent follow poll appended, shown as a clickable
+  // "+N new" indicator until the next poll replaces the count (zero hides it).
+  const [appendedCount, setAppendedCount] = useState(0)
   // Whether the current buffer's lines are pod-tagged and/or container-tagged (set
   // from the response, so the parser never has to guess the wire format). Pod
   // tagging marks the all-pods view, container tagging the all-containers view;
@@ -624,6 +640,9 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
 
   const bodyRef = useRef(null)
   const prevLogsRef = useRef('')
+  // Mirror of the current `logs` buffer, so a follow poll can count the entries it
+  // appends against the live buffer without listing `logs` in fetchLogs' deps.
+  const logsRef = useRef('')
   // Identity (timestamp + text) of the most recent visible line, so the
   // new-entry highlight fires only when that line actually changes.
   const prevLatestKeyRef = useRef(null)
@@ -755,8 +774,15 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
       if (fetchGenRef.current !== gen) return
       const incoming = resp?.logs || ''
       if (append) {
+        // Count the new entries against the live buffer before merging, so the
+        // "+N new" indicator reflects what this poll appended. It's set on every
+        // poll (0 hides it), so the count persists until the next refresh replaces it.
+        const added = countNewEntries(logsRef.current, incoming)
         setLogs(prev => mergeLogs(prev, incoming))
+        setAppendedCount(added)
       } else {
+        // A reset replaces the buffer; no "appended" count applies.
+        setAppendedCount(0)
         setLogs(incoming)
       }
       // The response states whether its lines are pod-tagged and how many requested
@@ -808,14 +834,14 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     if (!formatted) setLevelFilter('all')
   }, [formatted])
 
-  // Persist the follow/formatted/tailLines settings so they carry across sessions.
-  // The signal's own effect writes them to localStorage. On mount this writes the
-  // seeded values back (a redundant but harmless write of identical content). The
-  // component seeds via peek() and never reads the signal reactively, so writing it
-  // here cannot re-render the viewer or feed back into this effect.
+  // Persist the follow/formatted/tailLines/fontSize settings so they carry across
+  // sessions. The signal's own effect writes them to localStorage. On mount this
+  // writes the seeded values back (a redundant but harmless write of identical
+  // content). The component seeds via peek() and never reads the signal reactively,
+  // so writing it here cannot re-render the viewer or feed back into this effect.
   useEffect(() => {
-    logSettings.value = { follow, formatted, tail: tailLines }
-  }, [follow, formatted, tailLines])
+    logSettings.value = { follow, formatted, tail: tailLines, fontSize }
+  }, [follow, formatted, tailLines, fontSize])
 
   // Poll for new logs while following: silent (no spinner flicker) and appending
   // (visible lines stay put).
@@ -1074,6 +1100,10 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
     return () => clearTimeout(id)
   }, [logs, logGroups])
 
+  // Keep logsRef in sync with the buffer so a follow poll can diff its append
+  // against the live buffer (fetchLogs intentionally omits `logs` from its deps).
+  useEffect(() => { logsRef.current = logs }, [logs])
+
   // Track whether the view is pinned to the bottom. Updated on every user
   // scroll so the auto-scroll below only follows new entries when the user is
   // already at the bottom; scrolling up to read older logs stops the next poll
@@ -1103,6 +1133,13 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
 
   // Download the current logs as a text file, named after the pod for a single
   // pod or the workload for the all-pods view.
+  // Resolve the selected font-size key to its pixel value for the CSS variable,
+  // defaulting to medium if a stale key somehow slips through.
+  const fontSizePx = useMemo(
+    () => (FONT_SIZES.find(f => f.key === fontSize) || FONT_SIZES[1]).px,
+    [fontSize]
+  )
+
   const downloadName = allPods ? (workloadName || 'workload') : effectivePodKey
   const handleDownload = useCallback(() => {
     downloadBlob(new window.Blob([logs], { type: 'text/plain' }), `${downloadName}.log`)
@@ -1178,20 +1215,20 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
               </svg>
             </ToggleButton>
 
-            {/* Lines select — shares row 1 with the toggles and the filter. Sized to
-                its content (the contains filter takes the remaining width). */}
-            <select
-              value={tailLines}
-              onChange={(e) => setTailLines(Number(e.target.value))}
-              class={`${SELECT_CLASS} shrink-0 sm:w-auto`}
-              data-testid="logs-lines-select"
-              aria-label="Number of lines"
-              title="Number of log lines to fetch"
+            {/* Settings — expands a panel below the toolbar with the tail-lines
+                slider and the font size toggle group. */}
+            <ToggleButton
+              active={showSettings}
+              onClick={() => setShowSettings(v => !v)}
+              label="Log settings"
+              title="Tail lines and font size"
+              testid="logs-settings-toggle"
             >
-              {LINE_LIMITS.map((n) => (
-                <option key={n} value={n}>{n} ln</option>
-              ))}
-            </select>
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 0 1 1.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.894.149c-.424.07-.764.383-.929.78-.165.398-.143.854.107 1.204l.527.738c.32.447.27 1.06-.12 1.45l-.774.773a1.125 1.125 0 0 1-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.27-1.45-.12l-.773-.774a1.125 1.125 0 0 1-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.893-.15c-.543-.09-.94-.56-.94-1.109v-1.094c0-.55.397-1.02.94-1.11l.894-.149c.424-.07.764-.383.929-.78.165-.398.143-.854-.107-1.204l-.527-.738a1.125 1.125 0 0 1 .12-1.45l.773-.773a1.125 1.125 0 0 1 1.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894Z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+              </svg>
+            </ToggleButton>
 
             {/* Separator (desktop only) between the view controls and the filter. */}
             <div class="hidden sm:block w-px h-5 bg-gray-300 dark:bg-gray-600" />
@@ -1248,7 +1285,20 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
 
             {/* Minimum level filter. Formatted mode only — raw is verbatim with no
                 level semantics, so the filter is hidden (and reset to "all"). */}
-            {formatted && <LevelMenu value={levelFilter} onChange={setLevelFilter} />}
+            {formatted && (
+              <select
+                value={levelFilter}
+                onChange={(e) => setLevelFilter(e.target.value)}
+                class={`${SELECT_CLASS} flex-1 min-w-0 truncate sm:flex-none sm:w-40`}
+                data-testid="logs-level-filter"
+                aria-label="Log level"
+                title="Show only logs of this level"
+              >
+                {LEVEL_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            )}
           </div>
 
           {/* Actions (desktop only): download + fullscreen are hidden on mobile,
@@ -1289,8 +1339,33 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
           </div>
         </div>
 
+        {/* Settings panel: expands below the toolbar with the tail-lines slider and
+            the font size toggle group. Both apply on the spot and persist via the
+            settings effect above. */}
+        {showSettings && (
+          <div
+            class="flex flex-col gap-3 px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800"
+            data-testid="logs-settings-panel"
+          >
+            <ToggleGroup
+              label="Tail lines"
+              testid="logs-tail-group"
+              value={tailLines}
+              onChange={setTailLines}
+              options={TAIL_LINES.map(n => ({ value: n, label: n >= 1000 ? `${n / 1000}K` : String(n), testid: `logs-tail-${n}` }))}
+            />
+            <ToggleGroup
+              label="Font size"
+              testid="logs-fontsize-group"
+              value={fontSize}
+              onChange={setFontSize}
+              options={FONT_SIZES.map(f => ({ value: f.key, label: f.label, testid: `logs-fontsize-${f.key}` }))}
+            />
+          </div>
+        )}
+
         {/* Body */}
-        <div ref={bodyRef} onScroll={handleScroll} class="flex-1 overflow-auto overscroll-contain bg-white dark:bg-gray-950" data-testid="logs-body">
+        <div ref={bodyRef} onScroll={handleScroll} style={`--logs-font-size: ${fontSizePx}px`} class="flex-1 overflow-auto overscroll-contain bg-white dark:bg-gray-950" data-testid="logs-body">
           {error ? (
             <div class="m-3 p-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-xs text-red-800 dark:text-red-200" data-testid="logs-error">
               {error}
@@ -1392,6 +1467,23 @@ export function WorkloadLogsViewer({ kind, namespace, workloadName, pods = [], i
                   ? `showing ${partial.streamed} of ${partial.total} pods`
                   : 'results truncated'}
               </span>
+            )}
+            {/* Transient indicator of how many entries the last follow poll appended.
+                Clicking jumps to the latest line and re-pins the view to the bottom. */}
+            {appendedCount > 0 && (
+              <button
+                type="button"
+                onClick={scrollToBottom}
+                class="inline-flex items-center gap-1 text-xs font-medium text-flux-blue hover:underline flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue rounded"
+                data-testid="logs-appended-count"
+                aria-live="polite"
+                title="Scroll to latest logs"
+              >
+                <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                </svg>
+                +{appendedCount} new
+              </button>
             )}
           </div>
           {loading ? (

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.jsx
@@ -8,6 +8,8 @@ import 'prismjs/components/prism-json'
 import { fetchWithMock } from '../../../utils/fetch'
 import { downloadBlob } from '../../../utils/download'
 import { usePrismTheme } from '../common/yaml'
+import { LEVELS, LEVEL_META, DEFAULT_LEVEL, detectLevel, stripAnsi } from '../../../utils/logLevel'
+import { useDismiss } from '../../../utils/useDismiss'
 
 // Selectable limits for the number of log lines to fetch from the backend.
 const LINE_LIMITS = [100, 500, 1000, 5000]
@@ -82,16 +84,87 @@ function ToggleButton({ active, onClick, label, title, testid, children }) {
   )
 }
 
+// Button styled like the toolbar selects, but for a custom dropdown (a native
+// <select> can't render the per-level color swatches).
+const LEVEL_BUTTON_CLASS = `${FIELD_CLASS} px-2 inline-flex items-center gap-1.5`
+
+// Level filter options: "All levels" plus one entry per level. Constant.
+const LEVEL_OPTIONS = [
+  { value: 'all', label: 'All levels', swatch: null },
+  ...LEVELS.map((l) => ({ value: l, label: LEVEL_META[l].label, swatch: LEVEL_META[l].swatch }))
+]
+
+/**
+ * LevelMenu - log-level filter. A custom dropdown (not a native select) so each
+ * option can show its level color swatch. Selecting a level shows only entries
+ * of that exact level; "All levels" disables the filter.
+ *
+ * @param {Object} props
+ * @param {string} props.value - Current level, or 'all'
+ * @param {Function} props.onChange - Called with the chosen value
+ */
+function LevelMenu({ value, onChange }) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef(null)
+
+  useDismiss(ref, () => setOpen(false), open)
+
+  const current = LEVEL_OPTIONS.find(o => o.value === value) || LEVEL_OPTIONS[0]
+
+  return (
+    <div class="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        class={LEVEL_BUTTON_CLASS}
+        data-testid="logs-level-filter"
+        aria-label="Log level"
+        aria-expanded={open}
+        title="Show only logs of this level"
+      >
+        {current.swatch && <span class={`w-2 h-2 rounded-full ${current.swatch}`} />}
+        <span>{current.label}</span>
+        <svg class="w-3 h-3 ml-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <div
+          class="absolute left-0 mt-1 w-36 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50"
+          data-testid="logs-level-menu"
+        >
+          {LEVEL_OPTIONS.map((o) => (
+            <button
+              key={o.value}
+              type="button"
+              onClick={() => { onChange(o.value); setOpen(false) }}
+              class={`w-full px-2 py-1 text-left text-xs inline-flex items-center gap-2 hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                o.value === value ? 'font-semibold text-gray-900 dark:text-gray-100' : 'text-gray-700 dark:text-gray-300'
+              }`}
+              data-testid={`logs-level-option-${o.value}`}
+            >
+              <span class={`w-2 h-2 rounded-full flex-shrink-0 ${o.swatch || 'border border-gray-400 dark:border-gray-500'}`} />
+              {o.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 /**
  * WorkloadLogsViewer - Modal that displays the logs of a pod container.
  *
  * Fetches logs from GET /api/v1/workload/logs for the selected container and
  * renders each log entry on its own row, with its timestamp shown as a pill on
- * the row separator. Supports following (live polling), pretty-printing JSON
- * lines, filtering by substring, choosing the number of lines, selecting a
- * container (restarted containers also expose a "(previous)" entry for the
- * prior instance's logs), downloading the logs as a <pod>.log file, and a
- * fullscreen mode.
+ * the row separator. The pill border and rule are colored by the detected log
+ * level (JSON/klog/logfmt/plain text), and the footer summarizes the per-level
+ * counts. Supports following (live polling), pretty-printing JSON lines,
+ * filtering by substring and minimum level, choosing the number of lines,
+ * selecting a container (restarted containers also expose a "(previous)" entry
+ * for the prior instance's logs), downloading the logs as a <pod>.log file, and
+ * a fullscreen mode.
  *
  * @param {Object} props
  * @param {string} props.namespace - Pod namespace
@@ -111,6 +184,7 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
   const [tailLines, setTailLines] = useState(DEFAULT_TAIL_LINES)
   const [follow, setFollow] = useState(true)
   const [filter, setFilter] = useState('')
+  const [levelFilter, setLevelFilter] = useState('all')
   const [prettyJson, setPrettyJson] = useState(false)
   const [fullScreen, setFullScreen] = useState(false)
   const [logs, setLogs] = useState('')
@@ -206,21 +280,22 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     return () => clearTimeout(id)
   }, [logs])
 
-  // Split the raw payload into entries once, separating the leading timestamp
-  // from the message so the timestamp can be shown as a separator pill while
-  // the message occupies the row. Only re-runs when the payload changes, not on
-  // every filter keystroke.
+  // Split the raw payload into entries once: strip the leading timestamp (shown
+  // as a separator pill) and any ANSI escapes from the message, then detect the
+  // log level. Only re-runs when the payload changes, not on every keystroke.
   const baseLines = useMemo(() => {
     return logs.split('\n').filter(line => line.length > 0).map(line => {
       const m = line.match(TIMESTAMP_PREFIX)
-      return m ? { ts: m[1], text: line.slice(m[0].length) } : { ts: '', text: line }
+      const ts = m ? m[1] : ''
+      const text = stripAnsi(m ? line.slice(m[0].length) : line)
+      return { ts, text, level: detectLevel(text) }
     })
   }, [logs])
 
   // Apply the substring filter on the message text; cheap pass over the
   // already-split entries. A leading "!" negates the match, keeping only lines
   // that do NOT contain the text (e.g. "!debug" hides every line mentioning debug).
-  const logLines = useMemo(() => {
+  const containsLines = useMemo(() => {
     const raw = filter.trim()
     if (!raw) return baseLines
     const negate = raw.startsWith('!')
@@ -229,14 +304,29 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
     return baseLines.filter(entry => entry.text.toLowerCase().includes(needle) !== negate)
   }, [baseLines, filter])
 
+  // Per-level counts over the contains-filtered set, before the minimum-level
+  // threshold (so the footer summary shows how many errors exist even while
+  // viewing "error and above"). Doubles as the footer legend.
+  const levelCounts = useMemo(() => {
+    const counts = {}
+    for (const entry of containsLines) counts[entry.level] = (counts[entry.level] || 0) + 1
+    return counts
+  }, [containsLines])
+
+  // Apply the level filter on top of the contains filter (exact level match).
+  const logLines = useMemo(() => {
+    if (levelFilter === 'all') return containsLines
+    return containsLines.filter(entry => entry.level === levelFilter)
+  }, [containsLines, levelFilter])
+
   // When the JSON toggle is on, every line renders as a code block sharing the
   // same monospace font and size as the YAML blocks (`code: true`). Valid JSON
   // gets indented and Prism-highlighted (`html`); other lines keep their plain
   // text in the same styling. Filtering happens first on the raw text, so this
   // only transforms what is actually shown.
   const displayLines = useMemo(() => {
-    if (!prettyJson) return logLines.map(entry => ({ ...entry, code: false, html: null }))
     return logLines.map(entry => {
+      if (!prettyJson) return { ...entry, code: false, html: null }
       const json = formatJson(entry.text)
       if (json == null) return { ...entry, code: true, html: null }
       return { ...entry, text: json, code: true, html: Prism.highlight(json, Prism.languages.json, 'json') }
@@ -350,6 +440,9 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             title="Keep lines containing this text; prefix with ! to exclude (e.g. !debug)"
           />
 
+          {/* Minimum level filter */}
+          <LevelMenu value={levelFilter} onChange={setLevelFilter} />
+
           {/* Lines select */}
           <select
             value={tailLines}
@@ -411,20 +504,27 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             <div class="pb-2" data-testid="logs-content">
               {displayLines.map((entry, i) => {
                 const isLatest = flashLatest && i === displayLines.length - 1
+                const meta = LEVEL_META[entry.level] || LEVEL_META[DEFAULT_LEVEL]
                 return (
                   <Fragment key={i}>
                     {entry.ts && (
-                      <div class="flex items-center gap-2 px-3 pt-2 select-none" data-testid="logs-timestamp" data-latest={isLatest ? 'true' : undefined}>
+                      <div
+                        class="flex items-center gap-2 px-3 pt-2 select-none"
+                        data-testid="logs-timestamp"
+                        data-level={entry.level}
+                        data-latest={isLatest ? 'true' : undefined}
+                      >
                         <span
-                          class={`text-[10px] font-mono px-1.5 py-0.5 rounded-full transition-colors duration-1000 ${
-                            isLatest
-                              ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
-                              : 'bg-gray-200 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-                          }`}
+                          class={`text-[10px] font-mono px-1.5 py-0.5 rounded-full border bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 ${meta.border} ${isLatest ? 'log-glow' : ''}`}
+                          style={isLatest ? `--glow-color: ${meta.glow}` : undefined}
+                          title={`${meta.label} level`}
                         >
                           {entry.ts}
                         </span>
-                        <span class="flex-1 border-t border-gray-200 dark:border-gray-800" />
+                        <span
+                          class={`flex-1 border-t ${meta.border} ${isLatest ? 'log-glow' : ''}`}
+                          style={isLatest ? `--glow-color: ${meta.glow}` : undefined}
+                        />
                       </div>
                     )}
                     {entry.code ? (
@@ -459,25 +559,32 @@ export function WorkloadLogsViewer({ namespace, name, containers = [], onClose }
             </div>
           ) : (
             <p class="p-3 text-xs text-gray-500 dark:text-gray-400" data-testid="logs-empty">
-              {filter.trim() ? 'No matching log entries' : 'No logs available'}
+              {filter.trim() || levelFilter !== 'all' ? 'No matching log entries' : 'No logs available'}
             </p>
           )}
         </div>
 
-        {/* Footer showing the current line count, with a loader to its left
-            while a fetch is in flight. */}
+        {/* Footer: a per-level count summary that doubles as the color legend,
+            with the loader trailing it while a fetch is in flight. */}
         <div
-          class="flex items-center justify-center gap-2 px-4 py-2 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800"
+          class="flex items-center justify-between gap-3 px-4 py-2 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800"
           data-testid="logs-footer"
         >
+          <div class="flex items-center gap-3 text-xs text-gray-600 dark:text-gray-400" data-testid="logs-level-summary">
+            {LEVELS.filter(l => levelCounts[l]).map((l) => (
+              <span key={l} class="inline-flex items-center gap-1" title={`${LEVEL_META[l].label}: ${levelCounts[l]}`}>
+                <span class={`w-2 h-2 rounded-full ${LEVEL_META[l].swatch}`} />
+                {LEVEL_META[l].label} {levelCounts[l]}
+              </span>
+            ))}
+          </div>
           {loading && (
             <div
-              class="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-400"
+              class="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-400 flex-shrink-0"
               data-testid="logs-loader"
               aria-label="Loading logs"
             />
           )}
-          <span class="text-xs text-gray-500 dark:text-gray-400">{logLines.length} lines</span>
         </div>
       </div>
     </div>

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -160,6 +160,29 @@ describe('WorkloadLogsViewer component', () => {
     })
   })
 
+  it('downloads the logs as a <pod>.log file', async () => {
+    const user = userEvent.setup()
+    fetchWithMock.mockResolvedValue({ logs: 'line one\nline two\n' })
+
+    let downloadName
+    window.URL.createObjectURL = vi.fn(() => 'blob:mock')
+    window.URL.revokeObjectURL = vi.fn()
+    const clickSpy = vi.spyOn(window.HTMLAnchorElement.prototype, 'click').mockImplementation(function () {
+      downloadName = this.download
+    })
+
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    await user.click(screen.getByTestId('logs-download-button'))
+    expect(window.URL.createObjectURL).toHaveBeenCalled()
+    expect(clickSpy).toHaveBeenCalled()
+    expect(downloadName).toBe('my-pod.log')
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+
+    clickSpy.mockRestore()
+  })
+
   it('toggles fullscreen mode', async () => {
     const user = userEvent.setup()
     render(<WorkloadLogsViewer {...defaultProps} />)
@@ -170,7 +193,7 @@ describe('WorkloadLogsViewer component', () => {
     expect(toggle).toHaveAttribute('aria-pressed', 'true')
   })
 
-  it('does not follow by default and sets up polling once enabled', async () => {
+  it('follows by default, sets up polling and can be disabled', async () => {
     const user = userEvent.setup()
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
     const polls = () => setIntervalSpy.mock.calls.filter(c => c[1] === 5000).length
@@ -179,13 +202,32 @@ describe('WorkloadLogsViewer component', () => {
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
     const toggle = screen.getByTestId('logs-follow-toggle')
-    expect(toggle).toHaveAttribute('aria-pressed', 'false')
-    expect(polls()).toBe(0)
-
-    await user.click(toggle)
     expect(toggle).toHaveAttribute('aria-pressed', 'true')
     await waitFor(() => expect(polls()).toBe(1))
 
+    await user.click(toggle)
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
     setIntervalSpy.mockRestore()
+  })
+
+  it('highlights the latest line when new logs arrive', async () => {
+    const user = userEvent.setup()
+    fetchWithMock.mockResolvedValue({ logs: 'line one\nline two\n' })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
+
+    // No highlight on the initial load.
+    expect(screen.getAllByTestId('logs-line').some(el => el.getAttribute('data-latest') === 'true')).toBe(false)
+
+    // A new entry arrives on the next fetch.
+    fetchWithMock.mockResolvedValue({ logs: 'line one\nline two\nline three\n' })
+    await user.click(screen.getByTestId('logs-refresh-button'))
+    await waitFor(() => {
+      const rows = screen.getAllByTestId('logs-line')
+      expect(rows).toHaveLength(3)
+      expect(rows[rows.length - 1]).toHaveAttribute('data-latest', 'true')
+    })
+    expect(screen.getAllByTestId('logs-line')[0]).not.toHaveAttribute('data-latest')
   })
 })

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -18,6 +18,15 @@ const containersOf = (endpoint) => [...new URLSearchParams(endpoint.split('?')[1
 const podsOf = (endpoint) => [...new URLSearchParams(endpoint.split('?')[1]).getAll('pod')]
 const lastCall = () => fetchWithMock.mock.calls.at(-1)[0]
 
+// setTailLines opens the settings panel (if closed) and clicks the tail-lines
+// toggle for the given value. Returns once the change is applied.
+const setTailLines = async (value) => {
+  if (!screen.queryByTestId('logs-settings-panel')) {
+    await act(async () => { fireEvent.click(screen.getByTestId('logs-settings-toggle')) })
+  }
+  await act(async () => { fireEvent.click(screen.getByTestId(`logs-tail-${value}`)) })
+}
+
 describe('WorkloadLogsViewer component', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -470,11 +479,10 @@ describe('WorkloadLogsViewer component', () => {
   })
 
   it('requests the selected number of lines', async () => {
-    const user = userEvent.setup()
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
-    await user.selectOptions(screen.getByTestId('logs-lines-select'), '500')
+    await setTailLines(500)
     await waitFor(() => expect(lastCall().endpoint).toContain('tailLines=500'))
   })
 
@@ -609,8 +617,7 @@ describe('WorkloadLogsViewer component', () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(3))
 
-    await user.click(screen.getByTestId('logs-level-filter'))
-    await user.click(screen.getByTestId('logs-level-option-warn'))
+    await user.selectOptions(screen.getByTestId('logs-level-filter'), 'warn')
 
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(1))
     expect(screen.getByTestId('logs-line')).toHaveTextContent('slow')
@@ -683,8 +690,7 @@ describe('WorkloadLogsViewer component', () => {
     // Formatted mode: the level filter and per-level legend are present. Narrow to warn.
     expect(screen.getByTestId('logs-level-filter')).toBeInTheDocument()
     expect(screen.getByTestId('logs-level-summary')).toBeInTheDocument()
-    await user.click(screen.getByTestId('logs-level-filter'))
-    await user.click(screen.getByTestId('logs-level-option-warn'))
+    await user.selectOptions(screen.getByTestId('logs-level-filter'), 'warn')
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(1))
 
     // Raw mode: the filter is hidden and reset to "all" (all 3 lines return), and the
@@ -890,7 +896,7 @@ describe('WorkloadLogsViewer component', () => {
       expect(fetchWithMock).toHaveBeenCalledTimes(1)
 
       fetchWithMock.mockReturnValueOnce(new Promise(() => {}))
-      await act(async () => { fireEvent.change(screen.getByTestId('logs-lines-select'), { target: { value: '500' } }) })
+      await setTailLines(500)
       await flush()
       expect(fetchWithMock).toHaveBeenCalledTimes(2)
 
@@ -917,7 +923,7 @@ describe('WorkloadLogsViewer component', () => {
       await act(async () => { vi.advanceTimersByTime(5000) })
 
       fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:05Z reset one\n' })
-      await act(async () => { fireEvent.change(screen.getByTestId('logs-lines-select'), { target: { value: '500' } }) })
+      await setTailLines(500)
       await flush()
       expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['reset one'])
 
@@ -958,7 +964,6 @@ describe('WorkloadLogsViewer component', () => {
   })
 
   it('highlights the latest timestamp pill when new logs arrive', async () => {
-    const user = userEvent.setup()
     fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
@@ -966,7 +971,7 @@ describe('WorkloadLogsViewer component', () => {
     expect(screen.getAllByTestId('logs-timestamp').some(el => el.getAttribute('data-latest') === 'true')).toBe(false)
 
     fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n2026-01-01T00:00:02Z line three\n' })
-    await user.selectOptions(screen.getByTestId('logs-lines-select'), '500')
+    await setTailLines(500)
     await waitFor(() => {
       const pills = screen.getAllByTestId('logs-timestamp')
       expect(pills).toHaveLength(3)
@@ -998,6 +1003,63 @@ describe('WorkloadLogsViewer component', () => {
       expect(poll).toContain('sinceTime=2026-01-01T00%3A00%3A01Z')
       expect(poll).not.toContain('since=')
       expect(containersOf(poll)).toEqual(['app', 'sidecar'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows a "+N new" indicator counting a follow poll\'s appends, until the next refresh', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+      // Initial load: 2 entries. First poll re-sends the last one and adds two more,
+      // so 2 new entries are appended (the re-sent head is deduped, not counted).
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z one\n2026-01-01T00:00:01Z two\n' })
+      fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:01Z two\n2026-01-01T00:00:02Z three\n2026-01-01T00:00:03Z four\n' })
+
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await flush()
+      // No indicator on the initial (non-append) load.
+      expect(screen.queryByTestId('logs-appended-count')).not.toBeInTheDocument()
+
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+      expect(screen.getByTestId('logs-appended-count')).toHaveTextContent('+2 new')
+
+      // Clicking it scrolls to the latest line and re-pins to the bottom.
+      const body = screen.getByTestId('logs-body')
+      let scrollTop = 0
+      Object.defineProperty(body, 'scrollHeight', { configurable: true, value: 4321 })
+      Object.defineProperty(body, 'scrollTop', { configurable: true, get: () => scrollTop, set: v => { scrollTop = v } })
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-appended-count')) })
+      expect(scrollTop).toBe(4321)
+
+      // It persists across the 2s mark (no auto-hide) — only the next refresh clears it.
+      await act(async () => { vi.advanceTimersByTime(2000) })
+      expect(screen.getByTestId('logs-appended-count')).toHaveTextContent('+2 new')
+
+      // The next poll appends nothing new (same payload, all buffered), so it hides.
+      await act(async () => { vi.advanceTimersByTime(3000) })
+      await flush()
+      expect(screen.queryByTestId('logs-appended-count')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not show the "+N new" indicator when a follow poll appends nothing', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z one\n2026-01-01T00:00:01Z two\n' })
+      // Poll re-sends only already-buffered entries: nothing new to append.
+      fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:01Z two\n' })
+
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await flush()
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+      expect(screen.queryByTestId('logs-appended-count')).not.toBeInTheDocument()
     } finally {
       vi.useRealTimers()
     }
@@ -1037,7 +1099,7 @@ describe('WorkloadLogsViewer component', () => {
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
 
     fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z keep me\n2026-01-01T00:00:01Z keep me too\n2026-01-01T00:00:02Z noise\n' })
-    await user.selectOptions(screen.getByTestId('logs-lines-select'), '500')
+    await setTailLines(500)
     await waitFor(() => expect(lastCall().endpoint).toContain('tailLines=500'))
     expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
     expect(screen.getAllByTestId('logs-timestamp').some(el => el.getAttribute('data-latest') === 'true')).toBe(false)
@@ -1158,8 +1220,7 @@ describe('WorkloadLogsViewer component', () => {
       render(<WorkloadLogsViewer {...defaultProps} />)
       await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
-      await user.click(screen.getByTestId('logs-level-filter'))
-      await user.click(screen.getByTestId('logs-level-option-error'))
+      await user.selectOptions(screen.getByTestId('logs-level-filter'), 'error')
 
       expect(screen.getByTestId('logs-content')).toHaveTextContent('Error: boom from c')
       expect(screen.queryByText('plain info line')).toBeNull()
@@ -1347,32 +1408,48 @@ describe('WorkloadLogsViewer component', () => {
   })
 
   describe('persisted settings', () => {
-    it('seeds follow, format and lines from the stored settings', async () => {
-      logSettings.value = { follow: false, formatted: false, tail: 500 }
+    it('seeds follow, format, lines and font size from the stored settings', async () => {
+      logSettings.value = { follow: false, formatted: false, tail: 500, fontSize: 'lg' }
       render(<WorkloadLogsViewer {...defaultProps} />)
       await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
       expect(screen.getByTestId('logs-follow-toggle')).toHaveAttribute('aria-pressed', 'false')
       expect(screen.getByTestId('logs-format-toggle')).toHaveAttribute('aria-pressed', 'false')
-      expect(screen.getByTestId('logs-lines-select')).toHaveValue('500')
+
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-settings-toggle')) })
+      expect(screen.getByTestId('logs-tail-500')).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByTestId('logs-fontsize-lg')).toHaveAttribute('aria-pressed', 'true')
     })
 
-    it('persists follow, format and lines changes to the settings signal', async () => {
+    it('persists follow, format, lines and font size changes to the settings signal', async () => {
       render(<WorkloadLogsViewer {...defaultProps} />)
       await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
-      await act(async () => { fireEvent.change(screen.getByTestId('logs-lines-select'), { target: { value: '1000' } }) })
+      await setTailLines(1000)
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-fontsize-sm')) })
       await act(async () => { fireEvent.click(screen.getByTestId('logs-follow-toggle')) })
       await act(async () => { fireEvent.click(screen.getByTestId('logs-format-toggle')) })
 
-      expect(logSettings.value).toEqual({ follow: false, formatted: false, tail: 1000 })
+      expect(logSettings.value).toEqual({ follow: false, formatted: false, tail: 1000, fontSize: 'sm' })
+    })
+
+    it('applies the font size to the log body via a CSS variable', async () => {
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      // Default is medium (12px).
+      expect(screen.getByTestId('logs-body')).toHaveStyle({ '--logs-font-size': '12px' })
+
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-settings-toggle')) })
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-fontsize-lg')) })
+      expect(screen.getByTestId('logs-body')).toHaveStyle({ '--logs-font-size': '14px' })
     })
 
     it('does not change an already-open viewer when the settings are reset', async () => {
       render(<WorkloadLogsViewer {...defaultProps} />)
       await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
-      await act(async () => { fireEvent.change(screen.getByTestId('logs-lines-select'), { target: { value: '1000' } }) })
+      await setTailLines(1000)
       await act(async () => { fireEvent.click(screen.getByTestId('logs-format-toggle')) })
 
       // Reset the persisted settings (as "Clear local storage" does) while the
@@ -1382,7 +1459,7 @@ describe('WorkloadLogsViewer component', () => {
       await act(async () => { resetLogSettings() })
 
       expect(logSettings.value).toEqual(DEFAULT_LOG_SETTINGS)
-      expect(screen.getByTestId('logs-lines-select')).toHaveValue('1000')
+      expect(screen.getByTestId('logs-tail-1000')).toHaveAttribute('aria-pressed', 'true')
       expect(screen.getByTestId('logs-format-toggle')).toHaveAttribute('aria-pressed', 'false')
     })
   })

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -884,4 +884,51 @@ describe('WorkloadLogsViewer component', () => {
     expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
     expect(screen.getAllByTestId('logs-timestamp').some(el => el.getAttribute('data-latest') === 'true')).toBe(false)
   })
+
+  it('reflows a structured klog entry into one logs-line holding stacked rows', async () => {
+    fetchWithMock.mockResolvedValue({
+      logs: '2026-01-01T00:00:00Z E0526 23:03:57.521582       1 leaderelection.go:452] "Error retrieving lease lock" err="i/o timeout" logger="cert-manager.controller"\n'
+    })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(1))
+
+    // Still one logs-line per entry, but it now holds header + message + 2 field rows.
+    const rows = screen.getAllByTestId('logs-line-row').map(r => r.textContent)
+    expect(rows).toEqual([
+      'E0526 23:03:57.521582       1 leaderelection.go:452]',
+      'Error retrieving lease lock',
+      'err: i/o timeout',
+      'logger: cert-manager.controller'
+    ])
+  })
+
+  it('strips a trailing CR from a CRLF stream so it does not leak into a field', async () => {
+    fetchWithMock.mockResolvedValue({
+      logs: '2026-01-01T00:00:00Z level=info msg=hi controller=foo\r\n'
+    })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line-row').length).toBeGreaterThan(0))
+
+    const rows = screen.getAllByTestId('logs-line-row').map(r => r.textContent)
+    expect(rows).toContain('controller: foo')
+    expect(rows.some(t => t.includes('\r'))).toBe(false)
+  })
+
+  it('leaves a structured entry verbatim in raw mode', async () => {
+    const user = userEvent.setup()
+    fetchWithMock.mockResolvedValue({
+      logs: '2026-01-01T00:00:00Z level=info msg="reconcile complete" controller=gitrepository\n'
+    })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line-row')).toHaveLength(3))
+
+    // Toggling Format off renders the line byte-for-byte: one logs-line, no row
+    // splitting, exact text (toHaveTextContent normalizes whitespace, so assert
+    // the exact textContent to catch a tab/CR change or an accidental split).
+    await user.click(screen.getByTestId('logs-format-toggle'))
+    await waitFor(() => expect(screen.queryByTestId('logs-line-row')).toBeNull())
+    const lines = screen.getAllByTestId('logs-line')
+    expect(lines).toHaveLength(1)
+    expect(lines[0].textContent).toBe('level=info msg="reconcile complete" controller=gitrepository')
+  })
 })

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -221,6 +221,37 @@ describe('WorkloadLogsViewer component', () => {
     expect(screen.getByTestId('logs-footer')).toHaveTextContent('2 lines')
   })
 
+  it('renders JSON lines as highlighted code blocks when the JSON toggle is on, leaving plain lines intact', async () => {
+    const user = userEvent.setup()
+    fetchWithMock.mockResolvedValue({
+      logs: '2026-01-01T00:00:00Z {"level":"info","msg":"hello"}\n2026-01-01T00:00:01Z plain text line\n'
+    })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
+
+    const toggle = screen.getByTestId('logs-json-toggle')
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    // Off: the JSON line is shown compact, exactly as received, as a plain row.
+    expect(screen.getAllByTestId('logs-line')[0].tagName).toBe('DIV')
+    expect(screen.getAllByTestId('logs-line')[0].textContent).toBe('{"level":"info","msg":"hello"}')
+
+    // On: the JSON line becomes an indented, syntax-highlighted code block. The
+    // plain line also renders as a code block (so all lines share the same font
+    // and size) but with its text unchanged and no syntax highlighting.
+    await user.click(toggle)
+    expect(toggle).toHaveAttribute('aria-pressed', 'true')
+    const rows = screen.getAllByTestId('logs-line')
+    expect(rows[0].tagName).toBe('PRE')
+    expect(rows[0].querySelector('code')).toHaveClass('language-json')
+    expect(rows[0].querySelector('.token')).not.toBeNull()
+    expect(rows[0].textContent).toBe('{\n  "level": "info",\n  "msg": "hello"\n}')
+    expect(rows[1].tagName).toBe('PRE')
+    expect(rows[1].querySelector('code')).toHaveClass('language-json')
+    expect(rows[1].querySelector('.token')).toBeNull()
+    expect(rows[1].textContent).toBe('plain text line')
+  })
+
   it('toggles fullscreen mode', async () => {
     const user = userEvent.setup()
     render(<WorkloadLogsViewer {...defaultProps} />)

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -400,9 +400,9 @@ describe('WorkloadLogsViewer component', () => {
 
       render(<WorkloadLogsViewer {...allPodsProps} />)
       await flush()
-      // Turn off stack-trace grouping so the frames render as flat rows; this test
-      // asserts mergeLogs keeps both pods' frames, independent of the fold UI.
-      await act(async () => { fireEvent.click(screen.getByTestId('logs-group-toggle')) })
+      // Switch to raw mode so the frames render as flat rows; this test asserts
+      // mergeLogs keeps both pods' frames, independent of the fold UI.
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-format-toggle')) })
       await act(async () => { vi.advanceTimersByTime(5000) })
       await flush()
 
@@ -984,18 +984,6 @@ describe('WorkloadLogsViewer component', () => {
       expect(screen.getByText('goroutine 1 [running]:')).toBeInTheDocument()
     })
 
-    it('renders every trace line flat when grouping is toggled off', async () => {
-      const user = userEvent.setup()
-      fetchWithMock.mockResolvedValue({ logs: GO_PANIC_LOGS })
-      render(<WorkloadLogsViewer {...defaultProps} />)
-      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
-      expect(screen.queryByText('main.c(...)')).toBeNull()
-
-      await user.click(screen.getByTestId('logs-group-toggle'))
-      expect(screen.getByText('main.c(...)')).toBeInTheDocument()
-      expect(screen.queryByTestId('logs-group-fold')).toBeNull()
-    })
-
     it('renders every trace line flat in raw mode', async () => {
       const user = userEvent.setup()
       fetchWithMock.mockResolvedValue({ logs: GO_PANIC_LOGS })
@@ -1118,6 +1106,111 @@ describe('WorkloadLogsViewer component', () => {
       } finally {
         vi.useRealTimers()
       }
+    })
+  })
+
+  describe('unstructured-run grouping', () => {
+    // A curl -v dump: co-timestamped, structure-less lines that the format layer
+    // leaves plain, so they group under one timestamp pill — rendered in full, not
+    // folded behind an expand control.
+    const CURL_LOGS =
+      '2026-01-01T00:00:00.000000000Z * Host frontend was resolved.\n' +
+      '2026-01-01T00:00:00.000000001Z *   Trying 10.0.0.1:80...\n' +
+      '2026-01-01T00:00:00.000000002Z > GET /api/info HTTP/1.1\n' +
+      '2026-01-01T00:00:00.000000003Z < HTTP/1.1 200 OK\n' +
+      '2026-01-01T00:00:00.000000004Z * Connection #0 to host frontend left intact\n'
+
+    it('groups a co-timestamped curl dump under one pill with every line visible', async () => {
+      fetchWithMock.mockResolvedValue({ logs: CURL_LOGS })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      // Grouped, not folded: all lines render, nothing hidden, no expand control.
+      expect(screen.queryByTestId('logs-group-fold')).toBeNull()
+      expect(screen.getByText('* Host frontend was resolved.')).toBeInTheDocument()
+      expect(screen.getByText('> GET /api/info HTTP/1.1')).toBeInTheDocument()
+      expect(screen.getByText('< HTTP/1.1 200 OK')).toBeInTheDocument()
+      expect(screen.getByText('* Connection #0 to host frontend left intact')).toBeInTheDocument()
+
+      // One timestamp block heads the whole run (a single separator pill), default
+      // info level (not error-tinted).
+      const pills = screen.getAllByTestId('logs-timestamp')
+      expect(pills).toHaveLength(1)
+      expect(pills[0]).toHaveAttribute('data-level', 'info')
+    })
+
+    it('does not group structured logger lines emitted milliseconds apart', async () => {
+      // Leading app Logback date → parseJava recognizes each as structured, so they
+      // stay separate entries despite the tight timestamp window.
+      fetchWithMock.mockResolvedValue({
+        logs:
+          '2026-01-01T00:00:00.000000000Z 2026-01-01 00:00:00.000 [main] DEBUG com.x - one\n' +
+          '2026-01-01T00:00:00.000000002Z 2026-01-01 00:00:00.002 [main] DEBUG com.x - two\n'
+      })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      // Each structured line is its own timestamp block.
+      expect(screen.getAllByTestId('logs-timestamp')).toHaveLength(2)
+      expect(screen.getByTestId('logs-content')).toHaveTextContent('one')
+      expect(screen.getByTestId('logs-content')).toHaveTextContent('two')
+    })
+
+    it('does not group a date-less leveled console line into a burst', async () => {
+      // `[main] DEBUG com.x - msg` renders plain (no leading digit for parseJava),
+      // but detectLevel finds DEBUG, so the level catch keeps it out of a burst even
+      // though decorateLine fell through to plain.
+      fetchWithMock.mockResolvedValue({
+        logs:
+          '2026-01-01T00:00:00.000000000Z [main] DEBUG com.x - one\n' +
+          '2026-01-01T00:00:00.000000002Z [main] DEBUG com.x - two\n' +
+          '2026-01-01T00:00:00.000000004Z [main] WARN com.x - three\n'
+      })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      expect(screen.getAllByTestId('logs-timestamp')).toHaveLength(3)
+    })
+  })
+
+  describe('container-scoped grouping', () => {
+    // A pod running two containers; the all-containers view tags each line with its
+    // container of origin so folding can be scoped per container.
+    const twoContainerProps = {
+      ...defaultProps,
+      pods: onePod([{ name: 'app', isInit: false }, { name: 'envoy', isInit: false }]),
+    }
+
+    it('keeps an interleaved container\'s trace intact and never folds in another container', async () => {
+      const user = userEvent.setup()
+      // app panics while envoy logs a co-timestamped, frame-shaped line right in the
+      // middle of app's trace. Per-(pod, container) partitioning keeps app's trace
+      // whole (2 frames) and envoy's line a separate, visible entry — without the
+      // partition + guard, envoy's line would split or be swallowed by app's trace.
+      fetchWithMock.mockResolvedValue({
+        pod: 'my-pod', container: 'app,envoy', containerTagged: true,
+        logs:
+          'app 2026-01-01T00:00:00.000000000Z panic: boom from app\n' +
+          'app 2026-01-01T00:00:00.000000001Z goroutine 1 [running]:\n' +
+          'envoy 2026-01-01T00:00:00.000000002Z   at Envoy::drain (conn.cc:42)\n' +
+          'app 2026-01-01T00:00:00.000000003Z main.crash()\n'
+      })
+      render(<WorkloadLogsViewer {...twoContainerProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      // Exactly one fold (app's trace), holding both app frames; envoy's line is
+      // never folded into it.
+      const folds = screen.getAllByTestId('logs-group-fold')
+      expect(folds).toHaveLength(1)
+      expect(folds[0]).toHaveTextContent('2 frames')
+      expect(screen.getByTestId('logs-content')).toHaveTextContent('at Envoy::drain (conn.cc:42)')
+      expect(screen.queryByText('main.crash()')).toBeNull()
+
+      // Expanding app's trace reveals both its frames (the one that arrived after
+      // envoy's line included), never envoy's line.
+      await user.click(folds[0])
+      expect(screen.getByText('goroutine 1 [running]:')).toBeInTheDocument()
+      expect(screen.getByText('main.crash()')).toBeInTheDocument()
     })
   })
 })

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -53,7 +53,7 @@ describe('WorkloadLogsViewer component', () => {
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
     const select = screen.getByTestId('logs-container-select')
     expect(select).toBeInTheDocument()
-    expect(select).toHaveValue('app')
+    expect(select).toHaveValue('app::false')
   })
 
   it('shows the container selector for multiple containers and refetches on change', async () => {
@@ -67,7 +67,7 @@ describe('WorkloadLogsViewer component', () => {
     const select = await screen.findByTestId('logs-container-select')
     expect(select).toBeInTheDocument()
 
-    await user.selectOptions(select, 'sidecar')
+    await user.selectOptions(select, 'sidecar::false')
     await waitFor(() => {
       const lastCall = fetchWithMock.mock.calls[fetchWithMock.mock.calls.length - 1][0]
       expect(lastCall.endpoint).toContain('container=sidecar')
@@ -140,32 +140,45 @@ describe('WorkloadLogsViewer component', () => {
     expect(screen.getByTestId('logs-line')).toHaveTextContent('line one')
   })
 
-  it('hides timestamps by default and shows them when toggled', async () => {
-    const user = userEvent.setup()
+  it('always shows the timestamp as a separator pill, separate from the message row', async () => {
     fetchWithMock.mockResolvedValue({ logs: '2026-06-16T00:00:00Z hello world\n' })
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getByTestId('logs-line')).toHaveTextContent('hello world'))
 
-    // Timestamps are hidden by default: the leading timestamp is stripped.
-    const toggle = screen.getByTestId('logs-timestamps-toggle')
-    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+    // The timestamp lives in the pill; the message row carries only the message.
+    expect(screen.getByTestId('logs-timestamp')).toHaveTextContent('2026-06-16T00:00:00Z')
+    expect(screen.getByTestId('logs-line')).toHaveTextContent('hello world')
     expect(screen.getByTestId('logs-line')).not.toHaveTextContent('2026-06-16T00:00:00Z')
 
-    // Toggle on to reveal the timestamps.
-    await user.click(toggle)
-    expect(toggle).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByTestId('logs-line')).toHaveTextContent('2026-06-16T00:00:00Z')
+    // There is no timestamps toggle anymore.
+    expect(screen.queryByTestId('logs-timestamps-toggle')).not.toBeInTheDocument()
   })
 
-  it('toggles the previous container instance and refetches', async () => {
+  it('offers a "(previous)" entry only for restarted containers and refetches with previous=true', async () => {
     const user = userEvent.setup()
-    render(<WorkloadLogsViewer {...defaultProps} />)
+    const props = {
+      ...defaultProps,
+      containers: [
+        { name: 'app', isInit: false, restartCount: 2 },
+        { name: 'sidecar', isInit: false, restartCount: 0 }
+      ]
+    }
+    render(<WorkloadLogsViewer {...props} />)
     await waitFor(() => expect(fetchWithMock).toHaveBeenCalled())
     expect(fetchWithMock.mock.calls[0][0].endpoint).toContain('previous=false')
 
-    await user.click(screen.getByTestId('logs-previous-toggle'))
+    const select = screen.getByTestId('logs-container-select')
+    const values = [...select.querySelectorAll('option')].map(o => o.value)
+    // Restarted container gets a previous entry; the non-restarted one does not.
+    expect(values).toContain('app::false')
+    expect(values).toContain('app::true')
+    expect(values).toContain('sidecar::false')
+    expect(values).not.toContain('sidecar::true')
+
+    await user.selectOptions(select, 'app::true')
     await waitFor(() => {
       const lastCall = fetchWithMock.mock.calls[fetchWithMock.mock.calls.length - 1][0]
+      expect(lastCall.endpoint).toContain('container=app')
       expect(lastCall.endpoint).toContain('previous=true')
     })
   })
@@ -191,6 +204,21 @@ describe('WorkloadLogsViewer component', () => {
     expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
 
     clickSpy.mockRestore()
+  })
+
+  it('always shows the line count in the footer, with a loader while fetching', async () => {
+    let resolveFetch
+    fetchWithMock.mockReturnValue(new Promise((resolve) => { resolveFetch = resolve }))
+    render(<WorkloadLogsViewer {...defaultProps} />)
+
+    // The footer always shows the line count; the loader shows alongside it
+    // while the fetch is pending.
+    expect(screen.getByTestId('logs-footer')).toHaveTextContent('0 lines')
+    expect(screen.getByTestId('logs-loader')).toBeInTheDocument()
+
+    resolveFetch({ logs: 'line one\nline two\n' })
+    await waitFor(() => expect(screen.queryByTestId('logs-loader')).not.toBeInTheDocument())
+    expect(screen.getByTestId('logs-footer')).toHaveTextContent('2 lines')
   })
 
   it('toggles fullscreen mode', async () => {
@@ -221,23 +249,23 @@ describe('WorkloadLogsViewer component', () => {
     setIntervalSpy.mockRestore()
   })
 
-  it('highlights the latest line when new logs arrive', async () => {
+  it('highlights the latest timestamp pill when new logs arrive', async () => {
     const user = userEvent.setup()
-    fetchWithMock.mockResolvedValue({ logs: 'line one\nline two\n' })
+    fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
 
     // No highlight on the initial load.
-    expect(screen.getAllByTestId('logs-line').some(el => el.getAttribute('data-latest') === 'true')).toBe(false)
+    expect(screen.getAllByTestId('logs-timestamp').some(el => el.getAttribute('data-latest') === 'true')).toBe(false)
 
-    // A new entry arrives on the next fetch (triggered by toggling previous).
-    fetchWithMock.mockResolvedValue({ logs: 'line one\nline two\nline three\n' })
-    await user.click(screen.getByTestId('logs-previous-toggle'))
+    // A new entry arrives on the next fetch (triggered by changing the line count).
+    fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n2026-01-01T00:00:02Z line three\n' })
+    await user.selectOptions(screen.getByTestId('logs-lines-select'), '500')
     await waitFor(() => {
-      const rows = screen.getAllByTestId('logs-line')
-      expect(rows).toHaveLength(3)
-      expect(rows[rows.length - 1]).toHaveAttribute('data-latest', 'true')
+      const pills = screen.getAllByTestId('logs-timestamp')
+      expect(pills).toHaveLength(3)
+      expect(pills[pills.length - 1]).toHaveAttribute('data-latest', 'true')
     })
-    expect(screen.getAllByTestId('logs-line')[0]).not.toHaveAttribute('data-latest')
+    expect(screen.getAllByTestId('logs-timestamp')[0]).not.toHaveAttribute('data-latest')
   })
 })

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -1,12 +1,11 @@
 // Copyright 2026 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/preact'
 import userEvent from '@testing-library/user-event'
 import { WorkloadLogsViewer } from './WorkloadLogsViewer'
 
-// Mock the fetchWithMock function
 vi.mock('../../../utils/fetch', () => ({
   fetchWithMock: vi.fn()
 }))
@@ -19,6 +18,11 @@ describe('WorkloadLogsViewer component', () => {
     // Each line carries a leading timestamp (as the API returns); timestamps are
     // hidden by default so the viewer strips it, leaving the message text.
     fetchWithMock.mockResolvedValue({ pod: 'my-pod', container: 'app', logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
+  })
+
+  afterEach(() => {
+    // Restore real timers so a leaked fake-timer interval can't bleed into the next test.
+    vi.useRealTimers()
   })
 
   const defaultProps = {
@@ -48,12 +52,16 @@ describe('WorkloadLogsViewer component', () => {
     expect(call.endpoint).toContain('container=app')
   })
 
-  it('always shows the container selector, even for a single container', async () => {
+  it('always shows the container selector, defaulting to "All containers"', async () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
     const select = screen.getByTestId('logs-container-select')
     expect(select).toBeInTheDocument()
-    expect(select).toHaveValue('app::false')
+    // "All containers" is the default even for a single container; the container
+    // itself stays individually selectable.
+    expect(select).toHaveValue('all')
+    const values = [...select.querySelectorAll('option')].map(o => o.value)
+    expect(values).toEqual(['all', 'app::false'])
   })
 
   it('shows the container selector for multiple containers and refetches on change', async () => {
@@ -72,6 +80,182 @@ describe('WorkloadLogsViewer component', () => {
       const lastCall = fetchWithMock.mock.calls[fetchWithMock.mock.calls.length - 1][0]
       expect(lastCall.endpoint).toContain('container=sidecar')
     })
+  })
+
+  it('defaults to "All containers" for multiple regular containers and streams them all', async () => {
+    const props = {
+      ...defaultProps,
+      containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]
+    }
+    render(<WorkloadLogsViewer {...props} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    // The selector defaults to the "All containers" option.
+    const select = screen.getByTestId('logs-container-select')
+    expect(select).toHaveValue('all')
+    const values = [...select.querySelectorAll('option')].map(o => o.value)
+    expect(values).toContain('all')
+    expect(values).toContain('app::false')
+    expect(values).toContain('sidecar::false')
+
+    // The initial request streams every regular container via repeated params.
+    const endpoint = fetchWithMock.mock.calls[0][0].endpoint
+    const containers = [...new URLSearchParams(endpoint.split('?')[1]).getAll('container')]
+    expect(containers).toEqual(['app', 'sidecar'])
+    expect(endpoint).toContain('previous=false')
+  })
+
+  it('excludes init containers from "All containers" but keeps them selectable', async () => {
+    const user = userEvent.setup()
+    const props = {
+      ...defaultProps,
+      containers: [
+        { name: 'setup', isInit: true },
+        { name: 'app', isInit: false },
+        { name: 'sidecar', isInit: false }
+      ]
+    }
+    render(<WorkloadLogsViewer {...props} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    // "All containers" streams only the regular containers, not the init one.
+    const containers = [...new URLSearchParams(fetchWithMock.mock.calls[0][0].endpoint.split('?')[1]).getAll('container')]
+    expect(containers).toEqual(['app', 'sidecar'])
+
+    // The init container is still individually selectable and fetched on its own.
+    const select = screen.getByTestId('logs-container-select')
+    const values = [...select.querySelectorAll('option')].map(o => o.value)
+    expect(values).toContain('setup::false')
+
+    await user.selectOptions(select, 'setup::false')
+    await waitFor(() => {
+      const last = fetchWithMock.mock.calls.at(-1)[0].endpoint
+      const c = [...new URLSearchParams(last.split('?')[1]).getAll('container')]
+      expect(c).toEqual(['setup'])
+    })
+  })
+
+  it('switches from "All containers" to a single container', async () => {
+    const user = userEvent.setup()
+    const props = {
+      ...defaultProps,
+      containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]
+    }
+    render(<WorkloadLogsViewer {...props} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    await user.selectOptions(screen.getByTestId('logs-container-select'), 'sidecar::false')
+    await waitFor(() => {
+      const last = fetchWithMock.mock.calls.at(-1)[0].endpoint
+      const c = [...new URLSearchParams(last.split('?')[1]).getAll('container')]
+      expect(c).toEqual(['sidecar'])
+    })
+  })
+
+  it('defaults to "All containers" for a single regular container, streaming only it', async () => {
+    const props = {
+      ...defaultProps,
+      containers: [{ name: 'setup', isInit: true }, { name: 'app', isInit: false }]
+    }
+    render(<WorkloadLogsViewer {...props} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    // "All containers" is offered and is the default even with one regular
+    // container; the init container is not part of it.
+    const select = screen.getByTestId('logs-container-select')
+    expect(select).toHaveValue('all')
+    const containers = [...new URLSearchParams(fetchWithMock.mock.calls[0][0].endpoint.split('?')[1]).getAll('container')]
+    expect(containers).toEqual(['app'])
+  })
+
+  it('titles the modal "Log Viewer" over the workload kind/namespace/name', async () => {
+    const props = { ...defaultProps, kind: 'Deployment', workloadName: 'podinfo' }
+    render(<WorkloadLogsViewer {...props} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    expect(screen.getByTestId('logs-viewer')).toHaveTextContent('Log Viewer')
+    expect(screen.getByTestId('logs-title')).toHaveTextContent('Deployment/default/podinfo')
+  })
+
+  it('lists the workload pods and invokes onSelectPod when the pod changes', async () => {
+    const user = userEvent.setup()
+    const onSelectPod = vi.fn()
+    const props = {
+      ...defaultProps,
+      name: 'pod-a',
+      pods: [{ name: 'pod-a' }, { name: 'pod-b' }],
+      onSelectPod
+    }
+    render(<WorkloadLogsViewer {...props} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    const podSelect = screen.getByTestId('logs-pod-select')
+    expect(podSelect).toHaveValue('pod-a')
+    expect([...podSelect.querySelectorAll('option')].map(o => o.value)).toEqual(['pod-a', 'pod-b'])
+
+    await user.selectOptions(podSelect, 'pod-b')
+    expect(onSelectPod).toHaveBeenCalledWith('pod-b')
+  })
+
+  it('resets the container selection to "All containers" when the pod changes', async () => {
+    const user = userEvent.setup()
+    const props = {
+      ...defaultProps,
+      name: 'pod-a',
+      containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }],
+      pods: [{ name: 'pod-a' }, { name: 'pod-b' }],
+      onSelectPod: vi.fn()
+    }
+    const { rerender } = render(<WorkloadLogsViewer {...props} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    // Pick a specific container, away from the "All containers" default.
+    await user.selectOptions(screen.getByTestId('logs-container-select'), 'sidecar::false')
+    expect(screen.getByTestId('logs-container-select')).toHaveValue('sidecar::false')
+
+    // The parent switches the pod (the viewer is controlled): it re-renders with
+    // the new pod's name and containers, and the container dropdown snaps back to
+    // "All containers".
+    rerender(<WorkloadLogsViewer {...props} name="pod-b" containers={[{ name: 'web', isInit: false }]} />)
+    await waitFor(() => expect(screen.getByTestId('logs-container-select')).toHaveValue('all'))
+  })
+
+  it('appends and dedupes across merged streams while following "All containers"', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+      const props = {
+        ...defaultProps,
+        containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]
+      }
+      // Initial load: lines from both containers, already interleaved by the backend.
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z app one\n2026-01-01T00:00:01Z side one\n' })
+      // Follow poll: the last line is re-sent (sinceTime is second-granular) plus a new one.
+      fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:01Z side one\n2026-01-01T00:00:02Z app two\n' })
+
+      render(<WorkloadLogsViewer {...props} />)
+      await flush()
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['app one', 'side one'])
+
+      // The initial load streams every regular container and asks for the tail.
+      const first = fetchWithMock.mock.calls[0][0].endpoint
+      expect([...new URLSearchParams(first.split('?')[1]).getAll('container')]).toEqual(['app', 'sidecar'])
+      expect(first).not.toContain('sinceTime')
+
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+
+      // The overlapping "side one" is deduped across the merged result; only the
+      // genuinely new "app two" is appended.
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['app one', 'side one', 'app two'])
+
+      // The follow poll narrows by sinceTime yet still streams all containers.
+      const poll = fetchWithMock.mock.calls.at(-1)[0].endpoint
+      expect(poll).toContain('sinceTime=2026-01-01T00%3A00%3A01Z')
+      expect([...new URLSearchParams(poll.split('?')[1]).getAll('container')]).toEqual(['app', 'sidecar'])
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('shows an error message when the fetch fails', async () => {
@@ -150,7 +334,7 @@ describe('WorkloadLogsViewer component', () => {
     expect(screen.getByTestId('logs-line')).toHaveTextContent('hello world')
     expect(screen.getByTestId('logs-line')).not.toHaveTextContent('2026-06-16T00:00:00Z')
 
-    // There is no timestamps toggle anymore.
+    // The timestamp is a separator pill, not a toggleable column.
     expect(screen.queryByTestId('logs-timestamps-toggle')).not.toBeInTheDocument()
   })
 
@@ -338,6 +522,36 @@ describe('WorkloadLogsViewer component', () => {
 
     await user.click(toggle)
     expect(toggle).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('shows the follow mode in the footer corner, toggling between Following and Snapshot', async () => {
+    const user = userEvent.setup()
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    // Follow is on by default, so the corner reads "Following".
+    const mode = screen.getByTestId('logs-mode')
+    expect(mode).toHaveTextContent('Following')
+
+    // Turning follow off switches the corner to "Snapshot".
+    await user.click(screen.getByTestId('logs-follow-toggle'))
+    expect(screen.getByTestId('logs-mode')).toHaveTextContent('Snapshot')
+  })
+
+  it('scrolls to the latest logs when the footer mode indicator is clicked', async () => {
+    const user = userEvent.setup()
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    // jsdom has no layout, so stub the scroll metrics to verify the handler pins
+    // the body to the bottom (scrollTop := scrollHeight).
+    const body = screen.getByTestId('logs-body')
+    let scrollTop = 0
+    Object.defineProperty(body, 'scrollHeight', { configurable: true, value: 4321 })
+    Object.defineProperty(body, 'scrollTop', { configurable: true, get: () => scrollTop, set: v => { scrollTop = v } })
+
+    await user.click(screen.getByTestId('logs-mode'))
+    expect(scrollTop).toBe(4321)
   })
 
   it('follows by default, sets up polling and can be disabled', async () => {

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -12,11 +12,16 @@ vi.mock('../../../utils/fetch', () => ({
 
 import { fetchWithMock } from '../../../utils/fetch'
 
+// containersAll returns the repeated `container` query params of an endpoint.
+const containersOf = (endpoint) => [...new URLSearchParams(endpoint.split('?')[1]).getAll('container')]
+const podsOf = (endpoint) => [...new URLSearchParams(endpoint.split('?')[1]).getAll('pod')]
+const lastCall = () => fetchWithMock.mock.calls.at(-1)[0]
+
 describe('WorkloadLogsViewer component', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Each line carries a leading timestamp (as the API returns); timestamps are
-    // hidden by default so the viewer strips it, leaving the message text.
+    // shown as a pill so the viewer strips it from the message text.
     fetchWithMock.mockResolvedValue({ pod: 'my-pod', container: 'app', logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
   })
 
@@ -25,12 +30,23 @@ describe('WorkloadLogsViewer component', () => {
     vi.useRealTimers()
   })
 
+  // A single-pod workload pre-selected on that pod: the common single-stream case.
+  const onePod = (containers = [{ name: 'app', isInit: false }]) => [{ name: 'my-pod', status: 'Running', containers }]
   const defaultProps = {
+    kind: 'Deployment',
     namespace: 'default',
-    name: 'my-pod',
-    containers: [{ name: 'app', isInit: false }],
+    workloadName: 'podinfo',
+    pods: onePod(),
+    initialPodName: 'my-pod',
     onClose: vi.fn()
   }
+
+  // A two-pod workload (pod ids gqh2x / p8x2k), each with one regular container.
+  const twoPods = [
+    { name: 'web-abc-gqh2x', status: 'Running', containers: [{ name: 'app', isInit: false }] },
+    { name: 'web-abc-p8x2k', status: 'Running', containers: [{ name: 'app', isInit: false }] }
+  ]
+  const allPodsProps = { ...defaultProps, pods: twoPods, initialPodName: undefined }
 
   it('fetches and renders logs on mount', async () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
@@ -57,8 +73,6 @@ describe('WorkloadLogsViewer component', () => {
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
     const select = screen.getByTestId('logs-container-select')
     expect(select).toBeInTheDocument()
-    // "All containers" is the default even for a single container; the container
-    // itself stays individually selectable.
     expect(select).toHaveValue('all')
     const values = [...select.querySelectorAll('option')].map(o => o.value)
     expect(values).toEqual(['all', 'app::false'])
@@ -66,196 +80,338 @@ describe('WorkloadLogsViewer component', () => {
 
   it('shows the container selector for multiple containers and refetches on change', async () => {
     const user = userEvent.setup()
-    const props = {
-      ...defaultProps,
-      containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]
-    }
+    const props = { ...defaultProps, pods: onePod([{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]) }
     render(<WorkloadLogsViewer {...props} />)
 
     const select = await screen.findByTestId('logs-container-select')
-    expect(select).toBeInTheDocument()
-
     await user.selectOptions(select, 'sidecar::false')
-    await waitFor(() => {
-      const lastCall = fetchWithMock.mock.calls[fetchWithMock.mock.calls.length - 1][0]
-      expect(lastCall.endpoint).toContain('container=sidecar')
-    })
+    await waitFor(() => expect(lastCall().endpoint).toContain('container=sidecar'))
   })
 
   it('defaults to "All containers" for multiple regular containers and streams them all', async () => {
-    const props = {
-      ...defaultProps,
-      containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]
-    }
+    const props = { ...defaultProps, pods: onePod([{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]) }
     render(<WorkloadLogsViewer {...props} />)
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
-    // The selector defaults to the "All containers" option.
-    const select = screen.getByTestId('logs-container-select')
-    expect(select).toHaveValue('all')
-    const values = [...select.querySelectorAll('option')].map(o => o.value)
-    expect(values).toContain('all')
-    expect(values).toContain('app::false')
-    expect(values).toContain('sidecar::false')
-
-    // The initial request streams every regular container via repeated params.
+    expect(screen.getByTestId('logs-container-select')).toHaveValue('all')
     const endpoint = fetchWithMock.mock.calls[0][0].endpoint
-    const containers = [...new URLSearchParams(endpoint.split('?')[1]).getAll('container')]
-    expect(containers).toEqual(['app', 'sidecar'])
+    expect(containersOf(endpoint)).toEqual(['app', 'sidecar'])
     expect(endpoint).toContain('previous=false')
+    // One pod: no repeated pod params.
+    expect(podsOf(endpoint)).toEqual([])
   })
 
-  it('excludes init containers from "All containers" but keeps them selectable', async () => {
+  it('includes init containers in "All containers" and keeps them selectable', async () => {
     const user = userEvent.setup()
     const props = {
       ...defaultProps,
-      containers: [
+      pods: onePod([
         { name: 'setup', isInit: true },
         { name: 'app', isInit: false },
         { name: 'sidecar', isInit: false }
-      ]
+      ])
     }
     render(<WorkloadLogsViewer {...props} />)
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
-    // "All containers" streams only the regular containers, not the init one.
-    const containers = [...new URLSearchParams(fetchWithMock.mock.calls[0][0].endpoint.split('?')[1]).getAll('container')]
-    expect(containers).toEqual(['app', 'sidecar'])
+    // "All containers" now streams every container, init included, sorted.
+    expect(containersOf(fetchWithMock.mock.calls[0][0].endpoint)).toEqual(['app', 'setup', 'sidecar'])
 
-    // The init container is still individually selectable and fetched on its own.
     const select = screen.getByTestId('logs-container-select')
     const values = [...select.querySelectorAll('option')].map(o => o.value)
     expect(values).toContain('setup::false')
 
     await user.selectOptions(select, 'setup::false')
-    await waitFor(() => {
-      const last = fetchWithMock.mock.calls.at(-1)[0].endpoint
-      const c = [...new URLSearchParams(last.split('?')[1]).getAll('container')]
-      expect(c).toEqual(['setup'])
-    })
+    await waitFor(() => expect(containersOf(lastCall().endpoint)).toEqual(['setup']))
   })
 
   it('switches from "All containers" to a single container', async () => {
     const user = userEvent.setup()
-    const props = {
-      ...defaultProps,
-      containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]
-    }
+    const props = { ...defaultProps, pods: onePod([{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]) }
     render(<WorkloadLogsViewer {...props} />)
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
     await user.selectOptions(screen.getByTestId('logs-container-select'), 'sidecar::false')
-    await waitFor(() => {
-      const last = fetchWithMock.mock.calls.at(-1)[0].endpoint
-      const c = [...new URLSearchParams(last.split('?')[1]).getAll('container')]
-      expect(c).toEqual(['sidecar'])
-    })
+    await waitFor(() => expect(containersOf(lastCall().endpoint)).toEqual(['sidecar']))
   })
 
-  it('defaults to "All containers" for a single regular container, streaming only it', async () => {
-    const props = {
-      ...defaultProps,
-      containers: [{ name: 'setup', isInit: true }, { name: 'app', isInit: false }]
-    }
+  it('defaults to "All containers" and streams every container including init', async () => {
+    const props = { ...defaultProps, pods: onePod([{ name: 'setup', isInit: true }, { name: 'app', isInit: false }]) }
     render(<WorkloadLogsViewer {...props} />)
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
-    // "All containers" is offered and is the default even with one regular
-    // container; the init container is not part of it.
+    expect(screen.getByTestId('logs-container-select')).toHaveValue('all')
+    expect(containersOf(fetchWithMock.mock.calls[0][0].endpoint)).toEqual(['app', 'setup'])
+  })
+
+  it('lists init containers in the container dropdown for "All pods"', async () => {
+    const pods = [
+      { name: 'web-abc-gqh2x', status: 'Running', containers: [{ name: 'setup', isInit: true }, { name: 'app', isInit: false }] },
+      { name: 'web-abc-p8x2k', status: 'Running', containers: [{ name: 'setup', isInit: true }, { name: 'app', isInit: false }] }
+    ]
+    render(<WorkloadLogsViewer {...allPodsProps} pods={pods} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    // "All containers" streams every container across pods (init included), sorted.
+    expect(containersOf(fetchWithMock.mock.calls[0][0].endpoint)).toEqual(['app', 'setup'])
+
+    // The init container is now offered in the dropdown, labelled "init:".
     const select = screen.getByTestId('logs-container-select')
-    expect(select).toHaveValue('all')
-    const containers = [...new URLSearchParams(fetchWithMock.mock.calls[0][0].endpoint.split('?')[1]).getAll('container')]
-    expect(containers).toEqual(['app'])
+    const labels = [...select.querySelectorAll('option')].map(o => o.textContent)
+    expect(labels).toContain('init:setup')
   })
 
   it('titles the modal "Log Viewer" over the workload kind/namespace/name', async () => {
-    const props = { ...defaultProps, kind: 'Deployment', workloadName: 'podinfo' }
-    render(<WorkloadLogsViewer {...props} />)
+    render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
     expect(screen.getByTestId('logs-viewer')).toHaveTextContent('Log Viewer')
     expect(screen.getByTestId('logs-title')).toHaveTextContent('Deployment/default/podinfo')
   })
 
-  it('lists the workload pods and invokes onSelectPod when the pod changes', async () => {
+  it('defaults to "All pods" and streams every pod (sorted) when no pod is pre-selected', async () => {
+    render(<WorkloadLogsViewer {...allPodsProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    const podSelect = screen.getByTestId('logs-pod-select')
+    expect(podSelect).toHaveValue('__all_pods__')
+    const options = [...podSelect.querySelectorAll('option')].map(o => o.value)
+    expect(options).toEqual(['__all_pods__', 'web-abc-gqh2x', 'web-abc-p8x2k'])
+
+    // The request streams the first pod as `name` and the rest as repeated `pod`.
+    const endpoint = fetchWithMock.mock.calls[0][0].endpoint
+    expect(endpoint).toContain('name=web-abc-gqh2x')
+    expect(podsOf(endpoint)).toEqual(['web-abc-p8x2k'])
+    expect(containersOf(endpoint)).toEqual(['app'])
+  })
+
+  it('pre-selects the pod passed as initialPodName', async () => {
+    render(<WorkloadLogsViewer {...allPodsProps} initialPodName="web-abc-p8x2k" />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    expect(screen.getByTestId('logs-pod-select')).toHaveValue('web-abc-p8x2k')
+    const endpoint = fetchWithMock.mock.calls[0][0].endpoint
+    expect(endpoint).toContain('name=web-abc-p8x2k')
+    expect(podsOf(endpoint)).toEqual([])
+  })
+
+  it('narrows to a single pod and resets the container selection on pod change', async () => {
     const user = userEvent.setup()
-    const onSelectPod = vi.fn()
     const props = {
-      ...defaultProps,
-      name: 'pod-a',
-      pods: [{ name: 'pod-a' }, { name: 'pod-b' }],
-      onSelectPod
+      ...allPodsProps,
+      pods: [
+        { name: 'web-abc-gqh2x', containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }] },
+        { name: 'web-abc-p8x2k', containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }] }
+      ]
     }
     render(<WorkloadLogsViewer {...props} />)
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
-    const podSelect = screen.getByTestId('logs-pod-select')
-    expect(podSelect).toHaveValue('pod-a')
-    expect([...podSelect.querySelectorAll('option')].map(o => o.value)).toEqual(['pod-a', 'pod-b'])
-
-    await user.selectOptions(podSelect, 'pod-b')
-    expect(onSelectPod).toHaveBeenCalledWith('pod-b')
-  })
-
-  it('resets the container selection to "All containers" when the pod changes', async () => {
-    const user = userEvent.setup()
-    const props = {
-      ...defaultProps,
-      name: 'pod-a',
-      containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }],
-      pods: [{ name: 'pod-a' }, { name: 'pod-b' }],
-      onSelectPod: vi.fn()
-    }
-    const { rerender } = render(<WorkloadLogsViewer {...props} />)
-    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
-
-    // Pick a specific container, away from the "All containers" default.
+    // Pick a specific container while on "All pods".
     await user.selectOptions(screen.getByTestId('logs-container-select'), 'sidecar::false')
     expect(screen.getByTestId('logs-container-select')).toHaveValue('sidecar::false')
 
-    // The parent switches the pod (the viewer is controlled): it re-renders with
-    // the new pod's name and containers, and the container dropdown snaps back to
-    // "All containers".
-    rerender(<WorkloadLogsViewer {...props} name="pod-b" containers={[{ name: 'web', isInit: false }]} />)
+    // Switching to a specific pod resets the container dropdown to "All containers"
+    // and narrows the request to that pod.
+    await user.selectOptions(screen.getByTestId('logs-pod-select'), 'web-abc-p8x2k')
     await waitFor(() => expect(screen.getByTestId('logs-container-select')).toHaveValue('all'))
+    const endpoint = lastCall().endpoint
+    expect(endpoint).toContain('name=web-abc-p8x2k')
+    expect(podsOf(endpoint)).toEqual([])
   })
 
-  it('appends and dedupes across merged streams while following "All containers"', async () => {
+  it('tags each row with its pod id in the "All pods" view', async () => {
+    fetchWithMock.mockResolvedValue({
+      pod: 'web-abc-gqh2x,web-abc-p8x2k',
+      container: 'app',
+      tagged: true,
+      total: 2,
+      streamed: 2,
+      logs: 'web-abc-gqh2x 2026-01-01T00:00:00Z first\nweb-abc-p8x2k 2026-01-01T00:00:01Z second\n'
+    })
+    render(<WorkloadLogsViewer {...allPodsProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
+
+    const pills = screen.getAllByTestId('logs-pod-id').map(el => el.textContent)
+    expect(pills).toEqual(['gqh2x · ', 'p8x2k · '])
+    // The pod tag is stripped from the message text.
+    const rows = screen.getAllByTestId('logs-line').map(r => r.textContent)
+    expect(rows).toEqual(['first', 'second'])
+  })
+
+  it('does not mistake a message starting with a non-pod word + timestamp for a tag', async () => {
+    fetchWithMock.mockResolvedValue({
+      pod: 'web-abc-gqh2x,web-abc-p8x2k',
+      container: 'app',
+      tagged: true,
+      total: 2,
+      streamed: 2,
+      // Second line's first token "retry" is not one of the requested pods, so it
+      // must render verbatim, not be parsed as a pod tag.
+      logs: 'web-abc-gqh2x 2026-01-01T00:00:00Z ok\nretry 2026-01-01T00:00:05Z failed\n'
+    })
+    render(<WorkloadLogsViewer {...allPodsProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
+
+    // Only the genuinely tagged line has a pod id.
+    expect(screen.getAllByTestId('logs-pod-id')).toHaveLength(1)
+    const rows = screen.getAllByTestId('logs-line').map(r => r.textContent)
+    expect(rows[1]).toBe('retry 2026-01-01T00:00:05Z failed')
+  })
+
+  it('orders the merged buffer chronologically when a lagging pod sends older lines', async () => {
+    // A pod can lag behind another's per-pod cursor, so the response (and thus the
+    // append order) is not globally chronological. The viewer must reorder by
+    // timestamp, keeping each entry's continuation lines attached.
+    fetchWithMock.mockResolvedValue({
+      pod: 'web-abc-gqh2x,web-abc-p8x2k',
+      container: 'app',
+      tagged: true,
+      total: 2,
+      streamed: 2,
+      logs: 'web-abc-p8x2k 2026-01-01T00:00:03Z newest\n' +
+            'web-abc-gqh2x 2026-01-01T00:00:01Z oldest\n' +
+            '  continued\n' +
+            'web-abc-gqh2x 2026-01-01T00:00:02Z middle\n'
+    })
+    render(<WorkloadLogsViewer {...allPodsProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(4))
+
+    const rows = screen.getAllByTestId('logs-line').map(r => r.textContent)
+    // Sorted by timestamp; the continuation line stays directly under "oldest".
+    expect(rows).toEqual(['oldest', '  continued', 'middle', 'newest'])
+  })
+
+  it('does not treat a date-shaped but invalid token as a tagged timestamp', async () => {
+    fetchWithMock.mockResolvedValue({
+      pod: 'web-abc-gqh2x,web-abc-p8x2k',
+      container: 'app',
+      tagged: true,
+      total: 2,
+      streamed: 2,
+      // Second line's first token is a requested pod, but the next token is
+      // date-shaped yet not a real instant, so it must render verbatim.
+      logs: 'web-abc-gqh2x 2026-01-01T00:00:00Z ok\nweb-abc-p8x2k 2026-13-45T99:99:99Z nope\n'
+    })
+    render(<WorkloadLogsViewer {...allPodsProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
+
+    expect(screen.getAllByTestId('logs-pod-id')).toHaveLength(1)
+    const rows = screen.getAllByTestId('logs-line').map(r => r.textContent)
+    expect(rows[1]).toBe('web-abc-p8x2k 2026-13-45T99:99:99Z nope')
+  })
+
+  it('shows a "showing N of M pods" note when the response is partial', async () => {
+    fetchWithMock.mockResolvedValue({
+      pod: 'web-abc-gqh2x,web-abc-p8x2k',
+      container: 'app',
+      tagged: true,
+      total: 2,
+      streamed: 1,
+      partial: true,
+      forbidden: 1,
+      logs: 'web-abc-gqh2x 2026-01-01T00:00:00Z only one\n'
+    })
+    render(<WorkloadLogsViewer {...allPodsProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    expect(screen.getByTestId('logs-partial')).toHaveTextContent('showing 1 of 2 pods')
+  })
+
+  it('falls back to "All pods" when the pre-selected pod disappears', async () => {
+    const { rerender } = render(<WorkloadLogsViewer {...allPodsProps} initialPodName="web-abc-p8x2k" />)
+    await waitFor(() => expect(screen.getByTestId('logs-pod-select')).toHaveValue('web-abc-p8x2k'))
+
+    // The pod is removed from the live list; the selection falls back to All pods.
+    rerender(<WorkloadLogsViewer {...allPodsProps} initialPodName="web-abc-p8x2k" pods={[twoPods[0]]} />)
+    await waitFor(() => expect(screen.getByTestId('logs-pod-select')).toHaveValue('__all_pods__'))
+
+    // A pod reappearing with the same name must not silently snap the view back
+    // to it; the fallback to All pods is committed, not just rendered.
+    rerender(<WorkloadLogsViewer {...allPodsProps} initialPodName="web-abc-p8x2k" pods={twoPods} />)
+    await waitFor(() => expect(screen.getByTestId('logs-pod-select')).toHaveValue('__all_pods__'))
+  })
+
+  it('appends per-pod via repeated since cursors while following "All pods"', async () => {
     vi.useFakeTimers()
     try {
       const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
-      const props = {
-        ...defaultProps,
-        containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]
-      }
-      // Initial load: lines from both containers, already interleaved by the backend.
-      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z app one\n2026-01-01T00:00:01Z side one\n' })
-      // Follow poll: the last line is re-sent (sinceTime is second-granular) plus a new one.
-      fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:01Z side one\n2026-01-01T00:00:02Z app two\n' })
+      fetchWithMock.mockResolvedValueOnce({
+        pod: 'web-abc-gqh2x,web-abc-p8x2k', container: 'app', tagged: true, total: 2, streamed: 2,
+        logs: 'web-abc-gqh2x 2026-01-01T00:00:00Z a one\nweb-abc-p8x2k 2026-01-01T00:00:01Z b one\n'
+      })
+      fetchWithMock.mockResolvedValue({
+        pod: 'web-abc-gqh2x,web-abc-p8x2k', container: 'app', tagged: true, total: 2, streamed: 2,
+        // Overlap (b one re-sent) plus a new line.
+        logs: 'web-abc-p8x2k 2026-01-01T00:00:01Z b one\nweb-abc-gqh2x 2026-01-01T00:00:02Z a two\n'
+      })
 
-      render(<WorkloadLogsViewer {...props} />)
+      render(<WorkloadLogsViewer {...allPodsProps} />)
       await flush()
-      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['app one', 'side one'])
-
-      // The initial load streams every regular container and asks for the tail.
-      const first = fetchWithMock.mock.calls[0][0].endpoint
-      expect([...new URLSearchParams(first.split('?')[1]).getAll('container')]).toEqual(['app', 'sidecar'])
-      expect(first).not.toContain('sinceTime')
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['a one', 'b one'])
+      expect(fetchWithMock.mock.calls[0][0].endpoint).not.toContain('since=')
 
       await act(async () => { vi.advanceTimersByTime(5000) })
       await flush()
 
-      // The overlapping "side one" is deduped across the merged result; only the
-      // genuinely new "app two" is appended.
-      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['app one', 'side one', 'app two'])
+      // The overlap is deduped; only the new line appends.
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['a one', 'b one', 'a two'])
 
-      // The follow poll narrows by sinceTime yet still streams all containers.
-      const poll = fetchWithMock.mock.calls.at(-1)[0].endpoint
-      expect(poll).toContain('sinceTime=2026-01-01T00%3A00%3A01Z')
-      expect([...new URLSearchParams(poll.split('?')[1]).getAll('container')]).toEqual(['app', 'sidecar'])
+      // The follow poll carries a per-pod `since` cursor for each pod.
+      const sinces = [...new URLSearchParams(lastCall().endpoint.split('?')[1]).getAll('since')]
+      expect(sinces).toContain('web-abc-gqh2x=2026-01-01T00:00:00Z')
+      expect(sinces).toContain('web-abc-p8x2k=2026-01-01T00:00:01Z')
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('keeps a new entry\'s stack frames on append when an identical frame is already buffered', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+      // First poll: pod gqh2x panics with a two-line stack (continuation lines are
+      // untagged, as the backend tags only timestamped lines).
+      fetchWithMock.mockResolvedValueOnce({
+        pod: 'web-abc-gqh2x,web-abc-p8x2k', container: 'app', tagged: true, total: 2, streamed: 2,
+        logs: 'web-abc-gqh2x 2026-01-01T00:00:00Z panic: boom\n  goroutine 1 [running]:\n  main.crash()\n'
+      })
+      // Second poll: pod p8x2k panics later with byte-identical stack frames.
+      fetchWithMock.mockResolvedValue({
+        pod: 'web-abc-gqh2x,web-abc-p8x2k', container: 'app', tagged: true, total: 2, streamed: 2,
+        logs: 'web-abc-p8x2k 2026-01-01T00:00:05Z panic: boom\n  goroutine 1 [running]:\n  main.crash()\n'
+      })
+
+      render(<WorkloadLogsViewer {...allPodsProps} />)
+      await flush()
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+
+      // Both panics keep their full stack: the identical frames appear once per
+      // pod, not collapsed by text dedup (which truncated the new trace before).
+      const rows = screen.getAllByTestId('logs-line').map(r => r.textContent)
+      expect(rows.filter(t => t === '  goroutine 1 [running]:')).toHaveLength(2)
+      expect(rows.filter(t => t === '  main.crash()')).toHaveLength(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resets the buffer when the pod set changes but not when it is merely reordered', async () => {
+    const { rerender } = render(<WorkloadLogsViewer {...allPodsProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+    const callsAfterMount = fetchWithMock.mock.calls.length
+
+    // Reorder the same pods: sorted names are unchanged, so no refetch.
+    rerender(<WorkloadLogsViewer {...allPodsProps} pods={[twoPods[1], twoPods[0]]} />)
+    await new Promise(r => setTimeout(r, 0))
+    expect(fetchWithMock.mock.calls.length).toBe(callsAfterMount)
+
+    // Add a pod: the set changed, so the buffer resets with a fresh fetch.
+    const threePods = [...twoPods, { name: 'web-abc-zzz99', containers: [{ name: 'app', isInit: false }] }]
+    rerender(<WorkloadLogsViewer {...allPodsProps} pods={threePods} />)
+    await waitFor(() => expect(fetchWithMock.mock.calls.length).toBeGreaterThan(callsAfterMount))
+    expect(podsOf(lastCall().endpoint)).toEqual(['web-abc-p8x2k', 'web-abc-zzz99'])
   })
 
   it('shows an error message when the fetch fails', async () => {
@@ -278,9 +434,7 @@ describe('WorkloadLogsViewer component', () => {
 
   it('renders each log entry as a separate row', async () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
-    await waitFor(() => {
-      expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
-    })
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
     const rows = screen.getAllByTestId('logs-line')
     expect(rows[0]).toHaveTextContent('line one')
     expect(rows[1]).toHaveTextContent('line two')
@@ -298,10 +452,7 @@ describe('WorkloadLogsViewer component', () => {
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
     await user.selectOptions(screen.getByTestId('logs-lines-select'), '500')
-    await waitFor(() => {
-      const lastCall = fetchWithMock.mock.calls[fetchWithMock.mock.calls.length - 1][0]
-      expect(lastCall.endpoint).toContain('tailLines=500')
-    })
+    await waitFor(() => expect(lastCall().endpoint).toContain('tailLines=500'))
   })
 
   it('filters log entries by the contains text', async () => {
@@ -329,12 +480,9 @@ describe('WorkloadLogsViewer component', () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getByTestId('logs-line')).toHaveTextContent('hello world'))
 
-    // The timestamp lives in the pill; the message row carries only the message.
     expect(screen.getByTestId('logs-timestamp')).toHaveTextContent('2026-06-16T00:00:00Z')
     expect(screen.getByTestId('logs-line')).toHaveTextContent('hello world')
     expect(screen.getByTestId('logs-line')).not.toHaveTextContent('2026-06-16T00:00:00Z')
-
-    // The timestamp is a separator pill, not a toggleable column.
     expect(screen.queryByTestId('logs-timestamps-toggle')).not.toBeInTheDocument()
   })
 
@@ -342,10 +490,10 @@ describe('WorkloadLogsViewer component', () => {
     const user = userEvent.setup()
     const props = {
       ...defaultProps,
-      containers: [
+      pods: onePod([
         { name: 'app', isInit: false, restartCount: 2 },
         { name: 'sidecar', isInit: false, restartCount: 0 }
-      ]
+      ])
     }
     render(<WorkloadLogsViewer {...props} />)
     await waitFor(() => expect(fetchWithMock).toHaveBeenCalled())
@@ -353,7 +501,6 @@ describe('WorkloadLogsViewer component', () => {
 
     const select = screen.getByTestId('logs-container-select')
     const values = [...select.querySelectorAll('option')].map(o => o.value)
-    // Restarted container gets a previous entry; the non-restarted one does not.
     expect(values).toContain('app::false')
     expect(values).toContain('app::true')
     expect(values).toContain('sidecar::false')
@@ -361,13 +508,13 @@ describe('WorkloadLogsViewer component', () => {
 
     await user.selectOptions(select, 'app::true')
     await waitFor(() => {
-      const lastCall = fetchWithMock.mock.calls[fetchWithMock.mock.calls.length - 1][0]
-      expect(lastCall.endpoint).toContain('container=app')
-      expect(lastCall.endpoint).toContain('previous=true')
+      const endpoint = lastCall().endpoint
+      expect(endpoint).toContain('container=app')
+      expect(endpoint).toContain('previous=true')
     })
   })
 
-  it('downloads the logs as a <pod>.log file', async () => {
+  it('downloads the logs as a <pod>.log file for a single pod', async () => {
     const user = userEvent.setup()
     fetchWithMock.mockResolvedValue({ logs: 'line one\nline two\n' })
 
@@ -382,11 +529,26 @@ describe('WorkloadLogsViewer component', () => {
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
     await user.click(screen.getByTestId('logs-download-button'))
-    expect(window.URL.createObjectURL).toHaveBeenCalled()
-    expect(clickSpy).toHaveBeenCalled()
     expect(downloadName).toBe('my-pod.log')
-    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+    clickSpy.mockRestore()
+  })
 
+  it('downloads as <workload>.log in the "All pods" view', async () => {
+    const user = userEvent.setup()
+    fetchWithMock.mockResolvedValue({ pod: 'a,b', container: 'app', tagged: true, total: 2, streamed: 2, logs: 'web-abc-gqh2x 2026-01-01T00:00:00Z x\n' })
+
+    let downloadName
+    window.URL.createObjectURL = vi.fn(() => 'blob:mock')
+    window.URL.revokeObjectURL = vi.fn()
+    const clickSpy = vi.spyOn(window.HTMLAnchorElement.prototype, 'click').mockImplementation(function () {
+      downloadName = this.download
+    })
+
+    render(<WorkloadLogsViewer {...allPodsProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    await user.click(screen.getByTestId('logs-download-button'))
+    expect(downloadName).toBe('podinfo.log')
     clickSpy.mockRestore()
   })
 
@@ -395,10 +557,8 @@ describe('WorkloadLogsViewer component', () => {
     fetchWithMock.mockReturnValue(new Promise((resolve) => { resolveFetch = resolve }))
     render(<WorkloadLogsViewer {...defaultProps} />)
 
-    // The loader shows while the fetch is pending.
     expect(screen.getByTestId('logs-loader')).toBeInTheDocument()
 
-    // Two plain lines default to info; the footer summary counts them.
     resolveFetch({ logs: 'line one\nline two\n' })
     await waitFor(() => expect(screen.queryByTestId('logs-loader')).not.toBeInTheDocument())
     expect(screen.getByTestId('logs-level-summary')).toHaveTextContent('Info 2')
@@ -426,21 +586,18 @@ describe('WorkloadLogsViewer component', () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(3))
 
-    // Selecting "warn" shows ONLY warn (not warn-and-above), proving exact match.
     await user.click(screen.getByTestId('logs-level-filter'))
     await user.click(screen.getByTestId('logs-level-option-warn'))
 
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(1))
     expect(screen.getByTestId('logs-line')).toHaveTextContent('slow')
 
-    // The level summary still counts all (it ignores the level filter).
     expect(screen.getByTestId('logs-level-summary')).toHaveTextContent('Warn 1')
     expect(screen.getByTestId('logs-level-summary')).toHaveTextContent('Error 1')
     expect(screen.getByTestId('logs-level-summary')).toHaveTextContent('Info 1')
   })
 
   it('strips ANSI escape codes from rendered lines', async () => {
-     
     fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z \x1b[31mred error\x1b[0m text\n' })
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getByTestId('logs-line')).toBeInTheDocument())
@@ -454,21 +611,15 @@ describe('WorkloadLogsViewer component', () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
 
-    // Formatted mode is the default and the toggle reflects it.
     const toggle = screen.getByTestId('logs-format-toggle')
     expect(toggle).toHaveAttribute('aria-pressed', 'true')
 
-    // The JSON line is indented and syntax-highlighted. The plain line also
-    // renders as a code block (so all lines share the same font and size) but
-    // with its text unchanged and no syntax highlighting.
     const rows = screen.getAllByTestId('logs-line')
     expect(rows[0].tagName).toBe('PRE')
     expect(rows[0].querySelector('code')).toHaveClass('language-json')
     expect(rows[0].querySelector('.token')).not.toBeNull()
     expect(rows[0].textContent).toBe('{\n  "level": "info",\n  "msg": "hello"\n}')
     expect(rows[1].tagName).toBe('PRE')
-    expect(rows[1].querySelector('code')).toHaveClass('language-json')
-    expect(rows[1].querySelector('.token')).toBeNull()
     expect(rows[1].textContent).toBe('plain text line')
   })
 
@@ -480,37 +631,14 @@ describe('WorkloadLogsViewer component', () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
 
-    // Switching off formatted mode enters raw mode.
     const toggle = screen.getByTestId('logs-format-toggle')
     await user.click(toggle)
     expect(toggle).toHaveAttribute('aria-pressed', 'false')
 
-    // Lines render as plain rows, JSON shown compact exactly as received.
     const rows = screen.getAllByTestId('logs-line')
     expect(rows[0].tagName).toBe('DIV')
     expect(rows[0].textContent).toBe('{"level":"info","msg":"hello"}')
-    expect(rows[1].tagName).toBe('DIV')
     expect(rows[1].textContent).toBe('plain text line')
-
-    // The timestamp pills (row separators) are gone in raw mode.
-    expect(screen.queryByTestId('logs-timestamp')).not.toBeInTheDocument()
-  })
-
-  it('does not highlight the latest line in raw mode when new logs arrive', async () => {
-    const user = userEvent.setup()
-    fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
-    render(<WorkloadLogsViewer {...defaultProps} />)
-    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
-
-    // Enter raw mode.
-    await user.click(screen.getByTestId('logs-format-toggle'))
-
-    // A new entry arrives on the next fetch (triggered by changing the line count).
-    fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n2026-01-01T00:00:02Z line three\n' })
-    await user.selectOptions(screen.getByTestId('logs-lines-select'), '500')
-    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(3))
-
-    // Raw mode has no timestamp pills, so nothing is ever highlighted.
     expect(screen.queryByTestId('logs-timestamp')).not.toBeInTheDocument()
   })
 
@@ -529,11 +657,7 @@ describe('WorkloadLogsViewer component', () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
-    // Follow is on by default, so the corner reads "Following".
-    const mode = screen.getByTestId('logs-mode')
-    expect(mode).toHaveTextContent('Following')
-
-    // Turning follow off switches the corner to "Snapshot".
+    expect(screen.getByTestId('logs-mode')).toHaveTextContent('Following')
     await user.click(screen.getByTestId('logs-follow-toggle'))
     expect(screen.getByTestId('logs-mode')).toHaveTextContent('Snapshot')
   })
@@ -543,8 +667,6 @@ describe('WorkloadLogsViewer component', () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
-    // jsdom has no layout, so stub the scroll metrics to verify the handler pins
-    // the body to the bottom (scrollTop := scrollHeight).
     const body = screen.getByTestId('logs-body')
     let scrollTop = 0
     Object.defineProperty(body, 'scrollHeight', { configurable: true, value: 4321 })
@@ -577,30 +699,23 @@ describe('WorkloadLogsViewer component', () => {
     try {
       const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
 
-      // Initial load returns two timestamped lines.
       fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
-      // The follow poll re-sends the last line (sinceTime is second-granular) plus a new one.
       fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:01Z line two\n2026-01-01T00:00:02Z line three\n' })
 
       render(<WorkloadLogsViewer {...defaultProps} />)
       await flush()
       expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
 
-      // The initial load asks for the tail, not a sinceTime window.
       expect(fetchWithMock.mock.calls[0][0].endpoint).toContain('tailLines=100')
       expect(fetchWithMock.mock.calls[0][0].endpoint).not.toContain('sinceTime')
 
-      // Advance to the first follow poll and let it resolve.
       await act(async () => { vi.advanceTimersByTime(5000) })
       await flush()
 
-      // The overlapping "line two" is deduped; only "line three" is appended.
       const rows = screen.getAllByTestId('logs-line')
       expect(rows.map(r => r.textContent)).toEqual(['line one', 'line two', 'line three'])
 
-      // The poll narrows to entries newer than the last seen line, and still
-      // sends tailLines so a catch-up stays bounded to the user's selection.
-      const pollCall = fetchWithMock.mock.calls[fetchWithMock.mock.calls.length - 1][0]
+      const pollCall = lastCall()
       expect(pollCall.endpoint).toContain('sinceTime=2026-01-01T00%3A00%3A01Z')
       expect(pollCall.endpoint).toContain('tailLines=100')
     } finally {
@@ -618,14 +733,11 @@ describe('WorkloadLogsViewer component', () => {
       await flush()
       expect(fetchWithMock).toHaveBeenCalledTimes(1)
 
-      // Change the line count: this starts a reset fetch that never resolves,
-      // so the viewer stays in the "resetting" state.
       fetchWithMock.mockReturnValueOnce(new Promise(() => {}))
       await act(async () => { fireEvent.change(screen.getByTestId('logs-lines-select'), { target: { value: '500' } }) })
       await flush()
       expect(fetchWithMock).toHaveBeenCalledTimes(2)
 
-      // A follow tick while the reset is in flight must NOT fire an append poll.
       await act(async () => { vi.advanceTimersByTime(5000) })
       await flush()
       expect(fetchWithMock).toHaveBeenCalledTimes(2)
@@ -639,24 +751,20 @@ describe('WorkloadLogsViewer component', () => {
     try {
       const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
 
-      // Initial load for the first stream.
       fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z app one\n2026-01-01T00:00:01Z app two\n' })
       render(<WorkloadLogsViewer {...defaultProps} />)
       await flush()
       expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['app one', 'app two'])
 
-      // The next follow poll is left in flight (its promise never resolves yet).
       let resolveAppend
       fetchWithMock.mockReturnValueOnce(new Promise((resolve) => { resolveAppend = resolve }))
       await act(async () => { vi.advanceTimersByTime(5000) })
 
-      // Meanwhile the user changes the line count, which resets the buffer.
       fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:05Z reset one\n' })
       await act(async () => { fireEvent.change(screen.getByTestId('logs-lines-select'), { target: { value: '500' } }) })
       await flush()
       expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['reset one'])
 
-      // The stale append (from before the reset) now resolves; it must be ignored.
       await act(async () => { resolveAppend({ logs: '2026-01-01T00:00:02Z app three\n' }) })
       await flush()
       expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['reset one'])
@@ -675,18 +783,14 @@ describe('WorkloadLogsViewer component', () => {
       await flush()
       expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
 
-      // The follow poll fails.
       fetchWithMock.mockRejectedValueOnce(new Error('Pod default/my-pod not found'))
       await act(async () => { vi.advanceTimersByTime(5000) })
       await flush()
 
-      // The buffer stays on screen and the error is shown inline at the tail,
-      // not as the full-pane error banner.
       expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
       expect(screen.getByTestId('logs-follow-error')).toHaveTextContent('Pod default/my-pod not found')
       expect(screen.queryByTestId('logs-error')).not.toBeInTheDocument()
 
-      // The next poll succeeds: the inline error clears and the new line appends.
       fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:02Z line three\n' })
       await act(async () => { vi.advanceTimersByTime(5000) })
       await flush()
@@ -703,10 +807,8 @@ describe('WorkloadLogsViewer component', () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
 
-    // No highlight on the initial load.
     expect(screen.getAllByTestId('logs-timestamp').some(el => el.getAttribute('data-latest') === 'true')).toBe(false)
 
-    // A new entry arrives on the next fetch (triggered by changing the line count).
     fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n2026-01-01T00:00:02Z line three\n' })
     await user.selectOptions(screen.getByTestId('logs-lines-select'), '500')
     await waitFor(() => {
@@ -717,24 +819,68 @@ describe('WorkloadLogsViewer component', () => {
     expect(screen.getAllByTestId('logs-timestamp')[0]).not.toHaveAttribute('data-latest')
   })
 
+  it('appends via the global sinceTime on follow for a single pod with multiple containers', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+      const props = { ...defaultProps, pods: onePod([{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]) }
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z one\n2026-01-01T00:00:01Z two\n' })
+      fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:01Z two\n2026-01-01T00:00:02Z three\n' })
+
+      render(<WorkloadLogsViewer {...props} />)
+      await flush()
+      const first = fetchWithMock.mock.calls[0][0].endpoint
+      expect(containersOf(first)).toEqual(['app', 'sidecar'])
+      expect(first).not.toContain('sinceTime')
+
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['one', 'two', 'three'])
+
+      // One pod streams via the global sinceTime cursor, not a per-pod `since`.
+      const poll = lastCall().endpoint
+      expect(poll).toContain('sinceTime=2026-01-01T00%3A00%3A01Z')
+      expect(poll).not.toContain('since=')
+      expect(containersOf(poll)).toEqual(['app', 'sidecar'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows the empty state and fires no request when there are no pods to stream', async () => {
+    render(<WorkloadLogsViewer {...defaultProps} pods={[]} />)
+    await new Promise(r => setTimeout(r, 0))
+    expect(fetchWithMock).not.toHaveBeenCalled()
+    expect(screen.getByTestId('logs-empty')).toBeInTheDocument()
+  })
+
+  it('falls back to the regular containers when the selected container disappears', async () => {
+    const user = userEvent.setup()
+    const props = { ...defaultProps, pods: onePod([{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]) }
+    const { rerender } = render(<WorkloadLogsViewer {...props} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    await user.selectOptions(screen.getByTestId('logs-container-select'), 'sidecar::false')
+    await waitFor(() => expect(containersOf(lastCall().endpoint)).toEqual(['sidecar']))
+
+    // The pod loses the 'sidecar' container (same pod, so no container reset): the
+    // request must fall back to the regular containers, not the vanished one.
+    rerender(<WorkloadLogsViewer {...props} pods={onePod([{ name: 'app', isInit: false }])} />)
+    await waitFor(() => expect(containersOf(lastCall().endpoint)).toEqual(['app']))
+  })
+
   it('does not highlight the last visible line when new logs are filtered out', async () => {
     const user = userEvent.setup()
     fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z keep me\n2026-01-01T00:00:01Z keep me too\n' })
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
 
-    // Keep only the lines containing "keep"; both current lines match.
     await user.type(screen.getByTestId('logs-filter-input'), 'keep')
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
 
-    // A new entry arrives that does not match the filter, so the visible set is
-    // unchanged. The unchanged last line must not be highlighted as if it were new.
     fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z keep me\n2026-01-01T00:00:01Z keep me too\n2026-01-01T00:00:02Z noise\n' })
     await user.selectOptions(screen.getByTestId('logs-lines-select'), '500')
-    await waitFor(() => {
-      const call = fetchWithMock.mock.calls.at(-1)[0]
-      expect(call.endpoint).toContain('tailLines=500')
-    })
+    await waitFor(() => expect(lastCall().endpoint).toContain('tailLines=500'))
     expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
     expect(screen.getAllByTestId('logs-timestamp').some(el => el.getAttribute('data-latest') === 'true')).toBe(false)
   })

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -206,19 +206,61 @@ describe('WorkloadLogsViewer component', () => {
     clickSpy.mockRestore()
   })
 
-  it('always shows the line count in the footer, with a loader while fetching', async () => {
+  it('shows a per-level count summary in the footer, with a loader while fetching', async () => {
     let resolveFetch
     fetchWithMock.mockReturnValue(new Promise((resolve) => { resolveFetch = resolve }))
     render(<WorkloadLogsViewer {...defaultProps} />)
 
-    // The footer always shows the line count; the loader shows alongside it
-    // while the fetch is pending.
-    expect(screen.getByTestId('logs-footer')).toHaveTextContent('0 lines')
+    // The loader shows while the fetch is pending.
     expect(screen.getByTestId('logs-loader')).toBeInTheDocument()
 
+    // Two plain lines default to info; the footer summary counts them.
     resolveFetch({ logs: 'line one\nline two\n' })
     await waitFor(() => expect(screen.queryByTestId('logs-loader')).not.toBeInTheDocument())
-    expect(screen.getByTestId('logs-footer')).toHaveTextContent('2 lines')
+    expect(screen.getByTestId('logs-level-summary')).toHaveTextContent('Info 2')
+  })
+
+  it('colors the timestamp pill by the detected log level', async () => {
+    fetchWithMock.mockResolvedValue({
+      logs: '2026-01-01T00:00:00Z {"level":"error","msg":"boom"}\n2026-01-01T00:00:01Z just some text\n'
+    })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-timestamp')).toHaveLength(2))
+
+    const pills = screen.getAllByTestId('logs-timestamp')
+    expect(pills[0]).toHaveAttribute('data-level', 'error')
+    expect(pills[1]).toHaveAttribute('data-level', 'info')
+  })
+
+  it('filters lines to the exact selected level', async () => {
+    const user = userEvent.setup()
+    fetchWithMock.mockResolvedValue({
+      logs: '2026-01-01T00:00:00Z {"level":"error","msg":"boom"}\n'
+        + '2026-01-01T00:00:01Z {"level":"warn","msg":"slow"}\n'
+        + '2026-01-01T00:00:02Z {"level":"info","msg":"hi"}\n'
+    })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(3))
+
+    // Selecting "warn" shows ONLY warn (not warn-and-above), proving exact match.
+    await user.click(screen.getByTestId('logs-level-filter'))
+    await user.click(screen.getByTestId('logs-level-option-warn'))
+
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(1))
+    expect(screen.getByTestId('logs-line')).toHaveTextContent('slow')
+
+    // The level summary still counts all (it ignores the level filter).
+    expect(screen.getByTestId('logs-level-summary')).toHaveTextContent('Warn 1')
+    expect(screen.getByTestId('logs-level-summary')).toHaveTextContent('Error 1')
+    expect(screen.getByTestId('logs-level-summary')).toHaveTextContent('Info 1')
+  })
+
+  it('strips ANSI escape codes from rendered lines', async () => {
+     
+    fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z \x1b[31mred error\x1b[0m text\n' })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-line')).toBeInTheDocument())
+    expect(screen.getByTestId('logs-line').textContent).toBe('red error text')
   })
 
   it('renders JSON lines as highlighted code blocks when the JSON toggle is on, leaving plain lines intact', async () => {

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/preact'
 import userEvent from '@testing-library/user-event'
-import { WorkloadLogsViewer } from './WorkloadLogsViewer'
+import { WorkloadLogsViewer, reconcileEntries } from './WorkloadLogsViewer'
 
 vi.mock('../../../utils/fetch', () => ({
   fetchWithMock: vi.fn()
@@ -666,6 +666,38 @@ describe('WorkloadLogsViewer component', () => {
     expect(screen.queryByTestId('logs-timestamp')).not.toBeInTheDocument()
   })
 
+  it('hides the level filter and shows a line count in raw mode, resetting an active filter', async () => {
+    const user = userEvent.setup()
+    fetchWithMock.mockResolvedValue({
+      logs: '2026-01-01T00:00:00Z {"level":"error","msg":"boom"}\n'
+        + '2026-01-01T00:00:01Z {"level":"warn","msg":"slow"}\n'
+        + '2026-01-01T00:00:02Z {"level":"info","msg":"hi"}\n'
+    })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(3))
+
+    // Formatted mode: the level filter and per-level legend are present. Narrow to warn.
+    expect(screen.getByTestId('logs-level-filter')).toBeInTheDocument()
+    expect(screen.getByTestId('logs-level-summary')).toBeInTheDocument()
+    await user.click(screen.getByTestId('logs-level-filter'))
+    await user.click(screen.getByTestId('logs-level-option-warn'))
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(1))
+
+    // Raw mode: the filter is hidden and reset to "all" (all 3 lines return), and the
+    // per-level legend is replaced by a plain line count.
+    await user.click(screen.getByTestId('logs-format-toggle'))
+    expect(screen.queryByTestId('logs-level-filter')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('logs-level-summary')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(3))
+    expect(screen.getByTestId('logs-line-count')).toHaveTextContent('3 log lines')
+
+    // Back to formatted: the filter returns and stays "all" (the warn filter did not
+    // survive the round-trip), so all 3 lines remain visible.
+    await user.click(screen.getByTestId('logs-format-toggle'))
+    expect(screen.getByTestId('logs-level-filter')).toBeInTheDocument()
+    expect(screen.getAllByTestId('logs-line')).toHaveLength(3)
+  })
+
   it('toggles fullscreen mode', async () => {
     const user = userEvent.setup()
     render(<WorkloadLogsViewer {...defaultProps} />)
@@ -742,6 +774,102 @@ describe('WorkloadLogsViewer component', () => {
       const pollCall = lastCall()
       expect(pollCall.endpoint).toContain('sinceTime=2026-01-01T00%3A00%3A01Z')
       expect(pollCall.endpoint).toContain('tailLines=100')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Part B: parsing is incremental — a follow poll re-parses only the appended
+  // lines and reuses the cached entries for the rest. These guard that the
+  // incrementally-built buffer is identical to a from-scratch parse across several
+  // polls, that the all-pods sort still runs over it, and that front-eviction at
+  // MAX_BUFFER_LINES keeps the parsed mirror in lock-step with the string buffer.
+  it('matches a from-scratch parse across several incremental follow polls', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z one\n2026-01-01T00:00:01Z two\n' })
+      // Each poll re-sends the last buffered line (the overlap) plus a new one.
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:01Z two\n2026-01-01T00:00:02Z three\n' })
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:02Z three\n2026-01-01T00:00:03Z four\n' })
+
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await flush()
+
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+
+      // The reused entries plus the freshly parsed tails reconstruct the exact
+      // ordered buffer a single fetch of the concatenation would have produced.
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent))
+        .toEqual(['one', 'two', 'three', 'four'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('sorts a lagging pod\'s older line into place after an incremental append', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+
+      fetchWithMock.mockResolvedValueOnce({
+        pod: 'web-abc-gqh2x,web-abc-p8x2k', container: 'app', tagged: true, total: 2, streamed: 2,
+        logs: 'web-abc-gqh2x 2026-01-01T00:00:00Z a one\nweb-abc-p8x2k 2026-01-01T00:00:02Z b one\n'
+      })
+      // The lagging pod delivers a line older than b one only on the follow poll, so
+      // the chronological re-sort must run over the incrementally-parsed buffer.
+      fetchWithMock.mockResolvedValue({
+        pod: 'web-abc-gqh2x,web-abc-p8x2k', container: 'app', tagged: true, total: 2, streamed: 2,
+        logs: 'web-abc-gqh2x 2026-01-01T00:00:01Z a two\n'
+      })
+
+      render(<WorkloadLogsViewer {...allPodsProps} />)
+      await flush()
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['a one', 'b one'])
+
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+
+      // a two (ts 1) sorts between a one (ts 0) and b one (ts 2), not at the tail.
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['a one', 'a two', 'b one'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the parsed buffer in lock-step with the string buffer through front-eviction', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+
+      // Fill the buffer to its MAX_BUFFER_LINES (5000) cap, then append two newer
+      // lines so the merge front-evicts the two oldest. The eviction branch must
+      // reuse the surviving entries and parse only the appended tail.
+      const initial = Array.from({ length: 5000 }, (_, i) =>
+        `2026-01-01T00:00:00.${String(i).padStart(4, '0')}Z line ${i}`).join('\n') + '\n'
+      fetchWithMock.mockResolvedValueOnce({ logs: initial })
+      fetchWithMock.mockResolvedValue({
+        logs: '2026-01-01T00:00:00.4999Z line 4999\n2026-01-01T00:00:01Z line 5000\n2026-01-01T00:00:02Z line 5001\n'
+      })
+
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await flush()
+      expect(screen.getAllByTestId('logs-line')).toHaveLength(5000)
+
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+
+      // Still capped at 5000: the two oldest evicted, the two newest appended, and
+      // every surviving line still parsed (timestamp stripped from the message).
+      const rows = screen.getAllByTestId('logs-line')
+      expect(rows).toHaveLength(5000)
+      expect(rows[0].textContent).toBe('line 2')
+      expect(rows.at(-1).textContent).toBe('line 5001')
+      expect(rows.at(-2).textContent).toBe('line 5000')
     } finally {
       vi.useRealTimers()
     }
@@ -1212,5 +1340,86 @@ describe('WorkloadLogsViewer component', () => {
       expect(screen.getByText('goroutine 1 [running]:')).toBeInTheDocument()
       expect(screen.getByText('main.crash()')).toBeInTheDocument()
     })
+  })
+})
+
+// Part B mechanism: reconcileEntries is the pure incremental-parse core, so these
+// prove the reuse itself (parse-call count + object identity), not just that the
+// final output happens to be right — a full re-parse on every poll would pass the
+// component-level output tests but fail these.
+describe('reconcileEntries', () => {
+  // Distinct object per line so identity reuse is observable.
+  const mkEntries = (lines) => lines.map(l => ({ src: l }))
+
+  it('parses every line when there is no previous buffer', () => {
+    const parse = vi.fn(l => ({ p: l }))
+    const out = reconcileEntries([], [], ['a', 'b'], parse)
+    expect(parse).toHaveBeenCalledTimes(2)
+    expect(out).toEqual([{ p: 'a' }, { p: 'b' }])
+  })
+
+  it('reuses every cached entry and parses only the appended tail when the buffer grows', () => {
+    const prevLines = ['a', 'b']
+    const prevEntries = mkEntries(prevLines)
+    const parse = vi.fn(l => ({ p: l }))
+    const out = reconcileEntries(prevLines, prevEntries, ['a', 'b', 'c', 'd'], parse)
+    expect(parse.mock.calls.map(c => c[0])).toEqual(['c', 'd'])
+    expect(out[0]).toBe(prevEntries[0]) // same object, not re-parsed
+    expect(out[1]).toBe(prevEntries[1])
+    expect(out).toHaveLength(4)
+  })
+
+  it('parses nothing when the buffer is unchanged across a poll', () => {
+    const prevLines = ['a', 'b']
+    const prevEntries = mkEntries(prevLines)
+    const parse = vi.fn(l => ({ p: l }))
+    const out = reconcileEntries(prevLines, prevEntries, ['a', 'b'], parse)
+    expect(parse).not.toHaveBeenCalled()
+    expect(out).toEqual(prevEntries)
+  })
+
+  it('reuses the survivors and parses the tail through front-eviction', () => {
+    const prevLines = ['a', 'b', 'c', 'd']
+    const prevEntries = mkEntries(prevLines)
+    const parse = vi.fn(l => ({ p: l }))
+    const out = reconcileEntries(prevLines, prevEntries, ['c', 'd', 'e'], parse)
+    expect(parse.mock.calls.map(c => c[0])).toEqual(['e'])
+    expect(out[0]).toBe(prevEntries[2])
+    expect(out[1]).toBe(prevEntries[3])
+    expect(out).toHaveLength(3)
+  })
+
+  it('finds the eviction offset past an earlier duplicate of the new head line', () => {
+    // 'c' also appears at index 0, but the real overlap is the [c,d] suffix; the
+    // scan starts at 1 and the verify loop confirms the right offset.
+    const prevLines = ['c', 'a', 'c', 'd']
+    const prevEntries = mkEntries(prevLines)
+    const parse = vi.fn(l => ({ p: l }))
+    const out = reconcileEntries(prevLines, prevEntries, ['c', 'd', 'e'], parse)
+    expect(parse.mock.calls.map(c => c[0])).toEqual(['e'])
+    expect(out[0]).toBe(prevEntries[2])
+    expect(out[1]).toBe(prevEntries[3])
+  })
+
+  it('falls back to a full parse when the overlap diverges', () => {
+    // lines[0] matches at drop=1, but the next line differs, so the verify loop
+    // rejects the reuse and re-parses everything (the mirror can never drift).
+    const prevLines = ['a', 'b', 'c']
+    const prevEntries = mkEntries(prevLines)
+    const parse = vi.fn(l => ({ p: l }))
+    const out = reconcileEntries(prevLines, prevEntries, ['b', 'X', 'Y'], parse)
+    expect(parse.mock.calls.map(c => c[0])).toEqual(['b', 'X', 'Y'])
+    expect(out).toEqual([{ p: 'b' }, { p: 'X' }, { p: 'Y' }])
+  })
+
+  it('falls back to a full parse when the computed overlap exceeds the new buffer', () => {
+    // The offset scan lands on drop=3 (reuse=2), but only one line remains, so the
+    // reuse>lines.length guard forces a full parse rather than reading past the end.
+    const prevLines = ['a', 'b', 'c', 'd', 'e']
+    const prevEntries = mkEntries(prevLines)
+    const parse = vi.fn(l => ({ p: l }))
+    const out = reconcileEntries(prevLines, prevEntries, ['d'], parse)
+    expect(parse.mock.calls.map(c => c[0])).toEqual(['d'])
+    expect(out).toEqual([{ p: 'd' }])
   })
 })

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/preact'
 import userEvent from '@testing-library/user-event'
 import { WorkloadLogsViewer, reconcileEntries } from './WorkloadLogsViewer'
+import { logSettings, DEFAULT_LOG_SETTINGS, resetLogSettings } from '../../../utils/logSettings'
 
 vi.mock('../../../utils/fetch', () => ({
   fetchWithMock: vi.fn()
@@ -20,6 +21,9 @@ const lastCall = () => fetchWithMock.mock.calls.at(-1)[0]
 describe('WorkloadLogsViewer component', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset the persisted log viewer settings (a module-level signal) so a case
+    // that toggles follow/format/lines can't leak its choice into the next.
+    logSettings.value = { ...DEFAULT_LOG_SETTINGS }
     // Each line carries a leading timestamp (as the API returns); timestamps are
     // shown as a pill so the viewer strips it from the message text.
     fetchWithMock.mockResolvedValue({ pod: 'my-pod', container: 'app', logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
@@ -1339,6 +1343,47 @@ describe('WorkloadLogsViewer component', () => {
       await user.click(folds[0])
       expect(screen.getByText('goroutine 1 [running]:')).toBeInTheDocument()
       expect(screen.getByText('main.crash()')).toBeInTheDocument()
+    })
+  })
+
+  describe('persisted settings', () => {
+    it('seeds follow, format and lines from the stored settings', async () => {
+      logSettings.value = { follow: false, formatted: false, tail: 500 }
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      expect(screen.getByTestId('logs-follow-toggle')).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByTestId('logs-format-toggle')).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByTestId('logs-lines-select')).toHaveValue('500')
+    })
+
+    it('persists follow, format and lines changes to the settings signal', async () => {
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      await act(async () => { fireEvent.change(screen.getByTestId('logs-lines-select'), { target: { value: '1000' } }) })
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-follow-toggle')) })
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-format-toggle')) })
+
+      expect(logSettings.value).toEqual({ follow: false, formatted: false, tail: 1000 })
+    })
+
+    it('does not change an already-open viewer when the settings are reset', async () => {
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      await act(async () => { fireEvent.change(screen.getByTestId('logs-lines-select'), { target: { value: '1000' } }) })
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-format-toggle')) })
+
+      // Reset the persisted settings (as "Clear local storage" does) while the
+      // viewer is open. The signal resets, but the open viewer seeded via peek and
+      // never subscribed, so its live state is untouched — the reset only applies
+      // the next time the viewer is opened.
+      await act(async () => { resetLogSettings() })
+
+      expect(logSettings.value).toEqual(DEFAULT_LOG_SETTINGS)
+      expect(screen.getByTestId('logs-lines-select')).toHaveValue('1000')
+      expect(screen.getByTestId('logs-format-toggle')).toHaveAttribute('aria-pressed', 'false')
     })
   })
 })

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -658,6 +658,95 @@ describe('WorkloadLogsViewer component', () => {
     expect(rows[1].textContent).toBe('plain text line')
   })
 
+  describe('JSON field selection', () => {
+    const jsonProps = () => {
+      fetchWithMock.mockResolvedValue({
+        logs: '2026-01-01T00:00:00Z {"level":"info","ts":"t","msg":"hello","ns":"apps"}\n'
+      })
+      return defaultProps
+    }
+    const typeFields = async (expr) => {
+      if (!screen.queryByTestId('logs-settings-panel')) {
+        await act(async () => { fireEvent.click(screen.getByTestId('logs-settings-toggle')) })
+      }
+      await act(async () => { fireEvent.input(screen.getByTestId('logs-fields-input'), { target: { value: expr } }) })
+    }
+
+    it('offers a field filter in the settings panel and shows all fields by default', async () => {
+      render(<WorkloadLogsViewer {...jsonProps()} />)
+      await waitFor(() => expect(screen.getByTestId('logs-line')).toBeInTheDocument())
+
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-settings-toggle')) })
+      const input = screen.getByTestId('logs-fields-input')
+      expect(input).toHaveValue('')
+      // The placeholder illustrates the syntax (a list with ! exclude and * glob).
+      expect(input.getAttribute('placeholder')).toMatch(/!\w.*\*/)
+      expect(screen.getByTestId('logs-line').textContent).toBe('"level": "info",\n"ts": "t",\n"msg": "hello",\n"ns": "apps"')
+    })
+
+    it('shows only the listed fields, in source order (pipe/space separated)', async () => {
+      render(<WorkloadLogsViewer {...jsonProps()} />)
+      await waitFor(() => expect(screen.getByTestId('logs-line')).toBeInTheDocument())
+
+      await typeFields('msg|ns')
+      expect(screen.getByTestId('logs-line').textContent).toBe('"msg": "hello",\n"ns": "apps"')
+    })
+
+    it('excludes fields with a ! prefix, keeping the rest', async () => {
+      render(<WorkloadLogsViewer {...jsonProps()} />)
+      await waitFor(() => expect(screen.getByTestId('logs-line')).toBeInTheDocument())
+
+      await typeFields('!level !ts')
+      expect(screen.getByTestId('logs-line').textContent).toBe('"msg": "hello",\n"ns": "apps"')
+    })
+
+    it('supports * glob matching on field names', async () => {
+      fetchWithMock.mockResolvedValue({
+        logs: '2026-01-01T00:00:00Z {"msg":"hi","reconcileID":"abc","controllerKind":"X"}\n'
+      })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-line')).toBeInTheDocument())
+
+      await typeFields('*id')
+      expect(screen.getByTestId('logs-line').textContent).toBe('"reconcileID": "abc"')
+    })
+
+    it('clears the filter when the expression is emptied', async () => {
+      render(<WorkloadLogsViewer {...jsonProps()} />)
+      await waitFor(() => expect(screen.getByTestId('logs-line')).toBeInTheDocument())
+
+      await typeFields('msg')
+      expect(screen.getByTestId('logs-line').textContent).toBe('"msg": "hello"')
+      await typeFields('')
+      expect(screen.getByTestId('logs-line').textContent).toBe('"level": "info",\n"ts": "t",\n"msg": "hello",\n"ns": "apps"')
+    })
+
+    it('discovers fields from a JSON line that has no leading timestamp, keeping the input usable', async () => {
+      // A line without the kubelet RFC3339 prefix parses with ts==='' but is still
+      // projected; discovery must see it too so the input stays visible and the body
+      // stays consistent (no unclearable collapse-to-{}).
+      fetchWithMock.mockResolvedValue({ logs: '{"msg":"hi","level":"info"}\n' })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-line')).toBeInTheDocument())
+
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-settings-toggle')) })
+      const input = screen.getByTestId('logs-fields-input')
+      expect(input).toBeInTheDocument()
+      await act(async () => { fireEvent.input(input, { target: { value: 'msg' } }) })
+      expect(screen.getByTestId('logs-line').textContent).toBe('"msg": "hi"')
+    })
+
+    it('does not offer the field filter in raw mode', async () => {
+      const user = userEvent.setup()
+      render(<WorkloadLogsViewer {...jsonProps()} />)
+      await waitFor(() => expect(screen.getByTestId('logs-line')).toBeInTheDocument())
+
+      await user.click(screen.getByTestId('logs-format-toggle')) // to raw
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-settings-toggle')) })
+      expect(screen.queryByTestId('logs-fields-input')).not.toBeInTheDocument()
+    })
+  })
+
   it('strips all styling in raw mode: plain rows, no timestamp pills or highlight', async () => {
     const user = userEvent.setup()
     fetchWithMock.mockResolvedValue({
@@ -1408,29 +1497,44 @@ describe('WorkloadLogsViewer component', () => {
   })
 
   describe('persisted settings', () => {
-    it('seeds follow, format, lines and font size from the stored settings', async () => {
-      logSettings.value = { follow: false, formatted: false, tail: 500, fontSize: 'lg' }
+    it('seeds follow, format, lines, font size and the field filter from the stored settings', async () => {
+      logSettings.value = { follow: false, formatted: false, tail: 500, fontSize: 'lg', fields: '' }
       render(<WorkloadLogsViewer {...defaultProps} />)
       await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
 
       expect(screen.getByTestId('logs-follow-toggle')).toHaveAttribute('aria-pressed', 'false')
       expect(screen.getByTestId('logs-format-toggle')).toHaveAttribute('aria-pressed', 'false')
 
+      // Back to formatted so the field input is available, then check the seeds.
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-format-toggle')) })
       await act(async () => { fireEvent.click(screen.getByTestId('logs-settings-toggle')) })
       expect(screen.getByTestId('logs-tail-500')).toHaveAttribute('aria-pressed', 'true')
       expect(screen.getByTestId('logs-fontsize-lg')).toHaveAttribute('aria-pressed', 'true')
     })
 
-    it('persists follow, format, lines and font size changes to the settings signal', async () => {
+    it('seeds the field filter from the stored expression and applies it', async () => {
+      logSettings.value = { ...DEFAULT_LOG_SETTINGS, fields: 'msg' }
+      fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z {"level":"info","msg":"hello"}\n' })
       render(<WorkloadLogsViewer {...defaultProps} />)
-      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+      await waitFor(() => expect(screen.getByTestId('logs-line')).toBeInTheDocument())
+
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-settings-toggle')) })
+      expect(screen.getByTestId('logs-fields-input')).toHaveValue('msg')
+      expect(screen.getByTestId('logs-line').textContent).toBe('"msg": "hello"')
+    })
+
+    it('persists follow, format, lines, font size and the field filter to the settings signal', async () => {
+      fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z {"level":"info","msg":"hi"}\n' })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-line')).toBeInTheDocument())
 
       await setTailLines(1000)
       await act(async () => { fireEvent.click(screen.getByTestId('logs-fontsize-sm')) })
+      await act(async () => { fireEvent.input(screen.getByTestId('logs-fields-input'), { target: { value: 'msg|error' } }) })
       await act(async () => { fireEvent.click(screen.getByTestId('logs-follow-toggle')) })
       await act(async () => { fireEvent.click(screen.getByTestId('logs-format-toggle')) })
 
-      expect(logSettings.value).toEqual({ follow: false, formatted: false, tail: 1000, fontSize: 'sm' })
+      expect(logSettings.value).toEqual({ follow: false, formatted: false, tail: 1000, fontSize: 'sm', fields: 'msg|error' })
     })
 
     it('applies the font size to the log body via a CSS variable', async () => {

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -1,0 +1,191 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/preact'
+import userEvent from '@testing-library/user-event'
+import { WorkloadLogsViewer } from './WorkloadLogsViewer'
+
+// Mock the fetchWithMock function
+vi.mock('../../../utils/fetch', () => ({
+  fetchWithMock: vi.fn()
+}))
+
+import { fetchWithMock } from '../../../utils/fetch'
+
+describe('WorkloadLogsViewer component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Each line carries a leading timestamp (as the API returns); timestamps are
+    // hidden by default so the viewer strips it, leaving the message text.
+    fetchWithMock.mockResolvedValue({ pod: 'my-pod', container: 'app', logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
+  })
+
+  const defaultProps = {
+    namespace: 'default',
+    name: 'my-pod',
+    containers: [{ name: 'app', isInit: false }],
+    onClose: vi.fn()
+  }
+
+  it('fetches and renders logs on mount', async () => {
+    render(<WorkloadLogsViewer {...defaultProps} />)
+
+    expect(screen.getByTestId('logs-viewer')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('logs-content')).toHaveTextContent('line one')
+    })
+
+    expect(fetchWithMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: expect.stringContaining('/api/v1/workload/logs?'),
+        mockExport: 'getMockWorkloadLogs'
+      })
+    )
+    const call = fetchWithMock.mock.calls[0][0]
+    expect(call.endpoint).toContain('namespace=default')
+    expect(call.endpoint).toContain('name=my-pod')
+    expect(call.endpoint).toContain('container=app')
+  })
+
+  it('always shows the container selector, even for a single container', async () => {
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+    const select = screen.getByTestId('logs-container-select')
+    expect(select).toBeInTheDocument()
+    expect(select).toHaveValue('app')
+  })
+
+  it('shows the container selector for multiple containers and refetches on change', async () => {
+    const user = userEvent.setup()
+    const props = {
+      ...defaultProps,
+      containers: [{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]
+    }
+    render(<WorkloadLogsViewer {...props} />)
+
+    const select = await screen.findByTestId('logs-container-select')
+    expect(select).toBeInTheDocument()
+
+    await user.selectOptions(select, 'sidecar')
+    await waitFor(() => {
+      const lastCall = fetchWithMock.mock.calls[fetchWithMock.mock.calls.length - 1][0]
+      expect(lastCall.endpoint).toContain('container=sidecar')
+    })
+  })
+
+  it('shows an error message when the fetch fails', async () => {
+    fetchWithMock.mockRejectedValue(new Error('Permission denied'))
+    render(<WorkloadLogsViewer {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('logs-error')).toHaveTextContent('Permission denied')
+    })
+  })
+
+  it('calls onClose when the close button is clicked', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(<WorkloadLogsViewer {...defaultProps} onClose={onClose} />)
+
+    await user.click(screen.getByTestId('logs-close-button'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('renders each log entry as a separate row', async () => {
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
+    })
+    const rows = screen.getAllByTestId('logs-line')
+    expect(rows[0]).toHaveTextContent('line one')
+    expect(rows[1]).toHaveTextContent('line two')
+  })
+
+  it('requests 100 lines by default', async () => {
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(fetchWithMock).toHaveBeenCalled())
+    expect(fetchWithMock.mock.calls[0][0].endpoint).toContain('tailLines=100')
+  })
+
+  it('requests the selected number of lines', async () => {
+    const user = userEvent.setup()
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    await user.selectOptions(screen.getByTestId('logs-lines-select'), '500')
+    await waitFor(() => {
+      const lastCall = fetchWithMock.mock.calls[fetchWithMock.mock.calls.length - 1][0]
+      expect(lastCall.endpoint).toContain('tailLines=500')
+    })
+  })
+
+  it('filters log entries by the contains text', async () => {
+    const user = userEvent.setup()
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
+
+    await user.type(screen.getByTestId('logs-filter-input'), 'two')
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(1))
+    expect(screen.getByTestId('logs-line')).toHaveTextContent('line two')
+  })
+
+  it('hides timestamps by default and shows them when toggled', async () => {
+    const user = userEvent.setup()
+    fetchWithMock.mockResolvedValue({ logs: '2026-06-16T00:00:00Z hello world\n' })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-line')).toHaveTextContent('hello world'))
+
+    // Timestamps are hidden by default: the leading timestamp is stripped.
+    const toggle = screen.getByTestId('logs-timestamps-toggle')
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByTestId('logs-line')).not.toHaveTextContent('2026-06-16T00:00:00Z')
+
+    // Toggle on to reveal the timestamps.
+    await user.click(toggle)
+    expect(toggle).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('logs-line')).toHaveTextContent('2026-06-16T00:00:00Z')
+  })
+
+  it('toggles the previous container instance and refetches', async () => {
+    const user = userEvent.setup()
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(fetchWithMock).toHaveBeenCalled())
+    expect(fetchWithMock.mock.calls[0][0].endpoint).toContain('previous=false')
+
+    await user.click(screen.getByTestId('logs-previous-toggle'))
+    await waitFor(() => {
+      const lastCall = fetchWithMock.mock.calls[fetchWithMock.mock.calls.length - 1][0]
+      expect(lastCall.endpoint).toContain('previous=true')
+    })
+  })
+
+  it('toggles fullscreen mode', async () => {
+    const user = userEvent.setup()
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    const toggle = screen.getByTestId('logs-fullscreen-toggle')
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(toggle)
+    expect(toggle).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('does not follow by default and sets up polling once enabled', async () => {
+    const user = userEvent.setup()
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const polls = () => setIntervalSpy.mock.calls.filter(c => c[1] === 5000).length
+
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+    const toggle = screen.getByTestId('logs-follow-toggle')
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+    expect(polls()).toBe(0)
+
+    await user.click(toggle)
+    expect(toggle).toHaveAttribute('aria-pressed', 'true')
+    await waitFor(() => expect(polls()).toBe(1))
+
+    setIntervalSpy.mockRestore()
+  })
+})

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -400,6 +400,9 @@ describe('WorkloadLogsViewer component', () => {
 
       render(<WorkloadLogsViewer {...allPodsProps} />)
       await flush()
+      // Turn off stack-trace grouping so the frames render as flat rows; this test
+      // asserts mergeLogs keeps both pods' frames, independent of the fold UI.
+      await act(async () => { fireEvent.click(screen.getByTestId('logs-group-toggle')) })
       await act(async () => { vi.advanceTimersByTime(5000) })
       await flush()
 
@@ -951,5 +954,170 @@ describe('WorkloadLogsViewer component', () => {
     const lines = screen.getAllByTestId('logs-line')
     expect(lines).toHaveLength(1)
     expect(lines[0].textContent).toBe('level=info msg="reconcile complete" controller=gitrepository')
+  })
+
+  describe('stack-trace grouping', () => {
+    // A Go panic followed by a flush-left line that closes the trace. Frames are
+    // timestamped (the CRI case), so each is its own entry the grouper folds.
+    const GO_PANIC_LOGS =
+      '2026-01-01T00:00:00.000000000Z panic: boom from c\n' +
+      '2026-01-01T00:00:00.000000001Z goroutine 1 [running]:\n' +
+      '2026-01-01T00:00:00.000000002Z main.c(...)\n' +
+      '2026-01-01T00:00:00.000000003Z \t/m.go:2\n' +
+      '2026-01-01T00:00:00.000000004Z after the panic\n'
+
+    it('folds a trace under its head and expands it on click', async () => {
+      const user = userEvent.setup()
+      fetchWithMock.mockResolvedValue({ logs: GO_PANIC_LOGS })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      // Collapsed: the head shows, the frames are hidden behind the fold control.
+      expect(screen.getByTestId('logs-content')).toHaveTextContent('panic: boom from c')
+      expect(screen.queryByText('main.c(...)')).toBeNull()
+      expect(screen.getByTestId('logs-group-fold')).toHaveTextContent('3 frames')
+      // The flush-left line after the trace is a separate, always-visible entry.
+      expect(screen.getByText('after the panic')).toBeInTheDocument()
+
+      await user.click(screen.getByTestId('logs-group-fold'))
+      expect(screen.getByText('main.c(...)')).toBeInTheDocument()
+      expect(screen.getByText('goroutine 1 [running]:')).toBeInTheDocument()
+    })
+
+    it('renders every trace line flat when grouping is toggled off', async () => {
+      const user = userEvent.setup()
+      fetchWithMock.mockResolvedValue({ logs: GO_PANIC_LOGS })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+      expect(screen.queryByText('main.c(...)')).toBeNull()
+
+      await user.click(screen.getByTestId('logs-group-toggle'))
+      expect(screen.getByText('main.c(...)')).toBeInTheDocument()
+      expect(screen.queryByTestId('logs-group-fold')).toBeNull()
+    })
+
+    it('renders every trace line flat in raw mode', async () => {
+      const user = userEvent.setup()
+      fetchWithMock.mockResolvedValue({ logs: GO_PANIC_LOGS })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      await user.click(screen.getByTestId('logs-format-toggle'))
+      expect(screen.getByText('main.c(...)')).toBeInTheDocument()
+      expect(screen.queryByTestId('logs-group-fold')).toBeNull()
+    })
+
+    it('keeps a whole trace on a frame match and drops it on a negated frame match', async () => {
+      const user = userEvent.setup()
+      fetchWithMock.mockResolvedValue({ logs: GO_PANIC_LOGS })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      const filter = screen.getByTestId('logs-filter-input')
+      // A needle inside a folded frame keeps the whole trace (head stays visible).
+      await user.type(filter, 'main.c')
+      expect(screen.getByTestId('logs-content')).toHaveTextContent('panic: boom from c')
+
+      // The negated complement drops the whole trace, even though the needle is
+      // only in a buried frame.
+      await user.clear(filter)
+      await user.type(filter, '!main.c')
+      expect(screen.queryByText('panic: boom from c')).toBeNull()
+    })
+
+    it('surfaces a level-bumped trace when filtering on Error', async () => {
+      const user = userEvent.setup()
+      // The bare `Error:` head detects as info; the grouper bumps a recognized
+      // trace head to error so the level filter surfaces it.
+      fetchWithMock.mockResolvedValue({
+        logs:
+          '2026-01-01T00:00:00.000000000Z Error: boom from c\n' +
+          '2026-01-01T00:00:00.000000001Z     at c ([eval]:1:56)\n' +
+          '2026-01-01T00:00:00.000000002Z plain info line\n'
+      })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      await user.click(screen.getByTestId('logs-level-filter'))
+      await user.click(screen.getByTestId('logs-level-option-error'))
+
+      expect(screen.getByTestId('logs-content')).toHaveTextContent('Error: boom from c')
+      expect(screen.queryByText('plain info line')).toBeNull()
+    })
+
+    it('keeps the pod id on a grouped trace head in the all-pods view', async () => {
+      fetchWithMock.mockResolvedValue({
+        pod: 'web-abc-gqh2x,web-abc-p8x2k', container: 'app', tagged: true, total: 2, streamed: 2,
+        logs:
+          'web-abc-gqh2x 2026-01-01T00:00:00.000000000Z panic: boom\n' +
+          '  goroutine 1 [running]:\n' +
+          '  main.crash()\n'
+      })
+      render(<WorkloadLogsViewer {...allPodsProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      // The trace folds (untimestamped frames included); its head pill keeps the pod id.
+      expect(screen.getByTestId('logs-pod-id')).toHaveTextContent('gqh2x')
+      expect(screen.getByTestId('logs-group-fold')).toBeInTheDocument()
+      expect(screen.queryByText('main.crash()')).toBeNull()
+    })
+
+    it('folds two pods\' interleaved timestamped traces per pod in the all-pods view', async () => {
+      const user = userEvent.setup()
+      // Both pods crash in the same window; with every frame timestamped (the CRI
+      // case) the backend interleaves them frame-by-frame. Per-pod folding must
+      // keep each trace intact instead of fragmenting around the other pod's lines.
+      fetchWithMock.mockResolvedValue({
+        pod: 'web-abc-gqh2x,web-abc-p8x2k', container: 'app', tagged: true, total: 2, streamed: 2,
+        logs:
+          'web-abc-gqh2x 2026-01-01T00:00:00.000000000Z panic: boom A\n' +
+          'web-abc-p8x2k 2026-01-01T00:00:00.000000001Z panic: boom B\n' +
+          'web-abc-gqh2x 2026-01-01T00:00:00.000000002Z goroutine 1 [running]:\n' +
+          'web-abc-p8x2k 2026-01-01T00:00:00.000000003Z goroutine 2 [running]:\n' +
+          'web-abc-gqh2x 2026-01-01T00:00:00.000000004Z main.a(...)\n' +
+          'web-abc-p8x2k 2026-01-01T00:00:00.000000005Z main.b(...)\n'
+      })
+      render(<WorkloadLogsViewer {...allPodsProps} />)
+      await waitFor(() => expect(screen.getByTestId('logs-content')).toBeInTheDocument())
+
+      // Two folded groups, each headed by its own pod id; all frames collapsed.
+      expect(screen.getAllByTestId('logs-group-fold')).toHaveLength(2)
+      expect(screen.getAllByTestId('logs-pod-id')).toHaveLength(2)
+      expect(screen.queryByText('main.a(...)')).toBeNull()
+      expect(screen.queryByText('main.b(...)')).toBeNull()
+
+      // Expanding pod A's trace reveals only its frame, never pod B's.
+      await user.click(screen.getAllByTestId('logs-group-fold')[0])
+      expect(screen.getByText('main.a(...)')).toBeInTheDocument()
+      expect(screen.queryByText('main.b(...)')).toBeNull()
+    })
+
+    it('keeps a folded group expanded across an append that adds a later entry', async () => {
+      vi.useFakeTimers()
+      try {
+        const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+        fetchWithMock.mockResolvedValueOnce({
+          logs:
+            '2026-01-01T00:00:00.000000000Z panic: boom from c\n' +
+            '2026-01-01T00:00:00.000000001Z goroutine 1 [running]:\n' +
+            '2026-01-01T00:00:00.000000002Z main.c(...)\n'
+        })
+        fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:05.000000000Z later line\n' })
+
+        render(<WorkloadLogsViewer {...defaultProps} />)
+        await flush()
+        await act(async () => { fireEvent.click(screen.getByTestId('logs-group-fold')) })
+        expect(screen.getByText('main.c(...)')).toBeInTheDocument()
+
+        // A follow poll appends a later line; the trace's identity key is unchanged,
+        // so its local expand state survives the re-render.
+        await act(async () => { vi.advanceTimersByTime(5000) })
+        await flush()
+        expect(screen.getByText('later line')).toBeInTheDocument()
+        expect(screen.getByText('main.c(...)')).toBeInTheDocument()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 })

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -616,10 +616,15 @@ describe('WorkloadLogsViewer component', () => {
 
     const rows = screen.getAllByTestId('logs-line')
     expect(rows[0].tagName).toBe('PRE')
-    expect(rows[0].querySelector('code')).toHaveClass('language-json')
-    expect(rows[0].querySelector('.token')).not.toBeNull()
-    expect(rows[0].textContent).toBe('{\n  "level": "info",\n  "msg": "hello"\n}')
-    expect(rows[1].tagName).toBe('PRE')
+    // JSON is highlighted by our own span serializer (no Prism): keys carry the gray
+    // key class and the indented structure is preserved byte-for-byte.
+    const keySpan = [...rows[0].querySelectorAll('span')].find(s => s.textContent === '"level"')
+    expect(keySpan).toBeTruthy()
+    expect(keySpan).toHaveClass('text-gray-500')
+    expect(rows[0].textContent).toBe('"level": "info",\n"msg": "hello"')
+    // A line matching no formatter renders as a wrapping div, not the JSON <pre>.
+    expect(rows[1].tagName).toBe('DIV')
+    expect(rows[1]).toHaveClass('whitespace-pre-wrap')
     expect(rows[1].textContent).toBe('plain text line')
   })
 
@@ -892,11 +897,10 @@ describe('WorkloadLogsViewer component', () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(1))
 
-    // Still one logs-line per entry, but it now holds header + message + 2 field rows.
+    // Still one logs-line per entry, but it now holds header+message + 2 field rows.
     const rows = screen.getAllByTestId('logs-line-row').map(r => r.textContent)
     expect(rows).toEqual([
-      'E0526 23:03:57.521582       1 leaderelection.go:452]',
-      'Error retrieving lease lock',
+      'E0526 23:03:57.521582 1 leaderelection.go:452] Error retrieving lease lock',
       'err: i/o timeout',
       'logger: cert-manager.controller'
     ])

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -78,6 +78,23 @@ describe('WorkloadLogsViewer component', () => {
     expect(values).toEqual(['all', 'app::false'])
   })
 
+  it('reports the selected pod via onPodChange on mount and on switch', async () => {
+    const user = userEvent.setup()
+    const onPodChange = vi.fn()
+    render(<WorkloadLogsViewer {...allPodsProps} onPodChange={onPodChange} />)
+
+    // The initial selection (All pods → null) is reported on mount so the parent
+    // can put it in the URL.
+    await waitFor(() => expect(onPodChange).toHaveBeenCalledWith(null))
+
+    // Switching to a specific pod reports the pod name; switching back reports null.
+    const select = await screen.findByTestId('logs-pod-select')
+    await user.selectOptions(select, 'web-abc-gqh2x')
+    await waitFor(() => expect(onPodChange).toHaveBeenLastCalledWith('web-abc-gqh2x'))
+    await user.selectOptions(select, '__all_pods__')
+    await waitFor(() => expect(onPodChange).toHaveBeenLastCalledWith(null))
+  })
+
   it('shows the container selector for multiple containers and refetches on change', async () => {
     const user = userEvent.setup()
     const props = { ...defaultProps, pods: onePod([{ name: 'app', isInit: false }, { name: 'sidecar', isInit: false }]) }
@@ -260,9 +277,8 @@ describe('WorkloadLogsViewer component', () => {
   })
 
   it('orders the merged buffer chronologically when a lagging pod sends older lines', async () => {
-    // A pod can lag behind another's per-pod cursor, so the response (and thus the
-    // append order) is not globally chronological. The viewer must reorder by
-    // timestamp, keeping each entry's continuation lines attached.
+    // A lagging pod makes the append order non-chronological; the viewer must
+    // reorder by timestamp, keeping each entry's continuation lines attached.
     fetchWithMock.mockResolvedValue({
       pod: 'web-abc-gqh2x,web-abc-p8x2k',
       container: 'app',
@@ -852,11 +868,13 @@ describe('WorkloadLogsViewer component', () => {
     }
   })
 
-  it('shows the empty state and fires no request when there are no pods to stream', async () => {
+  it('stays open with an inline error and fires no request when there are no pods to stream', async () => {
     render(<WorkloadLogsViewer {...defaultProps} pods={[]} />)
     await new Promise(r => setTimeout(r, 0))
     expect(fetchWithMock).not.toHaveBeenCalled()
-    expect(screen.getByTestId('logs-empty')).toBeInTheDocument()
+    // Empty pod list surfaces an inline error, not the neutral empty state.
+    expect(screen.queryByTestId('logs-empty')).not.toBeInTheDocument()
+    expect(screen.getByTestId('logs-no-pods')).toHaveTextContent('The workload has no running pods to stream logs from.')
   })
 
   it('falls back to the regular containers when the selected container disappears', async () => {
@@ -926,9 +944,8 @@ describe('WorkloadLogsViewer component', () => {
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getAllByTestId('logs-line-row')).toHaveLength(3))
 
-    // Toggling Format off renders the line byte-for-byte: one logs-line, no row
-    // splitting, exact text (toHaveTextContent normalizes whitespace, so assert
-    // the exact textContent to catch a tab/CR change or an accidental split).
+    // Format off renders byte-for-byte: one logs-line, no row split. Assert exact
+    // textContent (toHaveTextContent normalizes whitespace) to catch a tab/CR change.
     await user.click(screen.getByTestId('logs-format-toggle'))
     await waitFor(() => expect(screen.queryByTestId('logs-line-row')).toBeNull())
     const lines = screen.getAllByTestId('logs-line')

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -130,6 +130,16 @@ describe('WorkloadLogsViewer component', () => {
     expect(screen.getByTestId('logs-line')).toHaveTextContent('line two')
   })
 
+  it('excludes log entries when the filter is prefixed with "!"', async () => {
+    const user = userEvent.setup()
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
+
+    await user.type(screen.getByTestId('logs-filter-input'), '!two')
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(1))
+    expect(screen.getByTestId('logs-line')).toHaveTextContent('line one')
+  })
+
   it('hides timestamps by default and shows them when toggled', async () => {
     const user = userEvent.setup()
     fetchWithMock.mockResolvedValue({ logs: '2026-06-16T00:00:00Z hello world\n' })
@@ -220,9 +230,9 @@ describe('WorkloadLogsViewer component', () => {
     // No highlight on the initial load.
     expect(screen.getAllByTestId('logs-line').some(el => el.getAttribute('data-latest') === 'true')).toBe(false)
 
-    // A new entry arrives on the next fetch.
+    // A new entry arrives on the next fetch (triggered by toggling previous).
     fetchWithMock.mockResolvedValue({ logs: 'line one\nline two\nline three\n' })
-    await user.click(screen.getByTestId('logs-refresh-button'))
+    await user.click(screen.getByTestId('logs-previous-toggle'))
     await waitFor(() => {
       const rows = screen.getAllByTestId('logs-line')
       expect(rows).toHaveLength(3)

--- a/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsViewer.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/preact'
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/preact'
 import userEvent from '@testing-library/user-event'
 import { WorkloadLogsViewer } from './WorkloadLogsViewer'
 
@@ -263,26 +263,20 @@ describe('WorkloadLogsViewer component', () => {
     expect(screen.getByTestId('logs-line').textContent).toBe('red error text')
   })
 
-  it('renders JSON lines as highlighted code blocks when the JSON toggle is on, leaving plain lines intact', async () => {
-    const user = userEvent.setup()
+  it('pretty-prints JSON lines as highlighted code blocks by default, leaving plain lines intact', async () => {
     fetchWithMock.mockResolvedValue({
       logs: '2026-01-01T00:00:00Z {"level":"info","msg":"hello"}\n2026-01-01T00:00:01Z plain text line\n'
     })
     render(<WorkloadLogsViewer {...defaultProps} />)
     await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
 
-    const toggle = screen.getByTestId('logs-json-toggle')
-    expect(toggle).toHaveAttribute('aria-pressed', 'false')
-
-    // Off: the JSON line is shown compact, exactly as received, as a plain row.
-    expect(screen.getAllByTestId('logs-line')[0].tagName).toBe('DIV')
-    expect(screen.getAllByTestId('logs-line')[0].textContent).toBe('{"level":"info","msg":"hello"}')
-
-    // On: the JSON line becomes an indented, syntax-highlighted code block. The
-    // plain line also renders as a code block (so all lines share the same font
-    // and size) but with its text unchanged and no syntax highlighting.
-    await user.click(toggle)
+    // Formatted mode is the default and the toggle reflects it.
+    const toggle = screen.getByTestId('logs-format-toggle')
     expect(toggle).toHaveAttribute('aria-pressed', 'true')
+
+    // The JSON line is indented and syntax-highlighted. The plain line also
+    // renders as a code block (so all lines share the same font and size) but
+    // with its text unchanged and no syntax highlighting.
     const rows = screen.getAllByTestId('logs-line')
     expect(rows[0].tagName).toBe('PRE')
     expect(rows[0].querySelector('code')).toHaveClass('language-json')
@@ -292,6 +286,48 @@ describe('WorkloadLogsViewer component', () => {
     expect(rows[1].querySelector('code')).toHaveClass('language-json')
     expect(rows[1].querySelector('.token')).toBeNull()
     expect(rows[1].textContent).toBe('plain text line')
+  })
+
+  it('strips all styling in raw mode: plain rows, no timestamp pills or highlight', async () => {
+    const user = userEvent.setup()
+    fetchWithMock.mockResolvedValue({
+      logs: '2026-01-01T00:00:00Z {"level":"info","msg":"hello"}\n2026-01-01T00:00:01Z plain text line\n'
+    })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
+
+    // Switching off formatted mode enters raw mode.
+    const toggle = screen.getByTestId('logs-format-toggle')
+    await user.click(toggle)
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    // Lines render as plain rows, JSON shown compact exactly as received.
+    const rows = screen.getAllByTestId('logs-line')
+    expect(rows[0].tagName).toBe('DIV')
+    expect(rows[0].textContent).toBe('{"level":"info","msg":"hello"}')
+    expect(rows[1].tagName).toBe('DIV')
+    expect(rows[1].textContent).toBe('plain text line')
+
+    // The timestamp pills (row separators) are gone in raw mode.
+    expect(screen.queryByTestId('logs-timestamp')).not.toBeInTheDocument()
+  })
+
+  it('does not highlight the latest line in raw mode when new logs arrive', async () => {
+    const user = userEvent.setup()
+    fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
+
+    // Enter raw mode.
+    await user.click(screen.getByTestId('logs-format-toggle'))
+
+    // A new entry arrives on the next fetch (triggered by changing the line count).
+    fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n2026-01-01T00:00:02Z line three\n' })
+    await user.selectOptions(screen.getByTestId('logs-lines-select'), '500')
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(3))
+
+    // Raw mode has no timestamp pills, so nothing is ever highlighted.
+    expect(screen.queryByTestId('logs-timestamp')).not.toBeInTheDocument()
   })
 
   it('toggles fullscreen mode', async () => {
@@ -322,6 +358,131 @@ describe('WorkloadLogsViewer component', () => {
     setIntervalSpy.mockRestore()
   })
 
+  it('appends new lines on follow polls via sinceTime, deduping the overlap', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+
+      // Initial load returns two timestamped lines.
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
+      // The follow poll re-sends the last line (sinceTime is second-granular) plus a new one.
+      fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:01Z line two\n2026-01-01T00:00:02Z line three\n' })
+
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await flush()
+      expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
+
+      // The initial load asks for the tail, not a sinceTime window.
+      expect(fetchWithMock.mock.calls[0][0].endpoint).toContain('tailLines=100')
+      expect(fetchWithMock.mock.calls[0][0].endpoint).not.toContain('sinceTime')
+
+      // Advance to the first follow poll and let it resolve.
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+
+      // The overlapping "line two" is deduped; only "line three" is appended.
+      const rows = screen.getAllByTestId('logs-line')
+      expect(rows.map(r => r.textContent)).toEqual(['line one', 'line two', 'line three'])
+
+      // The poll narrows to entries newer than the last seen line, and still
+      // sends tailLines so a catch-up stays bounded to the user's selection.
+      const pollCall = fetchWithMock.mock.calls[fetchWithMock.mock.calls.length - 1][0]
+      expect(pollCall.endpoint).toContain('sinceTime=2026-01-01T00%3A00%3A01Z')
+      expect(pollCall.endpoint).toContain('tailLines=100')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('skips follow polls while a reset fetch is still in flight', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await flush()
+      expect(fetchWithMock).toHaveBeenCalledTimes(1)
+
+      // Change the line count: this starts a reset fetch that never resolves,
+      // so the viewer stays in the "resetting" state.
+      fetchWithMock.mockReturnValueOnce(new Promise(() => {}))
+      await act(async () => { fireEvent.change(screen.getByTestId('logs-lines-select'), { target: { value: '500' } }) })
+      await flush()
+      expect(fetchWithMock).toHaveBeenCalledTimes(2)
+
+      // A follow tick while the reset is in flight must NOT fire an append poll.
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+      expect(fetchWithMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('drops a stale in-flight append poll after a parameter reset', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+
+      // Initial load for the first stream.
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z app one\n2026-01-01T00:00:01Z app two\n' })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await flush()
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['app one', 'app two'])
+
+      // The next follow poll is left in flight (its promise never resolves yet).
+      let resolveAppend
+      fetchWithMock.mockReturnValueOnce(new Promise((resolve) => { resolveAppend = resolve }))
+      await act(async () => { vi.advanceTimersByTime(5000) })
+
+      // Meanwhile the user changes the line count, which resets the buffer.
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:05Z reset one\n' })
+      await act(async () => { fireEvent.change(screen.getByTestId('logs-lines-select'), { target: { value: '500' } }) })
+      await flush()
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['reset one'])
+
+      // The stale append (from before the reset) now resolves; it must be ignored.
+      await act(async () => { resolveAppend({ logs: '2026-01-01T00:00:02Z app three\n' }) })
+      await flush()
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['reset one'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows a failed follow poll inline at the tail without clearing the buffer', async () => {
+    vi.useFakeTimers()
+    try {
+      const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve() }) }
+
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
+      render(<WorkloadLogsViewer {...defaultProps} />)
+      await flush()
+      expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
+
+      // The follow poll fails.
+      fetchWithMock.mockRejectedValueOnce(new Error('Pod default/my-pod not found'))
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+
+      // The buffer stays on screen and the error is shown inline at the tail,
+      // not as the full-pane error banner.
+      expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
+      expect(screen.getByTestId('logs-follow-error')).toHaveTextContent('Pod default/my-pod not found')
+      expect(screen.queryByTestId('logs-error')).not.toBeInTheDocument()
+
+      // The next poll succeeds: the inline error clears and the new line appends.
+      fetchWithMock.mockResolvedValueOnce({ logs: '2026-01-01T00:00:02Z line three\n' })
+      await act(async () => { vi.advanceTimersByTime(5000) })
+      await flush()
+      expect(screen.queryByTestId('logs-follow-error')).not.toBeInTheDocument()
+      expect(screen.getAllByTestId('logs-line').map(r => r.textContent)).toEqual(['line one', 'line two', 'line three'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('highlights the latest timestamp pill when new logs arrive', async () => {
     const user = userEvent.setup()
     fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z line one\n2026-01-01T00:00:01Z line two\n' })
@@ -340,5 +501,27 @@ describe('WorkloadLogsViewer component', () => {
       expect(pills[pills.length - 1]).toHaveAttribute('data-latest', 'true')
     })
     expect(screen.getAllByTestId('logs-timestamp')[0]).not.toHaveAttribute('data-latest')
+  })
+
+  it('does not highlight the last visible line when new logs are filtered out', async () => {
+    const user = userEvent.setup()
+    fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z keep me\n2026-01-01T00:00:01Z keep me too\n' })
+    render(<WorkloadLogsViewer {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
+
+    // Keep only the lines containing "keep"; both current lines match.
+    await user.type(screen.getByTestId('logs-filter-input'), 'keep')
+    await waitFor(() => expect(screen.getAllByTestId('logs-line')).toHaveLength(2))
+
+    // A new entry arrives that does not match the filter, so the visible set is
+    // unchanged. The unchanged last line must not be highlighted as if it were new.
+    fetchWithMock.mockResolvedValue({ logs: '2026-01-01T00:00:00Z keep me\n2026-01-01T00:00:01Z keep me too\n2026-01-01T00:00:02Z noise\n' })
+    await user.selectOptions(screen.getByTestId('logs-lines-select'), '500')
+    await waitFor(() => {
+      const call = fetchWithMock.mock.calls.at(-1)[0]
+      expect(call.endpoint).toContain('tailLines=500')
+    })
+    expect(screen.getAllByTestId('logs-line')).toHaveLength(2)
+    expect(screen.getAllByTestId('logs-timestamp').some(el => el.getAttribute('data-latest') === 'true')).toBe(false)
   })
 })

--- a/web/src/components/dashboards/workload/WorkloadPage.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPage.jsx
@@ -1,0 +1,403 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useState, useEffect, useRef, useCallback, useMemo } from 'preact/hooks'
+import { fetchWithMock } from '../../../utils/fetch'
+import { usePrismTheme } from '../common/yaml'
+import { formatTime } from '../../../utils/time'
+import { usePageMeta } from '../../../utils/meta'
+import { ActionBar } from '../resource/ActionBar'
+import { WorkloadActionBar } from '../resource/WorkloadActionBar'
+import { WorkloadReconcilerPanel } from './WorkloadReconcilerPanel'
+import { WorkloadPipelinePanel } from './WorkloadPipelinePanel'
+import { WorkloadDetailPanel } from './WorkloadDetailPanel'
+
+// Polling intervals
+const POLL_INTERVAL_MS = 10000  // 10 seconds (workloads change more frequently)
+const FAST_POLL_INTERVAL_MS = 5000  // 5 seconds after actions
+const FAST_POLL_TIMEOUT_MS = 60000  // 60 seconds to revert
+
+/**
+ * Get loading status styling info
+ */
+function getLoadingStatusInfo() {
+  return {
+    color: 'text-blue-600 dark:text-blue-400',
+    bgColor: 'bg-blue-50',
+    borderColor: 'border-blue-500',
+    icon: (
+      <svg class="w-10 h-10 text-blue-600 dark:text-blue-400 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+      </svg>
+    )
+  }
+}
+
+/**
+ * Get error status styling info
+ */
+function getErrorStatusInfo() {
+  return {
+    color: 'text-danger',
+    bgColor: 'bg-red-50',
+    borderColor: 'border-danger',
+    icon: (
+      <svg class="w-10 h-10 text-danger" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    )
+  }
+}
+
+/**
+ * Get not found status styling info
+ */
+function getNotFoundStatusInfo() {
+  return {
+    color: 'text-gray-600 dark:text-gray-400',
+    bgColor: 'bg-gray-50',
+    borderColor: 'border-gray-400',
+    icon: (
+      <svg class="w-10 h-10 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    )
+  }
+}
+
+/**
+ * Get workload status styling info for the header card.
+ * Uses kstatus values (Current, InProgress, Failed, Terminating, Unknown).
+ */
+function getWorkloadStatusInfo(status) {
+  switch (status) {
+  case 'Current':
+  case 'Idle':
+    return {
+      color: 'text-success',
+      bgColor: 'bg-green-50',
+      borderColor: 'border-success',
+      icon: (
+        <svg class="w-10 h-10 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+        </svg>
+      )
+    }
+  case 'InProgress':
+  case 'Progressing':
+    return {
+      color: 'text-blue-600 dark:text-blue-400',
+      bgColor: 'bg-blue-50',
+      borderColor: 'border-blue-500',
+      icon: (
+        <svg class="w-10 h-10 text-blue-600 dark:text-blue-400 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+        </svg>
+      )
+    }
+  case 'Failed':
+    return {
+      color: 'text-danger',
+      bgColor: 'bg-red-50',
+      borderColor: 'border-danger',
+      icon: (
+        <svg class="w-10 h-10 text-danger" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      )
+    }
+  case 'Terminating':
+  case 'Suspended':
+    return {
+      color: 'text-yellow-600 dark:text-yellow-400',
+      bgColor: 'bg-yellow-50',
+      borderColor: 'border-yellow-500',
+      icon: (
+        <svg class="w-10 h-10 text-yellow-600 dark:text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      )
+    }
+  default:
+    return {
+      color: 'text-gray-600 dark:text-gray-400',
+      bgColor: 'bg-gray-50',
+      borderColor: 'border-gray-400',
+      icon: (
+        <svg class="w-10 h-10 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      )
+    }
+  }
+}
+
+/**
+ * WorkloadPage - Full page dashboard for a single Kubernetes workload
+ */
+export function WorkloadPage({ kind, namespace, name }) {
+  // Set page title and description
+  usePageMeta(name, `${kind}/${namespace}/${name} workload dashboard`)
+
+  // State
+  const [workloadData, setWorkloadData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [lastUpdatedAt, setLastUpdatedAt] = useState(null)
+  const [pendingDeletions, setPendingDeletions] = useState(new Set())
+
+  // Track fast polling mode (activated by user actions)
+  const [fastPolling, setFastPolling] = useState(false)
+  const fastPollTimeoutRef = useRef(null)
+
+  // Use faster polling when recently activated by action
+  const currentPollInterval = fastPolling ? FAST_POLL_INTERVAL_MS : POLL_INTERVAL_MS
+
+  // Load Prism theme based on current app theme
+  usePrismTheme()
+
+  // Reset state when navigating to a different workload
+  useEffect(() => {
+    setWorkloadData(null)
+    setLoading(true)
+    setError(null)
+    setPendingDeletions(new Set())
+  }, [kind, namespace, name])
+
+  // Fetch workload data
+  const fetchData = useCallback(async () => {
+    setError(null)
+    const params = new URLSearchParams({ kind, name, namespace })
+
+    try {
+      const resp = await fetchWithMock({
+        endpoint: `/api/v1/workload?${params.toString()}`,
+        mockPath: '../mock/workload',
+        mockExport: 'getMockWorkload'
+      })
+
+      setWorkloadData(resp)
+      setLastUpdatedAt(new Date())
+      setError(null)
+
+      // Clean up pending deletions for pods that have disappeared
+      const pods = resp?.workloadInfo?.pods || []
+      setPendingDeletions(prev => {
+        if (prev.size === 0) return prev
+        const allPodNames = new Set(pods.map(p => p.name))
+        const next = new Set([...prev].filter(n => allPodNames.has(n)))
+        return next.size === prev.size ? prev : next
+      })
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [kind, name, namespace])
+
+  // Fetch data on mount and when route params change
+  useEffect(() => {
+    fetchData()
+  }, [kind, namespace, name])
+
+  // Setup polling with dynamic interval
+  useEffect(() => {
+    const interval = setInterval(fetchData, currentPollInterval)
+    return () => clearInterval(interval)
+  }, [kind, namespace, name, currentPollInterval])
+
+  // Cleanup fast poll timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (fastPollTimeoutRef.current) {
+        window.clearTimeout(fastPollTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  // Handle action start - switch to fast polling with timeout
+  const handleActionStart = useCallback(() => {
+    setFastPolling(true)
+
+    if (fastPollTimeoutRef.current) {
+      window.clearTimeout(fastPollTimeoutRef.current)
+    }
+
+    fastPollTimeoutRef.current = window.setTimeout(() => {
+      setFastPolling(false)
+    }, FAST_POLL_TIMEOUT_MS)
+  }, [])
+
+  // Track pod deletion start
+  const handlePodDeleteStart = useCallback((podName) => {
+    setPendingDeletions(prev => new Set([...prev, podName]))
+  }, [])
+
+  // Remove pod from pending deletions on error
+  const handlePodDeleteFailed = useCallback((podName) => {
+    setPendingDeletions(prev => {
+      const next = new Set(prev)
+      next.delete(podName)
+      return next
+    })
+  }, [])
+
+  // Determine display state
+  const isStaleData = workloadData?.kind && workloadData.kind !== kind
+  const isInitialLoading = (loading && !workloadData) || isStaleData
+  const isInitialError = error && !workloadData && !isStaleData
+  const isNotFound = !isInitialLoading && !isInitialError && (!workloadData || !workloadData.metadata || !workloadData.metadata.name)
+  const isSuccess = !isInitialLoading && !isInitialError && !isNotFound
+
+  // Derived data (only valid when we have workloadData)
+  const workloadInfo = workloadData?.workloadInfo
+  const workloadStatus = workloadInfo?.status || 'Unknown'
+  const reconciler = workloadInfo?.reconciler
+
+  // Find the most recent triggered pod (has createdBy set) for CronJob Run Job button
+  const triggeredPod = useMemo(() => {
+    const pods = workloadInfo?.pods || []
+    return pods.reduce((latest, pod) => {
+      if (!pod.createdBy || !pod.createdAt) return latest
+      if (!latest) return pod
+      return new Date(pod.createdAt) > new Date(latest.createdAt) ? pod : latest
+    }, null)
+  }, [workloadInfo])
+
+  // Check if either action bar has actions to show
+  const hasReconcilerActions = reconciler?.status?.userActions?.length > 0
+  const hasWorkloadActions = workloadInfo?.userActions?.includes('restart')
+
+  // Compute statusInfo based on display state
+  let statusInfo
+  if (isInitialLoading) {
+    statusInfo = getLoadingStatusInfo()
+  } else if (isInitialError || isNotFound) {
+    statusInfo = isNotFound ? getNotFoundStatusInfo() : getErrorStatusInfo()
+  } else {
+    statusInfo = getWorkloadStatusInfo(workloadStatus)
+  }
+
+  return (
+    <main data-testid="workload-dashboard-view" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow w-full">
+      <div class="space-y-6">
+
+        {/* Header Card */}
+        <div class={`card ${statusInfo.bgColor} dark:bg-opacity-20 border-2 ${statusInfo.borderColor}`}>
+          <div class="flex items-center space-x-4">
+            <div class="flex-shrink-0">
+              <div class={`w-16 h-16 rounded-full ${statusInfo.bgColor} dark:bg-opacity-30 flex items-center justify-center`}>
+                {statusInfo.icon}
+              </div>
+            </div>
+            <div class="flex-grow min-w-0">
+              <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">{kind}</span>
+              <h1 class="text-lg sm:text-2xl font-semibold text-gray-900 dark:text-white break-all">
+                {name}
+              </h1>
+              <span class="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Namespace: {namespace}</span>
+            </div>
+            {isSuccess && (
+              <div class="hidden md:block text-right flex-shrink-0">
+                <div class="text-sm text-gray-600 dark:text-gray-400">Last Updated</div>
+                <div class="text-lg font-semibold text-gray-900 dark:text-white">{formatTime(lastUpdatedAt)}</div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Loading message */}
+        {isInitialLoading && (
+          <div data-testid="loading-message" class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-md p-4">
+            <p class="text-sm text-blue-800 dark:text-blue-200">Loading workload data...</p>
+          </div>
+        )}
+
+        {/* Error message */}
+        {isInitialError && (
+          <div data-testid="error-message" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-4">
+            <p class="text-sm text-red-800 dark:text-red-200">Failed to load workload: {error}</p>
+          </div>
+        )}
+
+        {/* Not found message */}
+        {isNotFound && (
+          <div data-testid="not-found-message" class="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-md p-4">
+            <p class="text-sm text-gray-600 dark:text-gray-400">Workload not found in the cluster.</p>
+          </div>
+        )}
+
+        {/* Success content */}
+        {isSuccess && (
+          <>
+            {/* Action Bars - Flux reconciler actions + workload actions on same line */}
+            {(hasReconcilerActions || hasWorkloadActions) && (
+              <div class="flex flex-wrap items-center gap-2" data-testid="combined-action-bar">
+                {reconciler && (
+                  <ActionBar
+                    kind={reconciler.kind}
+                    namespace={reconciler.metadata.namespace}
+                    name={reconciler.metadata.name}
+                    resourceData={reconciler}
+                    onActionComplete={fetchData}
+                    onActionStart={handleActionStart}
+                  />
+                )}
+                {hasReconcilerActions && hasWorkloadActions && (
+                  <div class="w-px h-5 bg-gray-300 dark:bg-gray-600" data-testid="action-bar-separator" />
+                )}
+                {hasWorkloadActions && (
+                  <WorkloadActionBar
+                    kind={kind}
+                    namespace={namespace}
+                    name={name}
+                    status={workloadStatus}
+                    restartedAt={workloadInfo?.restartedAt}
+                    lastTriggeredAt={triggeredPod?.createdAt}
+                    lastTriggeredPodStatus={triggeredPod?.status}
+                    userActions={workloadInfo?.userActions}
+                    onActionStart={handleActionStart}
+                    onActionComplete={fetchData}
+                  />
+                )}
+              </div>
+            )}
+
+            {/* Pipeline Panel */}
+            <WorkloadPipelinePanel
+              reconciler={reconciler}
+              kind={kind}
+              name={name}
+              workloadStatus={workloadStatus}
+              pods={workloadInfo?.pods}
+            />
+
+            {/* Workload Detail Panel */}
+            <WorkloadDetailPanel
+              kind={kind}
+              namespace={namespace}
+              name={name}
+              workloadData={workloadData}
+              workloadInfo={workloadInfo}
+              workloadStatus={workloadStatus}
+              pendingDeletions={pendingDeletions}
+              onPodDeleteStart={handlePodDeleteStart}
+              onPodDeleteFailed={handlePodDeleteFailed}
+              onActionStart={handleActionStart}
+              onActionComplete={fetchData}
+            />
+
+            {/* Reconciler Panel */}
+            {reconciler && (
+              <WorkloadReconcilerPanel
+                reconciler={reconciler}
+                workloadData={workloadData}
+              />
+            )}
+          </>
+        )}
+
+      </div>
+    </main>
+  )
+}

--- a/web/src/components/dashboards/workload/WorkloadPage.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPage.jsx
@@ -6,6 +6,7 @@ import { fetchWithMock } from '../../../utils/fetch'
 import { usePrismTheme } from '../common/yaml'
 import { formatTime } from '../../../utils/time'
 import { usePageMeta } from '../../../utils/meta'
+import { isFavorite, toggleFavorite, favorites } from '../../../utils/favorites'
 import { addToNavHistory } from '../../../utils/navHistory'
 import { ActionBar } from '../resource/ActionBar'
 import { WorkloadActionBar } from '../resource/WorkloadActionBar'
@@ -222,6 +223,16 @@ export function WorkloadPage({ kind, namespace, name }) {
     }
   }, [])
 
+  // Check if workload is a favorite (reactive via favorites signal)
+  // Access favorites.value to subscribe to changes and trigger re-renders
+  const isFavorited = favorites.value && isFavorite(kind, namespace, name)
+
+  // Handle favorite toggle
+  const handleFavoriteClick = useCallback((e) => {
+    e.stopPropagation()
+    toggleFavorite(kind, namespace, name)
+  }, [kind, namespace, name])
+
   // Handle action start - switch to fast polling with timeout
   const handleActionStart = useCallback(() => {
     setFastPolling(true)
@@ -301,8 +312,21 @@ export function WorkloadPage({ kind, namespace, name }) {
             </div>
             <div class="flex-grow min-w-0">
               <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">{kind}</span>
-              <h1 class="text-lg sm:text-2xl font-semibold text-gray-900 dark:text-white break-all">
+              <h1 class="text-lg sm:text-2xl font-semibold text-gray-900 dark:text-white break-all flex items-center gap-2">
                 {name}
+                <button
+                  onClick={handleFavoriteClick}
+                  class={`flex-shrink-0 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue focus:ring-offset-1 rounded ${
+                    isFavorited
+                      ? 'text-yellow-500 hover:text-yellow-600'
+                      : 'text-gray-300 dark:text-gray-600 hover:text-yellow-500'
+                  }`}
+                  title={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+                >
+                  <svg class="w-5 h-5 sm:w-6 sm:h-6" fill={isFavorited ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                  </svg>
+                </button>
               </h1>
               <span class="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Namespace: {namespace}</span>
             </div>

--- a/web/src/components/dashboards/workload/WorkloadPage.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPage.jsx
@@ -139,7 +139,6 @@ function getWorkloadStatusInfo(status) {
  * WorkloadPage - Full page dashboard for a single Kubernetes workload
  */
 export function WorkloadPage({ kind, namespace, name }) {
-  // Set page title and description
   usePageMeta(name, `${kind}/${namespace}/${name} workload dashboard`)
 
   // State
@@ -395,7 +394,9 @@ export function WorkloadPage({ kind, namespace, name }) {
                 )}
                 {canViewLogs && (
                   <WorkloadLogsAction
+                    kind={kind}
                     namespace={namespace}
+                    name={name}
                     pods={workloadInfo?.pods}
                     userActions={workloadInfo?.userActions}
                   />

--- a/web/src/components/dashboards/workload/WorkloadPage.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPage.jsx
@@ -8,6 +8,7 @@ import { formatTime } from '../../../utils/time'
 import { usePageMeta } from '../../../utils/meta'
 import { ActionBar } from '../resource/ActionBar'
 import { WorkloadActionBar } from '../resource/WorkloadActionBar'
+import { WorkloadLogsAction } from './WorkloadLogsAction'
 import { WorkloadReconcilerPanel } from './WorkloadReconcilerPanel'
 import { WorkloadPipelinePanel } from './WorkloadPipelinePanel'
 import { WorkloadDetailPanel } from './WorkloadDetailPanel'
@@ -267,6 +268,8 @@ export function WorkloadPage({ kind, namespace, name }) {
   // Check if either action bar has actions to show
   const hasReconcilerActions = reconciler?.status?.userActions?.length > 0
   const hasWorkloadActions = workloadInfo?.userActions?.includes('restart')
+  const canViewLogs = workloadInfo?.userActions?.includes('logs') &&
+    (workloadInfo?.pods || []).some(p => p.podStatus)
 
   // Compute statusInfo based on display state
   let statusInfo
@@ -331,7 +334,7 @@ export function WorkloadPage({ kind, namespace, name }) {
         {isSuccess && (
           <>
             {/* Action Bars - Flux reconciler actions + workload actions on same line */}
-            {(hasReconcilerActions || hasWorkloadActions) && (
+            {(hasReconcilerActions || hasWorkloadActions || canViewLogs) && (
               <div class="flex flex-wrap items-center gap-2" data-testid="combined-action-bar">
                 {reconciler && (
                   <ActionBar
@@ -358,6 +361,13 @@ export function WorkloadPage({ kind, namespace, name }) {
                     userActions={workloadInfo?.userActions}
                     onActionStart={handleActionStart}
                     onActionComplete={fetchData}
+                  />
+                )}
+                {canViewLogs && (
+                  <WorkloadLogsAction
+                    namespace={namespace}
+                    pods={workloadInfo?.pods}
+                    userActions={workloadInfo?.userActions}
                   />
                 )}
               </div>

--- a/web/src/components/dashboards/workload/WorkloadPage.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPage.jsx
@@ -284,8 +284,10 @@ export function WorkloadPage({ kind, namespace, name }) {
   // Check if either action bar has actions to show
   const hasReconcilerActions = reconciler?.status?.userActions?.length > 0
   const hasWorkloadActions = workloadInfo?.userActions?.includes('restart')
-  const canViewLogs = workloadInfo?.userActions?.includes('logs') &&
-    (workloadInfo?.pods || []).some(p => p.podStatus)
+  // Gated on the logs RBAC alone, not on pod presence: WorkloadLogsAction shows a
+  // disabled button when there are no inspectable pods (e.g. scaled to zero), so the
+  // capability stays visible.
+  const canViewLogs = workloadInfo?.userActions?.includes('logs')
 
   // Compute statusInfo based on display state
   let statusInfo

--- a/web/src/components/dashboards/workload/WorkloadPage.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPage.jsx
@@ -6,6 +6,7 @@ import { fetchWithMock } from '../../../utils/fetch'
 import { usePrismTheme } from '../common/yaml'
 import { formatTime } from '../../../utils/time'
 import { usePageMeta } from '../../../utils/meta'
+import { addToNavHistory } from '../../../utils/navHistory'
 import { ActionBar } from '../resource/ActionBar'
 import { WorkloadActionBar } from '../resource/WorkloadActionBar'
 import { WorkloadLogsAction } from './WorkloadLogsAction'
@@ -156,6 +157,11 @@ export function WorkloadPage({ kind, namespace, name }) {
 
   // Load Prism theme based on current app theme
   usePrismTheme()
+
+  // Track this workload visit in navigation history
+  useEffect(() => {
+    addToNavHistory(kind, namespace, name)
+  }, [kind, namespace, name])
 
   // Reset state when navigating to a different workload
   useEffect(() => {

--- a/web/src/components/dashboards/workload/WorkloadPage.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPage.test.jsx
@@ -1,0 +1,407 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/preact'
+import { WorkloadPage } from './WorkloadPage'
+import { fetchWithMock } from '../../../utils/fetch'
+
+// Polling constants used by WorkloadPage
+const POLL_INTERVAL_MS = 10000
+const FAST_POLL_INTERVAL_MS = 5000
+const FAST_POLL_TIMEOUT_MS = 60000
+
+// Mock fetchWithMock
+vi.mock('../../../utils/fetch', () => ({
+  fetchWithMock: vi.fn()
+}))
+
+// Store ActionBar callbacks for testing dynamic polling
+let capturedOnActionStart = null
+let capturedActionBarProps = null
+
+vi.mock('../resource/ActionBar', () => ({
+  ActionBar: (props) => {
+    capturedOnActionStart = props.onActionStart
+    capturedActionBarProps = props
+    return <div data-testid="action-bar">ActionBar: {props.kind}/{props.namespace}/{props.name}</div>
+  }
+}))
+
+vi.mock('../resource/WorkloadActionBar', () => ({
+  WorkloadActionBar: (props) => (
+    <div data-testid="workload-action-bar">WorkloadActionBar: {props.kind}/{props.name}</div>
+  )
+}))
+
+vi.mock('../resource/WorkloadDeleteAction', () => ({
+  WorkloadDeleteAction: (props) => (
+    <div data-testid="workload-delete-action">Delete: {props.name}</div>
+  )
+}))
+
+describe('WorkloadPage component', () => {
+  const mockWorkloadData = {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: 'nginx',
+      namespace: 'default',
+      creationTimestamp: '2023-01-01T00:00:00Z'
+    },
+    spec: {
+      replicas: 3,
+      strategy: {
+        type: 'RollingUpdate',
+        rollingUpdate: { maxUnavailable: 1, maxSurge: 1 }
+      },
+      selector: { matchLabels: { app: 'nginx' } },
+      template: { spec: { containers: [{ name: 'nginx', image: 'nginx:1.25.0' }] } }
+    },
+    status: {
+      readyReplicas: 3,
+      conditions: [
+        { type: 'Available', status: 'True', message: 'Deployment has minimum availability' }
+      ]
+    },
+    workloadInfo: {
+      status: 'Current',
+      statusMessage: 'Replicas: 3',
+      createdAt: '2023-01-01T00:00:00Z',
+      containerImages: ['nginx:1.25.0'],
+      userActions: ['restart', 'deletePods'],
+      pods: [
+        { name: 'nginx-abc-123', status: 'Running', statusMessage: 'Started at 2023-01-01 12:00:00 UTC', createdAt: '2023-01-01T12:00:00Z' },
+        { name: 'nginx-abc-456', status: 'Running', statusMessage: 'Started at 2023-01-01 12:00:00 UTC', createdAt: '2023-01-01T12:00:00Z' }
+      ],
+      reconciler: {
+        apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+        kind: 'Kustomization',
+        metadata: {
+          name: 'apps',
+          namespace: 'flux-system'
+        },
+        spec: {
+          interval: '10m',
+          prune: true,
+          wait: true
+        },
+        status: {
+          reconcilerRef: {
+            status: 'Ready',
+            message: 'Applied revision: main@sha1:abc123',
+            lastReconciled: '2023-01-01T12:00:00Z'
+          },
+          sourceRef: {
+            kind: 'GitRepository',
+            name: 'flux-system',
+            namespace: 'flux-system',
+            status: 'Ready',
+            url: 'https://github.com/example/repo',
+            message: 'stored artifact for revision main@sha1:abc123'
+          },
+          userActions: ['reconcile', 'suspend', 'resume']
+        }
+      }
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedOnActionStart = null
+    capturedActionBarProps = null
+  })
+
+  it('should render loading state with header card', () => {
+    fetchWithMock.mockReturnValue(new Promise(() => {}))
+
+    render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+    expect(screen.getByText('Deployment')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'nginx' })).toBeInTheDocument()
+    expect(screen.getByText('Namespace: default')).toBeInTheDocument()
+
+    expect(screen.getByTestId('loading-message')).toBeInTheDocument()
+    expect(screen.getByText('Loading workload data...')).toBeInTheDocument()
+
+    const headerCard = screen.getByRole('heading', { name: 'nginx' }).closest('.card')
+    expect(headerCard).toHaveClass('border-blue-500')
+  })
+
+  it('should render error state when fetch fails', async () => {
+    fetchWithMock.mockRejectedValue(new Error('API Error'))
+
+    render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toBeInTheDocument()
+      expect(screen.getByText('Failed to load workload: API Error')).toBeInTheDocument()
+
+      const headerCard = screen.getByRole('heading', { name: 'nginx' }).closest('.card')
+      expect(headerCard).toHaveClass('border-danger')
+    })
+  })
+
+  it('should render not found state when empty object returned', async () => {
+    fetchWithMock.mockResolvedValueOnce({})
+
+    render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('not-found-message')).toBeInTheDocument()
+      expect(screen.getByText('Workload not found in the cluster.')).toBeInTheDocument()
+
+      const headerCard = screen.getByRole('heading', { name: 'nginx' }).closest('.card')
+      expect(headerCard).toHaveClass('border-gray-400')
+    })
+  })
+
+  it('should render not found state when null returned', async () => {
+    fetchWithMock.mockResolvedValueOnce(null)
+
+    render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('not-found-message')).toBeInTheDocument()
+    })
+  })
+
+  it('should render header and panels on success', async () => {
+    fetchWithMock.mockResolvedValueOnce(mockWorkloadData)
+
+    render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'nginx' })).toBeInTheDocument()
+    })
+
+    // 'Deployment' appears in both the header kind label and the WorkloadPanel title
+    const deploymentTexts = screen.getAllByText('Deployment')
+    expect(deploymentTexts.length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Namespace: default')).toBeInTheDocument()
+
+    // Current status → green
+    const iconContainer = screen.getByRole('heading', { name: 'nginx' }).closest('.card').querySelector('.bg-green-50')
+    expect(iconContainer).toBeInTheDocument()
+
+    // ActionBar should receive reconciler props (not workload props)
+    expect(screen.getByTestId('action-bar')).toHaveTextContent('ActionBar: Kustomization/flux-system/apps')
+  })
+
+  it('should pass reconciler data to ActionBar', async () => {
+    fetchWithMock.mockResolvedValueOnce(mockWorkloadData)
+
+    render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+    await waitFor(() => {
+      expect(capturedActionBarProps).toBeTruthy()
+    })
+
+    expect(capturedActionBarProps.kind).toBe('Kustomization')
+    expect(capturedActionBarProps.namespace).toBe('flux-system')
+    expect(capturedActionBarProps.name).toBe('apps')
+    expect(capturedActionBarProps.resourceData).toBe(mockWorkloadData.workloadInfo.reconciler)
+  })
+
+  it('should render WorkloadActionBar alongside ActionBar with separator', async () => {
+    fetchWithMock.mockResolvedValueOnce(mockWorkloadData)
+
+    render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('combined-action-bar')).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('action-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('workload-action-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('action-bar-separator')).toBeInTheDocument()
+  })
+
+  it('should render correct status colors for Failed workload', async () => {
+    const failedData = {
+      ...mockWorkloadData,
+      workloadInfo: { ...mockWorkloadData.workloadInfo, status: 'Failed' }
+    }
+    fetchWithMock.mockResolvedValueOnce(failedData)
+
+    render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+    await waitFor(() => {
+      const headerCard = screen.getByRole('heading', { name: 'nginx' }).closest('.card')
+      expect(headerCard).toHaveClass('bg-red-50')
+      expect(headerCard).toHaveClass('border-danger')
+    })
+  })
+
+  it('should render correct status colors for InProgress workload', async () => {
+    const progressingData = {
+      ...mockWorkloadData,
+      workloadInfo: { ...mockWorkloadData.workloadInfo, status: 'InProgress' }
+    }
+    fetchWithMock.mockResolvedValueOnce(progressingData)
+
+    render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+    await waitFor(() => {
+      const headerCard = screen.getByRole('heading', { name: 'nginx' }).closest('.card')
+      expect(headerCard).toHaveClass('bg-blue-50')
+      expect(headerCard).toHaveClass('border-blue-500')
+    })
+  })
+
+  it('should render correct status colors for Terminating workload', async () => {
+    const terminatingData = {
+      ...mockWorkloadData,
+      workloadInfo: { ...mockWorkloadData.workloadInfo, status: 'Terminating' }
+    }
+    fetchWithMock.mockResolvedValueOnce(terminatingData)
+
+    render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+    await waitFor(() => {
+      const headerCard = screen.getByRole('heading', { name: 'nginx' }).closest('.card')
+      expect(headerCard).toHaveClass('bg-yellow-50')
+      expect(headerCard).toHaveClass('border-yellow-500')
+    })
+  })
+
+  describe('Auto-refresh functionality', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('should fetch data on mount and setup auto-refresh interval', async () => {
+      fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+      render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalledTimes(1)
+      })
+
+      fetchWithMock.mockClear()
+      fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+      vi.advanceTimersByTime(POLL_INTERVAL_MS)
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('should set lastUpdatedAt timestamp on successful fetch', async () => {
+      const now = new Date('2023-01-01T12:30:00Z')
+      vi.setSystemTime(now)
+
+      fetchWithMock.mockResolvedValueOnce(mockWorkloadData)
+
+      render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Last Updated')).toBeInTheDocument()
+      })
+    })
+
+    it('should preserve existing data when auto-refresh fails', async () => {
+      fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+      render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'nginx' })).toBeInTheDocument()
+      })
+
+      fetchWithMock.mockClear()
+      fetchWithMock.mockRejectedValue(new Error('Network error'))
+
+      vi.advanceTimersByTime(POLL_INTERVAL_MS)
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalled()
+      })
+
+      expect(screen.getByRole('heading', { name: 'nginx' })).toBeInTheDocument()
+      expect(screen.queryByText('Failed to load workload: Network error')).not.toBeInTheDocument()
+    })
+
+    it('should clear interval on unmount', async () => {
+      fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+      const { unmount } = render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'nginx' })).toBeInTheDocument()
+      })
+
+      fetchWithMock.mockClear()
+      unmount()
+
+      vi.advanceTimersByTime(POLL_INTERVAL_MS)
+
+      expect(fetchWithMock).not.toHaveBeenCalled()
+    })
+
+    it('should switch to fast polling when action is triggered', async () => {
+      fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+      render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+      await waitFor(() => {
+        expect(capturedOnActionStart).toBeTruthy()
+      })
+
+      fetchWithMock.mockClear()
+
+      await act(async () => {
+        capturedOnActionStart()
+      })
+
+      expect(fetchWithMock).not.toHaveBeenCalled()
+
+      await act(async () => {
+        vi.advanceTimersByTime(FAST_POLL_INTERVAL_MS)
+      })
+
+      expect(fetchWithMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should revert to normal polling after timeout', async () => {
+      fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+      render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+      await waitFor(() => {
+        expect(capturedOnActionStart).toBeTruthy()
+      })
+
+      fetchWithMock.mockClear()
+
+      await act(async () => {
+        capturedOnActionStart()
+      })
+
+      await act(async () => {
+        vi.advanceTimersByTime(FAST_POLL_TIMEOUT_MS)
+      })
+
+      fetchWithMock.mockClear()
+
+      await act(async () => {
+        vi.advanceTimersByTime(FAST_POLL_INTERVAL_MS)
+      })
+
+      // Only 5s into a 10s interval, so no fetch
+      expect(fetchWithMock).not.toHaveBeenCalled()
+
+      await act(async () => {
+        vi.advanceTimersByTime(POLL_INTERVAL_MS - FAST_POLL_INTERVAL_MS)
+      })
+
+      expect(fetchWithMock).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/web/src/components/dashboards/workload/WorkloadPage.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPage.test.jsx
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor, act } from '@testing-library/preact'
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/preact'
 import { WorkloadPage } from './WorkloadPage'
 import { fetchWithMock } from '../../../utils/fetch'
 import { navHistory, clearNavHistory, getNavHistoryKey } from '../../../utils/navHistory'
+import { isFavorite, clearFavorites } from '../../../utils/favorites'
 
 // Polling constants used by WorkloadPage
 const POLL_INTERVAL_MS = 10000
@@ -111,6 +112,7 @@ describe('WorkloadPage component', () => {
     vi.clearAllMocks()
     capturedOnActionStart = null
     capturedActionBarProps = null
+    clearFavorites()
   })
 
   it('should render loading state with header card', () => {
@@ -187,6 +189,34 @@ describe('WorkloadPage component', () => {
 
     // ActionBar should receive reconciler props (not workload props)
     expect(screen.getByTestId('action-bar')).toHaveTextContent('ActionBar: Kustomization/flux-system/apps')
+  })
+
+  it('should toggle the workload favorite from the hero button', async () => {
+    fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+    render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'nginx' })).toBeInTheDocument()
+    })
+
+    // Initially not favorited
+    expect(isFavorite('Deployment', 'default', 'nginx')).toBe(false)
+    const favoriteButton = screen.getByTitle('Add to favorites')
+
+    // Clicking adds the workload to favorites
+    await act(async () => {
+      fireEvent.click(favoriteButton)
+    })
+    expect(isFavorite('Deployment', 'default', 'nginx')).toBe(true)
+    expect(screen.getByTitle('Remove from favorites')).toBeInTheDocument()
+
+    // Clicking again removes it
+    await act(async () => {
+      fireEvent.click(screen.getByTitle('Remove from favorites'))
+    })
+    expect(isFavorite('Deployment', 'default', 'nginx')).toBe(false)
+    expect(screen.getByTitle('Add to favorites')).toBeInTheDocument()
   })
 
   it('should pass reconciler data to ActionBar', async () => {

--- a/web/src/components/dashboards/workload/WorkloadPage.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPage.test.jsx
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, waitFor, act } from '@testing-library/preact'
 import { WorkloadPage } from './WorkloadPage'
 import { fetchWithMock } from '../../../utils/fetch'
+import { navHistory, clearNavHistory, getNavHistoryKey } from '../../../utils/navHistory'
 
 // Polling constants used by WorkloadPage
 const POLL_INTERVAL_MS = 10000
@@ -262,6 +263,26 @@ describe('WorkloadPage component', () => {
       const headerCard = screen.getByRole('heading', { name: 'nginx' }).closest('.card')
       expect(headerCard).toHaveClass('bg-yellow-50')
       expect(headerCard).toHaveClass('border-yellow-500')
+    })
+  })
+
+  describe('Navigation history', () => {
+    beforeEach(() => {
+      clearNavHistory()
+    })
+
+    it('should record the workload visit in navigation history', async () => {
+      fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+      render(<WorkloadPage kind="Deployment" namespace="default" name="nginx" />)
+
+      await waitFor(() => {
+        expect(navHistory.value.length).toBe(1)
+      })
+
+      const entry = navHistory.value[0]
+      expect(getNavHistoryKey(entry.kind, entry.namespace, entry.name))
+        .toBe('Deployment/default/nginx')
     })
   })
 

--- a/web/src/components/dashboards/workload/WorkloadPipelinePanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPipelinePanel.jsx
@@ -1,0 +1,299 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { formatWorkloadStatus } from '../../../utils/status'
+
+/**
+ * Get border color class for pipeline node status.
+ * Uses the same color scheme as GraphTabContent's getStatusBorderClass.
+ * @param {string} status - Status value
+ * @returns {string} Tailwind CSS border classes
+ */
+function getStatusBorderClass(status) {
+  switch (status) {
+  case 'Ready':
+  case 'Current':
+  case 'Idle':
+    return 'border border-green-500 dark:border-green-400'
+  case 'Failed':
+    return 'border border-red-500 dark:border-red-400'
+  case 'Progressing':
+  case 'InProgress':
+    return 'border border-blue-500 dark:border-blue-400'
+  case 'Suspended':
+    return 'border border-yellow-500 dark:border-yellow-400'
+  default:
+    return 'border border-gray-400 dark:border-gray-500'
+  }
+}
+
+/**
+ * Check if a pod is truly ready using the Kubernetes Ready condition.
+ * Falls back to checking the pod phase when podStatus is not available.
+ * @param {object} pod - Pod object with status and optional podStatus
+ * @returns {boolean} true if the pod is ready
+ */
+function isPodReady(pod) {
+  // Use the Ready condition from podStatus when available (detail endpoint)
+  if (pod.podStatus?.conditions) {
+    return pod.podStatus.conditions.some(c => c.type === 'Ready' && c.status === 'True')
+  }
+  // Fallback: treat Running as ready when podStatus is not available
+  return pod.status === 'Running' || pod.status === 'Succeeded'
+}
+
+/**
+ * Compute the aggregated pod status for the Pods pipeline node.
+ * For CronJobs, success means all pods succeeded (no failures).
+ * For other workloads, uses the Kubernetes Ready condition to determine readiness.
+ * @param {Array} pods - Array of pod objects with status field
+ * @param {boolean} isCronJob - Whether the parent workload is a CronJob
+ * @returns {string} Aggregated status: Ready, Failed, Progressing, or Unknown
+ */
+function getPodAggregateStatus(pods, isCronJob) {
+  if (!pods || pods.length === 0) return 'Unknown'
+  const hasAnyFailed = pods.some(p => p.status === 'Failed')
+  if (hasAnyFailed) return 'Failed'
+  if (isCronJob) {
+    const allCompleted = pods.every(p => p.status === 'Succeeded')
+    if (allCompleted) return 'Ready'
+  } else {
+    if (pods.every(p => isPodReady(p))) return 'Ready'
+  }
+  return 'Progressing'
+}
+
+/**
+ * Build a human-readable summary of pod phases (e.g. "2 running", "1 running, 1 pending").
+ * Groups pods by lowercase phase and joins counts with commas.
+ * @param {Array} pods - Array of pod objects with status field
+ * @returns {string} Phase summary string
+ */
+function getPodPhaseSummary(pods) {
+  if (!pods || pods.length === 0) return ''
+  const counts = {}
+  for (const pod of pods) {
+    const phase = (pod.status || 'Unknown').toLowerCase()
+    counts[phase] = (counts[phase] || 0) + 1
+  }
+  return Object.entries(counts)
+    .map(([phase, count]) => `${count} ${phase}`)
+    .join(', ')
+}
+
+/**
+ * Compact card for a single pipeline node.
+ * Matches the NodeCard pattern from GraphTabContent.
+ */
+function PipelineNode({ kind, name, subtext, status, href }) {
+  const borderClass = getStatusBorderClass(status)
+  const isClickable = !!href
+
+  const card = (
+    <div
+      class={`bg-white dark:bg-gray-800 rounded-lg p-3 shadow-sm ${borderClass} transition-all duration-300 ${
+        isClickable ? 'cursor-pointer hover:shadow-md' : ''
+      }`}
+      data-testid="pipeline-node"
+    >
+      <div class="flex items-center gap-2 mb-1">
+        <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">{kind}</span>
+      </div>
+      <div class="text-sm font-medium text-gray-900 dark:text-white truncate" title={name}>
+        {name}
+      </div>
+      {subtext && (
+        <div class="text-xs text-gray-500 dark:text-gray-400 truncate mt-1" title={subtext}>
+          {subtext}
+        </div>
+      )}
+    </div>
+  )
+
+  if (isClickable) {
+    return <a href={href} class="block min-w-0" data-testid="pipeline-link">{card}</a>
+  }
+
+  return <div class="min-w-0">{card}</div>
+}
+
+/**
+ * Get connector color classes for the line and arrow based on the parent node status.
+ * @param {string} status - Status of the parent (source) node
+ * @returns {{ bg: string, hArrow: string, vArrow: string }}
+ */
+function getConnectorClasses(status) {
+  switch (status) {
+  case 'Ready':
+  case 'Current':
+  case 'Idle':
+    return {
+      bg: 'bg-green-500 dark:bg-green-400',
+      hArrow: 'border-l-green-500 dark:border-l-green-400',
+      vArrow: 'border-t-green-500 dark:border-t-green-400'
+    }
+  case 'Failed':
+    return {
+      bg: 'bg-red-500 dark:bg-red-400',
+      hArrow: 'border-l-red-500 dark:border-l-red-400',
+      vArrow: 'border-t-red-500 dark:border-t-red-400'
+    }
+  case 'Progressing':
+  case 'InProgress':
+    return {
+      bg: 'bg-blue-500 dark:bg-blue-400',
+      hArrow: 'border-l-blue-500 dark:border-l-blue-400',
+      vArrow: 'border-t-blue-500 dark:border-t-blue-400'
+    }
+  case 'Suspended':
+    return {
+      bg: 'bg-yellow-500 dark:bg-yellow-400',
+      hArrow: 'border-l-yellow-500 dark:border-l-yellow-400',
+      vArrow: 'border-t-yellow-500 dark:border-t-yellow-400'
+    }
+  default:
+    return {
+      bg: 'bg-gray-400 dark:bg-gray-500',
+      hArrow: 'border-l-gray-400 dark:border-l-gray-500',
+      vArrow: 'border-t-gray-400 dark:border-t-gray-500'
+    }
+  }
+}
+
+/**
+ * Horizontal connector arrow (desktop): line + right-pointing triangle
+ */
+function HorizontalConnector({ status }) {
+  const c = getConnectorClasses(status)
+  return (
+    <div class="flex items-center flex-shrink-0" data-testid="pipeline-connector">
+      <div class={`h-px w-4 ${c.bg}`} />
+      <div class={`w-0 h-0 border-t-[4px] border-b-[4px] border-l-[5px] border-t-transparent border-b-transparent ${c.hArrow}`} />
+    </div>
+  )
+}
+
+/**
+ * Vertical connector arrow (mobile): line + down-pointing triangle
+ */
+function VerticalConnector({ status }) {
+  const c = getConnectorClasses(status)
+  return (
+    <div class="flex flex-col items-center" data-testid="pipeline-connector">
+      <div class={`w-px h-6 ${c.bg}`} />
+      <div class={`w-0 h-0 border-l-[4px] border-r-[4px] border-t-[5px] border-l-transparent border-r-transparent ${c.vArrow}`} />
+    </div>
+  )
+}
+
+/**
+ * WorkloadPipelinePanel - Renders a compact horizontal pipeline:
+ * [Source] -> [Reconciler] -> [Workload] -> [Pods]
+ *
+ * @param {object} reconciler - The enriched parent Flux resource from GetResource API
+ * @param {string} kind - The workload kind (Deployment, StatefulSet, etc.)
+ * @param {string} name - The workload name
+ * @param {string} workloadStatus - The workload status (Current, InProgress, Failed, etc.)
+ * @param {Array} pods - Array of pod objects with name and status
+ */
+export function WorkloadPipelinePanel({ reconciler, kind, name, workloadStatus, pods }) {
+  if (!reconciler) return null
+
+  const sourceRef = reconciler.status?.sourceRef
+  const reconcilerStatus = reconciler.status?.reconcilerRef?.status || 'Unknown'
+  const revision = reconciler.status?.lastAttemptedRevision || reconciler.status?.lastAppliedRevision
+
+  // Build node data and track statuses for connector coloring
+  const nodes = []
+  const nodeStatuses = []
+
+  // Source node (optional)
+  if (sourceRef) {
+    const sourceStatus = sourceRef.status || 'Unknown'
+    const sourceNs = sourceRef.namespace || reconciler.metadata?.namespace
+    nodeStatuses.push(sourceStatus)
+    nodes.push(
+      <PipelineNode
+        kind={sourceRef.kind}
+        name={sourceRef.name}
+        subtext={sourceRef.url}
+        status={sourceStatus}
+        href={`/resource/${encodeURIComponent(sourceRef.kind)}/${encodeURIComponent(sourceNs)}/${encodeURIComponent(sourceRef.name)}`}
+      />
+    )
+  }
+
+  // Reconciler node
+  nodeStatuses.push(reconcilerStatus)
+  nodes.push(
+    <PipelineNode
+      kind={reconciler.kind}
+      name={reconciler.metadata?.name}
+      subtext={revision}
+      status={reconcilerStatus}
+      href={`/resource/${encodeURIComponent(reconciler.kind)}/${encodeURIComponent(reconciler.metadata?.namespace)}/${encodeURIComponent(reconciler.metadata?.name)}`}
+    />
+  )
+
+  // Workload node (current page, not clickable)
+  nodeStatuses.push(workloadStatus)
+  nodes.push(
+    <PipelineNode
+      kind={kind}
+      name={name}
+      subtext={formatWorkloadStatus(workloadStatus)}
+      status={workloadStatus}
+    />
+  )
+
+  // Pods node — CronJobs care about completion, other workloads care about readiness
+  const isCronJob = kind === 'CronJob'
+  const podCount = pods?.length || 0
+  const podStatus = getPodAggregateStatus(pods, isCronJob)
+  let podName, podSubtext
+  if (podCount === 0) {
+    podName = isCronJob ? 'No active pods' : 'Scaled to zero'
+    podSubtext = '0 pods'
+  } else if (isCronJob) {
+    const completedCount = pods.filter(p => p.status === 'Succeeded' || p.status === 'Failed').length
+    podName = `${completedCount}/${podCount} completed`
+    podSubtext = getPodPhaseSummary(pods)
+  } else {
+    const readyCount = pods.filter(p => isPodReady(p)).length
+    podName = `${readyCount}/${podCount} ready`
+    podSubtext = getPodPhaseSummary(pods)
+  }
+  nodeStatuses.push(podStatus)
+  nodes.push(
+    <PipelineNode
+      kind="Pods"
+      name={podName}
+      subtext={podSubtext}
+      status={podStatus}
+    />
+  )
+
+  return (
+    <div data-testid="workload-pipeline-panel">
+      {/* Desktop: horizontal pipeline */}
+      <div class="hidden sm:flex items-center" data-testid="pipeline-horizontal">
+        {nodes.map((node, idx) => (
+          <div key={idx} class="contents">
+            {idx > 0 && <HorizontalConnector status={nodeStatuses[idx - 1]} />}
+            <div class="flex-1 min-w-0">{node}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Mobile: vertical pipeline */}
+      <div class="sm:hidden flex flex-col items-center" data-testid="pipeline-vertical">
+        {nodes.map((node, idx) => (
+          <div key={idx} class="w-full">
+            {idx > 0 && <VerticalConnector status={nodeStatuses[idx - 1]} />}
+            {node}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/dashboards/workload/WorkloadPipelinePanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPipelinePanel.jsx
@@ -3,6 +3,7 @@
 
 import { formatWorkloadStatus } from '../../../utils/status'
 import { summarizePods } from '../../../utils/pods'
+import { getDashboardUrl } from '../../../utils/routing'
 
 /**
  * Get border color class for pipeline node status.
@@ -165,7 +166,7 @@ export function WorkloadPipelinePanel({ reconciler, kind, name, workloadStatus, 
         name={sourceRef.name}
         subtext={sourceRef.url}
         status={sourceStatus}
-        href={`/resource/${encodeURIComponent(sourceRef.kind)}/${encodeURIComponent(sourceNs)}/${encodeURIComponent(sourceRef.name)}`}
+        href={getDashboardUrl(sourceRef.kind, sourceNs, sourceRef.name)}
       />
     )
   }
@@ -178,7 +179,7 @@ export function WorkloadPipelinePanel({ reconciler, kind, name, workloadStatus, 
       name={reconciler.metadata?.name}
       subtext={revision}
       status={reconcilerStatus}
-      href={`/resource/${encodeURIComponent(reconciler.kind)}/${encodeURIComponent(reconciler.metadata?.namespace)}/${encodeURIComponent(reconciler.metadata?.name)}`}
+      href={getDashboardUrl(reconciler.kind, reconciler.metadata?.namespace, reconciler.metadata?.name)}
     />
   )
 

--- a/web/src/components/dashboards/workload/WorkloadPipelinePanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPipelinePanel.jsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { formatWorkloadStatus } from '../../../utils/status'
+import { summarizePods } from '../../../utils/pods'
 
 /**
  * Get border color class for pipeline node status.
@@ -25,60 +26,6 @@ function getStatusBorderClass(status) {
   default:
     return 'border border-gray-400 dark:border-gray-500'
   }
-}
-
-/**
- * Check if a pod is truly ready using the Kubernetes Ready condition.
- * Falls back to checking the pod phase when podStatus is not available.
- * @param {object} pod - Pod object with status and optional podStatus
- * @returns {boolean} true if the pod is ready
- */
-function isPodReady(pod) {
-  // Use the Ready condition from podStatus when available (detail endpoint)
-  if (pod.podStatus?.conditions) {
-    return pod.podStatus.conditions.some(c => c.type === 'Ready' && c.status === 'True')
-  }
-  // Fallback: treat Running as ready when podStatus is not available
-  return pod.status === 'Running' || pod.status === 'Succeeded'
-}
-
-/**
- * Compute the aggregated pod status for the Pods pipeline node.
- * For CronJobs, success means all pods succeeded (no failures).
- * For other workloads, uses the Kubernetes Ready condition to determine readiness.
- * @param {Array} pods - Array of pod objects with status field
- * @param {boolean} isCronJob - Whether the parent workload is a CronJob
- * @returns {string} Aggregated status: Ready, Failed, Progressing, or Unknown
- */
-function getPodAggregateStatus(pods, isCronJob) {
-  if (!pods || pods.length === 0) return 'Unknown'
-  const hasAnyFailed = pods.some(p => p.status === 'Failed')
-  if (hasAnyFailed) return 'Failed'
-  if (isCronJob) {
-    const allCompleted = pods.every(p => p.status === 'Succeeded')
-    if (allCompleted) return 'Ready'
-  } else {
-    if (pods.every(p => isPodReady(p))) return 'Ready'
-  }
-  return 'Progressing'
-}
-
-/**
- * Build a human-readable summary of pod phases (e.g. "2 running", "1 running, 1 pending").
- * Groups pods by lowercase phase and joins counts with commas.
- * @param {Array} pods - Array of pod objects with status field
- * @returns {string} Phase summary string
- */
-function getPodPhaseSummary(pods) {
-  if (!pods || pods.length === 0) return ''
-  const counts = {}
-  for (const pod of pods) {
-    const phase = (pod.status || 'Unknown').toLowerCase()
-    counts[phase] = (counts[phase] || 0) + 1
-  }
-  return Object.entries(counts)
-    .map(([phase, count]) => `${count} ${phase}`)
-    .join(', ')
 }
 
 /**
@@ -247,29 +194,14 @@ export function WorkloadPipelinePanel({ reconciler, kind, name, workloadStatus, 
   )
 
   // Pods node — CronJobs care about completion, other workloads care about readiness
-  const isCronJob = kind === 'CronJob'
-  const podCount = pods?.length || 0
-  const podStatus = getPodAggregateStatus(pods, isCronJob)
-  let podName, podSubtext
-  if (podCount === 0) {
-    podName = isCronJob ? 'No active pods' : 'Scaled to zero'
-    podSubtext = '0 pods'
-  } else if (isCronJob) {
-    const completedCount = pods.filter(p => p.status === 'Succeeded' || p.status === 'Failed').length
-    podName = `${completedCount}/${podCount} completed`
-    podSubtext = getPodPhaseSummary(pods)
-  } else {
-    const readyCount = pods.filter(p => isPodReady(p)).length
-    podName = `${readyCount}/${podCount} ready`
-    podSubtext = getPodPhaseSummary(pods)
-  }
-  nodeStatuses.push(podStatus)
+  const podSummary = summarizePods(pods, kind)
+  nodeStatuses.push(podSummary.status)
   nodes.push(
     <PipelineNode
       kind="Pods"
-      name={podName}
-      subtext={podSubtext}
-      status={podStatus}
+      name={podSummary.primary}
+      subtext={podSummary.detail}
+      status={podSummary.status}
     />
   )
 

--- a/web/src/components/dashboards/workload/WorkloadPipelinePanel.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPipelinePanel.test.jsx
@@ -1,0 +1,448 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/preact'
+import { WorkloadPipelinePanel } from './WorkloadPipelinePanel'
+
+const baseReconciler = {
+  apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+  kind: 'Kustomization',
+  metadata: {
+    name: 'apps',
+    namespace: 'flux-system'
+  },
+  status: {
+    reconcilerRef: {
+      status: 'Ready'
+    },
+    sourceRef: {
+      kind: 'GitRepository',
+      name: 'flux-system',
+      namespace: 'flux-system',
+      status: 'Ready',
+      url: 'https://github.com/example/repo'
+    },
+    lastAttemptedRevision: 'main@sha1:abc123'
+  }
+}
+
+const basePods = [
+  { name: 'nginx-abc-123', status: 'Running' },
+  { name: 'nginx-abc-456', status: 'Running' }
+]
+
+describe('WorkloadPipelinePanel', () => {
+  it('should not render when reconciler is null', () => {
+    const { container } = render(
+      <WorkloadPipelinePanel
+        reconciler={null}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={basePods}
+      />
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('should render all 4 pipeline nodes', () => {
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={basePods}
+      />
+    )
+
+    expect(screen.getByTestId('workload-pipeline-panel')).toBeInTheDocument()
+
+    // All nodes rendered (doubled for desktop + mobile)
+    const nodes = screen.getAllByTestId('pipeline-node')
+    expect(nodes).toHaveLength(8) // 4 nodes x 2 layouts
+
+    // Source node (CSS uppercase class transforms visually, DOM text is original case)
+    expect(screen.getAllByText('GitRepository').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('flux-system').length).toBeGreaterThanOrEqual(1)
+
+    // Reconciler node
+    expect(screen.getAllByText('Kustomization').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('apps').length).toBeGreaterThanOrEqual(1)
+
+    // Workload node
+    expect(screen.getAllByText('Deployment').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('nginx').length).toBeGreaterThanOrEqual(1)
+
+    // Pods node — readiness as name, phase summary as subtext
+    expect(screen.getAllByText('Pods').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('2/2 ready').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('2 running').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should show source URL as subtext', () => {
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={basePods}
+      />
+    )
+
+    expect(screen.getAllByText('https://github.com/example/repo').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should show reconciler revision as subtext', () => {
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={basePods}
+      />
+    )
+
+    expect(screen.getAllByText('main@sha1:abc123').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should render clickable links for source and reconciler', () => {
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={basePods}
+      />
+    )
+
+    const links = screen.getAllByTestId('pipeline-link')
+    // 2 clickable nodes (source + reconciler) x 2 layouts = 4
+    expect(links).toHaveLength(4)
+
+    // Check source link href
+    const sourceLinks = links.filter(l => l.getAttribute('href').includes('GitRepository'))
+    expect(sourceLinks.length).toBeGreaterThanOrEqual(1)
+    expect(sourceLinks[0].getAttribute('href')).toBe('/resource/GitRepository/flux-system/flux-system')
+
+    // Check reconciler link href
+    const reconcilerLinks = links.filter(l => l.getAttribute('href').includes('Kustomization'))
+    expect(reconcilerLinks.length).toBeGreaterThanOrEqual(1)
+    expect(reconcilerLinks[0].getAttribute('href')).toBe('/resource/Kustomization/flux-system/apps')
+  })
+
+  it('should handle missing source (no sourceRef)', () => {
+    const reconcilerNoSource = {
+      ...baseReconciler,
+      status: {
+        ...baseReconciler.status,
+        sourceRef: undefined
+      }
+    }
+
+    render(
+      <WorkloadPipelinePanel
+        reconciler={reconcilerNoSource}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={basePods}
+      />
+    )
+
+    // Should have 3 nodes instead of 4 (no source) x 2 layouts = 6
+    const nodes = screen.getAllByTestId('pipeline-node')
+    expect(nodes).toHaveLength(6)
+
+    // Source kind should not appear
+    expect(screen.queryByText('GitRepository')).not.toBeInTheDocument()
+
+    // Reconciler, workload, and pods should still render
+    expect(screen.getAllByText('Kustomization').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('Deployment').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('Pods').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should show pod summary with ready count and phase breakdown', () => {
+    const mixedPods = [
+      { name: 'pod-1', status: 'Running' },
+      { name: 'pod-2', status: 'Pending' },
+      { name: 'pod-3', status: 'Running' }
+    ]
+
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={mixedPods}
+      />
+    )
+
+    expect(screen.getAllByText('2/3 ready').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('2 running, 1 pending').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should use lastAppliedRevision as fallback', () => {
+    const reconcilerFallback = {
+      ...baseReconciler,
+      status: {
+        ...baseReconciler.status,
+        lastAttemptedRevision: undefined,
+        lastAppliedRevision: 'main@sha1:fallback'
+      }
+    }
+
+    render(
+      <WorkloadPipelinePanel
+        reconciler={reconcilerFallback}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={basePods}
+      />
+    )
+
+    expect(screen.getAllByText('main@sha1:fallback').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should format workload status for display', () => {
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={basePods}
+      />
+    )
+
+    // 'Current' should be formatted as 'Ready' by formatWorkloadStatus
+    expect(screen.getAllByText('Ready').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should render connectors between nodes', () => {
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={basePods}
+      />
+    )
+
+    const connectors = screen.getAllByTestId('pipeline-connector')
+    // 3 connectors per layout x 2 layouts = 6
+    expect(connectors).toHaveLength(6)
+  })
+
+  it('should show failed pod status border', () => {
+    const failedPods = [
+      { name: 'pod-1', status: 'Running' },
+      { name: 'pod-2', status: 'Failed' }
+    ]
+
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={failedPods}
+      />
+    )
+
+    // Pods node should show "1/2 ready" with phase breakdown
+    expect(screen.getAllByText('1/2 ready').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('1 running, 1 failed').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should show completed count for CronJob pods', () => {
+    const cronJobPods = [
+      { name: 'job-abc-123', status: 'Succeeded' },
+      { name: 'job-abc-456', status: 'Running' }
+    ]
+
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="CronJob"
+        name="backup"
+        workloadStatus="Idle"
+        pods={cronJobPods}
+      />
+    )
+
+    expect(screen.getAllByText('1/2 completed').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('1 succeeded, 1 running').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should show all completed for CronJob with succeeded pods', () => {
+    const cronJobPods = [
+      { name: 'job-abc-123', status: 'Succeeded' }
+    ]
+
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="CronJob"
+        name="backup"
+        workloadStatus="Idle"
+        pods={cronJobPods}
+      />
+    )
+
+    expect(screen.getAllByText('1/1 completed').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('1 succeeded').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should count failed CronJob pods as completed', () => {
+    const failedCronPods = [
+      { name: 'job-abc-123', status: 'Failed' },
+      { name: 'job-abc-456', status: 'Failed' }
+    ]
+
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="CronJob"
+        name="backup"
+        workloadStatus="Idle"
+        pods={failedCronPods}
+      />
+    )
+
+    expect(screen.getAllByText('2/2 completed').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('2 failed').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should use Ready condition from podStatus for readiness', () => {
+    // During a rollout: old pod is Running but Ready=False (terminating),
+    // new pod is Pending with Ready=False
+    const rolloutPods = [
+      {
+        name: 'nginx-old-abc',
+        status: 'Running',
+        podStatus: {
+          conditions: [
+            { type: 'Ready', status: 'False' }
+          ]
+        }
+      },
+      {
+        name: 'nginx-new-def',
+        status: 'Pending',
+        podStatus: {
+          conditions: [
+            { type: 'Ready', status: 'False' }
+          ]
+        }
+      }
+    ]
+
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="InProgress"
+        pods={rolloutPods}
+      />
+    )
+
+    // Neither pod is Ready, so 0/2 ready; phase summary shows actual phases
+    expect(screen.getAllByText('0/2 ready').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('1 running, 1 pending').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should count only pods with Ready=True condition as ready', () => {
+    const mixedPods = [
+      {
+        name: 'nginx-ready',
+        status: 'Running',
+        podStatus: {
+          conditions: [
+            { type: 'Ready', status: 'True' }
+          ]
+        }
+      },
+      {
+        name: 'nginx-not-ready',
+        status: 'Running',
+        podStatus: {
+          conditions: [
+            { type: 'Ready', status: 'False' }
+          ]
+        }
+      }
+    ]
+
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="InProgress"
+        pods={mixedPods}
+      />
+    )
+
+    expect(screen.getAllByText('1/2 ready').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should fall back to pod phase when podStatus is not available', () => {
+    // No podStatus — falls back to phase-based check
+    const simplePods = [
+      { name: 'nginx-abc', status: 'Running' },
+      { name: 'nginx-def', status: 'Pending' }
+    ]
+
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="InProgress"
+        pods={simplePods}
+      />
+    )
+
+    expect(screen.getAllByText('1/2 ready').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should show scaled to zero for Deployment with no pods', () => {
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="Deployment"
+        name="nginx"
+        workloadStatus="Current"
+        pods={[]}
+      />
+    )
+
+    expect(screen.getAllByText('Scaled to zero').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('0 pods').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should show no active pods for CronJob with no pods', () => {
+    render(
+      <WorkloadPipelinePanel
+        reconciler={baseReconciler}
+        kind="CronJob"
+        name="backup"
+        workloadStatus="Idle"
+        pods={[]}
+      />
+    )
+
+    expect(screen.getAllByText('No active pods').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('0 pods').length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/web/src/components/dashboards/workload/WorkloadPipelinePanel.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPipelinePanel.test.jsx
@@ -124,12 +124,10 @@ describe('WorkloadPipelinePanel', () => {
     // 2 clickable nodes (source + reconciler) x 2 layouts = 4
     expect(links).toHaveLength(4)
 
-    // Check source link href
     const sourceLinks = links.filter(l => l.getAttribute('href').includes('GitRepository'))
     expect(sourceLinks.length).toBeGreaterThanOrEqual(1)
     expect(sourceLinks[0].getAttribute('href')).toBe('/resource/GitRepository/flux-system/flux-system')
 
-    // Check reconciler link href
     const reconcilerLinks = links.filter(l => l.getAttribute('href').includes('Kustomization'))
     expect(reconcilerLinks.length).toBeGreaterThanOrEqual(1)
     expect(reconcilerLinks[0].getAttribute('href')).toBe('/resource/Kustomization/flux-system/apps')
@@ -154,14 +152,13 @@ describe('WorkloadPipelinePanel', () => {
       />
     )
 
-    // Should have 3 nodes instead of 4 (no source) x 2 layouts = 6
+    // Without a source, the pipeline has 3 nodes x 2 layouts = 6
     const nodes = screen.getAllByTestId('pipeline-node')
     expect(nodes).toHaveLength(6)
 
-    // Source kind should not appear
     expect(screen.queryByText('GitRepository')).not.toBeInTheDocument()
 
-    // Reconciler, workload, and pods should still render
+    // Reconciler, workload, and pods still render without the source
     expect(screen.getAllByText('Kustomization').length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByText('Deployment').length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByText('Pods').length).toBeGreaterThanOrEqual(1)
@@ -258,7 +255,6 @@ describe('WorkloadPipelinePanel', () => {
       />
     )
 
-    // Pods node should show "1/2 ready" with phase breakdown
     expect(screen.getAllByText('1/2 ready').length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByText('1 running, 1 failed').length).toBeGreaterThanOrEqual(1)
   })

--- a/web/src/components/dashboards/workload/WorkloadReconcilerPanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadReconcilerPanel.jsx
@@ -1,0 +1,319 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useMemo, useEffect, useRef, useState } from 'preact/hooks'
+import { fetchWithMock } from '../../../utils/fetch'
+import { formatTimestamp } from '../../../utils/time'
+import { getControllerName, getKindAlias } from '../../../utils/constants'
+import { DashboardPanel, TabButton } from '../common/panel'
+import { getStatusBadgeClass, getEventBadgeClass } from '../../../utils/status'
+import { FluxOperatorIcon } from '../../layout/Icons'
+import { useHashTab } from '../../../utils/hash'
+
+// Valid tabs for the WorkloadReconcilerPanel
+const RECONCILER_TABS = ['overview', 'source', 'events']
+
+/**
+ * WorkloadReconcilerPanel - Displays reconciler info for a workload's parent Flux resource.
+ * Owns tab state, events lazy-loading, and auto-refresh on workloadData changes.
+ */
+export function WorkloadReconcilerPanel({ reconciler, workloadData }) {
+  // Tab state synced with URL hash
+  const [reconcilerTab, setReconcilerTab] = useHashTab('reconciler', 'overview', RECONCILER_TABS, 'reconciler-panel')
+
+  // Events data state (lazy-loaded)
+  const [eventsData, setEventsData] = useState([])
+  const [eventsLoading, setEventsLoading] = useState(false)
+  const [eventsLoaded, setEventsLoaded] = useState(false)
+
+  // Track initial mount to avoid refetching on first render
+  const isInitialMount = useRef(true)
+
+  // Derived data
+  const reconcilerRef = reconciler?.status?.reconcilerRef
+  const sourceRef = reconciler?.status?.sourceRef
+  const reconcilerStatus = reconcilerRef?.status || 'Unknown'
+  const reconcilerMessage = reconcilerRef?.message || reconciler?.status?.conditions?.[0]?.message || ''
+  const reconcilerLastReconciled = reconcilerRef?.lastReconciled || reconciler?.status?.conditions?.[0]?.lastTransitionTime
+
+  // Compute reconcile interval from reconciler
+  const reconcileInterval = useMemo(() => {
+    if (!reconciler) return null
+    if (reconciler.spec?.interval) return reconciler.spec.interval
+    const annotation = reconciler.metadata?.annotations?.['fluxcd.controlplane.io/reconcileEvery']
+    if (annotation) return annotation
+    const k = reconciler.kind
+    if (k === 'FluxInstance' || k === 'ResourceSet') return '60m'
+    if (k === 'ResourceSetInputProvider') return '10m'
+    return null
+  }, [reconciler])
+
+  // Compute reconcile timeout from reconciler
+  const reconcileTimeout = useMemo(() => {
+    if (!reconciler) return null
+    const spec = reconciler.spec || {}
+    const annotations = reconciler.metadata?.annotations || {}
+    if (spec.timeout) return spec.timeout
+    if (reconciler.apiVersion?.startsWith('source.toolkit.fluxcd.io')) return '1m'
+    if (reconciler.kind === 'Kustomization') return spec.interval || null
+    if (reconciler.kind === 'HelmRelease') return '5m'
+    if (reconciler.kind === 'FluxInstance' || reconciler.kind === 'ResourceSet' || reconciler.kind === 'ResourceSetInputProvider') {
+      return annotations['fluxcd.controlplane.io/reconcileTimeout'] || '5m'
+    }
+    return null
+  }, [reconciler])
+
+  // Fetch events on demand when Events tab is clicked
+  useEffect(() => {
+    if (reconcilerTab === 'events' && !eventsLoaded && !eventsLoading && reconciler) {
+      const fetchEvents = async () => {
+        setEventsLoading(true)
+        const params = new URLSearchParams({
+          kind: reconciler.kind,
+          name: reconciler.metadata.name,
+          namespace: reconciler.metadata.namespace
+        })
+
+        try {
+          const eventsResp = await fetchWithMock({
+            endpoint: `/api/v1/events?${params.toString()}`,
+            mockPath: '../mock/events',
+            mockExport: 'getMockEvents'
+          })
+          setEventsData(eventsResp?.events || [])
+          setEventsLoaded(true)
+        } catch (err) {
+          console.error('Failed to fetch reconciler events:', err)
+        } finally {
+          setEventsLoading(false)
+        }
+      }
+
+      fetchEvents()
+    }
+  }, [reconcilerTab, eventsLoaded, eventsLoading, reconciler])
+
+  // Refetch events when workloadData changes (auto-refresh)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      if (workloadData) isInitialMount.current = false
+      return
+    }
+
+    if (reconcilerTab === 'events' && eventsLoaded && !eventsLoading && reconciler) {
+      const refetchEvents = async () => {
+        const params = new URLSearchParams({
+          kind: reconciler.kind,
+          name: reconciler.metadata.name,
+          namespace: reconciler.metadata.namespace
+        })
+
+        try {
+          const eventsResp = await fetchWithMock({
+            endpoint: `/api/v1/events?${params.toString()}`,
+            mockPath: '../mock/events',
+            mockExport: 'getMockEvents'
+          })
+          setEventsData(eventsResp?.events || [])
+        } catch (err) {
+          console.error('Failed to refetch reconciler events:', err)
+        }
+      }
+
+      refetchEvents()
+    }
+  }, [workloadData])
+
+  return (
+    <DashboardPanel title="Reconciler" id="reconciler-panel">
+      {/* Tab Navigation */}
+      <div class="border-b border-gray-200 dark:border-gray-700 mb-4">
+        <nav class="flex space-x-4">
+          <TabButton active={reconcilerTab === 'overview'} onClick={() => setReconcilerTab('overview')}>
+            <span class="sm:hidden">Info</span>
+            <span class="hidden sm:inline">Overview</span>
+          </TabButton>
+          {sourceRef && (
+            <TabButton active={reconcilerTab === 'source'} onClick={() => setReconcilerTab('source')}>
+              Source
+            </TabButton>
+          )}
+          <TabButton active={reconcilerTab === 'events'} onClick={() => setReconcilerTab('events')}>
+            Events
+          </TabButton>
+        </nav>
+      </div>
+
+      {/* Reconciler Overview Tab */}
+      {reconcilerTab === 'overview' && (
+        <div class="space-y-4">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* Left column: Status and metadata */}
+            <div class="space-y-4">
+              {/* Name */}
+              <div class="text-sm">
+                <span class="text-gray-500 dark:text-gray-400">Name</span>
+                <a
+                  href={`/resource/${encodeURIComponent(reconciler.kind)}/${encodeURIComponent(reconciler.metadata.namespace)}/${encodeURIComponent(reconciler.metadata.name)}`}
+                  class="ml-1 text-flux-blue dark:text-blue-400 hover:underline"
+                  data-testid="reconciler-link"
+                >
+                  <span class="hidden md:inline break-all">{reconciler.kind}/{reconciler.metadata.namespace}/{reconciler.metadata.name}</span>
+                  <span class="md:hidden break-all">{getKindAlias(reconciler.kind)}/{reconciler.metadata.name}</span>
+                </a>
+              </div>
+
+              {/* Status Badge */}
+              <div class="text-sm">
+                <span class="text-gray-500 dark:text-gray-400">Status</span>
+                <span class={`ml-1 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusBadgeClass(reconcilerStatus)}`}>
+                  {reconcilerStatus}
+                </span>
+              </div>
+
+              {/* Reconciled by */}
+              <div class="text-sm">
+                <span class="text-gray-500 dark:text-gray-400">Reconciled by</span>
+                <span class="ml-1 text-gray-900 dark:text-white">{getControllerName(reconciler.kind)}</span>
+              </div>
+
+              {/* Reconcile every */}
+              {reconcileInterval && (
+                <div class="text-sm">
+                  <span class="text-gray-500 dark:text-gray-400">Reconcile every</span>
+                  <span class="ml-1 text-gray-900 dark:text-white">
+                    {reconcileInterval}
+                  </span>
+                  {reconcileTimeout && (
+                    <span class="ml-1 text-gray-900 dark:text-white">
+                      (timeout {reconcileTimeout})
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Right column: Suspended by and Last action message */}
+            {(reconcilerMessage || (reconcilerStatus === 'Suspended' && reconciler.metadata?.annotations?.['fluxcd.controlplane.io/suspendedBy'])) && (
+              <div class="space-y-2 border-gray-200 dark:border-gray-700 border-t pt-4 md:border-t-0 md:border-l md:pt-0 md:pl-6">
+                {reconcilerStatus === 'Suspended' && reconciler.metadata?.annotations?.['fluxcd.controlplane.io/suspendedBy'] && (
+                  <div class="text-sm text-gray-500 dark:text-gray-400">
+                    Suspended by <span class="text-gray-900 dark:text-white">{reconciler.metadata.annotations['fluxcd.controlplane.io/suspendedBy']}</span>
+                  </div>
+                )}
+                {reconcilerMessage && (
+                  <>
+                    <div class="text-sm text-gray-500 dark:text-gray-400">
+                      Last action <span class="text-gray-900 dark:text-white">{reconcilerLastReconciled ? new Date(reconcilerLastReconciled).toLocaleString().replace(',', '') : '-'}</span>
+                    </div>
+                    <div class="text-sm text-gray-700 dark:text-gray-300">
+                      <pre class="whitespace-pre-wrap break-all font-sans">{reconcilerMessage}</pre>
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Reconciler Source Tab */}
+      {reconcilerTab === 'source' && sourceRef && (
+        <div class="space-y-4">
+          {/* Name */}
+          <div class="text-sm">
+            <span class="text-gray-500 dark:text-gray-400">Name</span>
+            <a
+              href={`/resource/${encodeURIComponent(sourceRef.kind)}/${encodeURIComponent(sourceRef.namespace || reconciler.metadata.namespace)}/${encodeURIComponent(sourceRef.name)}`}
+              class="ml-1 text-flux-blue dark:text-blue-400 hover:underline"
+            >
+              <span class="hidden md:inline break-all">{sourceRef.kind}/{sourceRef.namespace || reconciler.metadata.namespace}/{sourceRef.name}</span>
+              <span class="md:hidden break-all">{getKindAlias(sourceRef.kind)}/{sourceRef.name}</span>
+            </a>
+          </div>
+
+          {/* Status Badge */}
+          {sourceRef.status && (
+            <div class="text-sm">
+              <span class="text-gray-500 dark:text-gray-400">Status</span>
+              <span class={`ml-1 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusBadgeClass(sourceRef.status)}`}>
+                {sourceRef.status}
+              </span>
+            </div>
+          )}
+
+          {/* Reconciled by */}
+          <div class="text-sm">
+            <span class="text-gray-500 dark:text-gray-400">Reconciled by</span>
+            <span class="ml-1 text-gray-900 dark:text-white">{getControllerName(sourceRef.kind)}</span>
+          </div>
+
+          {/* URL */}
+          {sourceRef.url && (
+            <div class="text-sm">
+              <span class="text-gray-500 dark:text-gray-400">URL</span>
+              <span class="ml-1 text-gray-900 dark:text-white break-all">{sourceRef.url}</span>
+            </div>
+          )}
+
+          {/* Origin URL */}
+          {sourceRef.originURL && (
+            <div class="text-sm">
+              <span class="text-gray-500 dark:text-gray-400">Origin URL</span>
+              <span class="ml-1 text-gray-900 dark:text-white break-all">{sourceRef.originURL}</span>
+            </div>
+          )}
+
+          {/* Origin Revision */}
+          {sourceRef.originRevision && (
+            <div class="text-sm">
+              <span class="text-gray-500 dark:text-gray-400">Origin Revision</span>
+              <span class="ml-1 text-gray-900 dark:text-white break-all">{sourceRef.originRevision}</span>
+            </div>
+          )}
+
+          {/* Fetch result */}
+          {sourceRef.message && (
+            <div class="text-sm">
+              <span class="text-gray-500 dark:text-gray-400">Fetch result</span>
+              <span class="ml-1 text-gray-900 dark:text-white break-all">{sourceRef.message}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Reconciler Events Tab */}
+      {reconcilerTab === 'events' && (
+        <div>
+          {eventsLoading ? (
+            <div class="flex items-center justify-center p-8">
+              <FluxOperatorIcon className="animate-spin h-8 w-8 text-flux-blue" />
+              <span class="ml-3 text-gray-600 dark:text-gray-400">Loading events...</span>
+            </div>
+          ) : eventsData.length === 0 ? (
+            <p class="text-sm text-gray-500 dark:text-gray-400">No events found</p>
+          ) : (
+            <div class="space-y-4">
+              {eventsData.map((event, idx) => {
+                const displayStatus = event.type === 'Normal' ? 'Info' : 'Warning'
+                return (
+                  <div key={idx} class="card p-4 hover:shadow-md transition-shadow">
+                    <div class="flex items-center justify-between mb-3">
+                      <span class={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getEventBadgeClass(event.type)}`}>
+                        {displayStatus}
+                      </span>
+                      <span class="text-xs text-gray-500 dark:text-gray-400">{formatTimestamp(event.lastTimestamp)}</span>
+                    </div>
+                    <div class="text-sm text-gray-700 dark:text-gray-300">
+                      <pre class="whitespace-pre-wrap break-all font-sans">{event.message}</pre>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </DashboardPanel>
+  )
+}

--- a/web/src/components/dashboards/workload/WorkloadReconcilerPanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadReconcilerPanel.jsx
@@ -5,6 +5,7 @@ import { useMemo, useEffect, useRef, useState } from 'preact/hooks'
 import { fetchWithMock } from '../../../utils/fetch'
 import { formatTimestamp } from '../../../utils/time'
 import { getControllerName, getKindAlias } from '../../../utils/constants'
+import { getDashboardUrl } from '../../../utils/routing'
 import { DashboardPanel, TabButton } from '../common/panel'
 import { getStatusBadgeClass, getEventBadgeClass } from '../../../utils/status'
 import { FluxOperatorIcon } from '../../layout/Icons'
@@ -154,7 +155,7 @@ export function WorkloadReconcilerPanel({ reconciler, workloadData }) {
               <div class="text-sm">
                 <span class="text-gray-500 dark:text-gray-400">Name</span>
                 <a
-                  href={`/resource/${encodeURIComponent(reconciler.kind)}/${encodeURIComponent(reconciler.metadata.namespace)}/${encodeURIComponent(reconciler.metadata.name)}`}
+                  href={getDashboardUrl(reconciler.kind, reconciler.metadata.namespace, reconciler.metadata.name)}
                   class="ml-1 text-flux-blue dark:text-blue-400 hover:underline"
                   data-testid="reconciler-link"
                 >
@@ -224,7 +225,7 @@ export function WorkloadReconcilerPanel({ reconciler, workloadData }) {
           <div class="text-sm">
             <span class="text-gray-500 dark:text-gray-400">Name</span>
             <a
-              href={`/resource/${encodeURIComponent(sourceRef.kind)}/${encodeURIComponent(sourceRef.namespace || reconciler.metadata.namespace)}/${encodeURIComponent(sourceRef.name)}`}
+              href={getDashboardUrl(sourceRef.kind, sourceRef.namespace || reconciler.metadata.namespace, sourceRef.name)}
               class="ml-1 text-flux-blue dark:text-blue-400 hover:underline"
             >
               <span class="hidden md:inline break-all">{sourceRef.kind}/{sourceRef.namespace || reconciler.metadata.namespace}/{sourceRef.name}</span>

--- a/web/src/components/dashboards/workload/WorkloadReconcilerPanel.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadReconcilerPanel.test.jsx
@@ -1,0 +1,676 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/preact'
+import userEvent from '@testing-library/user-event'
+import { WorkloadReconcilerPanel } from './WorkloadReconcilerPanel'
+import { fetchWithMock } from '../../../utils/fetch'
+
+// Mock fetchWithMock
+vi.mock('../../../utils/fetch', () => ({
+  fetchWithMock: vi.fn()
+}))
+
+// Mock useHashTab to use simple useState instead
+vi.mock('../../../utils/hash', async () => {
+  const { useState } = await import('preact/hooks')
+  return {
+    useHashTab: (panel, defaultTab) => useState(defaultTab)
+  }
+})
+
+describe('WorkloadReconcilerPanel component', () => {
+  const mockReconciler = {
+    apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+    kind: 'Kustomization',
+    metadata: {
+      name: 'apps',
+      namespace: 'flux-system'
+    },
+    spec: {
+      interval: '10m',
+      prune: true,
+      wait: true
+    },
+    status: {
+      reconcilerRef: {
+        status: 'Ready',
+        message: 'Applied revision: main@sha1:abc123',
+        lastReconciled: '2023-01-01T12:00:00Z'
+      },
+      sourceRef: {
+        kind: 'GitRepository',
+        name: 'flux-system',
+        namespace: 'flux-system',
+        status: 'Ready',
+        url: 'https://github.com/example/repo',
+        message: 'stored artifact for revision main@sha1:abc123'
+      }
+    }
+  }
+
+  const mockWorkloadData = { metadata: { name: 'nginx' } }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render the Reconciler title', () => {
+    render(
+      <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+    )
+
+    expect(screen.getByText('Reconciler')).toBeInTheDocument()
+  })
+
+  it('should be expanded by default with tabs visible', () => {
+    render(
+      <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+    )
+
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+    expect(screen.getByText('Source')).toBeInTheDocument()
+    expect(screen.getByText('Events')).toBeInTheDocument()
+  })
+
+  it('should toggle collapse/expand state', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+    )
+
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+
+    const headerButton = screen.getByText('Reconciler').closest('button')
+    await user.click(headerButton)
+
+    expect(screen.queryByText('Overview')).not.toBeInTheDocument()
+
+    await user.click(headerButton)
+
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+  })
+
+  it('should display overview tab content', () => {
+    render(
+      <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+    )
+
+    // Status
+    expect(screen.getAllByText('Status').length).toBeGreaterThan(0)
+    expect(screen.getByText('Ready')).toBeInTheDocument()
+
+    // Reconciled by
+    expect(screen.getByText('Reconciled by')).toBeInTheDocument()
+
+    // Reconcile every
+    expect(screen.getByText('Reconcile every')).toBeInTheDocument()
+    expect(screen.getByText('10m')).toBeInTheDocument()
+
+    // Message
+    expect(screen.getByText(/Applied revision: main@sha1:abc123/)).toBeInTheDocument()
+  })
+
+  it('should render reconciler link with Name label and correct href', () => {
+    render(
+      <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+    )
+
+    const nameLabels = screen.getAllByText('Name')
+    expect(nameLabels.length).toBeGreaterThan(0)
+
+    const link = screen.getByTestId('reconciler-link')
+    expect(link).toHaveAttribute('href', '/resource/Kustomization/flux-system/apps')
+  })
+
+  describe('Reconcile interval', () => {
+    it('should calculate interval from spec.interval', () => {
+      render(
+        <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.getByText('10m')).toBeInTheDocument()
+    })
+
+    it('should calculate interval from annotation', () => {
+      const reconciler = {
+        ...mockReconciler,
+        spec: {},
+        metadata: {
+          ...mockReconciler.metadata,
+          annotations: { 'fluxcd.controlplane.io/reconcileEvery': '3m' }
+        }
+      }
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.getByText('3m')).toBeInTheDocument()
+    })
+
+    it('should use default 60m for FluxInstance', () => {
+      const reconciler = {
+        ...mockReconciler,
+        kind: 'FluxInstance',
+        spec: {},
+        metadata: { name: 'flux', namespace: 'flux-system' }
+      }
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.getByText('60m')).toBeInTheDocument()
+    })
+
+    it('should use default 60m for ResourceSet', () => {
+      const reconciler = {
+        ...mockReconciler,
+        kind: 'ResourceSet',
+        spec: {},
+        metadata: { name: 'rs', namespace: 'flux-system' }
+      }
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.getByText('60m')).toBeInTheDocument()
+    })
+
+    it('should use default 10m for ResourceSetInputProvider', () => {
+      const reconciler = {
+        ...mockReconciler,
+        kind: 'ResourceSetInputProvider',
+        spec: {},
+        metadata: { name: 'ip', namespace: 'flux-system' }
+      }
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.getByText('10m')).toBeInTheDocument()
+    })
+
+    it('should not show interval for unknown kind without spec.interval', () => {
+      const reconciler = {
+        ...mockReconciler,
+        kind: 'UnknownKind',
+        spec: {},
+        metadata: { name: 'x', namespace: 'default' }
+      }
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.queryByText('Reconcile every')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Reconcile timeout', () => {
+    it('should display timeout from spec.timeout', () => {
+      const reconciler = {
+        ...mockReconciler,
+        spec: { interval: '10m', timeout: '2m' }
+      }
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.getByText('(timeout 2m)')).toBeInTheDocument()
+    })
+
+    it('should display default timeout 1m for Source types', () => {
+      const reconciler = {
+        apiVersion: 'source.toolkit.fluxcd.io/v1beta2',
+        kind: 'GitRepository',
+        metadata: { name: 'git', namespace: 'flux-system' },
+        spec: { interval: '10m' },
+        status: {}
+      }
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.getByText('(timeout 1m)')).toBeInTheDocument()
+    })
+
+    it('should display timeout from spec.interval for Kustomization', () => {
+      render(
+        <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.getByText('(timeout 10m)')).toBeInTheDocument()
+    })
+
+    it('should display default timeout 5m for HelmRelease', () => {
+      const reconciler = {
+        apiVersion: 'helm.toolkit.fluxcd.io/v2beta1',
+        kind: 'HelmRelease',
+        metadata: { name: 'app', namespace: 'flux-system' },
+        spec: { interval: '10m' },
+        status: {}
+      }
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.getByText('(timeout 5m)')).toBeInTheDocument()
+    })
+
+    it('should display default timeout 5m for FluxInstance', () => {
+      const reconciler = {
+        ...mockReconciler,
+        kind: 'FluxInstance',
+        metadata: { name: 'flux', namespace: 'flux-system' },
+        spec: {}
+      }
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.getByText('(timeout 5m)')).toBeInTheDocument()
+    })
+
+    it('should display timeout from annotation for FluxInstance', () => {
+      const reconciler = {
+        ...mockReconciler,
+        kind: 'FluxInstance',
+        metadata: {
+          name: 'flux',
+          namespace: 'flux-system',
+          annotations: {
+            'fluxcd.controlplane.io/reconcileEvery': '1m',
+            'fluxcd.controlplane.io/reconcileTimeout': '10m'
+          }
+        },
+        spec: {}
+      }
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+      expect(screen.getByText('(timeout 10m)')).toBeInTheDocument()
+    })
+  })
+
+  describe('Source tab', () => {
+    it('should switch to Source tab and display source info', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+      )
+
+      await user.click(screen.getByText('Source'))
+
+      // Name label with source link
+      expect(screen.getByText('Name')).toBeInTheDocument()
+      const sourceLinks = screen.getAllByText(/GitRepository/)
+      expect(sourceLinks.length).toBeGreaterThan(0)
+
+      // Status badge
+      const readyBadges = screen.getAllByText('Ready')
+      expect(readyBadges.length).toBeGreaterThan(0)
+
+      // URL
+      expect(screen.getByText('https://github.com/example/repo')).toBeInTheDocument()
+
+      // Fetch result
+      expect(screen.getByText('stored artifact for revision main@sha1:abc123')).toBeInTheDocument()
+    })
+
+    it('should not show Source tab when sourceRef is missing', () => {
+      const reconciler = {
+        ...mockReconciler,
+        status: {
+          reconcilerRef: mockReconciler.status.reconcilerRef
+        }
+      }
+
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+
+      expect(screen.queryByText('Source')).not.toBeInTheDocument()
+    })
+
+    it('should display origin URL when present', async () => {
+      const user = userEvent.setup()
+      const reconciler = {
+        ...mockReconciler,
+        status: {
+          ...mockReconciler.status,
+          sourceRef: {
+            ...mockReconciler.status.sourceRef,
+            originURL: 'https://github.com/fork/repo',
+            originRevision: 'feature-branch/def456'
+          }
+        }
+      }
+
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+
+      await user.click(screen.getByText('Source'))
+
+      expect(screen.getByText('https://github.com/fork/repo')).toBeInTheDocument()
+      expect(screen.getByText('feature-branch/def456')).toBeInTheDocument()
+    })
+  })
+
+  describe('Events tab', () => {
+    it('should fetch and display events when Events tab is clicked', async () => {
+      const user = userEvent.setup()
+      const mockEvents = {
+        events: [
+          {
+            type: 'Normal',
+            reason: 'Reconciled',
+            message: 'Reconciliation finished',
+            lastTimestamp: '2023-01-01T12:05:00Z'
+          },
+          {
+            type: 'Warning',
+            reason: 'Failed',
+            message: 'Something went wrong',
+            lastTimestamp: '2023-01-01T12:10:00Z'
+          }
+        ]
+      }
+
+      fetchWithMock.mockResolvedValueOnce(mockEvents)
+
+      render(
+        <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+      )
+
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalledWith(expect.objectContaining({
+          endpoint: expect.stringContaining('/api/v1/events')
+        }))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Reconciliation finished')).toBeInTheDocument()
+        expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+      })
+
+      const infoBadges = screen.getAllByText('Info')
+      expect(infoBadges.length).toBeGreaterThan(0)
+      expect(screen.getByText('Warning')).toBeInTheDocument()
+    })
+
+    it('should display "No events found" when events list is empty', async () => {
+      const user = userEvent.setup()
+      fetchWithMock.mockResolvedValueOnce({ events: [] })
+
+      render(
+        <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+      )
+
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(screen.getByText('No events found')).toBeInTheDocument()
+      })
+    })
+
+    it('should handle fetch error gracefully', async () => {
+      const user = userEvent.setup()
+      fetchWithMock.mockRejectedValueOnce(new Error('Network error'))
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      render(
+        <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+      )
+
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalled()
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('No events found')).toBeInTheDocument()
+      })
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('Events auto-refresh', () => {
+    const mockEvents = {
+      events: [
+        {
+          type: 'Normal',
+          reason: 'Reconciled',
+          message: 'Reconciliation finished',
+          lastTimestamp: '2023-01-01T12:05:00Z'
+        }
+      ]
+    }
+
+    it('should refetch events when workloadData changes if Events tab is open', async () => {
+      const user = userEvent.setup()
+
+      const { rerender } = render(
+        <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+      )
+
+      fetchWithMock.mockResolvedValueOnce(mockEvents)
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(screen.getByText('Reconciliation finished')).toBeInTheDocument()
+      })
+
+      fetchWithMock.mockResolvedValueOnce({
+        events: [
+          {
+            type: 'Normal',
+            reason: 'Reconciled',
+            message: 'New reconciliation after refresh',
+            lastTimestamp: '2023-01-01T13:05:00Z'
+          }
+        ]
+      })
+
+      rerender(
+        <WorkloadReconcilerPanel
+          reconciler={mockReconciler}
+          workloadData={{ metadata: { name: 'nginx-updated' } }}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('New reconciliation after refresh')).toBeInTheDocument()
+      })
+      expect(fetchWithMock.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('should NOT refetch events when workloadData changes if Events tab is not open', async () => {
+      const { rerender } = render(
+        <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+      )
+
+      expect(fetchWithMock).not.toHaveBeenCalled()
+
+      rerender(
+        <WorkloadReconcilerPanel
+          reconciler={mockReconciler}
+          workloadData={{ metadata: { name: 'nginx-updated' } }}
+        />
+      )
+
+      await waitFor(() => {
+        expect(fetchWithMock).not.toHaveBeenCalled()
+      })
+    })
+
+    it('should NOT double-fetch events on initial mount', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+      )
+
+      fetchWithMock.mockResolvedValueOnce(mockEvents)
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('should preserve event data when refetch fails during auto-refresh', async () => {
+      const user = userEvent.setup()
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { rerender } = render(
+        <WorkloadReconcilerPanel reconciler={mockReconciler} workloadData={mockWorkloadData} />
+      )
+
+      fetchWithMock.mockResolvedValueOnce(mockEvents)
+      await user.click(screen.getByText('Events'))
+
+      await waitFor(() => {
+        expect(screen.getByText('Reconciliation finished')).toBeInTheDocument()
+      })
+
+      fetchWithMock.mockRejectedValueOnce(new Error('Network error'))
+
+      rerender(
+        <WorkloadReconcilerPanel
+          reconciler={mockReconciler}
+          workloadData={{ metadata: { name: 'nginx-updated' } }}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Reconciliation finished')).toBeInTheDocument()
+      })
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('Suspended by', () => {
+    it('should display "Suspended by" when status is Suspended and annotation exists', () => {
+      const reconciler = {
+        ...mockReconciler,
+        metadata: {
+          ...mockReconciler.metadata,
+          annotations: {
+            'fluxcd.controlplane.io/suspendedBy': 'test-user@example.com'
+          }
+        },
+        status: {
+          ...mockReconciler.status,
+          reconcilerRef: {
+            ...mockReconciler.status.reconcilerRef,
+            status: 'Suspended'
+          }
+        }
+      }
+
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+
+      expect(screen.getByText('Suspended by')).toBeInTheDocument()
+      expect(screen.getByText('test-user@example.com')).toBeInTheDocument()
+    })
+
+    it('should NOT display "Suspended by" when status is not Suspended', () => {
+      const reconciler = {
+        ...mockReconciler,
+        metadata: {
+          ...mockReconciler.metadata,
+          annotations: {
+            'fluxcd.controlplane.io/suspendedBy': 'test-user@example.com'
+          }
+        }
+      }
+
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+
+      expect(screen.queryByText('Suspended by')).not.toBeInTheDocument()
+    })
+
+    it('should NOT display "Suspended by" when annotation does not exist', () => {
+      const reconciler = {
+        ...mockReconciler,
+        status: {
+          ...mockReconciler.status,
+          reconcilerRef: {
+            ...mockReconciler.status.reconcilerRef,
+            status: 'Suspended'
+          }
+        }
+      }
+
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+
+      expect(screen.getByText('Suspended')).toBeInTheDocument()
+      expect(screen.queryByText('Suspended by')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should use condition message when reconcilerRef message is missing', () => {
+      const reconciler = {
+        ...mockReconciler,
+        status: {
+          ...mockReconciler.status,
+          reconcilerRef: undefined,
+          conditions: [
+            {
+              type: 'Ready',
+              status: 'True',
+              message: 'Message from condition',
+              lastTransitionTime: '2023-01-01T12:00:00Z'
+            }
+          ]
+        }
+      }
+
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+
+      expect(screen.getByText('Message from condition')).toBeInTheDocument()
+    })
+
+    it('should show Unknown status when reconcilerRef is missing', () => {
+      const reconciler = {
+        ...mockReconciler,
+        status: {
+          conditions: []
+        }
+      }
+
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+
+      expect(screen.getByText('Unknown')).toBeInTheDocument()
+    })
+
+    it('should not show message section when message is empty', () => {
+      const reconciler = {
+        ...mockReconciler,
+        status: {
+          ...mockReconciler.status,
+          reconcilerRef: {
+            status: 'Ready',
+            message: '',
+            lastReconciled: '2023-01-01T12:00:00Z'
+          },
+          conditions: []
+        }
+      }
+
+      render(
+        <WorkloadReconcilerPanel reconciler={reconciler} workloadData={mockWorkloadData} />
+      )
+
+      expect(screen.queryByText('Last action')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/components/dashboards/workload/WorkloadReconcilerPanel.test.jsx
+++ b/web/src/components/dashboards/workload/WorkloadReconcilerPanel.test.jsx
@@ -7,7 +7,6 @@ import userEvent from '@testing-library/user-event'
 import { WorkloadReconcilerPanel } from './WorkloadReconcilerPanel'
 import { fetchWithMock } from '../../../utils/fetch'
 
-// Mock fetchWithMock
 vi.mock('../../../utils/fetch', () => ({
   fetchWithMock: vi.fn()
 }))

--- a/web/src/components/favorites/FavoriteCard.jsx
+++ b/web/src/components/favorites/FavoriteCard.jsx
@@ -1,16 +1,11 @@
 // Copyright 2025 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { getStatusBadgeClass, getStatusBorderClass } from '../../utils/status'
+import { getStatusBadgeClass, getStatusBorderClass, getWorkloadStatusBadgeClass, formatWorkloadStatus } from '../../utils/status'
 import { formatTimestamp } from '../../utils/time'
 import { removeFavorite } from '../../utils/favorites'
-
-/**
- * Build URL path for a resource dashboard
- */
-function getResourceUrl(kind, namespace, name) {
-  return `/resource/${encodeURIComponent(kind)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`
-}
+import { workloadKinds } from '../../utils/constants'
+import { getDashboardUrl } from '../../utils/routing'
 
 /**
  * FavoriteCard - Card displaying a favorite Flux resource
@@ -31,15 +26,21 @@ export function FavoriteCard({ favorite, resourceData }) {
     removeFavorite(kind, namespace, name)
   }
 
+  // Workload favorites carry kstatus vocab (Current/InProgress/…) and use a different
+  // badge helper than Flux resources.
+  const isWorkload = workloadKinds.includes(kind)
+
   // Resource may not be found (deleted from cluster)
   const notFound = resourceData?.status === 'NotFound'
   const status = notFound ? 'Not Found' : (resourceData?.status || 'Unknown')
+  const displayStatus = notFound ? status : (isWorkload ? formatWorkloadStatus(status) : status)
+  const badgeClass = isWorkload ? getWorkloadStatusBadgeClass(status) : getStatusBadgeClass(status)
   const lastReconciled = resourceData?.lastReconciled
   const message = resourceData?.message
 
   return (
     <a
-      href={getResourceUrl(kind, namespace, name)}
+      href={getDashboardUrl(kind, namespace, name)}
       class={`card border-l-4 p-4 hover:shadow-md transition-shadow dark:shadow-none cursor-pointer text-left w-full block ${getStatusBorderClass(status)} ${notFound ? 'opacity-60' : ''}`}
     >
       {/* Header row: star + kind + status badge */}
@@ -58,8 +59,8 @@ export function FavoriteCard({ favorite, resourceData }) {
           <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
             {kind}
           </span>
-          <span class={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${notFound ? 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400' : getStatusBadgeClass(status)}`}>
-            {status}
+          <span class={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${notFound ? 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400' : badgeClass}`}>
+            {displayStatus}
           </span>
         </div>
       </div>

--- a/web/src/components/favorites/FavoriteCard.test.jsx
+++ b/web/src/components/favorites/FavoriteCard.test.jsx
@@ -301,6 +301,62 @@ describe('FavoriteCard component', () => {
     })
   })
 
+  describe('workload favorites', () => {
+    const workloadFavorite = {
+      kind: 'Deployment',
+      namespace: 'apps',
+      name: 'podinfo'
+    }
+
+    it('should link to the workload dashboard for workload kinds', () => {
+      render(
+        <FavoriteCard
+          favorite={workloadFavorite}
+          resourceData={{ status: 'Current', lastReconciled: '2024-01-15T10:30:00Z' }}
+        />
+      )
+
+      const cardLink = screen.getByText('podinfo').closest('a')
+      expect(cardLink).toHaveAttribute('href', '/workload/Deployment/apps/podinfo')
+    })
+
+    it('should format workload kstatus into the display vocabulary', () => {
+      render(
+        <FavoriteCard
+          favorite={workloadFavorite}
+          resourceData={{ status: 'Current', lastReconciled: '2024-01-15T10:30:00Z' }}
+        />
+      )
+
+      // Current → Ready via formatWorkloadStatus
+      expect(screen.getByText('Ready')).toBeInTheDocument()
+      expect(screen.queryByText('Current')).not.toBeInTheDocument()
+    })
+
+    it('should format InProgress into Progressing', () => {
+      render(
+        <FavoriteCard
+          favorite={workloadFavorite}
+          resourceData={{ status: 'InProgress', lastReconciled: '2024-01-15T10:30:00Z' }}
+        />
+      )
+
+      expect(screen.getByText('Progressing')).toBeInTheDocument()
+    })
+
+    it('should still use the resource dashboard URL for Flux kinds', () => {
+      render(
+        <FavoriteCard
+          favorite={mockFavorite}
+          resourceData={mockResourceData}
+        />
+      )
+
+      const cardLink = screen.getByText('flux').closest('a')
+      expect(cardLink).toHaveAttribute('href', '/resource/FluxInstance/flux-system/flux')
+    })
+  })
+
   describe('timestamp handling', () => {
     it('should not show timestamp section when lastReconciled is missing', () => {
       render(

--- a/web/src/components/favorites/FavoritesPage.jsx
+++ b/web/src/components/favorites/FavoritesPage.jsx
@@ -6,9 +6,20 @@ import { fetchWithMock } from '../../utils/fetch'
 import { favorites, reorderFavorites, getFavoriteKey, removeFavorite } from '../../utils/favorites'
 import { POLL_INTERVAL_MS } from '../../utils/constants'
 import { usePageMeta } from '../../utils/meta'
+import { normalizeToFluxStatus } from '../../utils/status'
 import { FavoritesHeader } from './FavoritesHeader'
 import { FavoriteCard } from './FavoriteCard'
 import { FluxOperatorIcon } from '../layout/Icons'
+
+/**
+ * Normalize a favorite's status to the Flux vocabulary (Ready/Failed/Progressing/
+ * Suspended/Unknown) used by the status chart and status filter. Workload favorites
+ * carry kstatus values (Current/Idle/InProgress/Terminating/…) which normalizeToFluxStatus
+ * maps so they bucket and color consistently; Flux values pass through unchanged.
+ */
+function getChartStatus(fav) {
+  return normalizeToFluxStatus(fav.resourceData?.status || 'Unknown')
+}
 
 /**
  * FavoritesPage - Main page displaying favorite resources
@@ -144,7 +155,7 @@ export function FavoritesPage() {
     return favoritesWithData.filter(fav => {
       if (filter.namespace && fav.namespace !== filter.namespace) return false
       if (filter.kind && fav.kind !== filter.kind) return false
-      if (statusFilter && (fav.resourceData?.status || 'Unknown') !== statusFilter) return false
+      if (statusFilter && getChartStatus(fav) !== statusFilter) return false
       if (filter.name) {
         const searchLower = filter.name.toLowerCase()
         const matchesName = fav.name.toLowerCase().includes(searchLower)
@@ -173,7 +184,7 @@ export function FavoritesPage() {
         return true
       })
       .map(f => ({
-        status: f.resourceData?.status || 'Unknown'
+        status: getChartStatus(f)
       }))
   }, [favoritesWithData, filter])
 

--- a/web/src/components/favorites/FavoritesPage.test.jsx
+++ b/web/src/components/favorites/FavoritesPage.test.jsx
@@ -280,6 +280,40 @@ describe('FavoritesPage component', () => {
       })
     })
 
+    it('should include workload favorites with kstatus when filtering by Flux vocab', async () => {
+      // Workload favorites return kstatus values (Current/Idle) but the chart/filter use
+      // Flux vocab (Ready); healthy workloads must survive a Ready status filter.
+      favorites.value = [
+        { kind: 'Deployment', namespace: 'default', name: 'web' },
+        { kind: 'CronJob', namespace: 'default', name: 'cron' },
+        { kind: 'Kustomization', namespace: 'default', name: 'app' }
+      ]
+
+      fetchWithMock.mockResolvedValue({
+        resources: [
+          { kind: 'Deployment', namespace: 'default', name: 'web', status: 'Current' },
+          { kind: 'CronJob', namespace: 'default', name: 'cron', status: 'Idle' },
+          { kind: 'Kustomization', namespace: 'default', name: 'app', status: 'Failed' }
+        ]
+      })
+
+      render(<FavoritesPage />)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('favorite-card-web')).toBeInTheDocument()
+      })
+
+      // Filter by Ready: Current/Idle workloads map to Ready and stay, Failed is dropped.
+      const statusFilterBtn = screen.getByTestId('status-filter-btn')
+      fireEvent.click(statusFilterBtn)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('favorite-card-web')).toBeInTheDocument()
+        expect(screen.getByTestId('favorite-card-cron')).toBeInTheDocument()
+        expect(screen.queryByTestId('favorite-card-app')).not.toBeInTheDocument()
+      })
+    })
+
     it('should show "No favorites match your search" when filter matches nothing', async () => {
       favorites.value = [
         { kind: 'FluxInstance', namespace: 'flux-system', name: 'flux' }

--- a/web/src/components/layout/UserMenu.jsx
+++ b/web/src/components/layout/UserMenu.jsx
@@ -6,6 +6,8 @@ import { signal } from '@preact/signals'
 import { themeMode, appliedTheme, cycleTheme, themes } from '../../utils/theme'
 import { clearFavorites } from '../../utils/favorites'
 import { clearNavHistory } from '../../utils/navHistory'
+import { resetLogSettings } from '../../utils/logSettings'
+import { writeSessionStorage } from '../../utils/storage'
 import { reportData } from '../../app'
 import { parseAuthProviderCookie } from '../../utils/cookies'
 import { OpenIDIcon, KubernetesIcon } from './Icons'
@@ -98,9 +100,10 @@ export function UserMenu() {
   }
 
   const handleClearLocalStorage = () => {
-    if (window.confirm('This will delete your favorites and navigation history from local storage. Continue?')) {
+    if (window.confirm('This will delete your favorites, navigation history and log viewer settings from local storage. Continue?')) {
       clearFavorites()
       clearNavHistory()
+      resetLogSettings()
       userMenuOpen.value = false
     }
   }
@@ -110,7 +113,7 @@ export function UserMenu() {
     // Store current path so LoginPage can redirect back after re-authentication
     const currentPath = window.location.pathname + window.location.search
     if (currentPath && currentPath !== '/') {
-      window.sessionStorage.setItem('flux-originalPath', currentPath)
+      writeSessionStorage('flux-originalPath', currentPath)
     }
     // Use POST to prevent CSRF attacks
     fetch('/logout', { method: 'POST' })

--- a/web/src/components/layout/UserMenu.test.jsx
+++ b/web/src/components/layout/UserMenu.test.jsx
@@ -6,6 +6,7 @@ import { render, screen, fireEvent } from '@testing-library/preact'
 import { UserMenu, userMenuOpen } from './UserMenu'
 import { themeMode, appliedTheme, themes } from '../../utils/theme'
 import { clearFavorites } from '../../utils/favorites'
+import { logSettings, DEFAULT_LOG_SETTINGS } from '../../utils/logSettings'
 import { reportData } from '../../app'
 
 // Mock the favorites module
@@ -203,23 +204,26 @@ describe('UserMenu', () => {
       expect(screen.getByText('Clear local storage')).toBeInTheDocument()
     })
 
-    it('should show confirmation and call clearFavorites when confirmed', () => {
+    it('should show confirmation and reset favorites and log settings when confirmed', () => {
       const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+      logSettings.value = { follow: false, formatted: false, tail: 500 }
       userMenuOpen.value = true
       render(<UserMenu />)
 
       const button = screen.getByText('Clear local storage').closest('button')
       fireEvent.click(button)
 
-      expect(confirmSpy).toHaveBeenCalledWith('This will delete your favorites and navigation history from local storage. Continue?')
+      expect(confirmSpy).toHaveBeenCalledWith('This will delete your favorites, navigation history and log viewer settings from local storage. Continue?')
       expect(clearFavorites).toHaveBeenCalledTimes(1)
+      expect(logSettings.value).toEqual(DEFAULT_LOG_SETTINGS)
       expect(userMenuOpen.value).toBe(false)
 
       confirmSpy.mockRestore()
     })
 
-    it('should not call clearFavorites when confirmation is cancelled', () => {
+    it('should not clear favorites or log settings when confirmation is cancelled', () => {
       const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+      logSettings.value = { follow: false, formatted: false, tail: 500 }
       userMenuOpen.value = true
       render(<UserMenu />)
 
@@ -228,6 +232,7 @@ describe('UserMenu', () => {
 
       expect(confirmSpy).toHaveBeenCalled()
       expect(clearFavorites).not.toHaveBeenCalled()
+      expect(logSettings.value).toEqual({ follow: false, formatted: false, tail: 500 })
       expect(userMenuOpen.value).toBe(true)
 
       confirmSpy.mockRestore()

--- a/web/src/components/search/EventList.jsx
+++ b/web/src/components/search/EventList.jsx
@@ -10,7 +10,7 @@ import { getEventBadgeClass } from '../../utils/status'
 import { usePageMeta } from '../../utils/meta'
 import { reportData } from '../../app'
 import { FilterForm } from './FilterForm'
-import { useRestoreFiltersFromUrl, useSyncFiltersToUrl } from '../../utils/routing'
+import { getDashboardUrl, useRestoreFiltersFromUrl, useSyncFiltersToUrl } from '../../utils/routing'
 import { StatusChart } from './StatusChart'
 import { useInfiniteScroll } from '../../utils/scroll'
 
@@ -72,8 +72,8 @@ function EventCard({ event }) {
   // Parse involvedObject to get kind and name
   const [kind, name] = event.involvedObject.split('/')
 
-  // Build resource URL
-  const resourceUrl = `/resource/${encodeURIComponent(kind)}/${encodeURIComponent(event.namespace)}/${encodeURIComponent(name)}`
+  // Build the dashboard URL, routing workload-kind events to the workload dashboard
+  const resourceUrl = getDashboardUrl(kind, event.namespace, name)
 
   // Map event type to display status
   const displayStatus = event.type === 'Normal' ? 'Info' : 'Warning'

--- a/web/src/components/search/EventList.test.jsx
+++ b/web/src/components/search/EventList.test.jsx
@@ -22,8 +22,9 @@ vi.mock('../../utils/fetch', () => ({
   fetchWithMock: vi.fn()
 }))
 
-// Mock routing utilities
-vi.mock('../../utils/routing', () => ({
+// Mock routing utilities (stub the URL-sync hooks, keep the real getDashboardUrl)
+vi.mock('../../utils/routing', async (importActual) => ({
+  ...(await importActual()),
   useRestoreFiltersFromUrl: vi.fn(),
   useSyncFiltersToUrl: vi.fn()
 }))

--- a/web/src/components/search/FilterForm.jsx
+++ b/web/src/components/search/FilterForm.jsx
@@ -16,9 +16,11 @@ const crdGroups = [...new Set(fluxCRDs.map(crd => crd.group))]
  * @param {Array<string>} props.namespaces - Array of namespace names from report
  * @param {Signal} [props.severitySignal] - Optional signal for event severity filter (Normal, Warning)
  * @param {Signal} [props.statusSignal] - Optional signal for resource status filter (Ready, Failed, etc.)
+ * @param {Array<string>} [props.kinds] - Optional flat list of kinds. When provided, the kind
+ *   dropdown renders a flat list instead of the Flux group-based optgroup layout.
  * @param {Function} props.onClear - Callback function to clear filters
  */
-export function FilterForm({ kindSignal, nameSignal, namespaceSignal, namespaces, severitySignal, statusSignal, onClear }) {
+export function FilterForm({ kindSignal, nameSignal, namespaceSignal, namespaces, severitySignal, statusSignal, kinds, onClear }) {
   return (
     <div class="flex flex-wrap gap-4 items-center">
       {/* Name Filter */}
@@ -60,13 +62,17 @@ export function FilterForm({ kindSignal, nameSignal, namespaceSignal, namespaces
           class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-flux-blue"
         >
           <option value="">All kinds</option>
-          {crdGroups.map(group => (
-            <optgroup key={group} label={group}>
-              {fluxCRDs.filter(crd => crd.group === group).map(crd => (
-                <option key={crd.kind} value={crd.kind}>{crd.kind}</option>
-              ))}
-            </optgroup>
-          ))}
+          {kinds
+            ? kinds.map(kind => (
+              <option key={kind} value={kind}>{kind}</option>
+            ))
+            : crdGroups.map(group => (
+              <optgroup key={group} label={group}>
+                {fluxCRDs.filter(crd => crd.group === group).map(crd => (
+                  <option key={crd.kind} value={crd.kind}>{crd.kind}</option>
+                ))}
+              </optgroup>
+            ))}
         </select>
       </div>
 

--- a/web/src/components/search/FilterForm.test.jsx
+++ b/web/src/components/search/FilterForm.test.jsx
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/preact'
 import { signal } from '@preact/signals'
 import { FilterForm } from './FilterForm'
-import { fluxKinds, eventSeverities, resourceStatuses } from '../../utils/constants'
+import { fluxKinds, eventSeverities, resourceStatuses, workloadKinds } from '../../utils/constants'
 
 describe('FilterForm', () => {
   let kindSignal
@@ -304,6 +304,61 @@ describe('FilterForm', () => {
       fireEvent.click(clearButton)
 
       expect(onClear).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Flat kinds prop', () => {
+    it('should render a flat list of the provided kinds without optgroups', () => {
+      const { container } = render(
+        <FilterForm
+          kindSignal={kindSignal}
+          nameSignal={nameSignal}
+          namespaceSignal={namespaceSignal}
+          namespaces={mockNamespaces}
+          kinds={workloadKinds}
+          onClear={onClear}
+        />
+      )
+
+      // All workload kinds should be present as options
+      workloadKinds.forEach(kind => {
+        expect(screen.getByRole('option', { name: kind })).toBeInTheDocument()
+      })
+
+      // No optgroups should be rendered in flat mode
+      expect(container.querySelector('optgroup')).not.toBeInTheDocument()
+    })
+
+    it('should not render Flux kinds when a flat kinds prop is provided', () => {
+      render(
+        <FilterForm
+          kindSignal={kindSignal}
+          nameSignal={nameSignal}
+          namespaceSignal={namespaceSignal}
+          namespaces={mockNamespaces}
+          kinds={workloadKinds}
+          onClear={onClear}
+        />
+      )
+
+      // Flux-only kinds should not appear in the workload kind list
+      expect(screen.queryByRole('option', { name: 'FluxInstance' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('option', { name: 'GitRepository' })).not.toBeInTheDocument()
+    })
+
+    it('should render Flux optgroups by default when no kinds prop is provided', () => {
+      const { container } = render(
+        <FilterForm
+          kindSignal={kindSignal}
+          nameSignal={nameSignal}
+          namespaceSignal={namespaceSignal}
+          namespaces={mockNamespaces}
+          onClear={onClear}
+        />
+      )
+
+      expect(container.querySelector('optgroup')).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'FluxInstance' })).toBeInTheDocument()
     })
   })
 

--- a/web/src/components/search/QuickSearch.jsx
+++ b/web/src/components/search/QuickSearch.jsx
@@ -5,8 +5,10 @@ import { signal } from '@preact/signals'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { useLocation } from 'preact-iso'
 import { fetchWithMock } from '../../utils/fetch'
+import { getStatusDotClass } from '../../utils/status'
+import { getDashboardUrl } from '../../utils/routing'
 import { reportData } from '../../app'
-import { fluxKinds } from '../../utils/constants'
+import { searchKinds, workloadKinds } from '../../utils/constants'
 import { userMenuOpen } from '../layout/UserMenu'
 import { navHistory, isHomePage } from '../../utils/navHistory'
 
@@ -106,7 +108,72 @@ export function parseSearchQuery(query) {
 }
 
 /**
- * Fetch search results from API
+ * Build the dashboard URL for a search result, routing workload kinds to the
+ * workload dashboard and everything else to the Flux resource dashboard.
+ * @param {{kind: string, namespace: string, name: string}} item - Result item
+ * @returns {string} Dashboard URL path
+ */
+export function getResultUrl(item) {
+  return getDashboardUrl(item.kind, item.namespace, item.name)
+}
+
+/**
+ * Build the query string suffix shared by the resource and workload search endpoints.
+ */
+function buildSearchQuery(name, namespace, kind) {
+  let query = `?name=${encodeURIComponent(name)}`
+  if (namespace) {
+    query += `&namespace=${encodeURIComponent(namespace)}`
+  }
+  if (kind) {
+    query += `&kind=${encodeURIComponent(kind)}`
+  }
+  return query
+}
+
+/**
+ * Fetch resource search results and normalize to the unified result shape.
+ */
+async function fetchResourceResults(name, namespace, kind) {
+  const data = await fetchWithMock({
+    endpoint: `/api/v1/search${buildSearchQuery(name, namespace, kind)}`,
+    mockPath: '../mock/resources',
+    mockExport: 'getMockSearchResults'
+  })
+  return (data.resources || []).map(r => ({
+    kind: r.kind,
+    namespace: r.namespace,
+    name: r.name,
+    status: r.status,
+    url: getResultUrl(r)
+  }))
+}
+
+/**
+ * Fetch workload search results and normalize to the unified result shape.
+ * Workload results leave `status` undefined so the result dot renders gray.
+ */
+async function fetchWorkloadResults(name, namespace, kind) {
+  const data = await fetchWithMock({
+    endpoint: `/api/v1/workloads/search${buildSearchQuery(name, namespace, kind)}`,
+    mockPath: '../mock/workloads',
+    mockExport: 'getMockWorkloadsSearch'
+  })
+  return (data.workloads || []).map(w => ({
+    kind: w.kind,
+    namespace: w.namespace,
+    name: w.name,
+    status: undefined,
+    url: getResultUrl(w)
+  }))
+}
+
+/**
+ * Fetch search results from both the resource and workload indexes.
+ *
+ * - With a `kind:` filter, query only the owning endpoint.
+ * - Otherwise, query both endpoints in parallel and merge results
+ *   (resources first, then workloads).
  */
 async function fetchSearchResults(name, namespace, kind) {
   if (!name || name.length < 2) {
@@ -118,19 +185,29 @@ async function fetchSearchResults(name, namespace, kind) {
   quickSearchLoading.value = true
 
   try {
-    let endpoint = `/api/v1/search?name=${encodeURIComponent(name)}`
-    if (namespace) {
-      endpoint += `&namespace=${encodeURIComponent(namespace)}`
-    }
+    let results
     if (kind) {
-      endpoint += `&kind=${encodeURIComponent(kind)}`
+      // A kind filter routes to a single owning endpoint.
+      results = workloadKinds.includes(kind)
+        ? await fetchWorkloadResults(name, namespace, kind)
+        : await fetchResourceResults(name, namespace, kind)
+    } else {
+      // No kind filter: query both indexes and merge (resources first). Use
+      // allSettled so a failure of one index still surfaces the other's results.
+      const [resourceOutcome, workloadOutcome] = await Promise.allSettled([
+        fetchResourceResults(name, namespace, kind),
+        fetchWorkloadResults(name, namespace, kind)
+      ])
+      for (const outcome of [resourceOutcome, workloadOutcome]) {
+        if (outcome.status === 'rejected') {
+          console.error('Failed to fetch search results:', outcome.reason)
+        }
+      }
+      const resourceResults = resourceOutcome.status === 'fulfilled' ? resourceOutcome.value : []
+      const workloadResults = workloadOutcome.status === 'fulfilled' ? workloadOutcome.value : []
+      results = [...resourceResults, ...workloadResults]
     }
-    const data = await fetchWithMock({
-      endpoint,
-      mockPath: '../mock/resources',
-      mockExport: 'getMockSearchResults'
-    })
-    quickSearchResults.value = data.resources || []
+    quickSearchResults.value = results
   } catch (error) {
     console.error('Failed to fetch search results:', error)
     quickSearchResults.value = []
@@ -175,28 +252,9 @@ function getNamespaceSuggestions(partial) {
  */
 function getKindSuggestions(partial) {
   const filtered = partial
-    ? fluxKinds.filter(k => k.toLowerCase().includes(partial.toLowerCase()))
-    : fluxKinds
+    ? searchKinds.filter(k => k.toLowerCase().includes(partial.toLowerCase()))
+    : searchKinds
   return filtered
-}
-
-/**
- * Get status dot color
- */
-function getStatusDotClass(status) {
-  switch (status) {
-  case 'Ready':
-    return 'bg-green-500'
-  case 'Failed':
-    return 'bg-red-500'
-  case 'Progressing':
-    return 'bg-blue-500'
-  case 'Suspended':
-    return 'bg-yellow-500'
-  case 'Unknown':
-  default:
-    return 'bg-gray-500'
-  }
 }
 
 /**
@@ -457,22 +515,17 @@ export function QuickSearch() {
     }
   }
 
-  // Build URL for a resource
-  const getResourceUrl = (kind, namespace, name) => {
-    return `/resource/${encodeURIComponent(kind)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`
-  }
-
-  // Get URL for a history entry
+  // Get URL for a history entry (workload-aware via getResultUrl)
   const getHistoryUrl = (entry) => {
     if (isHomePage(entry.kind)) {
       return '/'
     }
-    return getResourceUrl(entry.kind, entry.namespace, entry.name)
+    return getResultUrl(entry)
   }
 
   // Handle result click via keyboard Enter (anchor will handle mouse clicks)
   const handleResultClick = (resource) => {
-    location.route(getResourceUrl(resource.kind, resource.namespace, resource.name))
+    location.route(getResultUrl(resource))
     handleClose()
   }
 
@@ -561,7 +614,7 @@ export function QuickSearch() {
               value={inputValue}
               onInput={handleInputChange}
               onKeyDown={handleKeyDown}
-              placeholder={(selectedNamespace || selectedKind) ? 'Search...' : 'Search appliers...'}
+              placeholder={(selectedNamespace || selectedKind) ? 'Search...' : 'Search appliers & workloads...'}
               class="flex-1 min-w-0 text-sm text-gray-900 dark:text-gray-100 bg-transparent placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none"
             />
 
@@ -654,7 +707,7 @@ export function QuickSearch() {
                 {quickSearchResults.value.map((resource, index) => (
                   <li key={`${resource.kind}-${resource.namespace}-${resource.name}-${index}`}>
                     <a
-                      href={getResourceUrl(resource.kind, resource.namespace, resource.name)}
+                      href={resource.url}
                       onClick={handleClose}
                       class={`block w-full text-left py-1 px-2 focus:outline-none transition-colors ${
                         index === selectedIndex
@@ -678,13 +731,22 @@ export function QuickSearch() {
             {panelState === 'empty' && (
               <div class="p-3 text-sm text-gray-500 dark:text-gray-400">
                 <p>No resources found</p>
-                <a
-                  href="/resources"
-                  onClick={handleClose}
-                  class="mt-2 inline-block text-flux-blue hover:underline focus:outline-none"
-                >
-                  Browse all resources →
-                </a>
+                <div class="mt-2 flex flex-col gap-1">
+                  <a
+                    href="/resources"
+                    onClick={handleClose}
+                    class="inline-block text-flux-blue hover:underline focus:outline-none"
+                  >
+                    Browse all resources →
+                  </a>
+                  <a
+                    href="/workloads"
+                    onClick={handleClose}
+                    class="inline-block text-flux-blue hover:underline focus:outline-none"
+                  >
+                    Browse all workloads →
+                  </a>
+                </div>
               </div>
             )}
 

--- a/web/src/components/search/QuickSearch.test.jsx
+++ b/web/src/components/search/QuickSearch.test.jsx
@@ -37,7 +37,7 @@ vi.mock('../../app', async () => {
   }
 })
 
-import { QuickSearch, quickSearchOpen, quickSearchQuery, quickSearchResults, quickSearchLoading, parseSearchQuery } from './QuickSearch'
+import { QuickSearch, quickSearchOpen, quickSearchQuery, quickSearchResults, quickSearchLoading, parseSearchQuery, getResultUrl } from './QuickSearch'
 import { fetchWithMock } from '../../utils/fetch'
 import { navHistory, clearNavHistory } from '../../utils/navHistory'
 
@@ -94,7 +94,7 @@ describe('QuickSearch', () => {
       fireEvent.click(searchButtons[0])
 
       expect(quickSearchOpen.value).toBe(true)
-      expect(screen.getByPlaceholderText('Search appliers...')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Search appliers & workloads...')).toBeInTheDocument()
     })
   })
 
@@ -106,7 +106,7 @@ describe('QuickSearch', () => {
     it('should render input when search is open', () => {
       render(<QuickSearch />)
 
-      expect(screen.getByPlaceholderText('Search appliers...')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Search appliers & workloads...')).toBeInTheDocument()
     })
 
     it('should render close button', () => {
@@ -128,7 +128,7 @@ describe('QuickSearch', () => {
     it('should close search when Escape key is pressed', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.keyDown(input, { key: 'Escape' })
 
       expect(quickSearchOpen.value).toBe(false)
@@ -137,7 +137,7 @@ describe('QuickSearch', () => {
     it('should update query signal on input', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       expect(quickSearchQuery.value).toBe('flux')
@@ -153,7 +153,7 @@ describe('QuickSearch', () => {
     it('should not call API for queries less than 2 characters', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'f' } })
 
       vi.advanceTimersByTime(500)
@@ -164,7 +164,7 @@ describe('QuickSearch', () => {
     it('should call API after debounce delay for valid queries', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       // Should show loading immediately
@@ -183,7 +183,7 @@ describe('QuickSearch', () => {
     it('should debounce multiple rapid inputs', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
 
       // Type multiple times rapidly
       fireEvent.input(input, { target: { value: 'f' } })
@@ -197,12 +197,17 @@ describe('QuickSearch', () => {
       // Advance past debounce delay
       vi.advanceTimersByTime(400)
 
-      // Should only call API once with final value
-      expect(fetchWithMock).toHaveBeenCalledTimes(1)
+      // Dual-source search: queries both the resource and workload indexes once each
+      expect(fetchWithMock).toHaveBeenCalledTimes(2)
       expect(fetchWithMock).toHaveBeenCalledWith({
         endpoint: '/api/v1/search?name=flux',
         mockPath: '../mock/resources',
         mockExport: 'getMockSearchResults'
+      })
+      expect(fetchWithMock).toHaveBeenCalledWith({
+        endpoint: '/api/v1/workloads/search?name=flux',
+        mockPath: '../mock/workloads',
+        mockExport: 'getMockWorkloadsSearch'
       })
     })
   })
@@ -216,7 +221,7 @@ describe('QuickSearch', () => {
     it('should display loading state', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       expect(screen.getByText('Searching...')).toBeInTheDocument()
@@ -232,7 +237,7 @@ describe('QuickSearch', () => {
 
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       vi.advanceTimersByTime(400)
@@ -250,7 +255,7 @@ describe('QuickSearch', () => {
 
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       vi.advanceTimersByTime(400)
@@ -268,7 +273,7 @@ describe('QuickSearch', () => {
 
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       vi.advanceTimersByTime(400)
@@ -287,7 +292,7 @@ describe('QuickSearch', () => {
 
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       vi.advanceTimersByTime(400)
@@ -306,7 +311,7 @@ describe('QuickSearch', () => {
 
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'test' } })
 
       vi.advanceTimersByTime(400)
@@ -325,7 +330,7 @@ describe('QuickSearch', () => {
 
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'suspended' } })
 
       vi.advanceTimersByTime(400)
@@ -349,7 +354,7 @@ describe('QuickSearch', () => {
     it('should have correct href on search result links', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       vi.advanceTimersByTime(400)
@@ -362,7 +367,7 @@ describe('QuickSearch', () => {
     it('should close search after clicking result link', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       vi.advanceTimersByTime(400)
@@ -505,7 +510,7 @@ describe('QuickSearch', () => {
     it('should show namespace suggestions when typing ns:', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
 
       expect(screen.getByText('Type or select namespace')).toBeInTheDocument()
@@ -516,7 +521,7 @@ describe('QuickSearch', () => {
     it('should filter namespace suggestions based on partial input', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:flux' } })
 
       expect(screen.getByText('flux-system')).toBeInTheDocument()
@@ -526,7 +531,7 @@ describe('QuickSearch', () => {
     it('should show no matching namespaces message', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:nonexistent' } })
 
       expect(screen.getByText('No matching namespaces')).toBeInTheDocument()
@@ -535,7 +540,7 @@ describe('QuickSearch', () => {
     it('should select namespace on click', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
 
       const namespaceButton = screen.getByText('flux-system')
@@ -547,7 +552,7 @@ describe('QuickSearch', () => {
     it('should show namespace badge when namespace is selected', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
 
       const namespaceButton = screen.getByText('flux-system')
@@ -562,7 +567,7 @@ describe('QuickSearch', () => {
     it('should show different placeholder when namespace is selected', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
 
       const namespaceButton = screen.getByText('flux-system')
@@ -575,7 +580,7 @@ describe('QuickSearch', () => {
       render(<QuickSearch />)
 
       // First select a namespace
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
 
       const namespaceButton = screen.getByText('flux-system')
@@ -598,7 +603,7 @@ describe('QuickSearch', () => {
       render(<QuickSearch />)
 
       // First select a namespace
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
 
       const namespaceButton = screen.getByText('flux-system')
@@ -616,7 +621,7 @@ describe('QuickSearch', () => {
     it('should not call API when typing ns prefix', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns' } })
 
       vi.advanceTimersByTime(500)
@@ -627,7 +632,7 @@ describe('QuickSearch', () => {
     it('should not call API when typing ns: without completing namespace', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:flux' } })
 
       vi.advanceTimersByTime(500)
@@ -638,7 +643,7 @@ describe('QuickSearch', () => {
     it('should limit namespace suggestions to 10 items', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
 
       // We have 7 namespaces in mock, so all should show
@@ -657,7 +662,7 @@ describe('QuickSearch', () => {
     it('should navigate namespace suggestions with arrow keys', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
 
       // Press ArrowDown to select first item
@@ -671,7 +676,7 @@ describe('QuickSearch', () => {
     it('should select namespace on Enter key', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
 
       // Navigate to first item and select
@@ -684,7 +689,7 @@ describe('QuickSearch', () => {
     it('should navigate up with ArrowUp', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
 
       // Navigate down twice then up once
@@ -706,7 +711,7 @@ describe('QuickSearch', () => {
     it('should show hint when typing 1 character', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'f' } })
 
       expect(screen.getByText(/Type 2\+ chars/)).toBeInTheDocument()
@@ -717,7 +722,7 @@ describe('QuickSearch', () => {
     it('should not show hint when typing 2+ characters', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'fl' } })
 
       expect(screen.queryByText(/Type 2\+ chars/)).not.toBeInTheDocument()
@@ -726,7 +731,7 @@ describe('QuickSearch', () => {
     it('should set ns: prefix when clicking hint link', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'f' } })
 
       const nsLink = screen.getByText('ns:')
@@ -738,7 +743,7 @@ describe('QuickSearch', () => {
     it('should set kind: prefix when clicking hint link', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'f' } })
 
       const kindLink = screen.getByText('kind:')
@@ -750,7 +755,7 @@ describe('QuickSearch', () => {
     it('should not show hint when typing ns prefix', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'n' } })
 
       // Hint should appear for single char
@@ -771,7 +776,7 @@ describe('QuickSearch', () => {
     it('should show kind suggestions when typing kind:', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'kind:' } })
 
       expect(screen.getByText('Type or select kind')).toBeInTheDocument()
@@ -782,7 +787,7 @@ describe('QuickSearch', () => {
     it('should select kind on click and show badge', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'kind:' } })
 
       const kindButton = screen.getByText('HelmRelease')
@@ -797,7 +802,7 @@ describe('QuickSearch', () => {
       render(<QuickSearch />)
 
       // First select a kind
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'kind:' } })
 
       const kindButton = screen.getByText('HelmRelease')
@@ -820,7 +825,7 @@ describe('QuickSearch', () => {
       render(<QuickSearch />)
 
       // First select a namespace
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
       fireEvent.click(screen.getByText('flux-system'))
 
@@ -845,7 +850,7 @@ describe('QuickSearch', () => {
     it('should filter kind suggestions based on partial input', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'kind:Helm' } })
 
       expect(screen.getByText('HelmRelease')).toBeInTheDocument()
@@ -855,7 +860,7 @@ describe('QuickSearch', () => {
     it('should show no matching kinds message', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'kind:nonexistent' } })
 
       expect(screen.getByText('No matching kinds')).toBeInTheDocument()
@@ -865,7 +870,7 @@ describe('QuickSearch', () => {
       render(<QuickSearch />)
 
       // First select a kind
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'kind:' } })
       fireEvent.click(screen.getByText('HelmRelease'))
 
@@ -886,7 +891,7 @@ describe('QuickSearch', () => {
     it('should navigate kind suggestions with arrow keys', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'kind:' } })
 
       // Press ArrowDown to select first item
@@ -900,7 +905,7 @@ describe('QuickSearch', () => {
     it('should select kind on Enter key', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'kind:' } })
 
       // Navigate to first item and select
@@ -913,7 +918,7 @@ describe('QuickSearch', () => {
     it('should navigate up with ArrowUp', () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'kind:' } })
 
       // Navigate down twice then up once
@@ -936,7 +941,7 @@ describe('QuickSearch', () => {
       render(<QuickSearch />)
 
       // First select a namespace
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'ns:' } })
       fireEvent.click(screen.getByText('flux-system'))
 
@@ -965,7 +970,7 @@ describe('QuickSearch', () => {
       render(<QuickSearch />)
 
       // First select a kind
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'kind:' } })
       fireEvent.click(screen.getByText('HelmRelease'))
 
@@ -997,7 +1002,7 @@ describe('QuickSearch', () => {
     it('should navigate results with arrow keys', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       vi.advanceTimersByTime(400)
@@ -1013,7 +1018,7 @@ describe('QuickSearch', () => {
     it('should navigate to resource on Enter key', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       vi.advanceTimersByTime(400)
@@ -1029,7 +1034,7 @@ describe('QuickSearch', () => {
     it('should navigate up with ArrowUp in results', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       vi.advanceTimersByTime(400)
@@ -1054,7 +1059,7 @@ describe('QuickSearch', () => {
     it('should have correct href on browse resources link', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'nonexistent' } })
 
       vi.advanceTimersByTime(400)
@@ -1067,7 +1072,7 @@ describe('QuickSearch', () => {
     it('should close search when browse link is clicked', async () => {
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'nonexistent' } })
 
       vi.advanceTimersByTime(400)
@@ -1094,7 +1099,7 @@ describe('QuickSearch', () => {
 
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'test' } })
 
       vi.advanceTimersByTime(400)
@@ -1113,7 +1118,7 @@ describe('QuickSearch', () => {
 
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'test' } })
 
       vi.advanceTimersByTime(400)
@@ -1135,7 +1140,7 @@ describe('QuickSearch', () => {
 
       render(<QuickSearch />)
 
-      const input = screen.getByPlaceholderText('Search appliers...')
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
       fireEvent.input(input, { target: { value: 'flux' } })
 
       vi.advanceTimersByTime(400)
@@ -1143,6 +1148,33 @@ describe('QuickSearch', () => {
 
       expect(quickSearchResults.value).toEqual([])
       expect(quickSearchLoading.value).toBe(false)
+      expect(consoleError).toHaveBeenCalledWith('Failed to fetch search results:', expect.any(Error))
+
+      consoleError.mockRestore()
+    })
+
+    it('should surface resource results when the workloads index fails', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      fetchWithMock.mockImplementation(({ endpoint }) =>
+        endpoint.startsWith('/api/v1/workloads/search')
+          ? Promise.reject(new Error('workloads down'))
+          : Promise.resolve({
+            resources: [{ kind: 'Kustomization', namespace: 'flux-system', name: 'app', status: 'Ready' }]
+          })
+      )
+
+      render(<QuickSearch />)
+
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
+      fireEvent.input(input, { target: { value: 'flux' } })
+
+      vi.advanceTimersByTime(400)
+      await vi.runAllTimersAsync()
+
+      // One source failing must not wipe the other's results.
+      expect(quickSearchResults.value).toEqual([
+        expect.objectContaining({ kind: 'Kustomization', name: 'app' })
+      ])
       expect(consoleError).toHaveBeenCalledWith('Failed to fetch search results:', expect.any(Error))
 
       consoleError.mockRestore()
@@ -1356,6 +1388,206 @@ describe('QuickSearch', () => {
       fireEvent.keyDown(input, { key: 'Enter' })
 
       expect(mockRoute).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getResultUrl', () => {
+    it('should route Flux kinds to the resource dashboard', () => {
+      expect(getResultUrl({ kind: 'HelmRelease', namespace: 'flux-system', name: 'podinfo' }))
+        .toBe('/resource/HelmRelease/flux-system/podinfo')
+    })
+
+    it('should route workload kinds to the workload dashboard', () => {
+      expect(getResultUrl({ kind: 'Deployment', namespace: 'apps', name: 'podinfo' }))
+        .toBe('/workload/Deployment/apps/podinfo')
+    })
+
+    it('should encode special characters', () => {
+      expect(getResultUrl({ kind: 'CronJob', namespace: 'apps', name: 'a b' }))
+        .toBe('/workload/CronJob/apps/a%20b')
+    })
+  })
+
+  describe('Combined kind suggestions', () => {
+    beforeEach(() => {
+      quickSearchOpen.value = true
+      fetchWithMock.mockResolvedValue({ resources: [] })
+    })
+
+    it('should show both Flux kinds and workload kinds', () => {
+      render(<QuickSearch />)
+
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
+      fireEvent.input(input, { target: { value: 'kind:' } })
+
+      // Flux kind
+      expect(screen.getByText('HelmRelease')).toBeInTheDocument()
+      // Workload kinds
+      expect(screen.getByText('Deployment')).toBeInTheDocument()
+      expect(screen.getByText('StatefulSet')).toBeInTheDocument()
+    })
+
+    it('should filter to workload kinds on partial match', () => {
+      render(<QuickSearch />)
+
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
+      fireEvent.input(input, { target: { value: 'kind:Daemon' } })
+
+      expect(screen.getByText('DaemonSet')).toBeInTheDocument()
+      expect(screen.queryByText('HelmRelease')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Dual-source search', () => {
+    beforeEach(() => {
+      quickSearchOpen.value = true
+    })
+
+    it('should query both indexes and merge results (resources first)', async () => {
+      fetchWithMock.mockImplementation(({ endpoint }) => {
+        if (endpoint.startsWith('/api/v1/workloads/search')) {
+          return Promise.resolve({
+            workloads: [{ kind: 'Deployment', namespace: 'apps', name: 'podinfo' }]
+          })
+        }
+        return Promise.resolve({
+          resources: [{ kind: 'HelmRelease', namespace: 'apps', name: 'podinfo', status: 'Ready' }]
+        })
+      })
+
+      render(<QuickSearch />)
+
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
+      fireEvent.input(input, { target: { value: 'podinfo' } })
+
+      vi.advanceTimersByTime(400)
+      await vi.runAllTimersAsync()
+
+      // Both endpoints queried
+      expect(fetchWithMock).toHaveBeenCalledWith({
+        endpoint: '/api/v1/search?name=podinfo',
+        mockPath: '../mock/resources',
+        mockExport: 'getMockSearchResults'
+      })
+      expect(fetchWithMock).toHaveBeenCalledWith({
+        endpoint: '/api/v1/workloads/search?name=podinfo',
+        mockPath: '../mock/workloads',
+        mockExport: 'getMockWorkloadsSearch'
+      })
+
+      // Merge: resource first, then workload
+      expect(quickSearchResults.value).toHaveLength(2)
+      expect(quickSearchResults.value[0].kind).toBe('HelmRelease')
+      expect(quickSearchResults.value[1].kind).toBe('Deployment')
+    })
+
+    it('should query only the workload endpoint when kind is a workload kind', async () => {
+      fetchWithMock.mockResolvedValue({
+        workloads: [{ kind: 'Deployment', namespace: 'apps', name: 'podinfo' }]
+      })
+
+      render(<QuickSearch />)
+
+      // Select a workload kind filter
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
+      fireEvent.input(input, { target: { value: 'kind:' } })
+      fireEvent.click(screen.getByText('Deployment'))
+
+      const searchInput = screen.getByPlaceholderText('Search...')
+      fireEvent.input(searchInput, { target: { value: 'podinfo' } })
+
+      vi.advanceTimersByTime(400)
+      await vi.runAllTimersAsync()
+
+      expect(fetchWithMock).toHaveBeenCalledTimes(1)
+      expect(fetchWithMock).toHaveBeenCalledWith({
+        endpoint: '/api/v1/workloads/search?name=podinfo&kind=Deployment',
+        mockPath: '../mock/workloads',
+        mockExport: 'getMockWorkloadsSearch'
+      })
+    })
+
+    it('should query only the resource endpoint when kind is a Flux kind', async () => {
+      fetchWithMock.mockResolvedValue({
+        resources: [{ kind: 'HelmRelease', namespace: 'apps', name: 'podinfo', status: 'Ready' }]
+      })
+
+      render(<QuickSearch />)
+
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
+      fireEvent.input(input, { target: { value: 'kind:' } })
+      fireEvent.click(screen.getByText('HelmRelease'))
+
+      const searchInput = screen.getByPlaceholderText('Search...')
+      fireEvent.input(searchInput, { target: { value: 'podinfo' } })
+
+      vi.advanceTimersByTime(400)
+      await vi.runAllTimersAsync()
+
+      expect(fetchWithMock).toHaveBeenCalledTimes(1)
+      expect(fetchWithMock).toHaveBeenCalledWith({
+        endpoint: '/api/v1/search?name=podinfo&kind=HelmRelease',
+        mockPath: '../mock/resources',
+        mockExport: 'getMockSearchResults'
+      })
+    })
+
+    it('should render a gray bullet for workload results (no status)', async () => {
+      fetchWithMock.mockImplementation(({ endpoint }) => {
+        if (endpoint.startsWith('/api/v1/workloads/search')) {
+          return Promise.resolve({
+            workloads: [{ kind: 'Deployment', namespace: 'apps', name: 'podinfo' }]
+          })
+        }
+        return Promise.resolve({ resources: [] })
+      })
+
+      render(<QuickSearch />)
+
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
+      fireEvent.input(input, { target: { value: 'podinfo' } })
+
+      vi.advanceTimersByTime(400)
+      await vi.runAllTimersAsync()
+
+      // Workload result link points to the workload dashboard
+      const link = screen.getByText('apps/podinfo').closest('a')
+      expect(link).toHaveAttribute('href', '/workload/Deployment/apps/podinfo')
+
+      // Status is undefined → default gray dot
+      const dot = document.querySelector('.bg-gray-500')
+      expect(dot).toBeInTheDocument()
+    })
+
+    it('should route workload history entries to the workload dashboard', () => {
+      navHistory.value = [
+        { kind: 'Deployment', namespace: 'apps', name: 'podinfo' }
+      ]
+      quickSearchOpen.value = true
+      render(<QuickSearch />)
+
+      const historyLink = screen.getByText('Deployment/').closest('a')
+      expect(historyLink).toHaveAttribute('href', '/workload/Deployment/apps/podinfo')
+    })
+  })
+
+  describe('Browse all workloads link', () => {
+    beforeEach(() => {
+      quickSearchOpen.value = true
+      fetchWithMock.mockResolvedValue({ resources: [] })
+    })
+
+    it('should have a browse all workloads link in the empty state', async () => {
+      render(<QuickSearch />)
+
+      const input = screen.getByPlaceholderText('Search appliers & workloads...')
+      fireEvent.input(input, { target: { value: 'nonexistent' } })
+
+      vi.advanceTimersByTime(400)
+      await vi.runAllTimersAsync()
+
+      const browseLink = screen.getByText('Browse all workloads →')
+      expect(browseLink).toHaveAttribute('href', '/workloads')
     })
   })
 })

--- a/web/src/components/search/ResourceDetailsView.jsx
+++ b/web/src/components/search/ResourceDetailsView.jsx
@@ -4,7 +4,7 @@
 import { useState, useMemo, useEffect, useRef } from 'preact/hooks'
 import { fetchWithMock } from '../../utils/fetch'
 import { usePrismTheme, YamlBlock } from '../dashboards/common/yaml'
-import { isKindWithInventory, getKindAlias, isFluxInventoryItem } from '../../utils/constants'
+import { isKindWithInventory, getKindAlias, isFluxInventoryItem, isWorkloadInventoryItem } from '../../utils/constants'
 import { getStatusBadgeClass, cleanStatus } from '../../utils/status'
 import { FluxOperatorIcon } from '../layout/Icons'
 
@@ -54,16 +54,18 @@ function groupInventoryByApiVersion(inventory) {
  */
 function InventoryItem({ item }) {
   const isFluxResource = isFluxInventoryItem(item)
+  const isWorkload = !isFluxResource && isWorkloadInventoryItem(item)
 
   // Build resource URL
   const ns = item.namespace || ''
   const resourceUrl = `/resource/${encodeURIComponent(item.kind)}/${encodeURIComponent(ns)}/${encodeURIComponent(item.name)}`
+  const workloadUrl = `/workload/${encodeURIComponent(item.kind)}/${encodeURIComponent(ns)}/${encodeURIComponent(item.name)}`
 
-  if (isFluxResource) {
+  if (isFluxResource || isWorkload) {
     return (
       <div class="py-1 px-2 text-xs break-all">
         <a
-          href={resourceUrl}
+          href={isFluxResource ? resourceUrl : workloadUrl}
           class="text-left hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue rounded inline-block group"
         >
           <span class="text-gray-600 dark:text-gray-400">{item.kind}/</span>{item.namespace && <span class="text-gray-500 dark:text-gray-400">{item.namespace}/</span>}<span class="text-gray-900 dark:text-gray-100 group-hover:text-flux-blue dark:group-hover:text-blue-400">{item.name}</span><svg class="w-3 h-3 text-gray-400 group-hover:text-flux-blue dark:group-hover:text-blue-400 transition-colors ml-1 inline-block align-middle" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
@@ -72,7 +74,7 @@ function InventoryItem({ item }) {
     )
   }
 
-  // Non-Flux resource - render as plain text
+  // Non-Flux, non-workload resource - render as plain text
   return (
     <div class="py-1 px-2 text-xs break-all">
       <span class="text-gray-900 dark:text-gray-100">

--- a/web/src/components/search/ResourceDetailsView.jsx
+++ b/web/src/components/search/ResourceDetailsView.jsx
@@ -5,6 +5,7 @@ import { useState, useMemo, useEffect, useRef } from 'preact/hooks'
 import { fetchWithMock } from '../../utils/fetch'
 import { usePrismTheme, YamlBlock } from '../dashboards/common/yaml'
 import { isKindWithInventory, getKindAlias, isFluxInventoryItem, isWorkloadInventoryItem } from '../../utils/constants'
+import { getDashboardUrl } from '../../utils/routing'
 import { getStatusBadgeClass, cleanStatus } from '../../utils/status'
 import { FluxOperatorIcon } from '../layout/Icons'
 
@@ -56,16 +57,15 @@ function InventoryItem({ item }) {
   const isFluxResource = isFluxInventoryItem(item)
   const isWorkload = !isFluxResource && isWorkloadInventoryItem(item)
 
-  // Build resource URL
+  // Build the dashboard URL, routing workloads and Flux resources accordingly
   const ns = item.namespace || ''
-  const resourceUrl = `/resource/${encodeURIComponent(item.kind)}/${encodeURIComponent(ns)}/${encodeURIComponent(item.name)}`
-  const workloadUrl = `/workload/${encodeURIComponent(item.kind)}/${encodeURIComponent(ns)}/${encodeURIComponent(item.name)}`
+  const dashboardUrl = getDashboardUrl(item.kind, ns, item.name)
 
   if (isFluxResource || isWorkload) {
     return (
       <div class="py-1 px-2 text-xs break-all">
         <a
-          href={isFluxResource ? resourceUrl : workloadUrl}
+          href={dashboardUrl}
           class="text-left hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue rounded inline-block group"
         >
           <span class="text-gray-600 dark:text-gray-400">{item.kind}/</span>{item.namespace && <span class="text-gray-500 dark:text-gray-400">{item.namespace}/</span>}<span class="text-gray-900 dark:text-gray-100 group-hover:text-flux-blue dark:group-hover:text-blue-400">{item.name}</span><svg class="w-3 h-3 text-gray-400 group-hover:text-flux-blue dark:group-hover:text-blue-400 transition-colors ml-1 inline-block align-middle" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
@@ -350,7 +350,7 @@ export function ResourceDetailsView({ kind, name, namespace, isExpanded }) {
             <div class="space-y-4">
               {/* Resource Link */}
               <a
-                href={`/resource/${encodeURIComponent(resourceData.status.sourceRef.kind)}/${encodeURIComponent(resourceData.status.sourceRef.namespace)}/${encodeURIComponent(resourceData.status.sourceRef.name)}`}
+                href={getDashboardUrl(resourceData.status.sourceRef.kind, resourceData.status.sourceRef.namespace, resourceData.status.sourceRef.name)}
                 class="flex items-center gap-2 text-sm text-flux-blue dark:text-blue-400 hover:underline"
               >
                 <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/web/src/components/search/ResourceList.jsx
+++ b/web/src/components/search/ResourceList.jsx
@@ -10,7 +10,7 @@ import { usePageMeta } from '../../utils/meta'
 import { reportData } from '../../app'
 import { FilterForm } from './FilterForm'
 import { ResourceDetailsView } from './ResourceDetailsView'
-import { useRestoreFiltersFromUrl, useSyncFiltersToUrl } from '../../utils/routing'
+import { getDashboardUrl, useRestoreFiltersFromUrl, useSyncFiltersToUrl } from '../../utils/routing'
 import { StatusChart } from './StatusChart'
 import { useInfiniteScroll } from '../../utils/scroll'
 import { isFavorite, toggleFavorite, favorites } from '../../utils/favorites'
@@ -53,13 +53,6 @@ export async function fetchResourcesStatus() {
   }
 }
 
-
-/**
- * Build URL path for a resource dashboard
- */
-function getResourceUrl(kind, namespace, name) {
-  return `/resource/${encodeURIComponent(kind)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`
-}
 
 /**
  * ResourceCard - Individual card displaying a Flux resource with status and details
@@ -137,7 +130,7 @@ function ResourceCard({ resource }) {
       {/* Resource namespace/name - clickable link to dashboard */}
       <div class="mb-1 sm:mb-2">
         <a
-          href={getResourceUrl(resource.kind, resource.namespace, resource.name)}
+          href={getDashboardUrl(resource.kind, resource.namespace, resource.name)}
           class="text-sm text-left hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue rounded inline-block group"
         >
           <span class="text-gray-500 dark:text-gray-400">{resource.namespace}/</span><span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-flux-blue dark:group-hover:text-blue-400">{resource.name}</span><svg class="w-3.5 h-3.5 text-gray-400 group-hover:text-flux-blue dark:group-hover:text-blue-400 transition-colors ml-1 inline-block align-middle" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>

--- a/web/src/components/search/ResourceList.test.jsx
+++ b/web/src/components/search/ResourceList.test.jsx
@@ -22,8 +22,9 @@ vi.mock('../../utils/fetch', () => ({
   fetchWithMock: vi.fn()
 }))
 
-// Mock routing utilities
-vi.mock('../../utils/routing', () => ({
+// Mock routing utilities (stub the URL-sync hooks, keep the real getDashboardUrl)
+vi.mock('../../utils/routing', async (importActual) => ({
+  ...(await importActual()),
   useRestoreFiltersFromUrl: vi.fn(),
   useSyncFiltersToUrl: vi.fn()
 }))

--- a/web/src/components/search/StatusChart.jsx
+++ b/web/src/components/search/StatusChart.jsx
@@ -104,7 +104,7 @@ export function StatusChart({ items, loading, mode = 'events', onBarClick }) {
   }, [loading, items, mode, itemsKey])
 
   return (
-    <div class="card p-4">
+    <div class="card p-4" data-testid="status-chart">
       <style>{`
         @keyframes fillRight {
           from {

--- a/web/src/components/search/WorkloadDetailsView.jsx
+++ b/web/src/components/search/WorkloadDetailsView.jsx
@@ -1,0 +1,299 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useState, useMemo, useEffect, useRef } from 'preact/hooks'
+import { fetchWithMock } from '../../utils/fetch'
+import { getWorkloadStatusBadgeClass, formatWorkloadStatus } from '../../utils/status'
+import { summarizePods } from '../../utils/pods'
+import { formatScheduleMessage } from '../../utils/cron'
+import { usePrismTheme, YamlBlock } from '../dashboards/common/yaml'
+import { FluxOperatorIcon } from '../layout/Icons'
+
+/**
+ * WorkloadDetailsView - Read-only inline detail panel for a Kubernetes workload
+ *
+ * @param {Object} props
+ * @param {string} props.kind - Workload kind (Deployment, StatefulSet, DaemonSet, CronJob)
+ * @param {string} props.name - Workload name
+ * @param {string} props.namespace - Workload namespace
+ * @param {boolean} props.isExpanded - Whether the view is expanded
+ *
+ * Features:
+ * - Lazy loads workload data from the RBAC-enforced /api/v1/workload endpoint on
+ *   first expand and caches it to avoid redundant fetches.
+ * - Tabbed interface with three read-only sections: Overview, Specification, Status.
+ * - Mirrors the Resources list detail panel (ResourceDetailsView). Pod listing,
+ *   events, and actions live on the full workload dashboard, not here.
+ * - Handles loading, error, and not-found states (e.g. forbidden namespaces).
+ */
+export function WorkloadDetailsView({ kind, name, namespace, isExpanded }) {
+  const [workloadData, setWorkloadData] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [activeTab, setActiveTab] = useState('overview')
+  const fetchingRef = useRef(false)
+
+  // Load Prism theme based on current app theme
+  usePrismTheme()
+
+  // Reset state when workload identity changes
+  useEffect(() => {
+    setWorkloadData(null)
+    setError(null)
+    setActiveTab('overview')
+  }, [kind, name, namespace])
+
+  // Fetch workload details when expanded
+  useEffect(() => {
+    if (!isExpanded || workloadData || fetchingRef.current) return
+
+    let cancelled = false
+    fetchingRef.current = true
+
+    const fetchWorkloadDetails = async () => {
+      if (!cancelled) {
+        setLoading(true)
+        setError(null)
+      }
+
+      const params = new URLSearchParams({ kind, name, namespace })
+
+      try {
+        const data = await fetchWithMock({
+          endpoint: `/api/v1/workload?${params.toString()}`,
+          mockPath: '../mock/workload',
+          mockExport: 'getMockWorkload'
+        })
+        if (!cancelled) setWorkloadData(data)
+      } catch (err) {
+        console.error('Failed to fetch workload details:', err)
+        if (!cancelled) setError(err.message)
+      } finally {
+        fetchingRef.current = false
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    fetchWorkloadDetails()
+    return () => { cancelled = true }
+  }, [isExpanded, kind, name, namespace, workloadData])
+
+  const workloadInfo = workloadData?.workloadInfo
+  const workloadStatus = workloadInfo?.status || 'Unknown'
+
+  // Pod readiness/phase summary shown in the overview (CronJobs report completion)
+  const podSummary = useMemo(
+    () => summarizePods(workloadInfo?.pods, kind),
+    [workloadInfo, kind]
+  )
+
+  // True when the object carries no metadata.name, i.e. it was not found or the
+  // user is not allowed to read it in this namespace.
+  const isNotFound = !!workloadData && !workloadData?.metadata?.name
+
+  // Resolve the pod spec based on workload kind
+  const podSpec = useMemo(() => {
+    if (!workloadData?.spec) return null
+    return kind === 'CronJob'
+      ? workloadData.spec.jobTemplate?.spec?.template?.spec
+      : workloadData.spec.template?.spec
+  }, [workloadData, kind])
+
+  // Extract and sort unique container ports from the spec
+  const containerPorts = useMemo(() => {
+    if (!podSpec) return []
+    const containers = [...(podSpec.containers || []), ...(podSpec.initContainers || [])]
+    const ports = new Set()
+    for (const c of containers) {
+      for (const p of c.ports || []) {
+        if (p.containerPort) ports.add(p.containerPort)
+      }
+    }
+    return [...ports].sort((a, b) => a - b)
+  }, [podSpec])
+
+  // Last action timestamp: conditions for apps/v1, lastScheduleTime for CronJob
+  const lastActionTime = useMemo(() => {
+    if (!workloadData?.status) return null
+    const conditions = workloadData.status.conditions || []
+    const lastUpdateTime = conditions.reduce((latest, c) => {
+      if (!c.lastUpdateTime) return latest
+      if (!latest) return c.lastUpdateTime
+      return new Date(c.lastUpdateTime) > new Date(latest) ? c.lastUpdateTime : latest
+    }, null)
+    if (lastUpdateTime) return lastUpdateTime
+    if (workloadData.status.lastScheduleTime) return workloadData.status.lastScheduleTime
+    return workloadInfo?.createdAt || null
+  }, [workloadData, workloadInfo])
+
+  // Memoized YAML data for the spec and status tabs
+  const workloadSpecYaml = useMemo(() => {
+    if (!workloadData) return null
+    return {
+      apiVersion: workloadData.apiVersion,
+      kind: workloadData.kind,
+      metadata: workloadData.metadata,
+      spec: workloadData.spec
+    }
+  }, [workloadData])
+
+  const workloadStatusYaml = useMemo(() => {
+    if (!workloadData?.status) return null
+    return {
+      apiVersion: workloadData.apiVersion,
+      kind: workloadData.kind,
+      metadata: { name: workloadData.metadata.name, namespace: workloadData.metadata.namespace },
+      status: workloadData.status
+    }
+  }, [workloadData])
+
+  if (!isExpanded) return null
+
+  return (
+    <div class="mt-3 space-y-4">
+      {/* Loading State */}
+      {loading && (
+        <div class="flex items-center justify-center p-4">
+          <FluxOperatorIcon className="animate-spin h-6 w-6 text-flux-blue" />
+          <span class="ml-2 text-sm text-gray-600 dark:text-gray-400">
+            Loading details...
+          </span>
+        </div>
+      )}
+
+      {/* Error State */}
+      {error && (
+        <div class="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+          <p class="text-sm text-red-800 dark:text-red-200">
+            Failed to load details: {error}
+          </p>
+        </div>
+      )}
+
+      {/* Not Found State (deleted or not visible to the user) */}
+      {!loading && !error && isNotFound && (
+        <div class="p-3 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-md">
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            Workload not found in the cluster.
+          </p>
+        </div>
+      )}
+
+      {/* Tabs + Content */}
+      {!loading && !error && workloadData && !isNotFound && (
+        <>
+          {/* Tab Navigation */}
+          <div class="border-b border-gray-200 dark:border-gray-700 mb-4">
+            <nav class="flex space-x-4 overflow-x-auto" aria-label="Tabs">
+              <button
+                onClick={() => setActiveTab('overview')}
+                class={`py-2 px-1 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === 'overview'
+                    ? 'border-flux-blue text-flux-blue dark:text-blue-400'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
+                }`}
+              >
+                <span class="inline sm:hidden">Info</span>
+                <span class="hidden sm:inline">Overview</span>
+              </button>
+              <button
+                onClick={() => setActiveTab('specification')}
+                class={`py-2 px-1 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === 'specification'
+                    ? 'border-flux-blue text-flux-blue dark:text-blue-400'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
+                }`}
+              >
+                <span class="inline sm:hidden">Spec</span>
+                <span class="hidden sm:inline">Specification</span>
+              </button>
+              <button
+                onClick={() => setActiveTab('status')}
+                class={`py-2 px-1 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === 'status'
+                    ? 'border-flux-blue text-flux-blue dark:text-blue-400'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
+                }`}
+              >
+                Status
+              </button>
+            </nav>
+          </div>
+
+          {/* Overview Tab */}
+          {activeTab === 'overview' && (
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {/* Left column: status and metadata */}
+              <div class="space-y-4">
+                {/* Status Badge */}
+                <div class="text-sm">
+                  <span class="text-gray-500 dark:text-gray-400">{kind}</span>
+                  <span class={`ml-1 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getWorkloadStatusBadgeClass(workloadStatus)}`}>
+                    {formatWorkloadStatus(workloadStatus)}
+                  </span>
+                </div>
+
+                {/* Created At */}
+                {workloadInfo?.createdAt && (
+                  <div class="text-sm">
+                    <span class="text-gray-500 dark:text-gray-400">Created</span>
+                    <span class="ml-1 text-gray-900 dark:text-white">{new Date(workloadInfo.createdAt).toLocaleString().replace(',', '')}</span>
+                  </div>
+                )}
+
+                {/* Pods readiness / phase summary */}
+                <div class="text-sm">
+                  <span class="text-gray-500 dark:text-gray-400">Pods</span>
+                  <span class="ml-1 text-gray-900 dark:text-white">{podSummary.primary}</span>
+                  {podSummary.detail && podSummary.total > 0 && (
+                    <span class="text-gray-500 dark:text-gray-400"> ({podSummary.detail})</span>
+                  )}
+                </div>
+
+                {/* Service Account */}
+                {podSpec?.serviceAccountName && (
+                  <div class="text-sm">
+                    <span class="text-gray-500 dark:text-gray-400">Service account</span>
+                    <span class="ml-1 text-gray-900 dark:text-white">{podSpec.serviceAccountName}</span>
+                  </div>
+                )}
+
+                {/* Container Ports */}
+                {containerPorts.length > 0 && (
+                  <div class="text-sm">
+                    <span class="text-gray-500 dark:text-gray-400">Ports</span>
+                    <span class="ml-1 text-gray-900 dark:text-white">{containerPorts.join(', ')}</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Right column: last action and status message */}
+              {workloadInfo?.statusMessage && (
+                <div class="space-y-2 border-gray-200 dark:border-gray-700 border-t pt-4 md:border-t-0 md:border-l md:pt-0 md:pl-6">
+                  {lastActionTime && (
+                    <div class="text-sm text-gray-500 dark:text-gray-400">
+                      Last action <span class="text-gray-900 dark:text-white">{new Date(lastActionTime).toLocaleString().replace(',', '')}</span>
+                    </div>
+                  )}
+                  <div class="text-sm text-gray-700 dark:text-gray-300">
+                    <pre class="whitespace-pre-wrap break-all font-sans">{formatScheduleMessage(workloadInfo.statusMessage)}</pre>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Specification Tab */}
+          {activeTab === 'specification' && (
+            <YamlBlock data={workloadSpecYaml} />
+          )}
+
+          {/* Status Tab */}
+          {activeTab === 'status' && (
+            <YamlBlock data={workloadStatusYaml} />
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/search/WorkloadDetailsView.test.jsx
+++ b/web/src/components/search/WorkloadDetailsView.test.jsx
@@ -1,0 +1,237 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/preact'
+import userEvent from '@testing-library/user-event'
+import { WorkloadDetailsView } from './WorkloadDetailsView'
+import { fetchWithMock } from '../../utils/fetch'
+
+// Mock the fetch utility
+vi.mock('../../utils/fetch', () => ({
+  fetchWithMock: vi.fn()
+}))
+
+describe('WorkloadDetailsView component', () => {
+  const mockWorkloadData = {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: 'podinfo',
+      namespace: 'apps'
+    },
+    spec: {
+      strategy: {
+        type: 'RollingUpdate',
+        rollingUpdate: { maxUnavailable: 1, maxSurge: 1 }
+      },
+      template: {
+        spec: {
+          serviceAccountName: 'podinfo',
+          containers: [
+            { name: 'podinfod', ports: [{ containerPort: 9898 }, { containerPort: 9797 }] }
+          ]
+        }
+      }
+    },
+    status: {
+      replicas: 2,
+      conditions: [
+        { type: 'Available', status: 'True', lastUpdateTime: '2025-01-15T10:00:00Z' }
+      ]
+    },
+    workloadInfo: {
+      status: 'Current',
+      statusMessage: 'Deployment is available. Replicas: 2',
+      createdAt: '2025-01-10T08:00:00Z',
+      pods: [
+        { name: 'podinfo-1', status: 'Running', podStatus: { conditions: [{ type: 'Ready', status: 'True' }] } },
+        { name: 'podinfo-2', status: 'Running', podStatus: { conditions: [{ type: 'Ready', status: 'True' }] } }
+      ]
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render nothing when isExpanded is false', () => {
+    const { container } = render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={false} />
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('should not fetch until expanded', () => {
+    render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={false} />
+    )
+
+    expect(fetchWithMock).not.toHaveBeenCalled()
+  })
+
+  it('should fetch workload data when expanded for the first time', async () => {
+    fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+    render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />
+    )
+
+    await waitFor(() => {
+      expect(fetchWithMock).toHaveBeenCalledWith({
+        endpoint: '/api/v1/workload?kind=Deployment&name=podinfo&namespace=apps',
+        mockPath: '../mock/workload',
+        mockExport: 'getMockWorkload'
+      })
+    })
+  })
+
+  it('should show loading state while fetching', async () => {
+    let resolvePromise
+    const promise = new Promise((resolve) => { resolvePromise = resolve })
+    fetchWithMock.mockReturnValue(promise)
+
+    render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />
+    )
+
+    expect(screen.getByText('Loading details...')).toBeInTheDocument()
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
+
+    resolvePromise(mockWorkloadData)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading details...')).not.toBeInTheDocument()
+    })
+  })
+
+  it('should render the overview tab with status and metadata by default', async () => {
+    fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+    render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Service account')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Service account')).toBeInTheDocument()
+    expect(screen.getByText('podinfo')).toBeInTheDocument()
+    expect(screen.getByText('Ports')).toBeInTheDocument()
+    expect(screen.getByText('9797, 9898')).toBeInTheDocument()
+    expect(screen.getByText('Pods')).toBeInTheDocument()
+    expect(screen.getByText('2/2 ready')).toBeInTheDocument()
+    expect(screen.queryByText('Strategy')).not.toBeInTheDocument()
+  })
+
+  it('should display the specification tab as highlighted YAML', async () => {
+    fetchWithMock.mockResolvedValue(mockWorkloadData)
+    const user = userEvent.setup()
+
+    render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Specification')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Specification'))
+
+    await waitFor(() => {
+      const codeElement = document.querySelector('.language-yaml')
+      expect(codeElement).not.toBeNull()
+      expect(codeElement.innerHTML).toContain('apiVersion')
+      expect(codeElement.innerHTML).toContain('apps/v1')
+      expect(codeElement.innerHTML).toContain('Deployment')
+      expect(codeElement.innerHTML).toContain('serviceAccountName')
+    })
+  })
+
+  it('should display the status tab as highlighted YAML', async () => {
+    fetchWithMock.mockResolvedValue(mockWorkloadData)
+    const user = userEvent.setup()
+
+    render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Specification')).toBeInTheDocument()
+    })
+
+    // The Status tab button is disambiguated from the Overview "Status" label by role.
+    await user.click(screen.getByRole('button', { name: 'Status' }))
+
+    await waitFor(() => {
+      const codeElement = document.querySelector('.language-yaml')
+      expect(codeElement).not.toBeNull()
+      expect(codeElement.innerHTML).toContain('status')
+      expect(codeElement.innerHTML).toContain('replicas')
+    })
+  })
+
+  it('should show a not-found state when the workload has no metadata', async () => {
+    fetchWithMock.mockResolvedValue({ kind: 'Deployment' })
+
+    render(
+      <WorkloadDetailsView kind="Deployment" name="missing" namespace="apps" isExpanded={true} />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Workload not found in the cluster.')).toBeInTheDocument()
+    })
+  })
+
+  it('should show an error state when the fetch fails', async () => {
+    fetchWithMock.mockRejectedValue(new Error('User does not have access to the workload'))
+
+    render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load details: User does not have access to the workload/)).toBeInTheDocument()
+    })
+  })
+
+  it('should not render a pods tab, events tab, or action controls', async () => {
+    fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+    render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Service account')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole('button', { name: 'Pods' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Events' })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('logs-pod-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workload-delete-action')).not.toBeInTheDocument()
+  })
+
+  it('should fetch only once across collapse and re-expand', async () => {
+    fetchWithMock.mockResolvedValue(mockWorkloadData)
+
+    const { rerender } = render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />
+    )
+
+    await waitFor(() => {
+      expect(fetchWithMock).toHaveBeenCalledTimes(1)
+    })
+
+    // Collapse then re-expand: cached data must not trigger a second fetch
+    rerender(<WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={false} />)
+    rerender(<WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Service account')).toBeInTheDocument()
+    })
+    expect(fetchWithMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/components/search/WorkloadList.jsx
+++ b/web/src/components/search/WorkloadList.jsx
@@ -1,0 +1,266 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import { fetchWithMock } from '../../utils/fetch'
+import { formatTimestamp } from '../../utils/time'
+import { getStatusDotClass } from '../../utils/status'
+import { usePageMeta } from '../../utils/meta'
+import { workloadKinds } from '../../utils/constants'
+import { reportData } from '../../app'
+import { FilterForm } from './FilterForm'
+import { useRestoreFiltersFromUrl, useSyncFiltersToUrl, getDashboardUrl } from '../../utils/routing'
+import { useInfiniteScroll } from '../../utils/scroll'
+import { isFavorite, toggleFavorite, favorites } from '../../utils/favorites'
+
+// Workloads data signals
+export const workloadsData = signal([])
+export const workloadsLoading = signal(false)
+export const workloadsError = signal(null)
+
+// Filter signals - NO status signal (workloads have no status of their own)
+export const selectedWorkloadKind = signal('')
+export const selectedWorkloadName = signal('')
+export const selectedWorkloadNamespace = signal('')
+
+// Fetch workloads from API
+export async function fetchWorkloadsStatus() {
+  workloadsLoading.value = true
+  workloadsError.value = null
+
+  const params = new URLSearchParams()
+  if (selectedWorkloadKind.value) params.append('kind', selectedWorkloadKind.value)
+  if (selectedWorkloadName.value) params.append('name', selectedWorkloadName.value)
+  if (selectedWorkloadNamespace.value) params.append('namespace', selectedWorkloadNamespace.value)
+
+  try {
+    const data = await fetchWithMock({
+      endpoint: `/api/v1/workloads?${params.toString()}`,
+      mockPath: '../mock/workloads',
+      mockExport: 'getMockWorkloadsList'
+    })
+    workloadsData.value = data.workloads || []
+  } catch (error) {
+    console.error('Failed to fetch workloads:', error)
+    workloadsError.value = error.message
+    workloadsData.value = []
+  } finally {
+    workloadsLoading.value = false
+  }
+}
+
+/**
+ * WorkloadCard - Individual card displaying a Kubernetes workload and its parent reconciler
+ *
+ * @param {Object} props
+ * @param {Object} props.workload - WorkloadRef object with kind, name, namespace, reconciler ref
+ *   fields (reconcilerKind, reconcilerNamespace, reconcilerName, reconcilerStatus) and lastReconciled
+ *
+ * Features:
+ * - Shows workload kind, namespace, and name (links to the workload dashboard)
+ * - Displays the parent reconciler reference with a small status badge reflecting the
+ *   reconciler's status (never the reconciler message)
+ * - Favorite star button (writes via the kind-agnostic favorites store)
+ */
+function WorkloadCard({ workload }) {
+  // Check if workload is a favorite (reactive via favorites signal)
+  const isFavorited = favorites.value && isFavorite(workload.kind, workload.namespace, workload.name)
+
+  // Handle favorite toggle
+  const handleFavoriteClick = (e) => {
+    e.stopPropagation()
+    toggleFavorite(workload.kind, workload.namespace, workload.name)
+  }
+
+  return (
+    <div class="card p-4 hover:shadow-md transition-shadow">
+      {/* Header row: star + kind + timestamp */}
+      <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center gap-3">
+          {/* Favorite star button */}
+          <button
+            onClick={handleFavoriteClick}
+            class={`p-0.5 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue focus:ring-offset-1 ${
+              isFavorited
+                ? 'text-yellow-500 hover:text-yellow-600'
+                : 'text-gray-400 hover:text-flux-blue dark:hover:text-blue-400'
+            }`}
+            title={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+          >
+            <svg class="w-4 h-4" fill={isFavorited ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+            </svg>
+          </button>
+          <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
+            {workload.kind}
+          </span>
+        </div>
+        <span class="hidden sm:inline text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap ml-4">
+          {formatTimestamp(workload.lastReconciled)}
+        </span>
+      </div>
+
+      {/* Workload namespace/name - clickable link to dashboard */}
+      <div class="mb-1 sm:mb-2">
+        <a
+          href={getDashboardUrl(workload.kind, workload.namespace, workload.name)}
+          class="text-sm text-left hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue rounded inline-block group"
+        >
+          <span class="text-gray-500 dark:text-gray-400">{workload.namespace}/</span><span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-flux-blue dark:group-hover:text-blue-400">{workload.name}</span><svg class="w-3.5 h-3.5 text-gray-400 group-hover:text-flux-blue dark:group-hover:text-blue-400 transition-colors ml-1 inline-block align-middle" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+        </a>
+      </div>
+
+      {/* Mobile timestamp - below namespace/name */}
+      <div class="flex sm:hidden items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 mb-2">
+        <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+        </svg>
+        {formatTimestamp(workload.lastReconciled)}
+      </div>
+
+      {/* Parent reconciler reference: a muted "Managed by" line with a small status
+          dot. The status belongs to the reconciler, never the workload itself. */}
+      <div
+        class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400"
+        title={`Managed by ${workload.reconcilerKind} ${workload.reconcilerNamespace}/${workload.reconcilerName} (${workload.reconcilerStatus})`}
+      >
+        <span class="flex-shrink-0">Managed by</span>
+        <span class={`w-2 h-2 rounded-full flex-shrink-0 ${getStatusDotClass(workload.reconcilerStatus)}`} />
+        <span class="truncate min-w-0">{workload.reconcilerKind}/{workload.reconcilerNamespace}/{workload.reconcilerName}</span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * WorkloadList component - Displays and filters Flux-managed Kubernetes workloads
+ *
+ * Features:
+ * - Fetches workloads from the API with optional filters (kind, name, namespace)
+ * - Auto-refetches when filter signals change
+ * - Displays workloads in card format with the parent reconciler status badge
+ * - Shows loading, error, and empty states
+ * - No status filter and no status chart (workloads have no status of their own)
+ */
+export function WorkloadList() {
+  usePageMeta('Workloads', 'Workloads dashboard')
+
+  // Restore filter signals from URL query params on mount
+  useRestoreFiltersFromUrl({
+    kind: selectedWorkloadKind,
+    name: selectedWorkloadName,
+    namespace: selectedWorkloadNamespace
+  })
+
+  // Sync filter signals to URL query params on change (debounced)
+  useSyncFiltersToUrl({
+    kind: selectedWorkloadKind,
+    name: selectedWorkloadName,
+    namespace: selectedWorkloadNamespace
+  })
+
+  // Fetch workloads on mount and when filters change
+  useEffect(() => {
+    fetchWorkloadsStatus()
+  }, [selectedWorkloadKind.value, selectedWorkloadName.value, selectedWorkloadNamespace.value])
+
+  // Infinite scroll hook - reset when filters change or data refetches
+  const { visibleCount, sentinelRef, hasMore, loadMore } = useInfiniteScroll({
+    totalItems: workloadsData.value.length,
+    pageSize: 100,
+    deps: [selectedWorkloadKind.value, selectedWorkloadName.value, selectedWorkloadNamespace.value, workloadsData.value.length]
+  })
+
+  // Get visible workloads (slice the array - already sorted by server)
+  const visibleWorkloads = workloadsData.value.slice(0, visibleCount)
+
+  const handleClearFilters = () => {
+    selectedWorkloadKind.value = ''
+    selectedWorkloadName.value = ''
+    selectedWorkloadNamespace.value = ''
+  }
+
+  return (
+    <main data-testid="workload-list" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow w-full">
+      <div class="space-y-6">
+        {/* Page Title */}
+        <div class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Flux Workloads</h2>
+          {/* Workload count */}
+          {!workloadsLoading.value && workloadsData.value.length > 0 && (
+            <span class="text-sm text-gray-600 dark:text-gray-400">
+              {workloadsData.value.length} workloads
+            </span>
+          )}
+        </div>
+
+        {/* Filters */}
+        <div class="card p-4">
+          <FilterForm
+            kindSignal={selectedWorkloadKind}
+            nameSignal={selectedWorkloadName}
+            namespaceSignal={selectedWorkloadNamespace}
+            namespaces={reportData.value?.spec?.namespaces || []}
+            kinds={workloadKinds}
+            onClear={handleClearFilters}
+          />
+        </div>
+
+        {/* Error State */}
+        {workloadsError.value && (
+          <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-4">
+            <div class="flex">
+              <svg class="w-5 h-5 text-red-400 dark:text-red-600" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+              </svg>
+              <div class="ml-3">
+                <p class="text-sm text-red-800 dark:text-red-200">
+                  Failed to load workloads: {workloadsError.value}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Empty State */}
+        {!workloadsLoading.value && workloadsData.value.length === 0 && (
+          <div class="card py-12">
+            <div class="text-center">
+              <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+              </svg>
+              <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                No workloads found for the selected filters
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Workload Cards */}
+        {!workloadsLoading.value && workloadsData.value.length > 0 && (
+          <div class="space-y-4">
+            {visibleWorkloads.map((workload, index) => (
+              <WorkloadCard key={`${workload.namespace}-${workload.kind}-${workload.name}-${index}`} workload={workload} />
+            ))}
+
+            {/* Sentinel element for infinite scroll */}
+            {hasMore && <div ref={sentinelRef} class="h-4" />}
+
+            {/* Load more button - fallback for browsers without IntersectionObserver */}
+            {hasMore && !window.IntersectionObserver && (
+              <div class="flex justify-center py-4">
+                <button
+                  onClick={loadMore}
+                  class="px-4 py-2 bg-flux-blue text-white rounded-md hover:bg-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue focus:ring-offset-2"
+                >
+                  Load more workloads ({workloadsData.value.length - visibleCount} remaining)
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/web/src/components/search/WorkloadList.jsx
+++ b/web/src/components/search/WorkloadList.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { signal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { fetchWithMock } from '../../utils/fetch'
 import { formatTimestamp } from '../../utils/time'
 import { getStatusDotClass } from '../../utils/status'
@@ -10,6 +10,7 @@ import { usePageMeta } from '../../utils/meta'
 import { workloadKinds } from '../../utils/constants'
 import { reportData } from '../../app'
 import { FilterForm } from './FilterForm'
+import { WorkloadDetailsView } from './WorkloadDetailsView'
 import { useRestoreFiltersFromUrl, useSyncFiltersToUrl, getDashboardUrl } from '../../utils/routing'
 import { useInfiniteScroll } from '../../utils/scroll'
 import { isFavorite, toggleFavorite, favorites } from '../../utils/favorites'
@@ -64,6 +65,9 @@ export async function fetchWorkloadsStatus() {
  * - Favorite star button (writes via the kind-agnostic favorites store)
  */
 function WorkloadCard({ workload }) {
+  // Lazy-loaded inline details panel (collapsed by default)
+  const [isDetailsExpanded, setIsDetailsExpanded] = useState(false)
+
   // Check if workload is a favorite (reactive via favorites signal)
   const isFavorited = favorites.value && isFavorite(workload.kind, workload.namespace, workload.name)
 
@@ -129,6 +133,31 @@ function WorkloadCard({ workload }) {
         <span class={`w-2 h-2 rounded-full flex-shrink-0 ${getStatusDotClass(workload.reconcilerStatus)}`} />
         <span class="truncate min-w-0">{workload.reconcilerKind}/{workload.reconcilerNamespace}/{workload.reconcilerName}</span>
       </div>
+
+      {/* Details Panel - Overview/Spec/Status (lazy loaded on expand) */}
+      <div class="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+        <button
+          onClick={() => setIsDetailsExpanded(!isDetailsExpanded)}
+          class="flex items-center space-x-2 text-sm text-gray-700 dark:text-gray-300 hover:text-flux-blue dark:hover:text-blue-400 focus:outline-none transition-colors"
+        >
+          <svg
+            class={`w-4 h-4 transition-transform ${isDetailsExpanded ? 'rotate-90' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+          </svg>
+          <span class="font-medium">Details</span>
+        </button>
+      </div>
+
+      <WorkloadDetailsView
+        kind={workload.kind}
+        name={workload.name}
+        namespace={workload.namespace}
+        isExpanded={isDetailsExpanded}
+      />
     </div>
   )
 }

--- a/web/src/components/search/WorkloadList.test.jsx
+++ b/web/src/components/search/WorkloadList.test.jsx
@@ -37,6 +37,19 @@ vi.mock('preact-iso', () => ({
   })
 }))
 
+// Mock WorkloadDetailsView component to simplify testing
+vi.mock('./WorkloadDetailsView', () => ({
+  WorkloadDetailsView: ({ kind, name, namespace, isExpanded }) => (
+    isExpanded ? (
+      <div data-testid="workload-details-view">
+        <span data-testid="workload-details-view-kind">{kind}</span>
+        <span data-testid="workload-details-view-name">{name}</span>
+        <span data-testid="workload-details-view-namespace">{namespace}</span>
+      </div>
+    ) : null
+  )
+}))
+
 // Mock FilterForm to capture props (no statusSignal, flat kinds)
 vi.mock('./FilterForm', () => ({
   FilterForm: ({ onClear, kindSignal, nameSignal, namespaceSignal, statusSignal, kinds }) => (
@@ -240,6 +253,46 @@ describe('WorkloadList', () => {
       })
 
       expect(screen.queryByText('should not appear')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Details panel', () => {
+    it('should display a details toggle for every workload', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Details')).toHaveLength(2)
+      })
+    })
+
+    it('should keep the details view collapsed by default', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(screen.getByText('podinfo')).toBeInTheDocument()
+      })
+
+      expect(screen.queryByTestId('workload-details-view')).not.toBeInTheDocument()
+    })
+
+    it('should expand WorkloadDetailsView with the workload identity when toggled', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: [mockWorkloads[0]] })
+
+      render(<WorkloadList />)
+
+      const detailsToggle = await screen.findByText('Details')
+      fireEvent.click(detailsToggle)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('workload-details-view')).toBeInTheDocument()
+      })
+      expect(screen.getByTestId('workload-details-view-kind')).toHaveTextContent('Deployment')
+      expect(screen.getByTestId('workload-details-view-name')).toHaveTextContent('podinfo')
+      expect(screen.getByTestId('workload-details-view-namespace')).toHaveTextContent('apps')
     })
   })
 

--- a/web/src/components/search/WorkloadList.test.jsx
+++ b/web/src/components/search/WorkloadList.test.jsx
@@ -1,0 +1,299 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/preact'
+import {
+  WorkloadList,
+  workloadsData,
+  workloadsLoading,
+  workloadsError,
+  selectedWorkloadKind,
+  selectedWorkloadName,
+  selectedWorkloadNamespace,
+  fetchWorkloadsStatus
+} from './WorkloadList'
+import { reportData } from '../../app'
+import { fetchWithMock } from '../../utils/fetch'
+
+// Mock the fetch utility
+vi.mock('../../utils/fetch', () => ({
+  fetchWithMock: vi.fn()
+}))
+
+// Mock routing utilities
+vi.mock('../../utils/routing', () => ({
+  useRestoreFiltersFromUrl: vi.fn(),
+  useSyncFiltersToUrl: vi.fn(),
+  getDashboardUrl: (kind, namespace, name) => `/workload/${kind}/${namespace}/${name}`
+}))
+
+// Mock preact-iso
+vi.mock('preact-iso', () => ({
+  useLocation: () => ({
+    path: '/workloads',
+    query: {},
+    route: vi.fn()
+  })
+}))
+
+// Mock FilterForm to capture props (no statusSignal, flat kinds)
+vi.mock('./FilterForm', () => ({
+  FilterForm: ({ onClear, kindSignal, nameSignal, namespaceSignal, statusSignal, kinds }) => (
+    <div data-testid="filter-form">
+      <button onClick={onClear} data-testid="clear-filters">Clear</button>
+      <span data-testid="kind-signal">{kindSignal.value}</span>
+      <span data-testid="name-signal">{nameSignal.value}</span>
+      <span data-testid="namespace-signal">{namespaceSignal.value}</span>
+      <span data-testid="has-status-signal">{statusSignal ? 'yes' : 'no'}</span>
+      <span data-testid="kinds-prop">{(kinds || []).join(',')}</span>
+    </div>
+  )
+}))
+
+describe('WorkloadList', () => {
+  const mockWorkloads = [
+    {
+      kind: 'Deployment',
+      name: 'podinfo',
+      namespace: 'apps',
+      apiVersion: 'apps/v1',
+      reconcilerKind: 'Kustomization',
+      reconcilerNamespace: 'flux-system',
+      reconcilerName: 'apps',
+      reconcilerStatus: 'Ready',
+      lastReconciled: new Date('2025-01-15T10:00:00Z')
+    },
+    {
+      kind: 'DaemonSet',
+      name: 'node-exporter',
+      namespace: 'monitoring',
+      apiVersion: 'apps/v1',
+      reconcilerKind: 'HelmRelease',
+      reconcilerNamespace: 'monitoring',
+      reconcilerName: 'metrics',
+      reconcilerStatus: 'Failed',
+      lastReconciled: new Date('2025-01-15T09:00:00Z')
+    }
+  ]
+
+  beforeEach(() => {
+    workloadsData.value = []
+    workloadsLoading.value = false
+    workloadsError.value = null
+    selectedWorkloadKind.value = ''
+    selectedWorkloadName.value = ''
+    selectedWorkloadNamespace.value = ''
+
+    reportData.value = {
+      spec: {
+        namespaces: ['flux-system', 'apps', 'monitoring']
+      }
+    }
+
+    vi.clearAllMocks()
+    fetchWithMock.mockResolvedValue({ workloads: [] })
+  })
+
+  describe('fetchWorkloadsStatus function', () => {
+    it('should fetch workloads with no filters', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      await fetchWorkloadsStatus()
+
+      expect(fetchWithMock).toHaveBeenCalledWith({
+        endpoint: '/api/v1/workloads?',
+        mockPath: '../mock/workloads',
+        mockExport: 'getMockWorkloadsList'
+      })
+      expect(workloadsData.value).toEqual(mockWorkloads)
+      expect(workloadsLoading.value).toBe(false)
+    })
+
+    it('should pass kind, name, and namespace query params', async () => {
+      selectedWorkloadKind.value = 'Deployment'
+      selectedWorkloadName.value = 'podinfo'
+      selectedWorkloadNamespace.value = 'apps'
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      await fetchWorkloadsStatus()
+
+      expect(fetchWithMock).toHaveBeenCalledWith({
+        endpoint: '/api/v1/workloads?kind=Deployment&name=podinfo&namespace=apps',
+        mockPath: '../mock/workloads',
+        mockExport: 'getMockWorkloadsList'
+      })
+    })
+
+    it('should handle fetch errors', async () => {
+      fetchWithMock.mockRejectedValue(new Error('Network error'))
+
+      await fetchWorkloadsStatus()
+
+      expect(workloadsError.value).toBe('Network error')
+      expect(workloadsData.value).toEqual([])
+      expect(workloadsLoading.value).toBe(false)
+    })
+  })
+
+  describe('Component rendering', () => {
+    it('should fetch workloads on mount', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalled()
+      })
+    })
+
+    it('should display workload cards when data loads', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(screen.getByText('podinfo')).toBeInTheDocument()
+      })
+      expect(screen.getByText('node-exporter')).toBeInTheDocument()
+    })
+
+    it('should show empty state when no workloads match filters', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: [] })
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(screen.getByText('No workloads found for the selected filters')).toBeInTheDocument()
+      })
+    })
+
+    it('should show error state on fetch failure', async () => {
+      fetchWithMock.mockRejectedValue(new Error('Failed to connect'))
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(screen.getByText(/Failed to load workloads: Failed to connect/)).toBeInTheDocument()
+      })
+    })
+
+    it('should display workload count when loaded', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(screen.getByText('2 workloads')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Reconciler status', () => {
+    it('should render the parent reconciler ref as a "Managed by" line with a status dot', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(screen.getByText('podinfo')).toBeInTheDocument()
+      })
+
+      // Each card carries a muted "Managed by" label.
+      expect(screen.getAllByText('Managed by')).toHaveLength(2)
+
+      // Reconciler ref is shown as a single kind/namespace/name path.
+      expect(screen.getByText('Kustomization/flux-system/apps')).toBeInTheDocument()
+      expect(screen.getByText('HelmRelease/monitoring/metrics')).toBeInTheDocument()
+
+      // Reconciler status is conveyed via a colored dot + tooltip, never a message.
+      const readyLine = screen.getByText('Kustomization/flux-system/apps').closest('div')
+      expect(readyLine.querySelector('span.bg-green-500')).toBeInTheDocument()
+      expect(readyLine.getAttribute('title')).toContain('(Ready)')
+
+      const failedLine = screen.getByText('HelmRelease/monitoring/metrics').closest('div')
+      expect(failedLine.querySelector('span.bg-red-500')).toBeInTheDocument()
+      expect(failedLine.getAttribute('title')).toContain('(Failed)')
+    })
+
+    it('should link the workload name to the workload dashboard', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: [mockWorkloads[0]] })
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(screen.getByText('podinfo')).toBeInTheDocument()
+      })
+
+      const link = screen.getByText('podinfo').closest('a')
+      expect(link).toHaveAttribute('href', '/workload/Deployment/apps/podinfo')
+    })
+
+    it('should not render the workload reconciler message', async () => {
+      const withMessage = [{ ...mockWorkloads[0], reconcilerMessage: 'should not appear' }]
+      fetchWithMock.mockResolvedValue({ workloads: withMessage })
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(screen.getByText('podinfo')).toBeInTheDocument()
+      })
+
+      expect(screen.queryByText('should not appear')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('FilterForm wiring', () => {
+    it('should pass workload kinds and omit the status signal', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: [] })
+
+      render(<WorkloadList />)
+
+      expect(screen.getByTestId('has-status-signal')).toHaveTextContent('no')
+      expect(screen.getByTestId('kinds-prop')).toHaveTextContent('CronJob,DaemonSet,Deployment,StatefulSet')
+    })
+
+    it('should not render a StatusChart', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      const { container } = render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(screen.getByText('podinfo')).toBeInTheDocument()
+      })
+
+      // StatusChart renders a status timeline; none should be present
+      expect(container.querySelector('[data-testid="status-chart"]')).not.toBeInTheDocument()
+    })
+
+    it('should clear all filters when clear button clicked', async () => {
+      selectedWorkloadKind.value = 'Deployment'
+      selectedWorkloadName.value = 'test'
+      selectedWorkloadNamespace.value = 'apps'
+
+      render(<WorkloadList />)
+
+      fireEvent.click(screen.getByTestId('clear-filters'))
+
+      expect(selectedWorkloadKind.value).toBe('')
+      expect(selectedWorkloadName.value).toBe('')
+      expect(selectedWorkloadNamespace.value).toBe('')
+    })
+
+    it('should re-fetch when a filter changes', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: [] })
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalledTimes(1)
+      })
+
+      selectedWorkloadKind.value = 'StatefulSet'
+
+      await waitFor(() => {
+        expect(fetchWithMock).toHaveBeenCalledTimes(2)
+      })
+    })
+  })
+})

--- a/web/src/components/user/ProfilePage.jsx
+++ b/web/src/components/user/ProfilePage.jsx
@@ -11,7 +11,7 @@ import { DashboardPanel, TabButton } from '../dashboards/common/panel'
 import { KubernetesIcon, OpenIDIcon } from '../layout/Icons'
 import { favorites } from '../../utils/favorites'
 import { navHistory } from '../../utils/navHistory'
-import { logSettings } from '../../utils/logSettings'
+import { logSettings, FONT_SIZES } from '../../utils/logSettings'
 import Prism from 'prismjs'
 import 'prismjs/components/prism-json'
 
@@ -67,8 +67,9 @@ export function ProfilePage() {
 
   // One-line summary of the persisted log viewer settings.
   const logViewerSummary = useMemo(() => {
-    const { follow, formatted, tail } = logSettings.value
-    return `${follow ? 'Follow on' : 'Follow off'} · ${formatted ? 'Formatted' : 'Raw'} · ${tail} lines`
+    const { follow, formatted, tail, fontSize } = logSettings.value
+    const font = (FONT_SIZES.find(f => f.key === fontSize) || FONT_SIZES[1]).label
+    return `${follow ? 'Follow on' : 'Follow off'} · ${formatted ? 'Formatted' : 'Raw'} · ${tail} lines · ${font} font`
   }, [logSettings.value])
 
   return (

--- a/web/src/components/user/ProfilePage.jsx
+++ b/web/src/components/user/ProfilePage.jsx
@@ -67,9 +67,11 @@ export function ProfilePage() {
 
   // One-line summary of the persisted log viewer settings.
   const logViewerSummary = useMemo(() => {
-    const { follow, formatted, tail, fontSize } = logSettings.value
+    const { follow, formatted, tail, fontSize, fields } = logSettings.value
     const font = (FONT_SIZES.find(f => f.key === fontSize) || FONT_SIZES[1]).label
-    return `${follow ? 'Follow on' : 'Follow off'} · ${formatted ? 'Formatted' : 'Raw'} · ${tail} lines · ${font} font`
+    let s = `${follow ? 'Follow on' : 'Follow off'} · ${formatted ? 'Formatted' : 'Raw'} · ${tail} lines · ${font} font`
+    if (fields) s += ` · fields: ${fields}`
+    return s
   }, [logSettings.value])
 
   return (

--- a/web/src/components/user/ProfilePage.jsx
+++ b/web/src/components/user/ProfilePage.jsx
@@ -11,6 +11,7 @@ import { DashboardPanel, TabButton } from '../dashboards/common/panel'
 import { KubernetesIcon, OpenIDIcon } from '../layout/Icons'
 import { favorites } from '../../utils/favorites'
 import { navHistory } from '../../utils/navHistory'
+import { logSettings } from '../../utils/logSettings'
 import Prism from 'prismjs'
 import 'prismjs/components/prism-json'
 
@@ -54,14 +55,21 @@ export function ProfilePage() {
     try {
       const favoritesSize = (localStorage.getItem('favorites') || '').length * 2 // UTF-16
       const navHistorySize = (localStorage.getItem('nav-history') || '').length * 2
-      const totalBytes = favoritesSize + navHistorySize
+      const logSettingsSize = (localStorage.getItem('log-viewer') || '').length * 2
+      const totalBytes = favoritesSize + navHistorySize + logSettingsSize
       if (totalBytes < 1024) return `${totalBytes} B`
       if (totalBytes < 1024 * 1024) return `${(totalBytes / 1024).toFixed(1)} KB`
       return `${(totalBytes / (1024 * 1024)).toFixed(1)} MB`
     } catch {
       return '0 B'
     }
-  }, [favorites.value, navHistory.value])
+  }, [favorites.value, navHistory.value, logSettings.value])
+
+  // One-line summary of the persisted log viewer settings.
+  const logViewerSummary = useMemo(() => {
+    const { follow, formatted, tail } = logSettings.value
+    return `${follow ? 'Follow on' : 'Follow off'} · ${formatted ? 'Formatted' : 'Raw'} · ${tail} lines`
+  }, [logSettings.value])
 
   return (
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow w-full">
@@ -192,6 +200,10 @@ export function ProfilePage() {
               <span class="ml-1 text-gray-900 dark:text-white">
                 {navHistory.value.length} {navHistory.value.length === 1 ? 'item' : 'items'}
               </span>
+            </div>
+            <div class="text-sm">
+              <span class="text-gray-500 dark:text-gray-400">Log Viewer</span>
+              <span class="ml-1 text-gray-900 dark:text-white">{logViewerSummary}</span>
             </div>
             <div class="text-sm">
               <span class="text-gray-500 dark:text-gray-400">Storage Size</span>

--- a/web/src/components/user/ProfilePage.test.jsx
+++ b/web/src/components/user/ProfilePage.test.jsx
@@ -7,6 +7,7 @@ import { ProfilePage } from './ProfilePage'
 import { reportData } from '../../app'
 import { favorites } from '../../utils/favorites'
 import { navHistory } from '../../utils/navHistory'
+import { logSettings, DEFAULT_LOG_SETTINGS } from '../../utils/logSettings'
 
 // Mock the favorites module
 vi.mock('../../utils/favorites', async () => {
@@ -29,9 +30,10 @@ describe('ProfilePage', () => {
     // Reset mocks
     vi.clearAllMocks()
 
-    // Reset favorites and navHistory signals
+    // Reset favorites, navHistory and log viewer settings signals
     favorites.value = []
     navHistory.value = []
+    logSettings.value = { ...DEFAULT_LOG_SETTINGS }
 
     // Set mock user info in reportData
     reportData.value = {
@@ -326,6 +328,21 @@ describe('ProfilePage', () => {
       render(<ProfilePage />)
 
       expect(screen.getByText('Local Storage')).toBeInTheDocument()
+    })
+
+    it('should show the default log viewer settings on one line', () => {
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Log Viewer')).toBeInTheDocument()
+      expect(screen.getByText('Follow on · Formatted · 100 lines')).toBeInTheDocument()
+    })
+
+    it('should reflect non-default log viewer settings', () => {
+      logSettings.value = { follow: false, formatted: false, tail: 500 }
+
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Follow off · Raw · 500 lines')).toBeInTheDocument()
     })
 
     it('should show Favorites label', () => {

--- a/web/src/components/user/ProfilePage.test.jsx
+++ b/web/src/components/user/ProfilePage.test.jsx
@@ -334,15 +334,15 @@ describe('ProfilePage', () => {
       render(<ProfilePage />)
 
       expect(screen.getByText('Log Viewer')).toBeInTheDocument()
-      expect(screen.getByText('Follow on · Formatted · 100 lines')).toBeInTheDocument()
+      expect(screen.getByText('Follow on · Formatted · 100 lines · Medium font')).toBeInTheDocument()
     })
 
     it('should reflect non-default log viewer settings', () => {
-      logSettings.value = { follow: false, formatted: false, tail: 500 }
+      logSettings.value = { follow: false, formatted: false, tail: 500, fontSize: 'lg' }
 
       render(<ProfilePage />)
 
-      expect(screen.getByText('Follow off · Raw · 500 lines')).toBeInTheDocument()
+      expect(screen.getByText('Follow off · Raw · 500 lines · Large font')).toBeInTheDocument()
     })
 
     it('should show Favorites label', () => {

--- a/web/src/components/user/ProfilePage.test.jsx
+++ b/web/src/components/user/ProfilePage.test.jsx
@@ -338,11 +338,19 @@ describe('ProfilePage', () => {
     })
 
     it('should reflect non-default log viewer settings', () => {
-      logSettings.value = { follow: false, formatted: false, tail: 500, fontSize: 'lg' }
+      logSettings.value = { follow: false, formatted: false, tail: 500, fontSize: 'lg', fields: '' }
 
       render(<ProfilePage />)
 
       expect(screen.getByText('Follow off · Raw · 500 lines · Large font')).toBeInTheDocument()
+    })
+
+    it('should append the field filter to the summary when one is set', () => {
+      logSettings.value = { follow: true, formatted: true, tail: 100, fontSize: 'md', fields: 'msg|error' }
+
+      render(<ProfilePage />)
+
+      expect(screen.getByText('Follow on · Formatted · 100 lines · Medium font · fields: msg|error')).toBeInTheDocument()
     })
 
     it('should show Favorites label', () => {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -116,4 +116,19 @@
     }
   }
 
+  /* One-shot glow for the latest log line; color comes from --glow-color,
+     set per log level by the viewer. */
+  .log-glow {
+    animation: logGlowPulse 2.5s ease-out;
+  }
+
+  @keyframes logGlowPulse {
+    0% {
+      box-shadow: 0 0 7px 1px var(--glow-color);
+    }
+    100% {
+      box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+    }
+  }
+
 }

--- a/web/src/mock/resources.js
+++ b/web/src/mock/resources.js
@@ -4,6 +4,8 @@
 // Mock data for resources endpoint (GET /api/v1/resources)
 // Generated from real cluster API responses
 
+import { mockWorkloads } from './workloads'
+
 // Helper to match name with wildcard pattern
 // Supports * (matches any characters). If no wildcards, does exact match.
 const matchesWildcard = (name, pattern) => {
@@ -487,8 +489,14 @@ export const getMockSearchResults = (endpoint) => {
   return { resources: limitedResources }
 }
 
+// Kubernetes workload kinds that resolve to the workloads index for favorites.
+const favoriteWorkloadKinds = ['CronJob', 'DaemonSet', 'Deployment', 'StatefulSet']
+
 // Export function that returns resources matching the favorites list (POST /api/v1/favorites)
 // The body parameter is { favorites: [{kind, namespace, name}, ...] }
+// Flux favorites resolve from mockResources; workload favorites resolve from the
+// workloads index and carry a workload status (kstatus vocab) derived from the
+// parent reconciler status, mirroring the backend's user-client lookup.
 export const getMockFavorites = (body) => {
   const favorites = body?.favorites
   if (!favorites || !Array.isArray(favorites) || favorites.length === 0) {
@@ -498,6 +506,24 @@ export const getMockFavorites = (body) => {
   // Find matching resources for each favorite
   const matchedResources = []
   for (const fav of favorites) {
+    if (favoriteWorkloadKinds.includes(fav.kind)) {
+      const match = mockWorkloads.workloads.find(
+        w => w.kind === fav.kind && w.namespace === fav.namespace && w.name === fav.name
+      )
+      if (match) {
+        // Workload favorites expose their own live status (kstatus vocab).
+        matchedResources.push({
+          kind: match.kind,
+          namespace: match.namespace,
+          name: match.name,
+          status: match.reconcilerStatus === 'Failed' ? 'Failed' : 'Current',
+          message: 'Replicas: 1',
+          lastReconciled: match.lastReconciled
+        })
+      }
+      continue
+    }
+
     const match = mockResources.resources.find(
       r => r.kind === fav.kind && r.namespace === fav.namespace && r.name === fav.name
     )

--- a/web/src/mock/workload.js
+++ b/web/src/mock/workload.js
@@ -112,13 +112,53 @@ const mockWorkloads = {
         name: 'image-automation-controller-5c5fc5487b-w4458',
         status: 'Running',
         statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
-        createdAt: getTimestamp(5, 8, 45)
+        createdAt: getTimestamp(5, 8, 45),
+        podStatus: {
+          phase: 'Running',
+          containerStatuses: [
+            {
+              name: 'manager',
+              ready: true,
+              restartCount: 0,
+              imageID: 'ghcr.io/fluxcd/image-automation-controller:v1.0.4@sha256:f9383dccb80ec65e274648941af623ce74084d25026e14389111c14b630efece',
+              state: { running: { startedAt: getTimestamp(5, 8, 45) } }
+            }
+          ],
+          conditions: [
+            { type: 'Ready', status: 'True' },
+            { type: 'ContainersReady', status: 'True' },
+            { type: 'PodScheduled', status: 'True' }
+          ]
+        }
       },
       {
         name: 'image-automation-controller-dfcfc789b-9dtqk',
         status: 'Pending',
         statusMessage: 'Waiting: ImagePullBackOff',
-        createdAt: getTimestamp(0, 0, 5) // Recent pod with issue
+        createdAt: getTimestamp(0, 0, 5), // Recent pod with issue
+        podStatus: {
+          phase: 'Pending',
+          containerStatuses: [
+            {
+              name: 'manager',
+              ready: false,
+              restartCount: 3,
+              imageID: '',
+              state: {
+                waiting: {
+                  reason: 'ImagePullBackOff',
+                  message: 'Back-off pulling image "ghcr.io/fluxcd/image-automation-controller:v1.0.5"'
+                }
+              }
+            }
+          ],
+          conditions: [
+            { type: 'PodScheduled', status: 'True' },
+            { type: 'Initialized', status: 'True' },
+            { type: 'ContainersReady', status: 'False', reason: 'ContainersNotReady', message: 'containers with unready status: [manager]' },
+            { type: 'Ready', status: 'False', reason: 'ContainersNotReady', message: 'containers with unready status: [manager]' }
+          ]
+        }
       }
     ]
   },
@@ -355,9 +395,145 @@ const mockWorkloads = {
         name: 'cert-renewal-check-28945500-def34',
         status: 'Failed',
         statusMessage: 'Reason: Error',
-        createdAt: getTimestamp(0, 12, 0) // 12 hours ago
+        createdAt: getTimestamp(0, 12, 0), // 12 hours ago
+        podStatus: {
+          phase: 'Failed',
+          containerStatuses: [
+            {
+              name: 'cert-check',
+              ready: false,
+              restartCount: 3,
+              imageID: 'quay.io/jetstack/cert-manager-ctl:v1.19.1@sha256:abc123def456',
+              state: {
+                terminated: {
+                  reason: 'Error',
+                  exitCode: 1,
+                  startedAt: getTimestamp(0, 12, 0),
+                  finishedAt: getTimestamp(0, 11, 55)
+                }
+              }
+            }
+          ],
+          conditions: [
+            { type: 'PodScheduled', status: 'True' },
+            { type: 'Initialized', status: 'True' },
+            { type: 'ContainersReady', status: 'False', reason: 'PodFailed' },
+            { type: 'Ready', status: 'False', reason: 'PodFailed' }
+          ]
+        }
       }
     ]
+  }
+}
+
+// Mock reconciler data for workload detail view.
+// Maps "ReconcilerKind/Namespace/Name" to the enriched Flux resource.
+const mockReconcilers = {
+  'Kustomization/flux-system/flux-controllers': {
+    apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+    kind: 'Kustomization',
+    metadata: { name: 'flux-controllers', namespace: 'flux-system' },
+    spec: { interval: '10m', prune: true },
+    status: {
+      reconcilerRef: { status: 'Ready', message: 'Applied revision: main@sha1:9b9218f' },
+      sourceRef: {
+        kind: 'GitRepository',
+        name: 'flux-system',
+        namespace: 'flux-system',
+        status: 'Ready',
+        url: 'https://github.com/example/fleet-infra'
+      },
+      lastAttemptedRevision: 'main@sha1:9b9218f'
+    }
+  },
+  'HelmRelease/cert-manager/cert-manager': {
+    apiVersion: 'helm.toolkit.fluxcd.io/v2',
+    kind: 'HelmRelease',
+    metadata: { name: 'cert-manager', namespace: 'cert-manager' },
+    spec: { interval: '30m' },
+    status: {
+      reconcilerRef: { status: 'Ready', message: 'Helm install succeeded' },
+      sourceRef: {
+        kind: 'HelmRepository',
+        name: 'jetstack',
+        namespace: 'cert-manager',
+        status: 'Ready',
+        url: 'https://charts.jetstack.io'
+      },
+      lastAttemptedRevision: 'v1.19.1'
+    }
+  },
+  'Kustomization/flux-system/monitoring': {
+    apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+    kind: 'Kustomization',
+    metadata: { name: 'monitoring', namespace: 'flux-system' },
+    spec: { interval: '15m', prune: true },
+    status: {
+      reconcilerRef: { status: 'Ready', message: 'Applied revision: main@sha1:03bba48' },
+      sourceRef: {
+        kind: 'GitRepository',
+        name: 'flux-system',
+        namespace: 'flux-system',
+        status: 'Ready',
+        url: 'https://github.com/example/fleet-infra'
+      },
+      lastAttemptedRevision: 'main@sha1:03bba48'
+    }
+  }
+}
+
+// Maps workload keys to their parent reconciler keys
+const workloadReconcilerMap = {
+  'Deployment/flux-system/source-controller': 'Kustomization/flux-system/flux-controllers',
+  'Deployment/flux-system/kustomize-controller': 'Kustomization/flux-system/flux-controllers',
+  'Deployment/flux-system/helm-controller': 'Kustomization/flux-system/flux-controllers',
+  'Deployment/flux-system/notification-controller': 'Kustomization/flux-system/flux-controllers',
+  'Deployment/flux-system/image-automation-controller': 'Kustomization/flux-system/flux-controllers',
+  'Deployment/flux-system/image-reflector-controller': 'Kustomization/flux-system/flux-controllers',
+  'Deployment/flux-system/source-watcher': 'Kustomization/flux-system/flux-controllers',
+  'Deployment/flux-system/flux-operator': 'Kustomization/flux-system/flux-controllers',
+  'Deployment/cert-manager/cert-manager': 'HelmRelease/cert-manager/cert-manager',
+  'Deployment/cert-manager/cert-manager-cainjector': 'HelmRelease/cert-manager/cert-manager',
+  'Deployment/cert-manager/cert-manager-webhook': 'HelmRelease/cert-manager/cert-manager',
+  'Deployment/monitoring/metrics-server': 'Kustomization/flux-system/monitoring',
+  'Deployment/tailscale/operator': 'Kustomization/flux-system/monitoring',
+  'StatefulSet/registry/zot-registry': 'Kustomization/flux-system/monitoring',
+  'CronJob/flux-system/garbage-collection': 'Kustomization/flux-system/flux-controllers',
+  'CronJob/monitoring/prometheus-backup': 'Kustomization/flux-system/monitoring',
+  'CronJob/cert-manager/cert-renewal-check': 'HelmRelease/cert-manager/cert-manager'
+}
+
+/**
+ * Build a mock API response for the workload detail endpoint (GET /api/v1/workload).
+ * Wraps the flat workload data into the shape returned by the Go backend:
+ * the full Kubernetes resource with workloadInfo (status, pods, reconciler) injected.
+ * @param {object} workload - Flat workload data from mockWorkloads
+ * @param {object|undefined} reconciler - Optional reconciler mock data
+ * @returns {object} - Mock API response matching GetWorkloadDetails format
+ */
+function buildWorkloadDetailResponse(workload, reconciler) {
+  const apiVersion = workload.kind === 'CronJob' ? 'batch/v1' : 'apps/v1'
+
+  return {
+    apiVersion,
+    kind: workload.kind,
+    metadata: {
+      name: workload.name,
+      namespace: workload.namespace,
+      creationTimestamp: workload.createdAt
+    },
+    spec: {},
+    status: {},
+    workloadInfo: {
+      status: workload.status,
+      statusMessage: workload.statusMessage,
+      createdAt: workload.createdAt,
+      restartedAt: workload.restartedAt,
+      containerImages: workload.containerImages,
+      userActions: workload.userActions,
+      pods: workload.pods,
+      reconciler: reconciler || undefined
+    }
   }
 }
 
@@ -365,7 +541,7 @@ const mockWorkloads = {
  * Get mock workload by kind, name, and namespace
  * This function is called by fetchWithMock when in mock mode
  * @param {string} endpoint - The API endpoint with query parameters
- * @returns {object} - Mock workload data
+ * @returns {object} - Mock workload data matching GetWorkloadDetails response format
  */
 export function getMockWorkload(endpoint) {
   // Parse query parameters from endpoint
@@ -388,7 +564,10 @@ export function getMockWorkload(endpoint) {
     return {}
   }
 
-  return workload
+  const reconcilerKey = workloadReconcilerMap[key]
+  const reconciler = reconcilerKey ? mockReconcilers[reconcilerKey] : undefined
+
+  return buildWorkloadDetailResponse(workload, reconciler)
 }
 
 /**

--- a/web/src/mock/workload.js
+++ b/web/src/mock/workload.js
@@ -26,7 +26,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/source-controller:v1.7.4@sha256:16f21ac1795528df80ddef51ccbb14a57b78ea26e66dc8551636ef9a3cec71b3'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'source-controller-5f76f5c549-wz2gk',
@@ -46,7 +46,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/kustomize-controller:v1.7.3@sha256:e8ca82d66dafdd8ef77e0917f4adec53478075130ac61264dc0f91eb0f8cb6ce'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'kustomize-controller-5fc57fb9cc-bhl8q',
@@ -66,7 +66,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/helm-controller:v1.4.4@sha256:5eae73909e1471c0cd01bb23d87c9d4219a4f645134a23629c8708c72635398d'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'helm-controller-bf4685d7f-nxqsj',
@@ -85,7 +85,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/notification-controller:v1.7.5@sha256:ba723a55f7c7c7feedd50bb5db0ff2dd9a3b0ae85b50f61a0457184025b38c54'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'notification-controller-58cfb55954-fcf6l',
@@ -106,7 +106,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/image-automation-controller:v1.0.4@sha256:f9383dccb80ec65e274648941af623ce74084d25026e14389111c14b630efece'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'image-automation-controller-5c5fc5487b-w4458',
@@ -171,7 +171,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/image-reflector-controller:v1.0.4@sha256:0bdc30aea2b7cdfea02d0f6d53c06b9df0ea1c6516b85ed523792e222329c039'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'image-reflector-controller-547c8dbffc-2gjhj',
@@ -190,7 +190,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/source-watcher:v2.0.3@sha256:9cd46c3c958dcfcd8a3c857fa09989f9df5d8396eae165f219cbb472343371a9'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'source-watcher-85bcf4bd57-vfbs6',
@@ -209,7 +209,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/controlplaneio-fluxcd/flux-operator:v0.34.0'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'flux-operator-67cdfc557d-h656w',
@@ -230,7 +230,7 @@ const mockWorkloads = {
     containerImages: [
       'quay.io/jetstack/cert-manager-controller:v1.19.1'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'cert-manager-6b7bcdbb84-cclfj',
@@ -249,7 +249,7 @@ const mockWorkloads = {
     containerImages: [
       'quay.io/jetstack/cert-manager-cainjector:v1.19.1'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'cert-manager-cainjector-d74c65ddb-6v869',
@@ -268,7 +268,7 @@ const mockWorkloads = {
     containerImages: [
       'quay.io/jetstack/cert-manager-webhook:v1.19.1'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'cert-manager-webhook-6bf5dfc659-w95d9',
@@ -289,7 +289,7 @@ const mockWorkloads = {
     containerImages: [
       'registry.k8s.io/metrics-server/metrics-server:v0.8.0'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'metrics-server-57b56685f4-59gn2',
@@ -308,7 +308,7 @@ const mockWorkloads = {
     containerImages: [
       'tailscale/k8s-operator:v1.90.8'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'operator-84ddf77c66-gjsxz',
@@ -328,7 +328,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/project-zot/zot:v2.1.11'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'zot-registry-0',
@@ -350,7 +350,7 @@ const mockWorkloads = {
     containerImages: [
       'ghcr.io/fluxcd/flux-cli:v2.6.1'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'garbage-collection-28945678-xk9j2',
@@ -370,7 +370,7 @@ const mockWorkloads = {
     containerImages: [
       'prom/prometheus:v3.3.0'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'prometheus-backup-28945600-abc12',
@@ -389,7 +389,7 @@ const mockWorkloads = {
     containerImages: [
       'quay.io/jetstack/cert-manager-ctl:v1.19.1'
     ],
-    userActions: ['deletePods'],
+    userActions: ['deletePods', 'logs'],
     pods: [
       {
         name: 'cert-renewal-check-28945500-def34',
@@ -600,4 +600,40 @@ export function getMockWorkloads(body) {
   }
 
   return { workloads: results }
+}
+
+/**
+ * Get mock pod logs (GET /api/v1/workload/logs)
+ * This function is called by fetchWithMock when in mock mode
+ * @param {string} endpoint - The API endpoint with query parameters
+ * @returns {object} - Mock logs response matching WorkloadLogsResponse format
+ */
+export function getMockWorkloadLogs(endpoint) {
+  const queryString = endpoint.includes('?') ? endpoint.split('?')[1] : ''
+  const params = new URLSearchParams(queryString)
+  const name = params.get('name') || 'pod'
+  const container = params.get('container') || 'app'
+  const tailLines = Math.max(1, parseInt(params.get('tailLines'), 10) || 100)
+
+  // Generate up to tailLines entries, oldest first, each on its own line.
+  const messages = [
+    'no changes since last reconciliation: observed revision \'refs/heads/main@sha1:aa26680\'',
+    'artifact up-to-date with remote revision \'latest@sha256:fcf183b\'',
+    'reconciliation finished in 1.2s, next run in 1m0s',
+    'stored artifact for revision \'refs/heads/main@sha1:aa26680\'',
+    'serving metrics on :8080'
+  ]
+  const count = Math.min(tailLines, 200)
+  const lines = []
+  for (let i = count - 1; i >= 0; i--) {
+    const ts = getTimestamp(0, 0, i)
+    const msg = messages[i % messages.length]
+    lines.push(`${ts} {"level":"info","ts":"${ts}","msg":"${msg}","controller":"gitrepository","reconcileID":"id-${count - i}"}`)
+  }
+
+  return {
+    pod: name,
+    container,
+    logs: lines.join('\n') + '\n'
+  }
 }

--- a/web/src/mock/workload.js
+++ b/web/src/mock/workload.js
@@ -632,20 +632,21 @@ export function getMockWorkloadLogs(endpoint) {
   const container = params.get('container') || 'app'
   const tailLines = Math.max(1, parseInt(params.get('tailLines'), 10) || 100)
 
-  // Generate up to tailLines entries, oldest first, each on its own line.
+  // Generate up to tailLines entries, oldest first, each on its own line. The
+  // levels are varied so the viewer's per-level coloring and filter are visible.
   const messages = [
-    'no changes since last reconciliation: observed revision \'refs/heads/main@sha1:aa26680\'',
-    'artifact up-to-date with remote revision \'latest@sha256:fcf183b\'',
-    'reconciliation finished in 1.2s, next run in 1m0s',
-    'stored artifact for revision \'refs/heads/main@sha1:aa26680\'',
-    'serving metrics on :8080'
+    { level: 'info', msg: 'no changes since last reconciliation: observed revision \'refs/heads/main@sha1:aa26680\'' },
+    { level: 'debug', msg: 'artifact up-to-date with remote revision \'latest@sha256:fcf183b\'' },
+    { level: 'info', msg: 'reconciliation finished in 1.2s, next run in 1m0s' },
+    { level: 'warn', msg: 'slow reconciliation: took 4.7s, exceeding the 2s target' },
+    { level: 'error', msg: 'failed to fetch artifact: connection reset by peer' }
   ]
   const count = Math.min(tailLines, 200)
   const lines = []
   for (let i = count - 1; i >= 0; i--) {
     const ts = getTimestamp(0, 0, i)
-    const msg = messages[i % messages.length]
-    lines.push(`${ts} {"level":"info","ts":"${ts}","msg":"${msg}","controller":"gitrepository","reconcileID":"id-${count - i}"}`)
+    const { level, msg } = messages[i % messages.length]
+    lines.push(`${ts} {"level":"${level}","ts":"${ts}","msg":"${msg}","controller":"gitrepository","reconcileID":"id-${count - i}"}`)
   }
 
   return {

--- a/web/src/mock/workload.js
+++ b/web/src/mock/workload.js
@@ -631,9 +631,10 @@ export function getMockWorkloadLogs(endpoint) {
   const name = params.get('name') || 'pod'
   const container = params.get('container') || 'app'
   const tailLines = Math.max(1, parseInt(params.get('tailLines'), 10) || 100)
+  const sinceTime = params.get('sinceTime')
 
-  // Generate up to tailLines entries, oldest first, each on its own line. The
-  // levels are varied so the viewer's per-level coloring and filter are visible.
+  // The levels are varied so the viewer's per-level coloring and filter are
+  // visible, and so following appends a mix of levels.
   const messages = [
     { level: 'info', msg: 'no changes since last reconciliation: observed revision \'refs/heads/main@sha1:aa26680\'' },
     { level: 'debug', msg: 'artifact up-to-date with remote revision \'latest@sha256:fcf183b\'' },
@@ -641,12 +642,30 @@ export function getMockWorkloadLogs(endpoint) {
     { level: 'warn', msg: 'slow reconciliation: took 4.7s, exceeding the 2s target' },
     { level: 'error', msg: 'failed to fetch artifact: connection reset by peer' }
   ]
+  const entry = (ts, i) => {
+    const { level, msg } = messages[((i % messages.length) + messages.length) % messages.length]
+    return `${ts} {"level":"${level}","ts":"${ts}","msg":"${msg}","controller":"gitrepository","reconcileID":"id-${i}"}`
+  }
+
+  // Follow poll: emit a couple of fresh entries just after the last seen line so
+  // the viewer can demonstrate appending. Their timestamps advance past
+  // sinceTime, so each poll yields genuinely new lines.
+  const since = sinceTime ? new Date(sinceTime) : null
+  if (since && !Number.isNaN(since.getTime())) {
+    const lines = []
+    for (let i = 1; i <= 2; i++) {
+      const ts = new Date(since.getTime() + i * 1000).toISOString()
+      lines.push(entry(ts, since.getSeconds() + i))
+    }
+    return { pod: name, container, logs: lines.join('\n') + '\n' }
+  }
+
+  // Initial load: generate up to tailLines entries, oldest first.
   const count = Math.min(tailLines, 200)
   const lines = []
   for (let i = count - 1; i >= 0; i--) {
     const ts = getTimestamp(0, 0, i)
-    const { level, msg } = messages[i % messages.length]
-    lines.push(`${ts} {"level":"${level}","ts":"${ts}","msg":"${msg}","controller":"gitrepository","reconcileID":"id-${count - i}"}`)
+    lines.push(entry(ts, count - i))
   }
 
   return {

--- a/web/src/mock/workload.js
+++ b/web/src/mock/workload.js
@@ -132,6 +132,15 @@ const mockWorkloads = {
         createdAt: getTimestamp(5, 8, 45),
         podStatus: {
           phase: 'Running',
+          initContainerStatuses: [
+            {
+              name: 'setup',
+              ready: true,
+              restartCount: 0,
+              imageID: 'ghcr.io/fluxcd/flux-cli:v2.7.2@sha256:6e1c7c1a3a8f5b4d2e1f0a9c8b7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8',
+              state: { terminated: { reason: 'Completed', exitCode: 0, startedAt: getTimestamp(5, 8, 46), finishedAt: getTimestamp(5, 8, 45) } }
+            }
+          ],
           containerStatuses: [
             {
               name: 'manager',
@@ -629,13 +638,23 @@ export function getMockWorkloadLogs(endpoint) {
   const queryString = endpoint.includes('?') ? endpoint.split('?')[1] : ''
   const params = new URLSearchParams(queryString)
   const name = params.get('name') || 'pod'
-  // The container param may be repeated for the "All containers" view; the
-  // mock returns a single merged stream, so the joined names are only echoed
-  // back in the response for parity with the backend.
+  // The primary name plus repeated `pod` params form the "All pods" view; with
+  // more than one pod the lines are tagged with their origin, matching the
+  // backend wire format ("<pod> <ts> <msg>").
+  const pods = [...new Set([name, ...params.getAll('pod').filter(Boolean)])]
+  const tagged = pods.length > 1
+  // The container param may be repeated for the "All containers" view; the joined
+  // names are echoed back for parity with the backend.
   const containers = params.getAll('container')
   const container = containers.length > 0 ? containers.join(',') : 'app'
   const tailLines = Math.max(1, parseInt(params.get('tailLines'), 10) || 100)
   const sinceTime = params.get('sinceTime')
+  // Per-pod follow cursors ("<pod>=<rfc3339>") for the all-pods view.
+  const sinceByPod = {}
+  for (const v of params.getAll('since')) {
+    const idx = v.indexOf('=')
+    if (idx > 0) sinceByPod[v.slice(0, idx)] = v.slice(idx + 1)
+  }
 
   // The levels are varied so the viewer's per-level coloring and filter are
   // visible, and so following appends a mix of levels.
@@ -646,35 +665,69 @@ export function getMockWorkloadLogs(endpoint) {
     { level: 'warn', msg: 'slow reconciliation: took 4.7s, exceeding the 2s target' },
     { level: 'error', msg: 'failed to fetch artifact: connection reset by peer' }
   ]
-  const entry = (ts, i) => {
-    const { level, msg } = messages[((i % messages.length) + messages.length) % messages.length]
-    return `${ts} {"level":"${level}","ts":"${ts}","msg":"${msg}","controller":"gitrepository","reconcileID":"id-${i}"}`
-  }
-
-  // Follow poll: emit a couple of fresh entries just after the last seen line so
-  // the viewer can demonstrate appending. Their timestamps advance past
-  // sinceTime, so each poll yields genuinely new lines.
-  const since = sinceTime ? new Date(sinceTime) : null
-  if (since && !Number.isNaN(since.getTime())) {
-    const lines = []
-    for (let i = 1; i <= 2; i++) {
-      const ts = new Date(since.getTime() + i * 1000).toISOString()
-      lines.push(entry(ts, since.getSeconds() + i))
+  // A line, tagged with its pod in the all-pods view. Every fifth line is a
+  // multi-line panic whose stack-trace continuation is identical across pods,
+  // exercising the continuation-grouping and dedup paths.
+  const entry = (ts, i, pod) => {
+    const tag = tagged ? `${pod} ` : ''
+    if (i % 5 === 0) {
+      return `${tag}${ts} panic: runtime error: invalid memory address\ngoroutine 1 [running]:\nmain.reconcile(0x0)`
     }
-    return { pod: name, container, logs: lines.join('\n') + '\n' }
+    const { level, msg } = messages[((i % messages.length) + messages.length) % messages.length]
+    return `${tag}${ts} {"level":"${level}","ts":"${ts}","msg":"${msg}","controller":"gitrepository","reconcileID":"id-${i}"}`
   }
 
-  // Initial load: generate up to tailLines entries, oldest first.
+  const respond = (logs) => {
+    const resp = { pod: pods.join(','), container, logs }
+    if (tagged) {
+      resp.tagged = true
+      resp.total = pods.length
+      resp.streamed = pods.length
+      resp.partial = false
+    }
+    return resp
+  }
+
+  // Follow poll: emit a couple of fresh entries per pod just after that pod's last
+  // seen line, interleaved chronologically, so the viewer can demonstrate
+  // appending. In single-pod mode there is one global sinceTime cursor.
+  const followLines = []
+  if (tagged) {
+    for (const pod of pods) {
+      const cur = sinceByPod[pod]
+      const base = cur ? new Date(cur) : null
+      if (!base || Number.isNaN(base.getTime())) continue
+      for (let i = 1; i <= 2; i++) {
+        const ts = new Date(base.getTime() + i * 1000).toISOString()
+        followLines.push({ ts, line: entry(ts, base.getSeconds() + i, pod) })
+      }
+    }
+    if (followLines.length > 0) {
+      followLines.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0))
+      return respond(followLines.map(l => l.line).join('\n') + '\n')
+    }
+  } else {
+    const since = sinceTime ? new Date(sinceTime) : null
+    if (since && !Number.isNaN(since.getTime())) {
+      const lines = []
+      for (let i = 1; i <= 2; i++) {
+        const ts = new Date(since.getTime() + i * 1000).toISOString()
+        lines.push(entry(ts, since.getSeconds() + i, name))
+      }
+      return respond(lines.join('\n') + '\n')
+    }
+  }
+
+  // Initial load: generate up to tailLines entries per pod, interleaved oldest
+  // first so the all-pods view shows lines from every pod mixed by timestamp.
   const count = Math.min(tailLines, 200)
-  const lines = []
-  for (let i = count - 1; i >= 0; i--) {
-    const ts = getTimestamp(0, 0, i)
-    lines.push(entry(ts, count - i))
+  const all = []
+  for (const pod of pods) {
+    for (let i = count - 1; i >= 0; i--) {
+      const ts = getTimestamp(0, 0, i)
+      all.push({ ts, line: entry(ts, count - i, pod) })
+    }
   }
-
-  return {
-    pod: name,
-    container,
-    logs: lines.join('\n') + '\n'
-  }
+  all.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0))
+  return respond(all.map(l => l.line).join('\n') + '\n')
 }

--- a/web/src/mock/workload.js
+++ b/web/src/mock/workload.js
@@ -32,7 +32,24 @@ const mockWorkloads = {
         name: 'source-controller-5f76f5c549-wz2gk',
         status: 'Running',
         statusMessage: 'Started at 2026-01-26 09:45:00 UTC',
-        createdAt: getTimestamp(7, 2, 15) // 7 days, 2 hours, 15 minutes ago
+        createdAt: getTimestamp(7, 2, 15), // 7 days, 2 hours, 15 minutes ago
+        podStatus: {
+          phase: 'Running',
+          containerStatuses: [
+            {
+              name: 'manager',
+              ready: true,
+              restartCount: 0,
+              imageID: 'ghcr.io/fluxcd/source-controller:v1.7.4@sha256:16f21ac1795528df80ddef51ccbb14a57b78ea26e66dc8551636ef9a3cec71b3',
+              state: { running: { startedAt: getTimestamp(7, 2, 15) } }
+            }
+          ],
+          conditions: [
+            { type: 'Ready', status: 'True' },
+            { type: 'ContainersReady', status: 'True' },
+            { type: 'PodScheduled', status: 'True' }
+          ]
+        }
       }
     ]
   },

--- a/web/src/mock/workload.js
+++ b/web/src/mock/workload.js
@@ -629,7 +629,11 @@ export function getMockWorkloadLogs(endpoint) {
   const queryString = endpoint.includes('?') ? endpoint.split('?')[1] : ''
   const params = new URLSearchParams(queryString)
   const name = params.get('name') || 'pod'
-  const container = params.get('container') || 'app'
+  // The container param may be repeated for the "All containers" view; the
+  // mock returns a single merged stream, so the joined names are only echoed
+  // back in the response for parity with the backend.
+  const containers = params.getAll('container')
+  const container = containers.length > 0 ? containers.join(',') : 'app'
   const tailLines = Math.max(1, parseInt(params.get('tailLines'), 10) || 100)
   const sinceTime = params.get('sinceTime')
 

--- a/web/src/mock/workload.test.js
+++ b/web/src/mock/workload.test.js
@@ -9,28 +9,28 @@ describe('getMockWorkload', () => {
     const result = getMockWorkload('/api/v1/workload?kind=Deployment&name=source-controller&namespace=flux-system')
     expect(result).toBeDefined()
     expect(result.kind).toBe('Deployment')
-    expect(result.name).toBe('source-controller')
-    expect(result.namespace).toBe('flux-system')
-    expect(result.status).toBe('Current')
-    expect(result.pods).toBeDefined()
-    expect(result.pods.length).toBeGreaterThan(0)
+    expect(result.metadata.name).toBe('source-controller')
+    expect(result.metadata.namespace).toBe('flux-system')
+    expect(result.workloadInfo.status).toBe('Current')
+    expect(result.workloadInfo.pods).toBeDefined()
+    expect(result.workloadInfo.pods.length).toBeGreaterThan(0)
   })
 
   it('should return workload data for Deployment/flux-system/kustomize-controller', () => {
     const result = getMockWorkload('/api/v1/workload?kind=Deployment&name=kustomize-controller&namespace=flux-system')
     expect(result).toBeDefined()
     expect(result.kind).toBe('Deployment')
-    expect(result.name).toBe('kustomize-controller')
-    expect(result.namespace).toBe('flux-system')
+    expect(result.metadata.name).toBe('kustomize-controller')
+    expect(result.metadata.namespace).toBe('flux-system')
   })
 
   it('should return workload data for StatefulSet/registry/zot-registry', () => {
     const result = getMockWorkload('/api/v1/workload?kind=StatefulSet&name=zot-registry&namespace=registry')
     expect(result).toBeDefined()
     expect(result.kind).toBe('StatefulSet')
-    expect(result.name).toBe('zot-registry')
-    expect(result.namespace).toBe('registry')
-    expect(result.status).toBe('Current')
+    expect(result.metadata.name).toBe('zot-registry')
+    expect(result.metadata.namespace).toBe('registry')
+    expect(result.workloadInfo.status).toBe('Current')
   })
 
   it('should return empty object when kind parameter is missing', () => {
@@ -53,26 +53,35 @@ describe('getMockWorkload', () => {
     expect(result).toEqual({})
   })
 
-  it('should return containerImages array', () => {
+  it('should return containerImages array in workloadInfo', () => {
     const result = getMockWorkload('/api/v1/workload?kind=Deployment&name=source-controller&namespace=flux-system')
-    expect(result.containerImages).toBeDefined()
-    expect(Array.isArray(result.containerImages)).toBe(true)
-    expect(result.containerImages.length).toBeGreaterThan(0)
+    expect(result.workloadInfo.containerImages).toBeDefined()
+    expect(Array.isArray(result.workloadInfo.containerImages)).toBe(true)
+    expect(result.workloadInfo.containerImages.length).toBeGreaterThan(0)
   })
 
-  it('should return pods array with pod status', () => {
+  it('should return pods array with pod status in workloadInfo', () => {
     const result = getMockWorkload('/api/v1/workload?kind=Deployment&name=source-controller&namespace=flux-system')
-    expect(result.pods).toBeDefined()
-    expect(Array.isArray(result.pods)).toBe(true)
-    expect(result.pods[0]).toHaveProperty('name')
-    expect(result.pods[0]).toHaveProperty('status')
-    expect(result.pods[0]).toHaveProperty('statusMessage')
+    expect(result.workloadInfo.pods).toBeDefined()
+    expect(Array.isArray(result.workloadInfo.pods)).toBe(true)
+    expect(result.workloadInfo.pods[0]).toHaveProperty('name')
+    expect(result.workloadInfo.pods[0]).toHaveProperty('status')
+    expect(result.workloadInfo.pods[0]).toHaveProperty('statusMessage')
   })
 
-  it('should return statusMessage for workload', () => {
+  it('should return statusMessage in workloadInfo', () => {
     const result = getMockWorkload('/api/v1/workload?kind=Deployment&name=source-controller&namespace=flux-system')
-    expect(result.statusMessage).toBeDefined()
-    expect(typeof result.statusMessage).toBe('string')
-    expect(result.statusMessage.length).toBeGreaterThan(0)
+    expect(result.workloadInfo.statusMessage).toBeDefined()
+    expect(typeof result.workloadInfo.statusMessage).toBe('string')
+    expect(result.workloadInfo.statusMessage.length).toBeGreaterThan(0)
+  })
+
+  it('should include reconciler data in workloadInfo', () => {
+    const result = getMockWorkload('/api/v1/workload?kind=Deployment&name=source-controller&namespace=flux-system')
+    expect(result.workloadInfo.reconciler).toBeDefined()
+    expect(result.workloadInfo.reconciler.kind).toBe('Kustomization')
+    expect(result.workloadInfo.reconciler.metadata.name).toBe('flux-controllers')
+    expect(result.workloadInfo.reconciler.status.sourceRef).toBeDefined()
+    expect(result.workloadInfo.reconciler.status.reconcilerRef.status).toBe('Ready')
   })
 })

--- a/web/src/mock/workloads.js
+++ b/web/src/mock/workloads.js
@@ -1,0 +1,164 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Mock data for the workloads index endpoints:
+// - GET /api/v1/workloads        (list, getMockWorkloadsList)
+// - GET /api/v1/workloads/search (quick search, getMockWorkloadsSearch)
+//
+// Each entry mirrors the backend WorkloadRef shape. The list/search endpoints
+// carry the parent reconciler reference and its status (badge only), never the
+// reconciler message. Workloads have no status of their own in the index.
+
+// Helper to match name with wildcard pattern.
+// Supports * (matches any characters). If no wildcards, does exact match.
+const matchesWildcard = (name, pattern) => {
+  name = name.toLowerCase()
+  pattern = pattern.toLowerCase()
+
+  // If no wildcards, do exact match
+  if (!pattern.includes('*')) {
+    return name === pattern
+  }
+
+  // Convert wildcard pattern to regex (escape regex specials except *)
+  const regexPattern = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+
+  const regex = new RegExp(`^${regexPattern}$`, 'i')
+  return regex.test(name)
+}
+
+// Generate timestamps relative to now (same pattern as resources.js)
+const now = new Date()
+const getTimestamp = (minutesAgo) => {
+  const time = new Date(now.getTime() - minutesAgo * 60000)
+  return time.toISOString()
+}
+
+export const mockWorkloads = {
+  workloads: [
+    {
+      kind: 'Deployment',
+      name: 'podinfo',
+      namespace: 'apps',
+      apiVersion: 'apps/v1',
+      reconcilerKind: 'Kustomization',
+      reconcilerNamespace: 'flux-system',
+      reconcilerName: 'apps',
+      reconcilerStatus: 'Ready',
+      lastReconciled: getTimestamp(0)
+    },
+    {
+      kind: 'Deployment',
+      name: 'source-controller',
+      namespace: 'flux-system',
+      apiVersion: 'apps/v1',
+      reconcilerKind: 'FluxInstance',
+      reconcilerNamespace: 'flux-system',
+      reconcilerName: 'flux',
+      reconcilerStatus: 'Ready',
+      lastReconciled: getTimestamp(1)
+    },
+    {
+      kind: 'Deployment',
+      name: 'kustomize-controller',
+      namespace: 'flux-system',
+      apiVersion: 'apps/v1',
+      reconcilerKind: 'FluxInstance',
+      reconcilerNamespace: 'flux-system',
+      reconcilerName: 'flux',
+      reconcilerStatus: 'Ready',
+      lastReconciled: getTimestamp(1)
+    },
+    {
+      kind: 'StatefulSet',
+      name: 'redis',
+      namespace: 'apps',
+      apiVersion: 'apps/v1',
+      reconcilerKind: 'HelmRelease',
+      reconcilerNamespace: 'apps',
+      reconcilerName: 'redis',
+      reconcilerStatus: 'Ready',
+      lastReconciled: getTimestamp(5)
+    },
+    {
+      kind: 'DaemonSet',
+      name: 'node-exporter',
+      namespace: 'monitoring',
+      apiVersion: 'apps/v1',
+      reconcilerKind: 'Kustomization',
+      reconcilerNamespace: 'flux-system',
+      reconcilerName: 'monitoring',
+      reconcilerStatus: 'Failed',
+      lastReconciled: getTimestamp(8)
+    },
+    {
+      kind: 'CronJob',
+      name: 'backup',
+      namespace: 'apps',
+      apiVersion: 'batch/v1',
+      reconcilerKind: 'ResourceSet',
+      reconcilerNamespace: 'flux-system',
+      reconcilerName: 'apps-jobs',
+      reconcilerStatus: 'Ready',
+      lastReconciled: getTimestamp(12)
+    }
+  ]
+}
+
+// Filter workloads based on query parameters (kind, name wildcard, namespace).
+const filterWorkloads = (params, { wildcard }) => {
+  const kindFilter = params.get('kind')
+  const nameFilter = params.get('name')
+  const namespaceFilter = params.get('namespace')
+
+  return mockWorkloads.workloads.filter(workload => {
+    if (kindFilter && workload.kind !== kindFilter) {
+      return false
+    }
+    if (namespaceFilter && workload.namespace !== namespaceFilter) {
+      return false
+    }
+    if (nameFilter) {
+      if (wildcard) {
+        // Quick-search wraps the term, matching by contains (** matches all)
+        const term = nameFilter.toLowerCase()
+        if (term !== '**' && !workload.name.toLowerCase().includes(term)) {
+          return false
+        }
+      } else if (!matchesWildcard(workload.name, nameFilter)) {
+        return false
+      }
+    }
+    return true
+  })
+}
+
+// GET /api/v1/workloads - full list with optional filters.
+export const getMockWorkloadsList = (endpoint) => {
+  // eslint-disable-next-line no-undef
+  const url = new URL(endpoint, 'http://localhost')
+  const params = url.searchParams
+
+  if (!params.get('kind') && !params.get('name') && !params.get('namespace')) {
+    return mockWorkloads
+  }
+
+  return { workloads: filterWorkloads(params, { wildcard: false }) }
+}
+
+// GET /api/v1/workloads/search - quick-search variant (contains match, limited results).
+export const getMockWorkloadsSearch = (endpoint) => {
+  // eslint-disable-next-line no-undef
+  const url = new URL(endpoint, 'http://localhost')
+  const params = url.searchParams
+
+  // No name filter → empty results (mirrors search endpoint behavior)
+  if (!params.get('name')) {
+    return { workloads: [] }
+  }
+
+  const filtered = filterWorkloads(params, { wildcard: true })
+  return { workloads: filtered.slice(0, 10) }
+}

--- a/web/src/utils/constants.js
+++ b/web/src/utils/constants.js
@@ -175,6 +175,10 @@ export const workloadKinds = [
   'StatefulSet'
 ]
 
+// Combined list of Flux kinds and Kubernetes workload kinds, used for
+// dual-source search suggestions (resources + workloads).
+export const searchKinds = [...fluxKinds, ...workloadKinds]
+
 // Kubernetes workload API groups
 const workloadAPIGroups = ['apps/', 'batch/']
 

--- a/web/src/utils/download.js
+++ b/web/src/utils/download.js
@@ -1,0 +1,21 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+/**
+ * downloadBlob triggers a browser download of the given Blob under the given
+ * filename, using a temporary object URL that is revoked once the download
+ * has been initiated.
+ *
+ * @param {Blob} blob - The file contents to download.
+ * @param {string} filename - The name to save the file as.
+ */
+export function downloadBlob(blob, filename) {
+  const url = window.URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  window.URL.revokeObjectURL(url)
+}

--- a/web/src/utils/download.test.js
+++ b/web/src/utils/download.test.js
@@ -1,0 +1,32 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { downloadBlob } from './download'
+
+describe('downloadBlob', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('creates an object URL, clicks an anchor with the filename and revokes the URL', () => {
+    window.URL.createObjectURL = vi.fn(() => 'blob:mock')
+    window.URL.revokeObjectURL = vi.fn()
+
+    let downloadName
+    let href
+    const clickSpy = vi.spyOn(window.HTMLAnchorElement.prototype, 'click').mockImplementation(function () {
+      downloadName = this.download
+      href = this.href
+    })
+
+    const blob = new window.Blob(['hello'], { type: 'text/plain' })
+    downloadBlob(blob, 'out.log')
+
+    expect(window.URL.createObjectURL).toHaveBeenCalledWith(blob)
+    expect(clickSpy).toHaveBeenCalled()
+    expect(downloadName).toBe('out.log')
+    expect(href).toContain('blob:mock')
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+  })
+})

--- a/web/src/utils/favorites.js
+++ b/web/src/utils/favorites.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { signal, effect } from '@preact/signals'
+import { writeLocalStorage } from './storage'
 
 // LocalStorage key for favorites
 const STORAGE_KEY = 'favorites'
@@ -36,7 +37,7 @@ export const favorites = signal(getFavoritesFromStorage())
 
 // Sync favorites to localStorage whenever they change
 effect(() => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites.value))
+  writeLocalStorage(STORAGE_KEY, JSON.stringify(favorites.value))
 })
 
 /**

--- a/web/src/utils/logFormat.js
+++ b/web/src/utils/logFormat.js
@@ -2,29 +2,37 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 // Pretty-printing for the workload log viewer's Formatted mode beyond JSON: the
-// three most common Go non-JSON loggers seen in Kubernetes workloads — klog/glog,
-// logfmt (logrus text, go-kit/log, Go slog TextHandler), and zap's console
-// encoder. `decorateLine` runs a cheap cascade and returns a serializable
-// descriptor (never a VNode), which the viewer caches per raw line and renders.
+// common non-JSON loggers seen in Kubernetes workloads. Go: klog/glog, logfmt
+// (logrus text, go-kit/log, Go slog TextHandler), and zap's console encoder. Java:
+// the Spring Boot, Log4j2 and Logback default console layouts. .NET: the Serilog
+// Console sink and NLog default layouts (log4net's log4j-style layout reuses the
+// Java Log4j2 matcher). Scripting: Python (a common `logging` format, gunicorn,
+// uvicorn), Ruby `Logger`, and PHP Monolog. `decorateLine` runs a cheap cascade and
+// returns a serializable descriptor (never a VNode), which the viewer caches.
 //
-// The JSON step of the cascade lives in the viewer (it owns the Prism highlight
-// and the formatJson helper); this module covers klog → zap → logfmt → plain. A
-// structured entry reflows onto multiple visual lines (a bare message line, then
-// one `key: value` field per line); an unstructured line is highlighted in place.
+// The JSON step of the cascade is `highlightJson` (below): it pretty-prints a JSON
+// object/array into colored spans, preserving nesting, and also covers the
+// JSON-encoded Java loggers (logstash-logback-encoder, Log4j2 ECS layout) and .NET
+// ones (Serilog CLEF, the MEL JSON console). `decorateLine` covers the rest:
+// klog → zap → java → dotnet → python → ruby → monolog → logfmt → plain. A structured
+// entry reflows onto multiple visual lines (a bare message line, then one
+// `key: value` field per line); an unstructured line is highlighted in place.
 //
 // Safety: descriptors are plain data and the viewer maps spans to auto-escaped
 // Preact text nodes, so there is no innerHTML path here.
 
-// Span classes. Field key/value/separator reuse Prism's global JSON token classes
-// (loaded by usePrismTheme), so they are pixel-identical to the JSON view and
-// inherit the active light/dark theme. The scaffolding kinds (caller, muted ts /
-// thread / logger, message) carry their own Tailwind utility classes. Each Prism
-// span must include the base `token` class for the global rule to apply.
+import { fromString } from './logLevel'
+
+// Span classes. Field keys and the `:` separator are a muted gray so they recede;
+// values inherit the container's default body color (CLS.val is empty), reading as
+// the high-contrast foreground — near-black on light, near-white on dark. Green is
+// deliberately avoided for values since it is the app's status-ready color. The
+// scaffolding kinds (caller, muted ts / thread / logger, message) carry their own
+// Tailwind utility classes.
 const CLS = {
-  key: 'token property',
-  str: 'token string',
-  num: 'token number',
-  op: 'token operator',
+  key: 'text-gray-500 dark:text-gray-400',
+  val: '', // empty: values inherit the container's default body color
+  op: 'text-gray-400 dark:text-gray-500',
   caller: 'font-semibold text-violet-600 dark:text-violet-300',
   muted: 'text-gray-400 dark:text-gray-500',
   msg: '' // empty: inherits the container's default body color
@@ -165,20 +173,21 @@ function fieldRows(fields) {
     sp(CLS.key, f.key),
     sp(CLS.op, ':'),
     sp(CLS.msg, ' '),
-    sp(f.kind === 'num' ? CLS.num : CLS.str, f.val)
+    sp(CLS.val, f.val)
   ])
 }
 
-// klog header: severity char + MMDD + time + thread + caller. The whitespace runs
-// are captured so the header line is rebuilt verbatim.
-const KLOG_HEADER = /^([IWEF])(\d{4}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)(\s+)(\d+)\s(\S+?:\d+)\]\s?/
+// klog header: severity char + MMDD + time + thread + caller. klog space-pads the
+// goroutine/PID to a fixed width (e.g. PID `1` becomes `      1`); that run is
+// collapsed to a single space since the formatted view has no columns to align.
+const KLOG_HEADER = /^([IWEF])(\d{4}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)\s+(\d+)\s(\S+?:\d+)\]\s?/
 
 /**
  * parseKlog - decorates a klog/glog line. Classic lines (`Immdd … file:line] msg`)
  * highlight in place as a single `spans` row; structured `klog.InfoS/ErrorS` lines
  * (`… ] "msg" key="val"`) reflow to a `block` only when the body is a quoted
- * message followed by at least one valid field. Returns null when the header does
- * not match.
+ * message followed by at least one valid field — the message stays on the header
+ * row and the fields stack beneath it. Returns null when the header does not match.
  *
  * @param {string} text - The log line (timestamp and ANSI already stripped)
  * @param {string} level - The normalized level, for the severity-char tint
@@ -187,10 +196,10 @@ const KLOG_HEADER = /^([IWEF])(\d{4}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)(\s+)(\d+)\s(
 export function parseKlog(text, level) {
   const m = KLOG_HEADER.exec(text)
   if (!m) return null
-  const [, sev, mmdd, time, gap, thread, caller] = m
+  const [, sev, mmdd, time, thread, caller] = m
   const header = [
     sp(SEV_CLS[level] || CLS.muted, sev),
-    sp(CLS.muted, `${mmdd} ${time}${gap}${thread} `),
+    sp(CLS.muted, `${mmdd} ${time} ${thread} `),
     sp(CLS.caller, caller),
     sp(CLS.muted, ']')
   ]
@@ -207,7 +216,7 @@ export function parseKlog(text, level) {
     if (pre === '' && fields.length > 0) {
       return {
         kind: 'block',
-        rows: [header, [sp(CLS.msg, q.val)], ...fieldRows(fields)]
+        rows: [[...header, sp(CLS.msg, ` ${q.val}`)], ...fieldRows(fields)]
       }
     }
   }
@@ -274,14 +283,12 @@ function zapIsBlob(p) {
   }
 }
 
-// zapField renders one expanded blob entry as a `key: value` row, typing the
-// value by its JSON type (objects/arrays as compact JSON). Control characters in
-// a scalar value (a `stacktrace`/`error` field's newlines and tabs) are escaped
-// so the field stays on one line.
+// zapField renders one expanded blob entry as a `key: value` row, compacting
+// objects/arrays to JSON. Control characters in a scalar value (a `stacktrace`/
+// `error` field's newlines and tabs) are escaped so the field stays on one line.
 function zapField(key, val) {
-  const kind = typeof val === 'number' ? 'num' : 'str'
   const text = val !== null && typeof val === 'object' ? JSON.stringify(val) : oneLine(String(val))
-  return [sp(CLS.key, key), sp(CLS.op, ':'), sp(CLS.msg, ' '), sp(kind === 'num' ? CLS.num : CLS.str, text)]
+  return [sp(CLS.key, key), sp(CLS.op, ':'), sp(CLS.msg, ' '), sp(CLS.val, text)]
 }
 
 /**
@@ -353,12 +360,341 @@ export function parseZap(text) {
   return { kind: 'block', rows }
 }
 
+// Java-family console patterns (Spring Boot / Log4j2 / Logback). After the kubelet
+// timestamp is stripped the line still leads with the app's own date/time, so both
+// shapes begin with a digit. The JSON-encoded Java loggers (logstash-logback-encoder,
+// Log4j2 ECS layout) are handled by the viewer's JSON path, not here.
+//
+// SPRING: <ts> LEVEL [PID] --- [brackets…] [logger] : msg. The PID is optional
+// (Spring's default `${PID:- }` is blank when undiscoverable) and the logger is
+// optional (the root logger renders empty). The bracket run requires `\]\s+`, so a
+// logger that itself contains brackets (Tomcat's `o.a.c.c.C.[Tomcat].[localhost].[/]`)
+// is captured whole by \S+ instead of being torn into the run.
+const SPRING = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}[.,]\d{3}(?:Z|[+-]\d{2}:?\d{2})?\s+(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\s+(?:\d+\s+)?---\s+((?:\[[^\]]*\]\s+)+)(?:(\S+)\s+)?:\s(.*)$/
+// LOG4J2: <time|datetime> [thread] LEVEL [logger] - msg. Thread precedes the level
+// and the separator is ` - ` (no PID, no `---`); logger optional (root logger empty).
+const LOG4J2 = /^(?:\d{2}:\d{2}:\d{2}[.,]\d{3}|\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}[.,]\d{3}(?:Z|[+-]\d{2}:?\d{2})?)\s+(\[[^\]]+\])\s+(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\s+(?:(\S+)\s+)?-\s+(.*)$/
+
+// levelSpan tints a parsed level token by its normalized level, falling back to
+// muted for an unrecognized token. Uses logLevel's fromString so a level word maps
+// the same way here (the in-body tint) as in the pill — one source of truth — while
+// still being driven by the word literally parsed from the line.
+function levelSpan(word) {
+  return sp(SEV_CLS[fromString(word)] || CLS.muted, word)
+}
+
+// trimBrackets normalizes a captured bracket run (`[demo] [           main] `) to a
+// compact muted form (`[demo] [main]`): each `[…]` content is trimmed and empty
+// brackets are dropped. Returns '' when nothing remains.
+function trimBrackets(run) {
+  const out = []
+  const re = /\[([^\]]*)\]/g
+  let m
+  while ((m = re.exec(run)) !== null) {
+    const inner = m[1].trim()
+    if (inner) out.push(`[${inner}]`)
+  }
+  return out.join(' ')
+}
+
+// decoratedRow assembles the rendered row from the ordered muted parts, the accented
+// logger, and the default message, joined by two spaces and skipping empties — the
+// same shape as parseZap's message line.
+function decoratedRow(muted, logger, msg) {
+  const spans = []
+  const push = (sp) => { if (spans.length) spans.push({ cls: CLS.msg, text: '  ' }); spans.push(sp) }
+  for (const m of muted) if (m && m.text) push(m)
+  if (logger) push(sp(CLS.caller, logger))
+  if (msg) push(sp(CLS.msg, oneLine(msg)))
+  return spans.length ? { kind: 'spans', spans } : null
+}
+
+/**
+ * parseJava - decorates a Java-family console line (Spring Boot, Log4j2, Logback).
+ * Drops the app's own timestamp (redundant with the pill), the PID and the
+ * `---`/`:` scaffolding, but keeps the level word (tinted by the parsed word, so
+ * the in-body level is authoritative even when the pill's heuristic misfires), the
+ * thread bracket(s) and the logger. Renders a single `spans` row in each format's
+ * natural field order. Returns null when the line is not a recognized Java shape.
+ *
+ * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @returns {object|null} A `spans` descriptor or null
+ */
+export function parseJava(text) {
+  // Gate: Java console layouts are space-delimited, so reject any tab (this also
+  // keeps a non-zap tab-separated line out of the \s+-tolerant regexes below); both
+  // shapes lead with the app date/time, so require a leading digit (which also
+  // routes stack frames and exception headers to plain).
+  if (text.indexOf('\t') !== -1) return null
+  const c = text.charCodeAt(0)
+  if (c < 48 || c > 57) return null
+
+  // Spring first, then Log4j2 — mutually exclusive (Spring needs `---`; Log4j2 needs
+  // a [thread] where Spring has the level), so the order is for clarity only.
+  const s = SPRING.exec(text)
+  if (s) {
+    const [, level, brackets, logger, msg] = s
+    const br = trimBrackets(brackets)
+    return decoratedRow([levelSpan(level), br ? sp(CLS.muted, br) : null], logger || '', msg)
+  }
+  const l = LOG4J2.exec(text)
+  if (l) {
+    const [, thread, level, logger, msg] = l
+    const br = trimBrackets(thread)
+    return decoratedRow([br ? sp(CLS.muted, br) : null, levelSpan(level)], logger || '', msg)
+  }
+  return null
+}
+
+// .NET-family console patterns. Two text loggers are covered here; the JSON ones
+// (Serilog CLEF, the MEL JSON console formatter) go through the viewer's JSON path,
+// and log4net's log4j-style PatternLayout is already matched by parseJava's LOG4J2
+// branch. Microsoft.Extensions.Logging's Simple console is intentionally NOT here:
+// its default output is two physical lines (a `level: Category[id]` header then the
+// message on the next, indented line), so it belongs to the future stack-trace
+// grouping phase, when the header and message can be joined.
+//
+// SERILOG: the Console sink default template `[{Timestamp:HH:mm:ss} {Level:u3}]
+// {Message:lj}`. The real default has no date and no fractional seconds; the
+// optional date/fractional/zone tolerate common ISO custom timestamps. The u3 code
+// is a fixed 3-char token and there is no logger in the default template.
+const SERILOG = /^\[(?:\d{4}-\d{2}-\d{2}[ T])?\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})? (VRB|DBG|INF|WRN|ERR|FTL)\] (.*)$/
+// NLOG: the default `TargetWithLayout` layout
+// `${longdate}|${level:uppercase=true}|${logger}|${message:withexception=true}`.
+// Pipe-delimited; the logger field may be empty. With an exception the 4th field
+// carries it on this physical line (continuations go plain).
+const NLOG = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[.,]\d+\|(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\|([^|]*)\|(.*)$/
+
+/**
+ * parseDotnet - decorates a .NET-family console line (Serilog Console sink, NLog
+ * default layout). Drops the app's own timestamp (redundant with the pill) but
+ * keeps the level token (tinted by the parsed token), the NLog logger, and the
+ * message. Renders a single `spans` row. Returns null when the line is not a
+ * recognized .NET shape.
+ *
+ * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @returns {object|null} A `spans` descriptor or null
+ */
+export function parseDotnet(text) {
+  // Serilog leads with `[`; NLog leads with a longdate and is pipe-delimited. The
+  // two shapes are disjoint by first token, so dispatch cheaply.
+  if (text[0] === '[') {
+    const s = SERILOG.exec(text)
+    if (s) {
+      const [, code, msg] = s
+      return decoratedRow([levelSpan(code)], '', msg)
+    }
+    return null
+  }
+  if (text.indexOf('|') !== -1) {
+    const n = NLOG.exec(text)
+    if (n) {
+      const [, level, logger, msg] = n
+      return decoratedRow([levelSpan(level)], logger || '', msg)
+    }
+  }
+  return null
+}
+
+// Scripting-language console patterns.
+//
+// Python logging, a common custom `format='%(asctime)s - %(name)s - %(levelname)s -
+// %(message)s'` (asctime default millis is a comma). Not the stdlib default (which is
+// the deferred `LEVEL:name:msg`), but the most common configured shape.
+const PY_BASIC = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:[.,]\d+)? - (\S+) - (DEBUG|INFO|WARNING|ERROR|CRITICAL) - (.*)$/
+// gunicorn glogging default `[%(asctime)s] [%(process)d] [%(levelname)s] %(message)s`
+// (the datefmt brackets the date, with a ` %z` zone inside).
+const GUNICORN = /^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[^\]]*\] \[(\d+)\] \[(DEBUG|INFO|WARNING|ERROR|CRITICAL)\] (.*)$/
+// uvicorn `%(levelprefix)s %(message)s`, where levelprefix is `LEVEL:` right-padded
+// so the message starts at a fixed column: spaces-after-colon = 9 - len(level)
+// (CRITICAL gets just one, TRACE four). The exact-width check (level.length + spaces
+// === 9) both admits those and rejects prose like `INFO: hi`. TRACE is uvicorn's
+// extra `--log-level trace` level.
+const UVICORN = /^(TRACE|DEBUG|INFO|WARNING|ERROR|CRITICAL):( +)(.*)$/
+
+/**
+ * parsePython - decorates a Python-ecosystem console line: the common timestamped
+ * `logging` format, gunicorn, and uvicorn. Keeps the level word (tinted), accents
+ * the logger name (when the format carries one), drops the app timestamp. Returns
+ * null when the line is not a recognized Python shape.
+ *
+ * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @returns {object|null} A `spans` descriptor or null
+ */
+export function parsePython(text) {
+  // gunicorn leads with `[`; the timestamped logging format leads with a digit;
+  // uvicorn leads with an uppercase level word.
+  if (text[0] === '[') {
+    const g = GUNICORN.exec(text)
+    if (g) {
+      const [, pid, level, msg] = g
+      return decoratedRow([sp(CLS.muted, `[${pid}]`), levelSpan(level)], '', msg)
+    }
+    return null
+  }
+  const c = text.charCodeAt(0)
+  if (c >= 48 && c <= 57) {
+    const b = PY_BASIC.exec(text)
+    if (b) {
+      const [, name, level, msg] = b
+      return decoratedRow([levelSpan(level)], name, msg)
+    }
+    return null
+  }
+  const u = UVICORN.exec(text)
+  if (u && u[1].length + u[2].length === 9) {
+    const [, level, , msg] = u
+    return decoratedRow([levelSpan(level)], '', msg)
+  }
+  return null
+}
+
+// Ruby Logger default `%.1s, [%s #%d] %5s -- %s: %s` (severityID, datetime, pid,
+// label, progname, message). Labels DEBUG/INFO/WARN/ERROR/FATAL/ANY (ANY = UNKNOWN,
+// an unknown severity). `\s+` before `#` tolerates the stdlib's trailing-space
+// datetime (which yields two spaces); progname is commonly empty.
+const RUBY = /^[DIWEFA], \[\d{4}-\d{2}-\d{2}T[\d:.]+\s+#\d+\]\s+(DEBUG|INFO|WARN|ERROR|FATAL|ANY)\s+-- ([^:]*): (.*)$/
+
+/**
+ * parseRuby - decorates a Ruby `Logger` default-format line. Keeps the level word
+ * (tinted; ANY → fatal), accents the progname (when present), drops the severity
+ * char, datetime and pid. Returns null when the line is not the Ruby shape.
+ *
+ * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @returns {object|null} A `spans` descriptor or null
+ */
+export function parseRuby(text) {
+  // Cheap gate on the "S, [" shape; the anchored regex validates the severity char
+  // (D/I/W/E/F/A — not a contiguous range, so left to the regex).
+  if (text[1] !== ',') return null
+  const m = RUBY.exec(text)
+  if (!m) return null
+  const [, level, progname, msg] = m
+  // DEBUG/INFO/WARN/ERROR/FATAL tint by their level; ANY (Ruby's UNKNOWN) is an
+  // unknown severity, so levelSpan renders it muted like any unrecognized token —
+  // which keeps it consistent with the pill and level filter (detectLevel also
+  // defaults it to info). Mapping ANY to a real level would require adding it to
+  // TEXT_LEVEL, which would mis-tint the common word "ANY" in ordinary messages.
+  return decoratedRow([levelSpan(level)], progname || '', msg)
+}
+
+// PHP Monolog default LineFormatter `[%datetime%] %channel%.%level_name%: %message%
+// %context% %extra%` (default datetime ISO-8601 with offset, optional microseconds).
+// The context/extra JSON ride along in the message — splitting them is the JSON
+// phase. PSR-3 level set.
+const MONOLOG = /^\[\d{4}-\d{2}-\d{2}[T ][\d:.+-]+\] (\S+)\.(DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY): (.*)$/
+
+/**
+ * parseMonolog - decorates a PHP Monolog default LineFormatter line. Keeps the level
+ * word (tinted), accents the channel, drops the datetime. The trailing context/extra
+ * stay in the message. Returns null when the line is not the Monolog shape.
+ *
+ * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @returns {object|null} A `spans` descriptor or null
+ */
+export function parseMonolog(text) {
+  if (text[0] !== '[') return null
+  const m = MONOLOG.exec(text)
+  if (!m) return null
+  const [, channel, level, msg] = m
+  return decoratedRow([levelSpan(level)], channel, msg)
+}
+
+// jsonScalar renders a JSON primitive as a single value-colored span (CLS.val, the
+// body color used for field values). JSON.stringify renders strings quoted/escaped,
+// finite numbers verbatim, booleans/null plainly, and non-finite numbers (Infinity/
+// NaN from over-range literals) as `null` — matching JSON.stringify(value, null, 2)
+// rather than String()'s `Infinity`.
+function jsonScalar(v) {
+  return sp(CLS.val, JSON.stringify(v))
+}
+
+// emitJson appends the pretty-printed spans for a parsed JSON value at the given
+// indent depth, mirroring JSON.stringify(value, null, 2) byte-for-byte but with each
+// token wrapped in a colored span: keys and structural punctuation (braces, brackets,
+// `:` and `,`) muted gray, scalars in the body color. Indentation and newlines are
+// emitted as plain spans so a <pre> lays the nesting out. Empty objects/arrays stay
+// on one line.
+function emitJson(spans, value, depth) {
+  if (value === null || typeof value !== 'object') { spans.push(jsonScalar(value)); return }
+  const isArr = Array.isArray(value)
+  const keys = isArr ? null : Object.keys(value)
+  const len = isArr ? value.length : keys.length
+  if (len === 0) { spans.push(sp(CLS.op, isArr ? '[]' : '{}')); return }
+  const pad = '  '.repeat(depth + 1)
+  spans.push(sp(CLS.op, isArr ? '[' : '{'))
+  for (let i = 0; i < len; i++) {
+    spans.push(sp(CLS.msg, `\n${pad}`))
+    if (!isArr) spans.push(sp(CLS.key, JSON.stringify(keys[i])), sp(CLS.op, ':'), sp(CLS.msg, ' '))
+    emitJson(spans, isArr ? value[i] : value[keys[i]], depth + 1)
+    if (i < len - 1) spans.push(sp(CLS.op, ','))
+  }
+  spans.push(sp(CLS.msg, `\n${'  '.repeat(depth)}`), sp(CLS.op, isArr ? ']' : '}'))
+}
+
+// emitMembers appends the members of the top-level object/array WITHOUT the wrapping
+// braces/brackets, flush-left, one per line — a lone `{`/`}` (or `[`/`]`) would waste
+// two lines per entry and the keys already give context. Nested values keep their own
+// braces via emitJson. The caller guarantees a non-empty object/array.
+function emitMembers(spans, value, depth) {
+  const isArr = Array.isArray(value)
+  const keys = isArr ? null : Object.keys(value)
+  const len = isArr ? value.length : keys.length
+  const pad = '  '.repeat(depth)
+  for (let i = 0; i < len; i++) {
+    if (i > 0) spans.push(sp(CLS.msg, `\n${pad}`))
+    if (!isArr) spans.push(sp(CLS.key, JSON.stringify(keys[i])), sp(CLS.op, ':'), sp(CLS.msg, ' '))
+    emitJson(spans, isArr ? value[i] : value[keys[i]], depth)
+    if (i < len - 1) spans.push(sp(CLS.op, ','))
+  }
+}
+
+/**
+ * highlightJson - pretty-prints a JSON object/array log line into colored spans,
+ * preserving nesting (indentation + newlines) so complex structures stay readable.
+ * The outer braces/brackets are dropped and the members sit flush-left so the entry
+ * does not waste a line on a lone `{` and `}`; nested structures keep their braces.
+ * Returns null for a non-JSON line or a bare scalar that merely parses (`42`,
+ * `"hi"`), leaving those to the text cascade. The descriptor is plain data with no
+ * innerHTML; the viewer renders the spans inside a <pre> so the layout survives.
+ *
+ * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @returns {{kind: 'json', spans: Array}|null} A descriptor or null
+ */
+export function highlightJson(text) {
+  const t = text.trim()
+  const c = t.charCodeAt(0)
+  if (c !== 123 && c !== 91) return null // fast gate: not '{' or '['
+  let parsed
+  try {
+    parsed = JSON.parse(t)
+  } catch {
+    return null
+  }
+  if (parsed === null || typeof parsed !== 'object') return null
+  // An empty top-level object/array keeps its braces on one line (emitMembers would
+  // render nothing, leaving a blank entry).
+  if ((Array.isArray(parsed) ? parsed.length : Object.keys(parsed).length) === 0) {
+    return { kind: 'json', spans: [sp(CLS.op, Array.isArray(parsed) ? '[]' : '{}')] }
+  }
+  const spans = []
+  try {
+    emitMembers(spans, parsed, 0)
+  } catch {
+    // Pathologically deep nesting overflows the recursion (RangeError). Fall back to
+    // the plain (raw text) renderer rather than crashing the viewer on one bad line.
+    return null
+  }
+  return { kind: 'json', spans }
+}
+
 /**
  * decorateLine - the non-JSON formatting cascade for one timestamped log line.
  * The viewer handles the JSON step (cascade position 1) and the continuation-line
- * gate before calling this; here the order is klog → zap → logfmt → plain. Returns
- * a serializable descriptor: `block` (multi-line structured), `spans` (single
- * highlighted line), or `plain` (unchanged).
+ * gate before calling this; here the order is klog → zap → java → dotnet → python →
+ * ruby → monolog → logfmt → plain. Returns a serializable descriptor: `block`
+ * (multi-line structured), `spans`
+ * (single highlighted line), or `plain` (unchanged).
  *
  * @param {string} text - The log line (timestamp and ANSI already stripped)
  * @param {string} level - The normalized level, for the klog severity-char tint
@@ -366,5 +702,10 @@ export function parseZap(text) {
  */
 export function decorateLine(text, level) {
   if (!text) return { kind: 'plain' }
-  return parseKlog(text, level) || parseZap(text) || parseLogfmt(text) || { kind: 'plain' }
+  // Three parsers sniff a leading `[`: parseDotnet (Serilog `[time u3]`), parsePython
+  // (gunicorn `[date] [pid] [LEVEL]`) and parseMonolog (`[date] chan.LEVEL:`). Each
+  // returns null for a `[`-line it does not own, so order among them only sets
+  // precedence; they are mutually disjoint by the tokens after the first bracket.
+  return parseKlog(text, level) || parseZap(text) || parseJava(text) || parseDotnet(text) ||
+    parsePython(text) || parseRuby(text) || parseMonolog(text) || parseLogfmt(text) || { kind: 'plain' }
 }

--- a/web/src/utils/logFormat.js
+++ b/web/src/utils/logFormat.js
@@ -1,0 +1,370 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Pretty-printing for the workload log viewer's Formatted mode beyond JSON: the
+// three most common Go non-JSON loggers seen in Kubernetes workloads — klog/glog,
+// logfmt (logrus text, go-kit/log, Go slog TextHandler), and zap's console
+// encoder. `decorateLine` runs a cheap cascade and returns a serializable
+// descriptor (never a VNode), which the viewer caches per raw line and renders.
+//
+// The JSON step of the cascade lives in the viewer (it owns the Prism highlight
+// and the formatJson helper); this module covers klog → zap → logfmt → plain. A
+// structured entry reflows onto multiple visual lines (a bare message line, then
+// one `key: value` field per line); an unstructured line is highlighted in place.
+//
+// Safety: descriptors are plain data and the viewer maps spans to auto-escaped
+// Preact text nodes, so there is no innerHTML path here.
+
+// Span classes. Field key/value/separator reuse Prism's global JSON token classes
+// (loaded by usePrismTheme), so they are pixel-identical to the JSON view and
+// inherit the active light/dark theme. The scaffolding kinds (caller, muted ts /
+// thread / logger, message) carry their own Tailwind utility classes. Each Prism
+// span must include the base `token` class for the global rule to apply.
+const CLS = {
+  key: 'token property',
+  str: 'token string',
+  num: 'token number',
+  op: 'token operator',
+  caller: 'font-semibold text-violet-600 dark:text-violet-300',
+  muted: 'text-gray-400 dark:text-gray-500',
+  msg: '' // empty: inherits the container's default body color
+}
+
+// klog severity letter tint, by normalized level (the same palette family as
+// LEVEL_META's pill borders). Only the leading I/W/E/F character is tinted; the
+// rest of the header is muted.
+const SEV_CLS = {
+  trace: 'text-gray-500 dark:text-gray-400',
+  debug: 'text-slate-500 dark:text-slate-400',
+  info: 'text-blue-500 dark:text-blue-400',
+  warn: 'text-amber-500 dark:text-amber-400',
+  error: 'text-red-500 dark:text-red-400',
+  fatal: 'text-red-600 dark:text-red-400'
+}
+
+// sp builds a span descriptor. An empty class renders as a bare (still escaped)
+// text node in the viewer.
+function sp(cls, text) {
+  return { cls, text }
+}
+
+// matchKeyEnd returns the index just past a logfmt/klog key starting at i
+// (`[A-Za-z_][\w.-]*`), or -1 when no key starts there. Dotted/dashed keys cover
+// slog group keys (`req.method`) and hyphenated keys.
+function matchKeyEnd(s, i) {
+  if (i >= s.length || !/[A-Za-z_]/.test(s[i])) return -1
+  let j = i + 1
+  while (j < s.length && /[\w.-]/.test(s[j])) j++
+  return j
+}
+
+// readQuoted reads a double-quoted run starting at s[i], returning the inner
+// value and the index past the closing quote. Only `\"` and `\\` are unescaped;
+// any other backslash sequence (`\n`, `\t`, …) is kept verbatim so a value never
+// expands into multiple visual lines. An unterminated quote consumes to end of
+// string.
+function readQuoted(s, i) {
+  const q = s[i]
+  let j = i + 1
+  let out = ''
+  while (j < s.length) {
+    if (s[j] === '\\' && j + 1 < s.length) {
+      const nx = s[j + 1]
+      if (nx === '"' || nx === '\\') { out += nx; j += 2; continue }
+      out += s[j]; j++; continue
+    }
+    if (s[j] === q) { j++; break }
+    out += s[j]; j++
+  }
+  return { val: out, next: j }
+}
+
+// readValue reads a single logfmt/klog value at s[i]: a double-quoted run, or a
+// bare token that ends only at the next ` key=` boundary. Single quotes are NOT
+// value delimiters (logfmt/slog/go-kit never single-quote, and a leading `'` in a
+// bare value must be preserved). A bare token may contain spaces, `=`, and
+// unbalanced brackets — covering klog's unquoted `%+v` struct/map values
+// (`{Host:a Port:1}`, `map[a:1 b:2]`) without tearing or swallowing the next
+// field. An empty value (`key=` then a space or end) yields ''.
+function readValue(s, i) {
+  if (i >= s.length || s[i] === ' ') return { val: '', kind: 'str', next: i }
+  if (s[i] === '"') {
+    const r = readQuoted(s, i)
+    return { val: r.val, kind: 'str', next: r.next }
+  }
+  let j = i
+  while (j < s.length) {
+    if (s[j] === ' ') {
+      // A space only ends the value when the next non-space token is a `key=`
+      // pair; otherwise it belongs to an unquoted multi-word value.
+      let k = j + 1
+      while (k < s.length && s[k] === ' ') k++
+      const ke = matchKeyEnd(s, k)
+      if (ke !== -1 && s[ke] === '=') break
+    }
+    j++
+  }
+  const val = s.slice(i, j)
+  const kind = /^-?\d+(?:\.\d+)?$/.test(val) ? 'num' : 'str'
+  return { val, kind, next: j }
+}
+
+// oneLine renders control characters visibly so a value carrying embedded
+// newlines or tabs (e.g. a zap `stacktrace` field decoded from its JSON blob)
+// stays on its own single field line instead of spilling flush-left across the
+// pane and breaking the one-field-per-line model.
+function oneLine(s) {
+  return s.indexOf('\n') === -1 && s.indexOf('\r') === -1 && s.indexOf('\t') === -1
+    ? s
+    : s.replace(/\r/g, '\\r').replace(/\n/g, '\\n').replace(/\t/g, '\\t')
+}
+
+/**
+ * tokenizeKV - splits a logfmt-style tail into its leading bare-text fragment and
+ * its `key=value` fields. Quote- and bracket-aware: a value may be a quoted run
+ * with escapes, a balanced `{…}`/`[…]` struct (klog `%+v`), or a bare token that
+ * stops only at the next ` key=` boundary, so unquoted values containing spaces or
+ * `=` stay intact.
+ *
+ * @param {string} s - The text to tokenize
+ * @returns {{pre: string, fields: Array<{key: string, val: string, kind: string}>}}
+ *   `pre` is any text before the first key (trimmed); `kind` is 'num' or 'str'.
+ */
+export function tokenizeKV(s) {
+  const fields = []
+  let pre = null
+  let i = 0
+  while (i < s.length) {
+    while (i < s.length && s[i] === ' ') i++
+    if (i >= s.length) break
+    const start = i
+    const ke = matchKeyEnd(s, i)
+    if (ke !== -1 && s[ke] === '=') {
+      if (pre === null) pre = s.slice(0, start)
+      const key = s.slice(i, ke)
+      const r = readValue(s, ke + 1)
+      fields.push({ key, val: r.val, kind: r.kind })
+      i = r.next
+    } else if (fields.length === 0) {
+      // Still in the leading bare-text fragment: skip this word and keep looking
+      // for the first key.
+      while (i < s.length && s[i] !== ' ') i++
+    } else {
+      // Trailing non-kv text after the fields; stop rather than misparse it.
+      break
+    }
+  }
+  return { pre: pre === null ? '' : pre.trim(), fields }
+}
+
+// fieldRows turns parsed fields into one descriptor row each, rendered
+// `key: value` (single space, no alignment). The `=` is dropped in favour of a
+// colon to mirror the JSON view.
+function fieldRows(fields) {
+  return fields.map(f => [
+    sp(CLS.key, f.key),
+    sp(CLS.op, ':'),
+    sp(CLS.msg, ' '),
+    sp(f.kind === 'num' ? CLS.num : CLS.str, f.val)
+  ])
+}
+
+// klog header: severity char + MMDD + time + thread + caller. The whitespace runs
+// are captured so the header line is rebuilt verbatim.
+const KLOG_HEADER = /^([IWEF])(\d{4}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)(\s+)(\d+)\s(\S+?:\d+)\]\s?/
+
+/**
+ * parseKlog - decorates a klog/glog line. Classic lines (`Immdd … file:line] msg`)
+ * highlight in place as a single `spans` row; structured `klog.InfoS/ErrorS` lines
+ * (`… ] "msg" key="val"`) reflow to a `block` only when the body is a quoted
+ * message followed by at least one valid field. Returns null when the header does
+ * not match.
+ *
+ * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @param {string} level - The normalized level, for the severity-char tint
+ * @returns {object|null} A descriptor or null
+ */
+export function parseKlog(text, level) {
+  const m = KLOG_HEADER.exec(text)
+  if (!m) return null
+  const [, sev, mmdd, time, gap, thread, caller] = m
+  const header = [
+    sp(SEV_CLS[level] || CLS.muted, sev),
+    sp(CLS.muted, `${mmdd} ${time}${gap}${thread} `),
+    sp(CLS.caller, caller),
+    sp(CLS.muted, ']')
+  ]
+  const body = text.slice(m[0].length)
+
+  // Structured: a quoted message that the first field abuts, with ≥1 valid field.
+  // `pre` must be empty — genuine klog.InfoS/ErrorS emits the first field right
+  // after the message quote, so a quoted body with intervening prose (e.g.
+  // `"podinfo" scaled replicas=3`) or no field tail (`"GET /healthz" completed`)
+  // is classic, and reflowing it would drop the prose between message and field.
+  if (body[0] === '"') {
+    const q = readQuoted(body, 0)
+    const { pre, fields } = tokenizeKV(body.slice(q.next))
+    if (pre === '' && fields.length > 0) {
+      return {
+        kind: 'block',
+        rows: [header, [sp(CLS.msg, q.val)], ...fieldRows(fields)]
+      }
+    }
+  }
+
+  // Classic: the whole body is the message on the header line.
+  return { kind: 'spans', spans: [...header, sp(CLS.msg, ` ${body}`)] }
+}
+
+// logfmt must start with a key=value pair (rejecting prose such as
+// `Setting env GOFLAGS=-mod=vendor GOOS=linux`, which starts with a bare word)
+// and carry at least one anchor key, so a stray `x=y` in a sentence never reflows.
+const LOGFMT_START = /^[A-Za-z_][\w.-]*=/
+const LOGFMT_ANCHOR = /(?:^|\s)(?:level|lvl|severity|ts|time|msg|message|logger|caller)=/
+
+/**
+ * parseLogfmt - decorates a logfmt line (logrus text, go-kit/log, Go slog
+ * TextHandler). Promotes `msg`/`message` to a bare message line and stacks the
+ * remaining fields one per line; a line with only a message renders as a single
+ * highlighted row. Returns null when the line is not anchored logfmt.
+ *
+ * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @returns {object|null} A descriptor or null
+ */
+export function parseLogfmt(text) {
+  if (!LOGFMT_START.test(text) || !LOGFMT_ANCHOR.test(text)) return null
+  const { fields } = tokenizeKV(text)
+  if (fields.length === 0) return null
+  let message = null
+  const rest = []
+  for (const f of fields) {
+    if (message === null && (f.key === 'msg' || f.key === 'message')) message = f.val
+    else rest.push(f)
+  }
+  if (rest.length === 0) {
+    if (!message) return null
+    return { kind: 'spans', spans: [sp(CLS.msg, oneLine(message))] }
+  }
+  const rows = []
+  // Skip an empty promoted message so it doesn't render a blank leading row.
+  if (message) rows.push([sp(CLS.msg, oneLine(message))])
+  rows.push(...fieldRows(rest))
+  return { kind: 'block', rows }
+}
+
+// zap console field shapes. The app timestamp and level are conveyed by the
+// viewer's pill (kubelet time + detected level) and dropped from the inline body.
+// ZAP_TS is end-anchored AND requires the ISO `T` separator (or an epoch), so a
+// date-led TSV/audit line with a space separator — `2020-01-02 03:04:05.123\tERROR…`
+// (Java/Python `asctime`) — is not absorbed as zap. zap console emits ISO8601 (`T`)
+// or an epoch float by default.
+const ZAP_TS = /^(?:\d{4}-\d{2}-\d{2}T[\d:.]+(?:Z|[+-]\d{2}:?\d{2})?|\d{9,}(?:\.\d+)?)$/
+const ZAP_LEVEL = /^(?:trace|debug|info|warn|warning|error|dpanic|panic|fatal)$/i
+// Caller `pkg/file.go:line`, tolerating an optional `:column` suffix.
+const ZAP_CALLER = /^\S+\.go:\d+(?::\d+)?$/
+
+function zapIsBlob(p) {
+  const t = p.trim()
+  if (t[0] !== '{') return null
+  try {
+    const obj = JSON.parse(t)
+    return obj && typeof obj === 'object' && !Array.isArray(obj) ? obj : null
+  } catch {
+    return null
+  }
+}
+
+// zapField renders one expanded blob entry as a `key: value` row, typing the
+// value by its JSON type (objects/arrays as compact JSON). Control characters in
+// a scalar value (a `stacktrace`/`error` field's newlines and tabs) are escaped
+// so the field stays on one line.
+function zapField(key, val) {
+  const kind = typeof val === 'number' ? 'num' : 'str'
+  const text = val !== null && typeof val === 'object' ? JSON.stringify(val) : oneLine(String(val))
+  return [sp(CLS.key, key), sp(CLS.op, ':'), sp(CLS.msg, ' '), sp(kind === 'num' ? CLS.num : CLS.str, text)]
+}
+
+/**
+ * parseZap - decorates a zap console-encoder line
+ * (`ts⇥LEVEL⇥[logger]⇥[caller]⇥msg⇥{json}`). The field count is variable —
+ * controller-runtime inserts a named-logger field and caller/blob are optional —
+ * so parts are classified by shape, not fixed position. With a trailing JSON blob
+ * the line reflows to a `block` (message line led by logger/caller, then expanded
+ * fields); otherwise it highlights in place as `spans`. Returns null when the line
+ * is not confidently zap (needs a tab plus a recognized timestamp and level).
+ *
+ * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @returns {object|null} A descriptor or null
+ */
+export function parseZap(text) {
+  if (text.indexOf('\t') === -1) return null
+  const parts = text.split('\t')
+  let lo = 0
+  let hi = parts.length - 1
+  if (!ZAP_TS.test(parts[lo])) return null
+  lo++
+  if (lo > hi || !ZAP_LEVEL.test(parts[lo])) return null
+  lo++
+
+  // Locate the caller first (over the full remaining range) so blob extraction can
+  // tell a context blob from a JSON-string message. zap always emits the message,
+  // so the trailing JSON part is the field blob only when a message part still
+  // remains after removing it (and the caller); otherwise the JSON *is* the message.
+  let callerIdx = -1
+  for (let k = lo; k <= hi; k++) {
+    if (ZAP_CALLER.test(parts[k])) { callerIdx = k; break }
+  }
+  let blob = null
+  const canStripBlob = callerIdx !== -1 ? hi - 1 > callerIdx : hi > lo
+  if (hi >= lo && canStripBlob) {
+    const obj = zapIsBlob(parts[hi])
+    if (obj) { blob = obj; hi-- }
+  }
+  let logger = ''
+  let caller = ''
+  let msg = ''
+  if (callerIdx !== -1) {
+    caller = parts[callerIdx]
+    logger = parts.slice(lo, callerIdx).join('\t')
+    msg = parts.slice(callerIdx + 1, hi + 1).join('\t')
+  } else {
+    const mid = parts.slice(lo, hi + 1)
+    // Treat the leading part as a logger only when it is shaped like a zap logger
+    // name (dotted/slashed identifier, no spaces or punctuation); otherwise the
+    // whole middle is the message (a message containing a literal tab must not have
+    // its first word mistaken for a logger).
+    if (mid.length >= 2 && /^[\w./-]+$/.test(mid[0])) { logger = mid[0]; msg = mid.slice(1).join('\t') }
+    else { msg = mid.join('\t') }
+  }
+
+  // Message line: logger (muted) + caller (accent) + message (default), each
+  // separated by two spaces for legibility.
+  const line = []
+  if (logger) line.push(sp(CLS.muted, logger))
+  if (caller) { if (line.length) line.push(sp(CLS.msg, '  ')); line.push(sp(CLS.caller, caller)) }
+  if (msg) { if (line.length) line.push(sp(CLS.msg, '  ')); line.push(sp(CLS.msg, oneLine(msg))) }
+  // An empty message with fields (e.g. `logger.Info("", zap.String(...))`) still
+  // reflows the blob; only a wholly empty line with no blob is not zap.
+  if (line.length === 0 && !blob) return null
+
+  if (!blob) return { kind: 'spans', spans: line }
+  const rows = line.length ? [line] : []
+  for (const k of Object.keys(blob)) rows.push(zapField(k, blob[k]))
+  return { kind: 'block', rows }
+}
+
+/**
+ * decorateLine - the non-JSON formatting cascade for one timestamped log line.
+ * The viewer handles the JSON step (cascade position 1) and the continuation-line
+ * gate before calling this; here the order is klog → zap → logfmt → plain. Returns
+ * a serializable descriptor: `block` (multi-line structured), `spans` (single
+ * highlighted line), or `plain` (unchanged).
+ *
+ * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @param {string} level - The normalized level, for the klog severity-char tint
+ * @returns {{kind: string, rows?: Array, spans?: Array}} The descriptor
+ */
+export function decorateLine(text, level) {
+  if (!text) return { kind: 'plain' }
+  return parseKlog(text, level) || parseZap(text) || parseLogfmt(text) || { kind: 'plain' }
+}

--- a/web/src/utils/logFormat.js
+++ b/web/src/utils/logFormat.js
@@ -109,6 +109,10 @@ function readValue(s, i) {
       while (k < s.length && s[k] === ' ') k++
       const ke = matchKeyEnd(s, k)
       if (ke !== -1 && s[ke] === '=') break
+      // The space run is part of the value: jump past it in one step. Stepping by
+      // one would rescan the whole run at every space — O(m²) on a long run.
+      j = k
+      continue
     }
     j++
   }

--- a/web/src/utils/logFormat.js
+++ b/web/src/utils/logFormat.js
@@ -653,6 +653,88 @@ function emitMembers(spans, value, depth) {
   }
 }
 
+// globToTest compiles a `*`-glob pattern (the only wildcard) into a linear,
+// backtracking-free matcher. The pattern is split on `*` and matched as an ordered
+// sequence of case-insensitive literal segments — a required prefix, in-order middle
+// substrings, and a required suffix. This deliberately avoids a regex like
+// `^.*a.*b…$`, whose chained `.*` suffers catastrophic backtracking on crafted input
+// (a user could otherwise freeze the viewer by typing `*a*a*…*b`).
+function globToTest(pat) {
+  const parts = pat.toLowerCase().split('*')
+  const last = parts[parts.length - 1]
+  return (key) => {
+    const s = key.toLowerCase()
+    if (!s.startsWith(parts[0])) return false
+    if (!s.endsWith(last)) return false
+    const end = s.length - last.length // start index of the suffix region
+    let pos = parts[0].length
+    for (let i = 1; i < parts.length - 1; i++) {
+      const seg = parts[i]
+      if (seg === '') continue
+      const idx = s.indexOf(seg, pos)
+      if (idx === -1 || idx + seg.length > end) return false
+      pos = idx + seg.length
+    }
+    return pos <= end
+  }
+}
+
+/**
+ * fieldMatcher - compiles a field-selection expression into a predicate over field
+ * names, or null when the expression selects everything. The expression is a list of
+ * tokens separated by spaces, commas, or pipes (`msg error`, `msg, error`,
+ * `msg|message|error`). Matching is case-insensitive and exact by default; a `*`
+ * acts as a glob wildcard (`*id`, `controller*`). A token prefixed with `!` excludes
+ * the matching field. With only exclusions, every other field is kept; with any
+ * inclusion, the result is a whitelist (minus anything also excluded). An empty
+ * expression (or one with no usable tokens) returns null, meaning "all fields".
+ *
+ * @param {string} expr - The field-selection expression
+ * @returns {((key: string) => boolean)|null} A predicate, or null for "all fields"
+ */
+export function fieldMatcher(expr) {
+  const tokens = (expr || '').split(/[\s,|]+/).filter(Boolean)
+  const includes = []
+  const excludes = []
+  for (const t of tokens) {
+    if (t[0] === '!') { if (t.length > 1) excludes.push(t.slice(1)) }
+    else includes.push(t)
+  }
+  if (includes.length === 0 && excludes.length === 0) return null
+  const tester = (pat) => {
+    if (pat.includes('*')) return globToTest(pat)
+    const lower = pat.toLowerCase()
+    return (k) => k.toLowerCase() === lower
+  }
+  const inc = includes.map(tester)
+  const exc = excludes.map(tester)
+  return (key) => {
+    if (exc.some(t => t(key))) return false
+    return inc.length === 0 || inc.some(t => t(key))
+  }
+}
+
+/**
+ * topLevelJsonKeys - returns the top-level keys of a JSON object log line, or null
+ * when the line is not a JSON object (a scalar, an array — which has no keys — or
+ * non-JSON). Used to discover the set of structured fields a stream emits so the
+ * viewer can offer a field picker. Keys are returned in source order.
+ *
+ * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @returns {string[]|null} The object's top-level keys, or null
+ */
+export function topLevelJsonKeys(text) {
+  const t = text.trim()
+  if (t.charCodeAt(0) !== 123) return null // fast gate: only '{' (objects have keys)
+  try {
+    const parsed = JSON.parse(t)
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    return Object.keys(parsed)
+  } catch {
+    return null
+  }
+}
+
 /**
  * highlightJson - pretty-prints a JSON object/array log line into colored spans,
  * preserving nesting (indentation + newlines) so complex structures stay readable.
@@ -662,10 +744,15 @@ function emitMembers(spans, value, depth) {
  * `"hi"`), leaving those to the text cascade. The descriptor is plain data with no
  * innerHTML; the viewer renders the spans inside a <pre> so the layout survives.
  *
+ * When `selected` is a Set, a top-level object is projected to only those keys (in
+ * source order) so the viewer can show a subset of fields; arrays and nested values
+ * are unaffected. A null/undefined `selected` shows every field.
+ *
  * @param {string} text - The log line (timestamp and ANSI already stripped)
+ * @param {Set<string>} [selected] - Top-level keys to keep, or null/undefined for all
  * @returns {{kind: 'json', spans: Array}|null} A descriptor or null
  */
-export function highlightJson(text) {
+export function highlightJson(text, selected) {
   const t = text.trim()
   const c = t.charCodeAt(0)
   if (c !== 123 && c !== 91) return null // fast gate: not '{' or '['
@@ -676,14 +763,23 @@ export function highlightJson(text) {
     return null
   }
   if (parsed === null || typeof parsed !== 'object') return null
-  // An empty top-level object/array keeps its braces on one line (emitMembers would
-  // render nothing, leaving a blank entry).
-  if ((Array.isArray(parsed) ? parsed.length : Object.keys(parsed).length) === 0) {
-    return { kind: 'json', spans: [sp(CLS.op, Array.isArray(parsed) ? '[]' : '{}')] }
+  // Project a top-level object to the selected fields (source order preserved). A
+  // selection never applies to a top-level array, which carries no field keys.
+  let value = parsed
+  if (selected && !Array.isArray(parsed)) {
+    // Null-prototype object so a literal "__proto__" field is kept as an own key
+    // (a plain {} would assign it to the prototype and drop it from Object.keys).
+    value = Object.create(null)
+    for (const k of Object.keys(parsed)) if (selected.has(k)) value[k] = parsed[k]
+  }
+  // An empty top-level object/array (or one projected empty by the field filter)
+  // keeps its braces on one line (emitMembers would render nothing, leaving a blank).
+  if ((Array.isArray(value) ? value.length : Object.keys(value).length) === 0) {
+    return { kind: 'json', spans: [sp(CLS.op, Array.isArray(value) ? '[]' : '{}')] }
   }
   const spans = []
   try {
-    emitMembers(spans, parsed, 0)
+    emitMembers(spans, value, 0)
   } catch {
     // Pathologically deep nesting overflows the recursion (RangeError). Fall back to
     // the plain (raw text) renderer rather than crashing the viewer on one bad line.

--- a/web/src/utils/logFormat.test.js
+++ b/web/src/utils/logFormat.test.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { describe, it, expect } from 'vitest'
-import { decorateLine, parseKlog, parseLogfmt, parseZap, tokenizeKV } from './logFormat'
+import { decorateLine, highlightJson, parseDotnet, parseJava, parseKlog, parseLogfmt, parseMonolog, parsePython, parseRuby, parseZap, tokenizeKV } from './logFormat'
 
 // rowsText flattens a block descriptor to one string per visual row (spans joined),
 // so a test can assert the rendered text without caring about span boundaries.
@@ -62,15 +62,14 @@ describe('tokenizeKV', () => {
 })
 
 describe('parseKlog', () => {
-  it('decorates a structured klog.ErrorS line into a block (header, message, fields)', () => {
+  it('decorates a structured klog.ErrorS line into a block (header+message, fields)', () => {
     const line = 'E0526 23:03:57.521582       1 leaderelection.go:452] "Error retrieving lease lock" err="Get \\"https://10.96.0.1:443\\": i/o timeout" logger="cert-manager.controller" lock="kube-system/cert-manager-controller"'
     const d = parseKlog(line, 'error')
     expect(d.kind).toBe('block')
     const rows = rowsText(d)
-    // Header rebuilt verbatim, including the original padding.
-    expect(rows[0]).toBe('E0526 23:03:57.521582       1 leaderelection.go:452]')
-    // Message unquoted on its own line.
-    expect(rows[1]).toBe('Error retrieving lease lock')
+    // Header rebuilt with klog's PID padding collapsed to a single space, and the
+    // unquoted message kept on the same row as the header.
+    expect(rows[0]).toBe('E0526 23:03:57.521582 1 leaderelection.go:452] Error retrieving lease lock')
     // Three fields, one per line, with the escaped-quote value kept intact.
     expect(kvRows(d)).toEqual([
       'err: Get "https://10.96.0.1:443": i/o timeout',
@@ -87,14 +86,16 @@ describe('parseKlog', () => {
     const line = 'I0612 14:03:11.123456   12 server.go:80] "GET /healthz" completed'
     const d = parseKlog(line, 'info')
     expect(d.kind).toBe('spans')
-    expect(spansText(d)).toBe('I0612 14:03:11.123456   12 server.go:80] "GET /healthz" completed')
+    // PID padding collapsed to a single space.
+    expect(spansText(d)).toBe('I0612 14:03:11.123456 12 server.go:80] "GET /healthz" completed')
   })
 
   it('decorates a classic klog line as a single highlighted row', () => {
     const line = 'I0612 14:03:11.123456   12 reflector.go:243] Watch close - watch chan closed'
     const d = parseKlog(line, 'info')
     expect(d.kind).toBe('spans')
-    expect(spansText(d)).toBe(line)
+    // PID padding collapsed to a single space.
+    expect(spansText(d)).toBe('I0612 14:03:11.123456 12 reflector.go:243] Watch close - watch chan closed')
     // Caller highlighted, severity tinted.
     expect(d.spans.some(s => s.text === 'reflector.go:243' && /violet/.test(s.cls))).toBe(true)
   })
@@ -201,12 +202,288 @@ describe('parseZap', () => {
   })
 })
 
+describe('parseJava', () => {
+  describe('Spring Boot', () => {
+    it('decorates a 3.x line with app + thread brackets, keeping the level and accenting the logger', () => {
+      const line = '2025-12-18T07:25:01.584Z  INFO 132568 --- [myapp] [           main] o.s.b.d.f.logexample.MyApplication       : Started in 3.1s'
+      const d = parseJava(line)
+      expect(d.kind).toBe('spans')
+      // Level kept, brackets trimmed (15-char thread padding collapsed), logger, message.
+      expect(spansText(d)).toBe('INFO  [myapp] [main]  o.s.b.d.f.logexample.MyApplication  Started in 3.1s')
+      // Level tinted blue (info), brackets muted, logger violet.
+      expect(d.spans.some(s => s.text === 'INFO' && /blue/.test(s.cls))).toBe(true)
+      expect(d.spans.some(s => s.text === '[myapp] [main]' && /gray-4/.test(s.cls))).toBe(true)
+      expect(d.spans.some(s => s.text === 'o.s.b.d.f.logexample.MyApplication' && /violet/.test(s.cls))).toBe(true)
+    })
+
+    it('handles a line with only the padded thread bracket (no app name)', () => {
+      const d = parseJava('2026-06-16T10:00:00.123Z  WARN 12345 --- [  scheduler-1] c.e.Scheduler : tick')
+      expect(spansText(d)).toBe('WARN  [scheduler-1]  c.e.Scheduler  tick')
+      expect(d.spans.some(s => s.text === 'WARN' && /amber/.test(s.cls))).toBe(true)
+    })
+
+    it('keeps a Micrometer correlation bracket', () => {
+      const d = parseJava('2026-06-16T10:00:00.123Z  INFO 7 --- [demo] [  main] [abc123-def456] c.e.Trace : handled')
+      expect(spansText(d)).toBe('INFO  [demo] [main] [abc123-def456]  c.e.Trace  handled')
+    })
+
+    it('matches a 2.x space-separated local timestamp with dot millis and no zone', () => {
+      const d = parseJava('2019-08-30 12:30:04.031  INFO 22174 --- [  nio-8080-exec-0] demo.Controller : handled')
+      expect(d.kind).toBe('spans')
+      expect(spansText(d)).toBe('INFO  [nio-8080-exec-0]  demo.Controller  handled')
+    })
+
+    it('matches when the PID is blank (${PID:- })', () => {
+      const d = parseJava('2026-06-16T10:00:00.123Z  INFO  --- [  main] c.e.App : up')
+      expect(d.kind).toBe('spans')
+      expect(spansText(d)).toBe('INFO  [main]  c.e.App  up')
+    })
+
+    it('matches the root logger (empty logger name), omitting the logger span', () => {
+      const d = parseJava('2026-06-16T10:00:00.123Z ERROR 1 --- [  main]  : boom')
+      expect(d.kind).toBe('spans')
+      expect(spansText(d)).toBe('ERROR  [main]  boom')
+    })
+
+    it('captures a logger that itself contains brackets (Tomcat) whole', () => {
+      const d = parseJava('2026-06-16T10:00:00.123Z  INFO 1 --- [  main] o.a.c.c.C.[Tomcat].[localhost].[/]       : init')
+      expect(d.kind).toBe('spans')
+      expect(d.spans.some(s => s.text === 'o.a.c.c.C.[Tomcat].[localhost].[/]' && /violet/.test(s.cls))).toBe(true)
+      expect(spansText(d)).toBe('INFO  [main]  o.a.c.c.C.[Tomcat].[localhost].[/]  init')
+    })
+  })
+
+  describe('Log4j2 / Logback', () => {
+    it('decorates a default time-only line (thread before level, " - " separator)', () => {
+      const d = parseJava('10:00:00.123 [main] INFO  com.example.Demo - Started')
+      expect(d.kind).toBe('spans')
+      expect(spansText(d)).toBe('[main]  INFO  com.example.Demo  Started')
+      expect(d.spans.some(s => s.text === '[main]' && /gray-4/.test(s.cls))).toBe(true)
+      expect(d.spans.some(s => s.text === 'com.example.Demo' && /violet/.test(s.cls))).toBe(true)
+    })
+
+    it('matches a Logback full date-time with comma millis and ERROR', () => {
+      const d = parseJava('2026-06-16 10:00:00,123 [main] ERROR com.example.Demo - boom')
+      expect(d.kind).toBe('spans')
+      expect(spansText(d)).toBe('[main]  ERROR  com.example.Demo  boom')
+      expect(d.spans.some(s => s.text === 'ERROR' && /red/.test(s.cls))).toBe(true)
+    })
+
+    it('matches the root logger (empty logger name)', () => {
+      const d = parseJava('10:00:00.123 [main] ERROR  - Root logger message')
+      expect(d.kind).toBe('spans')
+      expect(spansText(d)).toBe('[main]  ERROR  Root logger message')
+    })
+
+    it('does not mis-split a message containing " - "', () => {
+      const d = parseJava('10:00:00.123 [main] INFO com.example.Demo - task a - b done')
+      expect(spansText(d)).toBe('[main]  INFO  com.example.Demo  task a - b done')
+    })
+  })
+
+  describe('negatives', () => {
+    it('returns null for a tab-separated line (Java console is space-delimited)', () => {
+      expect(parseJava('2026-06-16 10:00:00.123\t[worker]\tERROR\tpayments\t-\tdeclined')).toBeNull()
+    })
+
+    it('returns null for a Go zap TSV line and a klog line', () => {
+      expect(parseJava('2026-06-19T14:03:11.500Z\tinfo\tfoo.go:1\thi')).toBeNull()
+      expect(parseJava('I0612 14:03:11.123456 12 reflector.go:243] watch closed')).toBeNull()
+    })
+
+    it('returns null for Java stack-trace continuation lines (routed to plain)', () => {
+      expect(parseJava('\tat com.example.Foo.bar(Foo.java:42)')).toBeNull()
+      expect(parseJava('Caused by: java.lang.NullPointerException: x')).toBeNull()
+      expect(parseJava('\t... 3 more')).toBeNull()
+      expect(parseJava('java.lang.IllegalStateException: bad')).toBeNull()
+    })
+
+    it('returns null for plain prose', () => {
+      expect(parseJava('just a plain sentence')).toBeNull()
+      expect(parseJava('2026 was a good year for logging')).toBeNull()
+    })
+  })
+})
+
+describe('parseDotnet', () => {
+  describe('Serilog', () => {
+    it('decorates the default no-date template, keeping and tinting the u3 code', () => {
+      const d = parseDotnet('[14:30:00 INF] Starting up')
+      expect(d.kind).toBe('spans')
+      expect(spansText(d)).toBe('INF  Starting up')
+      expect(d.spans.some(s => s.text === 'INF' && /blue/.test(s.cls))).toBe(true)
+    })
+
+    it('maps every u3 code to its tint', () => {
+      expect(parseDotnet('[14:30:00 ERR] x').spans.some(s => s.text === 'ERR' && /red/.test(s.cls))).toBe(true)
+      expect(parseDotnet('[14:30:00 WRN] x').spans.some(s => s.text === 'WRN' && /amber/.test(s.cls))).toBe(true)
+      expect(parseDotnet('[14:30:00 FTL] x').spans.some(s => s.text === 'FTL' && /red-6/.test(s.cls))).toBe(true)
+      expect(parseDotnet('[14:30:00 DBG] x').spans.some(s => s.text === 'DBG' && /slate/.test(s.cls))).toBe(true)
+      expect(parseDotnet('[14:30:00 VRB] x').spans.some(s => s.text === 'VRB' && /gray-5/.test(s.cls))).toBe(true)
+    })
+
+    it('tolerates an ISO timestamp variant (date + fractional + zone)', () => {
+      const d = parseDotnet('[2024-01-15T14:30:00.123Z INF] booted')
+      expect(d.kind).toBe('spans')
+      expect(spansText(d)).toBe('INF  booted')
+    })
+
+    it('returns null when the bracketed token is not a u3 level code', () => {
+      expect(parseDotnet('[12:00:00 ABC] not serilog')).toBeNull()
+    })
+  })
+
+  describe('NLog', () => {
+    it('decorates the default pipe layout: level tinted, logger accented, message', () => {
+      const d = parseDotnet('2024-01-15 10:30:00.0000|WARN|MyApp.Program|slow start')
+      expect(d.kind).toBe('spans')
+      expect(spansText(d)).toBe('WARN  MyApp.Program  slow start')
+      expect(d.spans.some(s => s.text === 'WARN' && /amber/.test(s.cls))).toBe(true)
+      expect(d.spans.some(s => s.text === 'MyApp.Program' && /violet/.test(s.cls))).toBe(true)
+    })
+
+    it('handles an empty logger field', () => {
+      const d = parseDotnet('2024-01-15 10:30:00.0000|ERROR||boom')
+      expect(d.kind).toBe('spans')
+      expect(spansText(d)).toBe('ERROR  boom')
+    })
+
+    it('keeps an exception riding the message field (first line)', () => {
+      const d = parseDotnet('2024-01-15 10:30:00.0000|ERROR|MyApp.Svc|failed: System.Exception: x')
+      expect(spansText(d)).toBe('ERROR  MyApp.Svc  failed: System.Exception: x')
+    })
+
+    it('does not match a free-form pipe line without a leading longdate', () => {
+      expect(parseDotnet('result|ERROR|stack trace follows')).toBeNull()
+    })
+  })
+
+  describe('negatives', () => {
+    it('returns null for zap, klog, and plain prose', () => {
+      expect(parseDotnet('2026-06-19T14:03:11.500Z\tinfo\tfoo.go:1\thi')).toBeNull()
+      expect(parseDotnet('I0612 14:03:11.123456 12 reflector.go:243] watch closed')).toBeNull()
+      expect(parseDotnet('just a plain sentence')).toBeNull()
+    })
+  })
+})
+
+describe('parsePython', () => {
+  it('decorates a common timestamped logging format (comma millis), level tinted, name accented', () => {
+    const d = parsePython('2024-01-15 10:30:00,123 - myapp.module - WARNING - disk almost full')
+    expect(d.kind).toBe('spans')
+    expect(spansText(d)).toBe('WARNING  myapp.module  disk almost full')
+    expect(d.spans.some(s => s.text === 'WARNING' && /amber/.test(s.cls))).toBe(true)
+    expect(d.spans.some(s => s.text === 'myapp.module' && /violet/.test(s.cls))).toBe(true)
+  })
+
+  it('keeps a hyphenated logger name and maps CRITICAL to fatal', () => {
+    const d = parsePython('2024-01-15 10:30:00.000 - my-app - CRITICAL - dead')
+    expect(spansText(d)).toBe('CRITICAL  my-app  dead')
+    expect(d.spans.some(s => s.text === 'CRITICAL' && /red-6/.test(s.cls))).toBe(true)
+  })
+
+  it('decorates a gunicorn line: pid muted, level tinted', () => {
+    const d = parsePython('[2024-01-15 10:30:00 +0000] [8] [ERROR] Worker (pid:8) was sent SIGKILL!')
+    expect(d.kind).toBe('spans')
+    expect(spansText(d)).toBe('[8]  ERROR  Worker (pid:8) was sent SIGKILL!')
+    expect(d.spans.some(s => s.text === '[8]' && /gray-4/.test(s.cls))).toBe(true)
+    expect(d.spans.some(s => s.text === 'ERROR' && /red/.test(s.cls))).toBe(true)
+  })
+
+  it('decorates uvicorn padded prefixes, including CRITICAL (one space)', () => {
+    expect(spansText(parsePython('INFO:     Started server process [1]'))).toBe('INFO  Started server process [1]')
+    expect(spansText(parsePython('CRITICAL: Application startup failed. Exiting.'))).toBe('CRITICAL  Application startup failed. Exiting.')
+    // TRACE (uvicorn --log-level trace): 5-char level → 4 spaces (still width 9).
+    expect(spansText(parsePython('TRACE:    ASGI [1] Started'))).toBe('TRACE  ASGI [1] Started')
+    // Access-log line with colons/dashes in the message stays intact.
+    expect(spansText(parsePython('INFO:     127.0.0.1:0 - "GET / HTTP/1.1" 200 OK'))).toBe('INFO  127.0.0.1:0 - "GET / HTTP/1.1" 200 OK')
+  })
+
+  it('rejects prose that is not uvicorn-padded (single space after the level colon)', () => {
+    expect(parsePython('INFO: just one space here')).toBeNull()
+    expect(parsePython('ERROR: see above')).toBeNull()
+  })
+
+  it('returns null for non-Python lines', () => {
+    expect(parsePython('[14:30:00 INF] serilog')).toBeNull()
+    expect(parsePython('a plain sentence')).toBeNull()
+  })
+})
+
+describe('parseRuby', () => {
+  it('decorates a line with an empty progname', () => {
+    const d = parseRuby('I, [2024-01-15T10:30:00.123456 #1]  INFO -- : Started')
+    expect(d.kind).toBe('spans')
+    expect(spansText(d)).toBe('INFO  Started')
+  })
+
+  it('accents the progname and tints the level when present', () => {
+    const d = parseRuby('F, [2024-01-15T10:30:00.123456 #1] FATAL -- MyApp: boom')
+    expect(spansText(d)).toBe('FATAL  MyApp  boom')
+    expect(d.spans.some(s => s.text === 'MyApp' && /violet/.test(s.cls))).toBe(true)
+    expect(d.spans.some(s => s.text === 'FATAL' && /red/.test(s.cls))).toBe(true)
+  })
+
+  it('tolerates the stdlib trailing-space datetime (two spaces before #)', () => {
+    const d = parseRuby('W, [2024-01-15T10:30:00.123456  #1]  WARN -- : careful')
+    expect(spansText(d)).toBe('WARN  careful')
+  })
+
+  it('formats the ANY (UNKNOWN) level, tinting it muted (unknown severity)', () => {
+    const d = parseRuby('A, [2024-01-15T10:30:00.123456 #1]  ANY -- : unknown-level')
+    expect(spansText(d)).toBe('ANY  unknown-level')
+    // ANY is not a recognized severity, so it renders muted — consistent with the
+    // info pill/filter (see logLevel.test for the matching detection assertion).
+    expect(d.spans.some(s => s.text === 'ANY' && /gray-4/.test(s.cls))).toBe(true)
+  })
+
+  it('returns null for non-Ruby lines', () => {
+    expect(parseRuby('Info, something happened')).toBeNull()
+    expect(parseRuby('a plain sentence')).toBeNull()
+  })
+})
+
+describe('parseMonolog', () => {
+  it('decorates an ISO+offset line, channel accented, context kept in the message', () => {
+    const d = parseMonolog('[2024-01-15T10:30:00.123456+00:00] app.ERROR: Something failed {"k":"v"} []')
+    expect(d.kind).toBe('spans')
+    expect(spansText(d)).toBe('ERROR  app  Something failed {"k":"v"} []')
+    expect(d.spans.some(s => s.text === 'app' && /violet/.test(s.cls))).toBe(true)
+    expect(d.spans.some(s => s.text === 'ERROR' && /red/.test(s.cls))).toBe(true)
+  })
+
+  it('maps the upper PSR-3 levels (NOTICE→info, EMERGENCY→fatal)', () => {
+    expect(parseMonolog('[2024-01-15 10:30:00] app.NOTICE: heads up [] []').spans.some(s => s.text === 'NOTICE' && /blue/.test(s.cls))).toBe(true)
+    expect(parseMonolog('[2024-01-15 10:30:00] app.EMERGENCY: down [] []').spans.some(s => s.text === 'EMERGENCY' && /red-6/.test(s.cls))).toBe(true)
+  })
+
+  it('returns null for non-Monolog bracketed lines', () => {
+    expect(parseMonolog('[14:30:00 INF] serilog')).toBeNull()
+    expect(parseMonolog('[2024-01-15 10:30:00 +0000] [1] [INFO] gunicorn')).toBeNull()
+  })
+})
+
 describe('decorateLine cascade', () => {
-  it('routes klog, zap, and logfmt to their parsers and prose to plain', () => {
+  it('routes klog, zap, java, dotnet, and logfmt to their parsers and prose to plain', () => {
     expect(decorateLine('I0612 14:03:11.123456 12 reflector.go:243] watch closed', 'info').kind).toBe('spans')
     expect(decorateLine('2026-06-19T14:03:11.5Z\tinfo\tfoo.go:1\thi\t{"a":1}', 'info').kind).toBe('block')
+    expect(decorateLine('2025-12-18T07:25:01.584Z  INFO 1 --- [  main] c.e.App : up', 'info').kind).toBe('spans')
+    expect(decorateLine('10:00:00.123 [main] INFO com.example.Demo - started', 'info').kind).toBe('spans')
+    expect(decorateLine('[14:30:00 INF] Starting up', 'info').kind).toBe('spans')
+    expect(decorateLine('2024-01-15 10:30:00.0000|WARN|MyApp.Program|slow', 'warn').kind).toBe('spans')
+    expect(decorateLine('2024-01-15 10:30:00,123 - app - INFO - up', 'info').kind).toBe('spans')
+    expect(decorateLine('[2024-01-15 10:30:00 +0000] [1] [INFO] gunicorn', 'info').kind).toBe('spans')
+    expect(decorateLine('INFO:     uvicorn', 'info').kind).toBe('spans')
+    expect(decorateLine('I, [2024-01-15T10:30:00.1 #1]  INFO -- : ruby', 'info').kind).toBe('spans')
+    expect(decorateLine('[2024-01-15T10:30:00+00:00] app.ERROR: monolog [] []', 'error').kind).toBe('spans')
     expect(decorateLine('level=info msg=hi controller=foo', 'info').kind).toBe('block')
     expect(decorateLine('a plain sentence with no structure', 'info').kind).toBe('plain')
+  })
+
+  it('routes a log4net log4j-style PatternLayout line via the Java Log4j2 branch', () => {
+    const d = decorateLine('2024-12-21 14:07:41,517 [main] WARN  Animals.Carnivora.Dog - Meow!', 'warn')
+    expect(d.kind).toBe('spans')
+    expect(d.spans.some(s => s.text === 'Animals.Carnivora.Dog' && /violet/.test(s.cls))).toBe(true)
   })
 
   it('leaves a stray = or [error] in prose as plain', () => {
@@ -299,5 +576,66 @@ describe('review regressions', () => {
     const d = parseLogfmt('level=info msg="" controller=foo')
     expect(d.kind).toBe('block')
     expect(rowsText(d)).toEqual(['level: info', 'controller: foo'])
+  })
+})
+
+describe('highlightJson', () => {
+  it('pretty-prints an object flush-left, dropping the outer braces', () => {
+    const d = highlightJson('{"level":"info","msg":"hello"}')
+    expect(d.kind).toBe('json')
+    expect(spansText(d)).toBe('"level": "info",\n"msg": "hello"')
+  })
+
+  it('colors keys gray and leaves scalars in the body color', () => {
+    const d = highlightJson('{"n":1}')
+    expect(d.spans.find(s => s.text === '"n"').cls).toMatch(/gray-5/)
+    expect(d.spans.find(s => s.text === '1').cls).toBe('') // CLS.val inherits body color
+  })
+
+  it('keeps nested objects and arrays indented, with only the outer braces dropped', () => {
+    const src = '{"a":{"b":[1,2,{"c":true}]},"d":null}'
+    expect(spansText(highlightJson(src))).toBe(
+      '"a": {\n  "b": [\n    1,\n    2,\n    {\n      "c": true\n    }\n  ]\n},\n"d": null'
+    )
+  })
+
+  it('renders a top-level array flush-left without the outer brackets', () => {
+    expect(spansText(highlightJson('[1,"x",false]'))).toBe('1,\n"x",\nfalse')
+  })
+
+  it('keeps an empty top-level object or array on one line', () => {
+    expect(spansText(highlightJson('{}'))).toBe('{}')
+    expect(spansText(highlightJson('[]'))).toBe('[]')
+  })
+
+  it('keeps nested empty objects/arrays inline', () => {
+    expect(spansText(highlightJson('{"a":{},"b":[]}'))).toBe('"a": {},\n"b": []')
+  })
+
+  it('escapes control characters in string values, keeping them on one line', () => {
+    expect(spansText(highlightJson('{"m":"a\\nb"}'))).toBe('"m": "a\\nb"')
+  })
+
+  it('renders a non-finite number (over-range literal) as null, like JSON.stringify', () => {
+    // 1e999 parses to Infinity; JSON.stringify emits null, not "Infinity".
+    expect(spansText(highlightJson('{"n":1e999}'))).toBe('"n": null')
+  })
+
+  it('does not throw on pathologically deep nesting, falling back to plain', () => {
+    const deep = '['.repeat(200000) + ']'.repeat(200000)
+    expect(() => highlightJson(deep)).not.toThrow()
+    expect(highlightJson(deep)).toBeNull()
+  })
+
+  it('ignores whitespace around the JSON', () => {
+    expect(spansText(highlightJson('  {"a":1}  '))).toBe('"a": 1')
+  })
+
+  it('returns null for non-JSON, a bare scalar, or malformed input', () => {
+    expect(highlightJson('plain text line')).toBeNull()
+    expect(highlightJson('42')).toBeNull() // parses, but not an object/array
+    expect(highlightJson('"hi"')).toBeNull()
+    expect(highlightJson('{not json}')).toBeNull()
+    expect(highlightJson('{"a":1')).toBeNull() // truncated
   })
 })

--- a/web/src/utils/logFormat.test.js
+++ b/web/src/utils/logFormat.test.js
@@ -1,0 +1,303 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect } from 'vitest'
+import { decorateLine, parseKlog, parseLogfmt, parseZap, tokenizeKV } from './logFormat'
+
+// rowsText flattens a block descriptor to one string per visual row (spans joined),
+// so a test can assert the rendered text without caring about span boundaries.
+function rowsText(d) {
+  return d.rows.map(row => row.map(s => s.text).join(''))
+}
+
+// spansText flattens a spans descriptor to its single rendered line.
+function spansText(d) {
+  return d.spans.map(s => s.text).join('')
+}
+
+// fieldRowsOf returns the field rows of a block (everything after a leading header
+// and/or message row is matched by its `key: value` shape).
+function kvRows(d) {
+  return rowsText(d).filter(t => /^[\w.-]+: /.test(t))
+}
+
+describe('tokenizeKV', () => {
+  it('splits simple key=value pairs and types numbers', () => {
+    const { pre, fields } = tokenizeKV('controller=gitrepository name=flux-system duration=1.2s retries=3')
+    expect(pre).toBe('')
+    expect(fields).toEqual([
+      { key: 'controller', val: 'gitrepository', kind: 'str' },
+      { key: 'name', val: 'flux-system', kind: 'str' },
+      { key: 'duration', val: '1.2s', kind: 'str' },
+      { key: 'retries', val: '3', kind: 'num' }
+    ])
+  })
+
+  it('keeps escaped quotes inside a quoted value', () => {
+    const { fields } = tokenizeKV('err="Get \\"https://x\\": timeout" code=503')
+    expect(fields[0]).toEqual({ key: 'err', val: 'Get "https://x": timeout', kind: 'str' })
+    expect(fields[1]).toEqual({ key: 'code', val: '503', kind: 'num' })
+  })
+
+  it('keeps an unquoted %+v value with spaces and = intact (bracket-balanced)', () => {
+    const { fields } = tokenizeKV('config={Host:a Port:1} m=map[a:1 b:2] next=ok')
+    expect(fields.map(f => f.val)).toEqual(['{Host:a Port:1}', 'map[a:1 b:2]', 'ok'])
+    expect(fields.map(f => f.key)).toEqual(['config', 'm', 'next'])
+  })
+
+  it('handles an empty value and a = inside a quoted value', () => {
+    const { fields } = tokenizeKV('empty= url="https://x?a=b&c=d" tail=z')
+    expect(fields).toEqual([
+      { key: 'empty', val: '', kind: 'str' },
+      { key: 'url', val: 'https://x?a=b&c=d', kind: 'str' },
+      { key: 'tail', val: 'z', kind: 'str' }
+    ])
+  })
+
+  it('captures a leading bare-text fragment before the first key', () => {
+    const { pre, fields } = tokenizeKV('some leading words key=val')
+    expect(pre).toBe('some leading words')
+    expect(fields).toEqual([{ key: 'key', val: 'val', kind: 'str' }])
+  })
+})
+
+describe('parseKlog', () => {
+  it('decorates a structured klog.ErrorS line into a block (header, message, fields)', () => {
+    const line = 'E0526 23:03:57.521582       1 leaderelection.go:452] "Error retrieving lease lock" err="Get \\"https://10.96.0.1:443\\": i/o timeout" logger="cert-manager.controller" lock="kube-system/cert-manager-controller"'
+    const d = parseKlog(line, 'error')
+    expect(d.kind).toBe('block')
+    const rows = rowsText(d)
+    // Header rebuilt verbatim, including the original padding.
+    expect(rows[0]).toBe('E0526 23:03:57.521582       1 leaderelection.go:452]')
+    // Message unquoted on its own line.
+    expect(rows[1]).toBe('Error retrieving lease lock')
+    // Three fields, one per line, with the escaped-quote value kept intact.
+    expect(kvRows(d)).toEqual([
+      'err: Get "https://10.96.0.1:443": i/o timeout',
+      'logger: cert-manager.controller',
+      'lock: kube-system/cert-manager-controller'
+    ])
+    // The severity char carries the level tint (error → red); the caller is its own span.
+    expect(d.rows[0][0]).toMatchObject({ text: 'E' })
+    expect(d.rows[0][0].cls).toMatch(/red/)
+    expect(d.rows[0].some(s => s.text === 'leaderelection.go:452' && /violet/.test(s.cls))).toBe(true)
+  })
+
+  it('treats a quoted body with no field tail as classic (not block)', () => {
+    const line = 'I0612 14:03:11.123456   12 server.go:80] "GET /healthz" completed'
+    const d = parseKlog(line, 'info')
+    expect(d.kind).toBe('spans')
+    expect(spansText(d)).toBe('I0612 14:03:11.123456   12 server.go:80] "GET /healthz" completed')
+  })
+
+  it('decorates a classic klog line as a single highlighted row', () => {
+    const line = 'I0612 14:03:11.123456   12 reflector.go:243] Watch close - watch chan closed'
+    const d = parseKlog(line, 'info')
+    expect(d.kind).toBe('spans')
+    expect(spansText(d)).toBe(line)
+    // Caller highlighted, severity tinted.
+    expect(d.spans.some(s => s.text === 'reflector.go:243' && /violet/.test(s.cls))).toBe(true)
+  })
+
+  it('returns null when the klog header does not match', () => {
+    expect(parseKlog('just a plain sentence', 'info')).toBeNull()
+    expect(parseKlog('level=info msg=hi', 'info')).toBeNull()
+  })
+})
+
+describe('parseLogfmt', () => {
+  it('promotes msg to a bare message line and stacks the rest', () => {
+    const d = parseLogfmt('level=info msg="reconcile complete" controller=gitrepository name=flux-system duration=1.2s')
+    expect(d.kind).toBe('block')
+    expect(rowsText(d)[0]).toBe('reconcile complete')
+    expect(kvRows(d)).toEqual([
+      'level: info',
+      'controller: gitrepository',
+      'name: flux-system',
+      'duration: 1.2s'
+    ])
+  })
+
+  it('renders a message-only logfmt line as a single row', () => {
+    const d = parseLogfmt('msg="just a message"')
+    expect(d.kind).toBe('spans')
+    expect(spansText(d)).toBe('just a message')
+  })
+
+  it('renders a fields-only line with no blank message row', () => {
+    const d = parseLogfmt('level=warn controller=foo count=2')
+    expect(d.kind).toBe('block')
+    expect(rowsText(d)).toEqual(['level: warn', 'controller: foo', 'count: 2'])
+  })
+
+  it('does NOT reflow prose with stray key=value fragments', () => {
+    expect(parseLogfmt('Setting env GOFLAGS=-mod=vendor GOOS=linux')).toBeNull()
+    expect(parseLogfmt('exec failed: PATH=/bin USER=root ./run')).toBeNull()
+  })
+
+  describe('slog TextHandler', () => {
+    it('renders dotted group keys flat as fields', () => {
+      const d = parseLogfmt('time=2009-11-10T23:00:00Z level=INFO msg=hi req.method=GET req.user.id=42')
+      expect(kvRows(d)).toEqual([
+        'time: 2009-11-10T23:00:00Z',
+        'level: INFO',
+        'req.method: GET',
+        'req.user.id: 42'
+      ])
+    })
+
+    it('keeps a bare RFC3339 time= as a normal field', () => {
+      const d = parseLogfmt('time=2009-11-10T23:00:00Z level=INFO msg=ok')
+      expect(rowsText(d)).toContain('time: 2009-11-10T23:00:00Z')
+    })
+
+    it('renders a level offset field verbatim', () => {
+      const d = parseLogfmt('time=2009-11-10T23:00:00Z level=INFO+2 msg=ok')
+      expect(rowsText(d)).toContain('level: INFO+2')
+    })
+  })
+})
+
+describe('parseZap', () => {
+  it('expands a zap console line with a JSON blob into a block', () => {
+    const line = '2026-06-19T14:03:11.500Z\twarn\tinternal/controller/foo.go:88\treconciliation slow\t{"duration":"4.7s","retries":3}'
+    const d = parseZap(line)
+    expect(d.kind).toBe('block')
+    expect(rowsText(d)[0]).toBe('internal/controller/foo.go:88  reconciliation slow')
+    expect(kvRows(d)).toEqual(['duration: 4.7s', 'retries: 3'])
+  })
+
+  it('does not mistake a named logger field for the caller', () => {
+    const line = '2026-06-19T14:03:11.500Z\tinfo\tcontroller.gitrepository\tinternal/controller/foo.go:88\tstarting\t{"name":"flux-system"}'
+    const d = parseZap(line)
+    expect(d.kind).toBe('block')
+    // Logger (muted) precedes caller (accent) on the message line.
+    expect(rowsText(d)[0]).toBe('controller.gitrepository  internal/controller/foo.go:88  starting')
+    expect(d.rows[0].some(s => s.text === 'controller.gitrepository' && /gray-4/.test(s.cls))).toBe(true)
+    expect(d.rows[0].some(s => s.text === 'internal/controller/foo.go:88' && /violet/.test(s.cls))).toBe(true)
+  })
+
+  it('renders a zap line without caller or blob as a single row', () => {
+    const line = '2026-06-19T14:03:11.500Z\tinfo\tstarting manager'
+    const d = parseZap(line)
+    expect(d.kind).toBe('spans')
+    expect(spansText(d)).toBe('starting manager')
+  })
+
+  it('keeps a {…}-looking tail that does not parse as text', () => {
+    const line = '2026-06-19T14:03:11.500Z\tinfo\tfoo.go:1\tgot {partial json'
+    const d = parseZap(line)
+    expect(d.kind).toBe('spans')
+    expect(spansText(d)).toBe('foo.go:1  got {partial json')
+  })
+
+  it('returns null for a tabbed line without a timestamp+level', () => {
+    expect(parseZap('a\tb\tc')).toBeNull()
+    expect(parseZap('2026-06-19T14:03:11.500Z\tnot-a-level\tmsg')).toBeNull()
+  })
+
+  it('returns null when there is no tab', () => {
+    expect(parseZap('level=info msg=hi')).toBeNull()
+  })
+})
+
+describe('decorateLine cascade', () => {
+  it('routes klog, zap, and logfmt to their parsers and prose to plain', () => {
+    expect(decorateLine('I0612 14:03:11.123456 12 reflector.go:243] watch closed', 'info').kind).toBe('spans')
+    expect(decorateLine('2026-06-19T14:03:11.5Z\tinfo\tfoo.go:1\thi\t{"a":1}', 'info').kind).toBe('block')
+    expect(decorateLine('level=info msg=hi controller=foo', 'info').kind).toBe('block')
+    expect(decorateLine('a plain sentence with no structure', 'info').kind).toBe('plain')
+  })
+
+  it('leaves a stray = or [error] in prose as plain', () => {
+    expect(decorateLine('rerun with x=1 to debug', 'info').kind).toBe('plain')
+    expect(decorateLine('the [error] was transient', 'error').kind).toBe('plain')
+  })
+
+  it('returns plain for empty text', () => {
+    expect(decorateLine('', 'info').kind).toBe('plain')
+  })
+
+  it('routes a non-Go space-delimited console line (zerolog) to plain', () => {
+    expect(decorateLine('2026-06-19T14:03:11Z INF hello foo=bar', 'info').kind).toBe('plain')
+  })
+})
+
+// Regressions for issues found by the adversarial review.
+describe('review regressions', () => {
+  it('klog: intervening prose between message and field stays classic, nothing dropped', () => {
+    const line = 'I0612 14:03:11.123456 12 x.go:1] "podinfo" scaled replicas=3'
+    const d = parseKlog(line, 'info')
+    expect(d.kind).toBe('spans')
+    expect(spansText(d)).toBe(line) // "scaled" is not dropped
+  })
+
+  it('klog: an unbalanced %+v brace does not swallow the following field', () => {
+    const open = parseKlog('I0612 14:03:11.123456 1 x.go:1] "s" cfg={Name:a{b Port:1} next=ok', 'info')
+    expect(kvRows(open)).toEqual(['cfg: {Name:a{b Port:1}', 'next: ok'])
+    const close = parseKlog('I0612 14:03:11.123456 1 x.go:1] "s" cfg={Msg:a}b} next=ok', 'info')
+    expect(kvRows(close)).toEqual(['cfg: {Msg:a}b}', 'next: ok'])
+  })
+
+  it('logfmt: a value beginning with a single quote does not swallow the next field', () => {
+    const { fields } = tokenizeKV("user='admin level=info")
+    expect(fields).toEqual([
+      { key: 'user', val: "'admin", kind: 'str' },
+      { key: 'level', val: 'info', kind: 'str' }
+    ])
+  })
+
+  it('logfmt: a quoted value keeps \\n literal (one line) and the next field survives', () => {
+    const { fields } = tokenizeKV('msg="line1\\nline2" next=ok')
+    expect(fields[0]).toEqual({ key: 'msg', val: 'line1\\nline2', kind: 'str' })
+    expect(fields[0].val).not.toContain('\n')
+    expect(fields[1]).toEqual({ key: 'next', val: 'ok', kind: 'str' })
+  })
+
+  it('zap: a JSON-string message with no fields is preserved, not swallowed as a blob', () => {
+    const withCaller = parseZap('2026-06-19T14:03:11.5Z\tinfo\twebhook.go:88\t{"kind":"Pod","op":"CREATE"}')
+    expect(withCaller.kind).toBe('spans')
+    expect(spansText(withCaller)).toBe('webhook.go:88  {"kind":"Pod","op":"CREATE"}')
+    const noCaller = parseZap('2026-06-19T14:03:11.5Z\tinfo\t{"a":1}')
+    expect(noCaller.kind).toBe('spans')
+    expect(spansText(noCaller)).toBe('{"a":1}')
+  })
+
+  it('zap: a no-caller message containing a tab is not mis-split into a logger', () => {
+    const d = parseZap('2026-06-19T14:03:11.5Z\tinfo\theader:\tvalue')
+    expect(d.kind).toBe('spans')
+    expect(d.spans).toHaveLength(1)
+    expect(spansText(d)).toBe('header:\\tvalue')
+  })
+
+  it('zap: a caller with a column suffix is classified as the caller', () => {
+    const d = parseZap('2026-06-19T14:03:11.5Z\tinfo\tfoo.go:42:13\thi\t{"a":1}')
+    expect(d.kind).toBe('block')
+    expect(d.rows[0].some(s => s.text === 'foo.go:42:13' && /violet/.test(s.cls))).toBe(true)
+  })
+
+  it('zap: a date-led non-zap TSV line is not treated as zap (comma or dot millis, space separator)', () => {
+    expect(parseZap('2020-01-02 03:04:05,123\tERROR\tdb\tconnection refused')).toBeNull()
+    expect(parseZap('2020-01-02 03:04:05.123\tERROR\tdb\tconnection refused')).toBeNull()
+    expect(decorateLine('2020-01-02 03:04:05.123\tERROR\tdb\tconnection refused', 'error').kind).toBe('plain')
+  })
+
+  it('zap: an empty message with a JSON blob still reflows the fields', () => {
+    const d = parseZap('2026-06-19T14:03:11.5Z\tinfo\t\t{"foo":"bar","n":2}')
+    expect(d.kind).toBe('block')
+    expect(rowsText(d)).toEqual(['foo: bar', 'n: 2']) // no blank leading message row
+  })
+
+  it('zap: a blob field with embedded newlines renders on one line (escaped)', () => {
+    const d = parseZap('2026-06-19T14:03:11Z\terror\tfoo.go:1\tboom\t{"error":"x","stacktrace":"goroutine 1\\nmain.foo()"}')
+    expect(d.kind).toBe('block')
+    expect(rowsText(d).every(t => !t.includes('\n'))).toBe(true)
+    expect(kvRows(d)).toContain('stacktrace: goroutine 1\\nmain.foo()')
+  })
+
+  it('logfmt: an empty promoted message renders no blank leading row', () => {
+    const d = parseLogfmt('level=info msg="" controller=foo')
+    expect(d.kind).toBe('block')
+    expect(rowsText(d)).toEqual(['level: info', 'controller: foo'])
+  })
+})

--- a/web/src/utils/logFormat.test.js
+++ b/web/src/utils/logFormat.test.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { describe, it, expect } from 'vitest'
-import { decorateLine, highlightJson, parseDotnet, parseJava, parseKlog, parseLogfmt, parseMonolog, parsePython, parseRuby, parseZap, tokenizeKV } from './logFormat'
+import { decorateLine, fieldMatcher, highlightJson, parseDotnet, parseJava, parseKlog, parseLogfmt, parseMonolog, parsePython, parseRuby, parseZap, tokenizeKV, topLevelJsonKeys } from './logFormat'
 
 // rowsText flattens a block descriptor to one string per visual row (spans joined),
 // so a test can assert the rendered text without caring about span boundaries.
@@ -661,5 +661,113 @@ describe('highlightJson', () => {
     expect(highlightJson('"hi"')).toBeNull()
     expect(highlightJson('{not json}')).toBeNull()
     expect(highlightJson('{"a":1')).toBeNull() // truncated
+  })
+
+  describe('field selection', () => {
+    it('projects a top-level object to the selected keys, in source order', () => {
+      const d = highlightJson('{"level":"info","ts":"t","msg":"hi","ns":"x"}', new Set(['msg', 'ns']))
+      expect(spansText(d)).toBe('"msg": "hi",\n"ns": "x"')
+    })
+
+    it('shows every field when the selection is null/undefined', () => {
+      expect(spansText(highlightJson('{"a":1,"b":2}'))).toBe('"a": 1,\n"b": 2')
+      expect(spansText(highlightJson('{"a":1,"b":2}', null))).toBe('"a": 1,\n"b": 2')
+    })
+
+    it('renders {} when the selection keeps none of the line\'s fields', () => {
+      expect(spansText(highlightJson('{"a":1}', new Set(['other'])))).toBe('{}')
+    })
+
+    it('keeps a selected nested value whole', () => {
+      const d = highlightJson('{"msg":"hi","obj":{"x":1}}', new Set(['obj']))
+      expect(spansText(d)).toBe('"obj": {\n  "x": 1\n}')
+    })
+
+    it('leaves a top-level array unaffected by a selection (no field keys)', () => {
+      expect(spansText(highlightJson('[1,2]', new Set(['msg'])))).toBe('1,\n2')
+    })
+
+    it('keeps a literal "__proto__" field when selected (no prototype mutation)', () => {
+      const d = highlightJson('{"__proto__":"x","msg":"hi"}', new Set(['__proto__']))
+      expect(spansText(d)).toBe('"__proto__": "x"')
+    })
+  })
+})
+
+describe('fieldMatcher', () => {
+  const keep = (expr, keys) => keys.filter(fieldMatcher(expr) || (() => true))
+
+  it('returns null for an empty or token-less expression (all fields)', () => {
+    expect(fieldMatcher('')).toBeNull()
+    expect(fieldMatcher('   ')).toBeNull()
+    expect(fieldMatcher('!')).toBeNull() // a lone "!" yields no usable token
+  })
+
+  it('matches exact field names, case-insensitively, not as substrings', () => {
+    const m = fieldMatcher('msg')
+    expect(m('msg')).toBe(true)
+    expect(m('MSG')).toBe(true)
+    expect(m('msgCount')).toBe(false)
+    expect(m('message')).toBe(false)
+  })
+
+  it('splits on spaces, commas, and pipes interchangeably', () => {
+    const keys = ['level', 'ts', 'msg', 'message', 'error']
+    expect(keep('msg message error', keys)).toEqual(['msg', 'message', 'error'])
+    expect(keep('msg, message, error', keys)).toEqual(['msg', 'message', 'error'])
+    expect(keep('msg|message|error', keys)).toEqual(['msg', 'message', 'error'])
+  })
+
+  it('treats * as a glob wildcard', () => {
+    const keys = ['reconcileID', 'controllerKind', 'controllerGroup', 'msg']
+    expect(keep('*id', keys)).toEqual(['reconcileID'])
+    expect(keep('controller*', keys)).toEqual(['controllerKind', 'controllerGroup'])
+    expect(keep('*o*', keys)).toEqual(['reconcileID', 'controllerKind', 'controllerGroup'])
+  })
+
+  it('excludes fields prefixed with !, keeping everything else', () => {
+    const keys = ['level', 'ts', 'msg', 'ns']
+    expect(keep('!level !ts', keys)).toEqual(['msg', 'ns'])
+    expect(keep('!controller*', ['controllerKind', 'msg', 'level'])).toEqual(['msg', 'level'])
+  })
+
+  it('lets an exclusion override an inclusion', () => {
+    const keys = ['msg', 'error', 'level']
+    expect(keep('msg error !error', keys)).toEqual(['msg'])
+  })
+
+  it('matches multi-* globs in order without catastrophic backtracking', () => {
+    const m = fieldMatcher('a*b*c')
+    expect(m('axxbxxc')).toBe(true)
+    expect(m('abc')).toBe(true)
+    expect(m('axbxd')).toBe(false) // no trailing c
+    expect(m('ac')).toBe(false)    // missing b between
+  })
+
+  it('resolves a pathological *-heavy pattern on a long key quickly (no ReDoS)', () => {
+    // A chained-.* regex would hang here; the linear matcher returns at once.
+    const m = fieldMatcher('*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*b')
+    const key = 'a'.repeat(2000)
+    const start = Date.now()
+    expect(m(key)).toBe(false) // no trailing b
+    expect(Date.now() - start).toBeLessThan(1000)
+  })
+})
+
+describe('topLevelJsonKeys', () => {
+  it('returns the top-level keys of a JSON object in source order', () => {
+    expect(topLevelJsonKeys('{"level":"info","msg":"hi","ns":"x"}')).toEqual(['level', 'msg', 'ns'])
+  })
+
+  it('ignores surrounding whitespace', () => {
+    expect(topLevelJsonKeys('  {"a":1}  ')).toEqual(['a'])
+  })
+
+  it('returns null for an array, a scalar, or non-JSON', () => {
+    expect(topLevelJsonKeys('[1,2]')).toBeNull()
+    expect(topLevelJsonKeys('42')).toBeNull()
+    expect(topLevelJsonKeys('"hi"')).toBeNull()
+    expect(topLevelJsonKeys('plain text')).toBeNull()
+    expect(topLevelJsonKeys('{"a":1')).toBeNull() // truncated
   })
 })

--- a/web/src/utils/logFormat.test.js
+++ b/web/src/utils/logFormat.test.js
@@ -59,6 +59,30 @@ describe('tokenizeKV', () => {
     expect(pre).toBe('some leading words')
     expect(fields).toEqual([{ key: 'key', val: 'val', kind: 'str' }])
   })
+
+  it('keeps internal multi-space runs in a bare value and stops at the next key=', () => {
+    const { fields } = tokenizeKV('msg=word1    word2     word3 next=ok')
+    expect(fields).toEqual([
+      { key: 'msg', val: 'word1    word2     word3', kind: 'str' },
+      { key: 'next', val: 'ok', kind: 'str' }
+    ])
+  })
+
+  it('parses a long consecutive-space run in a bare value in linear time', () => {
+    // Pre-fix, readValue rescanned the whole space run at every space (O(m²)): this
+    // size took several seconds. Post-fix it jumps past the run, so it is linear and
+    // returns the value intact. The tight time bound is the regression guard.
+    const spaces = ' '.repeat(120000)
+    const input = `msg=start${spaces}end tail=ok`
+    const t0 = Date.now()
+    const { fields } = tokenizeKV(input)
+    const elapsed = Date.now() - t0
+    expect(fields).toHaveLength(2)
+    expect(fields[0].key).toBe('msg')
+    expect(fields[0].val).toBe(`start${spaces}end`)
+    expect(fields[1]).toEqual({ key: 'tail', val: 'ok', kind: 'str' })
+    expect(elapsed).toBeLessThan(1000)
+  })
 })
 
 describe('parseKlog', () => {

--- a/web/src/utils/logGroup.js
+++ b/web/src/utils/logGroup.js
@@ -1,0 +1,81 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { DEFAULT_LEVEL } from './logLevel'
+
+// Opens a stack trace: Go panic/fatal/goroutine dump, Python Traceback, Java
+// `Exception in thread`/FQCN throwable, Node/generic bare, prefixed, or bracketed
+// `Error:`/`Exception:` (e.g. `TypeError [ERR_X]:`). Derived from real captures.
+const TRACE_HEAD = /^(?:panic:|fatal error:|goroutine\s+\d+\s+\[|Traceback \(most recent call last\):|Exception in thread\s+"|(?:[a-z][\w$]*\.)+[A-Z][\w$]*(?:Exception|Error|Throwable)\b|(?:[A-Z][\w$]*)?(?:Error|Exception)(?:\s*\[[^\]]*\])?:)/
+
+// Flush-left Go function frame (`main.c(...)`). No space before the paren (so
+// `falling back (stale)` is excluded), and Go-gated via goTrace so a non-Go
+// `Error:` trace never absorbs a stray `)`-line.
+const GO_FRAME = /^\S+\(.*\)\s*$/
+
+// Go panic/fatal/goroutine head — the only context GO_FRAME may fold in.
+const GO_HEAD = /^(?:panic:|fatal error:|goroutine\s+\d+\s+\[)/
+
+// Flush-left lines that continue an open trace: Java `Caused by:`/`Suppressed:`/
+// `… N more`, goroutine separator, `created by`, `[signal …]`, suffix-less Python
+// finals (KeyboardInterrupt…), a FQCN throwable, and a final `<Name>Error:`.
+const MARKER = /^(?:Caused by:|Suppressed:|\.{3}\s+\d+\s+more\b|goroutine\s+\d+\s+\[|created by\s|\[signal\s|(?:KeyboardInterrupt|SystemExit|StopIteration|StopAsyncIteration|GeneratorExit)\b|(?:[a-z][\w$]*\.)+[A-Z][\w$]*(?:Exception|Error|Throwable)\b|(?:[A-Z][\w$]*)?(?:Error|Exception)(?:\s*\[[^\]]*\])?:)/
+
+// isTraceHead reports whether a line opens a recognized stack trace.
+function isTraceHead(text) { return TRACE_HEAD.test(text) }
+
+// isCont reports whether a line continues an open trace: blank, indented, a
+// flush-left marker, or — only in a Go trace — a flush-left Go frame.
+function isCont(text, goTrace) {
+  return text === '' || /^\s/.test(text) || MARKER.test(text) || (goTrace && GO_FRAME.test(text))
+}
+
+/**
+ * groupEntries - fold a multi-line stack trace into its head entry so it renders
+ * as one collapsible group instead of N rows.
+ *
+ * Content-driven (frames may or may not carry a timestamp): a line folds into
+ * `prev` (same pod) only while a recognized trace is open — `prev.isTrace &&
+ * isCont(e.text, prev.goTrace)` — and the first non-continuation line closes it.
+ * A trace whose head isn't in TRACE_HEAD does not open, so its frames stay
+ * separate rather than risk folding an unrelated indented/untimestamped line;
+ * extend TRACE_HEAD as formats surface. The caller partitions by pod in the
+ * all-pods view, so samePod is just a cross-pod backstop.
+ *
+ * @param {Array<{ts: string, tsMs: number, text: string, level: string, pod: string, podId: string}>} entries
+ * @param {boolean} enabled - when false, every entry becomes its own group (no fold)
+ * @returns {Array<{head: Object|null, lines: Array, ts: string, tsMs: number, pod: string, podId: string, level: string, isTrace: boolean, goTrace: boolean}>}
+ */
+export function groupEntries(entries, enabled) {
+  const groups = []
+  for (const e of entries) {
+    const prev = groups[groups.length - 1]
+    // An untimestamped orphan (pod '') belongs to its predecessor; a frame from a
+    // different (non-empty) pod never folds across.
+    const samePod = prev && (e.pod === prev.pod || e.pod === '')
+    if (enabled && prev && samePod && prev.isTrace && isCont(e.text, prev.goTrace)) {
+      prev.lines.push(e)
+      continue
+    }
+    // isTrace labels the group and keeps the trace open for the following lines.
+    const isTrace = enabled && isTraceHead(e.text)
+    const goTrace = isTrace && GO_HEAD.test(e.text)
+    // A bare exception head has no level word (detectLevel → default); bump a
+    // trace head to error so the exact-match level filter surfaces it. (`panic:`
+    // is already fatal, so the bump is a no-op.)
+    let level = e.level
+    if (isTrace && level === DEFAULT_LEVEL) level = 'error'
+    groups.push({
+      head: e.ts ? e : null,
+      lines: [e],
+      ts: e.ts,
+      tsMs: e.tsMs,
+      pod: e.pod,
+      podId: e.podId,
+      level,
+      isTrace,
+      goTrace,
+    })
+  }
+  return groups
+}

--- a/web/src/utils/logGroup.js
+++ b/web/src/utils/logGroup.js
@@ -30,36 +30,75 @@ function isCont(text, goTrace) {
   return text === '' || /^\s/.test(text) || MARKER.test(text) || (goTrace && GO_FRAME.test(text))
 }
 
+// Max gap between consecutive lines of an unstructured run. A real multi-line
+// write (a curl -v dump, a banner) lands within milliseconds; a primitive app
+// printing structure-less lines seconds apart stays separate entries.
+const BURST_WINDOW_MS = 250
+
+// Max total span of an unstructured run, from its head to the line being joined.
+// The per-gap window alone would let a steady plain stream (each line < 250 ms
+// after the last) coalesce without bound into one group under a single, ever more
+// stale timestamp. A genuine burst (curl dump, banner) lands well within a second;
+// past this span the run closes and a fresh group starts.
+const BURST_SPAN_MS = 1000
+
 /**
- * groupEntries - fold a multi-line stack trace into its head entry so it renders
- * as one collapsible group instead of N rows.
+ * groupEntries - collect a multi-line run into its head entry so it renders as one
+ * timestamp block instead of N rows. Two kinds of run group, each scoped to one
+ * (pod, container) — a line from a different non-empty pod or container never joins
+ * across, so streams interleaved in the all-pods/all-containers view can't merge:
  *
- * Content-driven (frames may or may not carry a timestamp): a line folds into
- * `prev` (same pod) only while a recognized trace is open — `prev.isTrace &&
- * isCont(e.text, prev.goTrace)` — and the first non-continuation line closes it.
- * A trace whose head isn't in TRACE_HEAD does not open, so its frames stay
- * separate rather than risk folding an unrelated indented/untimestamped line;
- * extend TRACE_HEAD as formats surface. The caller partitions by pod in the
- * all-pods view, so samePod is just a cross-pod backstop.
+ *  - **stack trace** (`isTrace`) — a recognized head opens it and each continuation
+ *    joins while `prev.isTrace && isCont(e.text, prev.goTrace)`. The renderer *folds*
+ *    a trace: head visible, frames hidden behind a click-to-expand control. A head
+ *    not in TRACE_HEAD does not open, so unknown-format frames stay separate;
+ *    extend TRACE_HEAD as needed.
+ *  - **unstructured burst** (`unstructuredRun`) — a structure-less line opens a run
+ *    and each following structure-less line joins while it lands within BURST_WINDOW_MS
+ *    of the previous line AND within BURST_SPAN_MS of the run's head; the first
+ *    structured line, a too-large gap, or an over-long total span closes it.
+ *    `e.structured` is set by the caller from the format layer (highlightJson/
+ *    decorateLine); a curl -v dump groups, a structured logger 1–3 ms apart does not,
+ *    and a continuous plain stream caps out instead of growing one group unbounded.
+ *    The renderer does NOT fold a burst: every line shows under the one timestamp
+ *    pill, nothing hidden. Mutually exclusive with a trace head (a bare `Error:`
+ *    opens a trace, not a run).
  *
- * @param {Array<{ts: string, tsMs: number, text: string, level: string, pod: string, podId: string}>} entries
- * @param {boolean} enabled - when false, every entry becomes its own group (no fold)
- * @returns {Array<{head: Object|null, lines: Array, ts: string, tsMs: number, pod: string, podId: string, level: string, isTrace: boolean, goTrace: boolean}>}
+ * Content-driven: a frame may or may not carry a timestamp. The caller also
+ * partitions by pod in the all-pods view, so samePod is a backstop; the container
+ * guard is the load-bearing scope within a single pod's interleaved containers.
+ *
+ * @param {Array<{ts: string, tsMs: number, text: string, level: string, pod: string, podId: string, container: string, structured?: boolean}>} entries
+ * @param {boolean} enabled - when false, every entry becomes its own group (no run)
+ * @returns {Array<{head: Object|null, lines: Array, ts: string, tsMs: number, lastTsMs: number, pod: string, podId: string, container: string, level: string, isTrace: boolean, goTrace: boolean, unstructuredRun: boolean}>}
  */
 export function groupEntries(entries, enabled) {
   const groups = []
   for (const e of entries) {
     const prev = groups[groups.length - 1]
-    // An untimestamped orphan (pod '') belongs to its predecessor; a frame from a
-    // different (non-empty) pod never folds across.
+    // An untimestamped orphan (pod/container '') belongs to its predecessor; a line
+    // from a different (non-empty) pod or container never joins across.
     const samePod = prev && (e.pod === prev.pod || e.pod === '')
-    if (enabled && prev && samePod && prev.isTrace && isCont(e.text, prev.goTrace)) {
+    const sameContainer = prev && (e.container === prev.container || e.container === '')
+    const scoped = prev && samePod && sameContainer
+    // isTrace labels the group and keeps the trace open for the following lines; a
+    // structure-less, non-trace head opens an unstructured run instead.
+    const isTrace = enabled && isTraceHead(e.text)
+    const joinTrace = scoped && prev.isTrace && isCont(e.text, prev.goTrace)
+    // A trace head is excluded from a burst (`!isTrace`) so it breaks the run and
+    // opens its own trace rather than joining as a plain line. Two timers bound a
+    // run: the per-gap window (close together) and the total span from the head
+    // (`prev.tsMs`), so a continuous plain stream doesn't grow one group unbounded.
+    const joinBurst = scoped && prev.unstructuredRun && !isTrace && !e.structured &&
+      !Number.isNaN(e.tsMs) && e.tsMs - prev.lastTsMs < BURST_WINDOW_MS &&
+      e.tsMs - prev.tsMs < BURST_SPAN_MS
+    if (enabled && (joinTrace || joinBurst)) {
       prev.lines.push(e)
+      if (!Number.isNaN(e.tsMs)) prev.lastTsMs = e.tsMs   // advance the burst cursor
       continue
     }
-    // isTrace labels the group and keeps the trace open for the following lines.
-    const isTrace = enabled && isTraceHead(e.text)
     const goTrace = isTrace && GO_HEAD.test(e.text)
+    const unstructuredRun = enabled && !isTrace && !e.structured
     // A bare exception head has no level word (detectLevel → default); bump a
     // trace head to error so the exact-match level filter surfaces it. (`panic:`
     // is already fatal, so the bump is a no-op.)
@@ -70,11 +109,14 @@ export function groupEntries(entries, enabled) {
       lines: [e],
       ts: e.ts,
       tsMs: e.tsMs,
+      lastTsMs: e.tsMs,
       pod: e.pod,
       podId: e.podId,
+      container: e.container,
       level,
       isTrace,
       goTrace,
+      unstructuredRun,
     })
   }
   return groups

--- a/web/src/utils/logGroup.test.js
+++ b/web/src/utils/logGroup.test.js
@@ -285,6 +285,176 @@ describe('groupEntries', () => {
   })
 })
 
+describe('groupEntries — unstructured bursts', () => {
+  // be builds a timestamped entry at a ms offset from a base, with an explicit
+  // `structured` flag (the viewer sets this from the format layer before grouping).
+  const T0 = Date.parse('2026-06-20T11:00:00.000Z')
+  const be = (text, offsetMs, structured, pod = '') => {
+    const iso = new Date(T0 + offsetMs).toISOString()
+    return { ...parseLogLine(`${iso} ${text}`, null), pod, podId: pod, structured }
+  }
+
+  it('groups a co-timestamped curl -v dump into one unstructured run', () => {
+    const dump = [
+      be('* Host kubernetes.default.svc.cluster.local:443 was resolved.', 0, false),
+      be('*   Trying 10.96.0.1:443...', 1, false),
+      be('> GET /healthz HTTP/2', 2, false),
+      be('< HTTP/2 200', 3, false),
+      be('* shutting down connection #0', 4, false),
+    ]
+    const groups = groupEntries(dump, true)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].unstructuredRun).toBe(true)
+    expect(groups[0].isTrace).toBe(false)
+    expect(groups[0].lines).toHaveLength(5)
+    expect(groups[0].head.text).toBe('* Host kubernetes.default.svc.cluster.local:443 was resolved.')
+  })
+
+  it('does not group structured lines milliseconds apart', () => {
+    const lines = [
+      be('2026-06-20 10:03:22.644 [main] DEBUG com.x - a', 0, true),
+      be('2026-06-20 10:03:22.646 [main] DEBUG com.x - b', 2, true),
+      be('2026-06-20 10:03:22.648 [main] DEBUG com.x - c', 4, true),
+    ]
+    const groups = groupEntries(lines, true)
+    expect(groups).toHaveLength(3)
+    expect(groups.every(g => g.unstructuredRun === false)).toBe(true)
+  })
+
+  it('does not group unstructured lines spaced beyond the burst window', () => {
+    const lines = [be('* line one', 0, false), be('* line two', 500, false)]
+    expect(groupEntries(lines, true)).toHaveLength(2)
+  })
+
+  it('caps a run at the total span even when every gap is within the window', () => {
+    // A continuous plain stream, each line 200 ms after the last (< 250 ms window)
+    // but running past the 1000 ms span: the run closes at the span boundary and a
+    // fresh group starts, so a steady stream never coalesces into one giant group.
+    const lines = [0, 200, 400, 600, 800, 1000, 1200].map(ms => be('* tick', ms, false))
+    const groups = groupEntries(lines, true)
+    expect(groups).toHaveLength(2)
+    expect(groups[0].lines).toHaveLength(5)   // offsets 0..800 (< 1000 ms span)
+    expect(groups[1].lines).toHaveLength(2)   // offsets 1000, 1200 (new run)
+  })
+
+  it('opens a trace (not a run) for a structure-less trace head', () => {
+    const lines = [
+      be('Error: boom from c', 0, false),
+      be('    at c (eval:1:2)', 1, false),
+      be('    at b (eval:3:4)', 2, false),
+    ]
+    const groups = groupEntries(lines, true)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].isTrace).toBe(true)
+    expect(groups[0].unstructuredRun).toBe(false)
+    expect(groups[0].lines).toHaveLength(3)
+  })
+
+  it('closes the run on a lone structured line mid-burst (curl JSON body split)', () => {
+    const lines = [
+      be('* request begin', 0, false),
+      be('> GET /api/info', 1, false),
+      be('{"hostname":"frontend","version":"6.14"}', 2, true),  // valid JSON → structured
+      be('* request end', 3, false),
+    ]
+    const groups = groupEntries(lines, true)
+    expect(groups).toHaveLength(3)
+    expect(groups[0].lines).toHaveLength(2)   // pre-JSON run
+    expect(groups[1].lines).toHaveLength(1)   // the structured JSON line
+    expect(groups[1].unstructuredRun).toBe(false)
+    expect(groups[2].lines).toHaveLength(1)   // post-JSON run
+  })
+
+  it('never groups a burst across pods', () => {
+    const lines = [be('* a one', 0, false, 'pod-a'), be('* b one', 1, false, 'pod-b')]
+    expect(groupEntries(lines, true)).toHaveLength(2)
+  })
+
+  it('does not group when disabled', () => {
+    const lines = [be('* one', 0, false), be('* two', 1, false), be('* three', 2, false)]
+    const groups = groupEntries(lines, false)
+    expect(groups).toHaveLength(3)
+    expect(groups.every(g => g.unstructuredRun === false)).toBe(true)
+  })
+})
+
+describe('groupEntries — container scoping', () => {
+  // ce builds a timestamped entry tagged with a container (and optional pod), via
+  // the production parser, mirroring what the viewer builds in the all-containers
+  // view where each line carries its container of origin.
+  let cseq = 0
+  const ce = (text, container, pod = '') => {
+    const ts = `2026-06-20T12:00:${String(cseq++ % 60).padStart(2, '0')}.000000000Z`
+    return { ...parseLogLine(`${ts} ${text}`, null), container, pod, podId: pod }
+  }
+
+  it('folds a trace within one container', () => {
+    const groups = groupEntries([
+      ce('panic: boom', 'app'),
+      ce('goroutine 1 [running]:', 'app'),
+      ce('main.main()', 'app'),
+    ], true)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].isTrace).toBe(true)
+    expect(groups[0].lines).toHaveLength(3)
+    expect(groups[0].container).toBe('app')
+  })
+
+  it('does not fold a continuation from a different container into an open trace', () => {
+    // app opens a Go panic; envoy emits a co-timestamped frame-shaped line — the
+    // container guard keeps it out of app's trace so two interleaved containers
+    // never merge.
+    const groups = groupEntries([
+      ce('panic: boom', 'app'),
+      ce('\t/main.go:2', 'envoy'),
+    ], true)
+    expect(groups).toHaveLength(2)
+    expect(groups[0].lines).toHaveLength(1)
+    expect(groups[1].container).toBe('envoy')
+  })
+
+  it('never merges containers across two interleaved traces', () => {
+    // app and side crash together; their frames interleave on the wire. No resulting
+    // group may mix containers.
+    const groups = groupEntries([
+      ce('panic: app boom', 'app'),
+      ce('Traceback (most recent call last):', 'side'),
+      ce('  File "x.py", line 1', 'side'),
+      ce('\tmain.main()', 'app'),
+    ], true)
+    for (const g of groups) {
+      const containers = new Set(g.lines.map(l => l.container).filter(Boolean))
+      expect(containers.size).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('an orphan continuation (no container) inherits its predecessor and folds in', () => {
+    const groups = groupEntries([
+      ce('panic: boom', 'app'),
+      { ...parseLogLine('  at frame', null), container: '', pod: '' },
+    ], true)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].lines).toHaveLength(2)
+  })
+
+  it('does not group an unstructured burst across containers', () => {
+    // Two structure-less lines 1 ms apart (within the burst window) but from
+    // different containers must not join one run.
+    const T0 = Date.parse('2026-06-20T12:30:00.000Z')
+    const bc = (text, offsetMs, container) => ({
+      ...parseLogLine(`${new Date(T0 + offsetMs).toISOString()} ${text}`, null),
+      container, pod: '', podId: '', structured: false,
+    })
+    const groups = groupEntries([
+      bc('* app request', 0, 'app'),
+      bc('* envoy upstream', 1, 'envoy'),
+    ], true)
+    expect(groups).toHaveLength(2)
+    expect(groups[0].container).toBe('app')
+    expect(groups[1].container).toBe('envoy')
+  })
+})
+
 describe('parseLogLine', () => {
   it('preserves a frame\'s leading tab after stripping the timestamp', () => {
     const entry = parseLogLine('2026-06-20T10:00:00.000000000Z \t/m.go:2', null)
@@ -302,5 +472,40 @@ describe('parseLogLine', () => {
     const cont = parseLogLine('  some continuation', null)
     expect(cont.ts).toBe('')
     expect(cont.text).toBe('  some continuation')
+  })
+
+  it('peels a container tag when a real timestamp follows', () => {
+    const cset = new Set(['app', 'envoy'])
+    const entry = parseLogLine('app 2026-06-20T10:00:00.000000000Z hello', null, cset)
+    expect(entry.container).toBe('app')
+    expect(entry.ts).toBe('2026-06-20T10:00:00.000000000Z')
+    expect(entry.text).toBe('hello')
+  })
+
+  it('peels pod then container in order in the combined view', () => {
+    const pset = new Set(['frontend-abc-x1'])
+    const cset = new Set(['app'])
+    const entry = parseLogLine('frontend-abc-x1 app 2026-06-20T10:00:00.000000000Z hello', pset, cset)
+    expect(entry.pod).toBe('frontend-abc-x1')
+    expect(entry.podId).toBe('x1')
+    expect(entry.container).toBe('app')
+    expect(entry.text).toBe('hello')
+  })
+
+  it('does not treat a name-shaped token as a container tag without a following timestamp', () => {
+    const cset = new Set(['app'])
+    // A message that merely begins with a known container name and a date-shaped
+    // (but invalid) token keeps its full text and no container.
+    const entry = parseLogLine('app 2026-13-45Tnope started', null, cset)
+    expect(entry.container).toBe('')
+    expect(entry.ts).toBe('')
+    expect(entry.text).toBe('app 2026-13-45Tnope started')
+  })
+
+  it('leaves a container-shaped continuation line untagged', () => {
+    const cset = new Set(['app'])
+    const entry = parseLogLine('  at app (x:1)', null, cset)
+    expect(entry.container).toBe('')
+    expect(entry.text).toBe('  at app (x:1)')
   })
 })

--- a/web/src/utils/logGroup.test.js
+++ b/web/src/utils/logGroup.test.js
@@ -1,0 +1,306 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect } from 'vitest'
+import { groupEntries } from './logGroup'
+import { parseLogLine } from '../components/dashboards/workload/WorkloadLogsViewer'
+
+// The fixtures below are verbatim `kubectl logs --timestamps` output captured from
+// throwaway pods on a containerd cluster (the same wire format the backend serves
+// with PodLogOptions{Timestamps: true}). Every physical line — frames included —
+// carries its own RFC3339 timestamp, and the kubelet separates it from the verbatim
+// line with a single space, so the frame's own indentation survives. `\t` is a real
+// tab; the lone "<ts> " line is a timestamped blank. Run through the production
+// parseLogLine so the {ts,text} shape under test equals what the viewer builds.
+
+// Go panic: flush-left function frames (`main.c(...)`), tab-indented file lines
+// (`\t/m.go:N`), a leading blank, bracketed by stdout `starting` / `exit status 2`.
+const GO_PANIC = [
+  '2026-06-20T10:09:30.111653171Z starting',
+  '2026-06-20T10:09:30.115719629Z panic: boom from c',
+  '2026-06-20T10:09:30.115726921Z ',
+  '2026-06-20T10:09:30.115727796Z goroutine 1 [running]:',
+  '2026-06-20T10:09:30.115728504Z main.c(...)',
+  '2026-06-20T10:09:30.115729171Z \t/m.go:2',
+  '2026-06-20T10:09:30.115729754Z main.b(...)',
+  '2026-06-20T10:09:30.115730296Z \t/m.go:3',
+  '2026-06-20T10:09:30.115730921Z main.a(...)',
+  '2026-06-20T10:09:30.115731463Z \t/m.go:4',
+  '2026-06-20T10:09:30.115731963Z main.main()',
+  '2026-06-20T10:09:30.115732504Z \t/m.go:5 +0x4c',
+  '2026-06-20T10:09:30.115891088Z exit status 2',
+]
+
+// Python traceback: 2/4-space-indented File/source/caret frames, flush-left final
+// `ValueError:`, then stdout `starting` interleaved after the trace.
+const PY_TRACE = [
+  '2026-06-20T10:10:08.026235800Z Traceback (most recent call last):',
+  '2026-06-20T10:10:08.026462300Z   File "<string>", line 4, in <module>',
+  '2026-06-20T10:10:08.026465467Z     print("starting"); a()',
+  '2026-06-20T10:10:08.026466300Z                        ~^^',
+  '2026-06-20T10:10:08.026466925Z   File "<string>", line 1, in a',
+  '2026-06-20T10:10:08.026467508Z     def a(): b()',
+  '2026-06-20T10:10:08.026468175Z              ~^^',
+  '2026-06-20T10:10:08.026468675Z   File "<string>", line 2, in b',
+  '2026-06-20T10:10:08.026469258Z     def b(): c()',
+  '2026-06-20T10:10:08.026469842Z              ~^^',
+  '2026-06-20T10:10:08.026470342Z   File "<string>", line 3, in c',
+  '2026-06-20T10:10:08.026470842Z     def c(): raise ValueError("boom from c")',
+  '2026-06-20T10:10:08.026471425Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^',
+  '2026-06-20T10:10:08.026472092Z ValueError: boom from c',
+  '2026-06-20T10:10:08.026505175Z starting',
+]
+
+// Node error: a flush-left preamble (`[eval]:1`, source echo, caret) precedes the
+// bare `Error:` head; frames are 4-space `    at …`; a `Node.js vX` footer closes.
+const NODE_ERR = [
+  '2026-06-20T10:12:05.325763924Z starting',
+  '2026-06-20T10:12:05.326386049Z [eval]:1',
+  '2026-06-20T10:12:05.326389049Z function a(){b()} function b(){c()} function c(){throw new Error("boom from c")} console.log("starting"); a()',
+  '2026-06-20T10:12:05.326390007Z                                                  ^',
+  '2026-06-20T10:12:05.326390590Z ',
+  '2026-06-20T10:12:05.326391382Z Error: boom from c',
+  '2026-06-20T10:12:05.326391965Z     at c ([eval]:1:56)',
+  '2026-06-20T10:12:05.326392465Z     at b ([eval]:1:32)',
+  '2026-06-20T10:12:05.326392965Z     at a ([eval]:1:14)',
+  '2026-06-20T10:12:05.326393507Z     at [eval]:1:107',
+  '2026-06-20T10:12:05.326394049Z     at runScriptInThisContext (node:internal/vm:219:10)',
+  '2026-06-20T10:12:05.326394715Z     at node:internal/process/execution:483:12',
+  '2026-06-20T10:12:05.326395340Z     at [eval]-wrapper:6:24',
+  '2026-06-20T10:12:05.326396007Z     at runScriptInContext (node:internal/process/execution:481:60)',
+  '2026-06-20T10:12:05.326396549Z     at evalFunction (node:internal/process/execution:315:30)',
+  '2026-06-20T10:12:05.326397007Z     at evalTypeScript (node:internal/process/execution:327:3)',
+  '2026-06-20T10:12:05.326397465Z ',
+  '2026-06-20T10:12:05.326398049Z Node.js v26.3.1',
+]
+
+// Java exception: tab-indented `\tat …` frames and a flush-left `Caused by:` chain.
+const JAVA_TRACE = [
+  '2026-06-20T10:31:05.433962257Z starting',
+  '2026-06-20T10:31:05.434200507Z Exception in thread "main" java.lang.IllegalStateException: boom from c',
+  '2026-06-20T10:31:05.434203507Z \tat App.c(App.java:2)',
+  '2026-06-20T10:31:05.434233965Z \tat App.b(App.java:3)',
+  '2026-06-20T10:31:05.434235882Z \tat App.a(App.java:4)',
+  '2026-06-20T10:31:05.434236465Z \tat App.main(App.java:5)',
+  '2026-06-20T10:31:05.434296965Z Caused by: java.lang.RuntimeException: root cause',
+  '2026-06-20T10:31:05.434298882Z \tat App.c(App.java:2)',
+  '2026-06-20T10:31:05.434299549Z \tat App.b(App.java:3)',
+  '2026-06-20T10:31:05.434326882Z \tat App.a(App.java:4)',
+  '2026-06-20T10:31:05.434328424Z \tat App.main(App.java:5)',
+  '2026-06-20T10:31:05.434329299Z \tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)',
+  '2026-06-20T10:31:05.434375465Z \tat java.base/java.lang.reflect.Method.invoke(Method.java:580)',
+  '2026-06-20T10:31:05.434378632Z \tat jdk.compiler/com.sun.tools.javac.launcher.Main.execute(Main.java:484)',
+  '2026-06-20T10:31:05.434379632Z \tat jdk.compiler/com.sun.tools.javac.launcher.Main.run(Main.java:208)',
+  '2026-06-20T10:31:05.434411215Z \tat jdk.compiler/com.sun.tools.javac.launcher.Main.main(Main.java:135)',
+]
+
+// parse turns a fixture (array of raw payload lines) into log entries via the
+// production parser, single-pod (no pod tags).
+const parse = (lines) => lines.map((l) => parseLogLine(l, null))
+
+// mk builds a single timestamped entry for the constructed (non-fixture) cases.
+let seq = 0
+const mk = (text, pod = '') => {
+  const ts = `2026-06-20T11:00:${String(seq++ % 60).padStart(2, '0')}.000000000Z`
+  return { ...parseLogLine(`${ts} ${text}`, null), pod }
+}
+
+describe('groupEntries', () => {
+  describe('Go panic', () => {
+    const groups = groupEntries(parse(GO_PANIC), true)
+
+    it('folds the panic, goroutine, flush-left frames and \\t file lines into one group', () => {
+      expect(groups).toHaveLength(3)
+      const trace = groups[1]
+      expect(trace.head.text).toBe('panic: boom from c')
+      expect(trace.lines).toHaveLength(11)
+      expect(trace.isTrace).toBe(true)
+      expect(trace.goTrace).toBe(true)
+    })
+
+    it('detects the panic as fatal and keeps stdout lines as their own entries', () => {
+      expect(groups[1].level).toBe('fatal')
+      expect(groups[0].lines).toHaveLength(1)
+      expect(groups[0].head.text).toBe('starting')
+      expect(groups[2].lines).toHaveLength(1)
+      expect(groups[2].head.text).toBe('exit status 2')
+    })
+  })
+
+  describe('Python traceback', () => {
+    const groups = groupEntries(parse(PY_TRACE), true)
+
+    it('folds the indented frames and the flush-left final exception into one group', () => {
+      expect(groups).toHaveLength(2)
+      const trace = groups[0]
+      expect(trace.head.text).toBe('Traceback (most recent call last):')
+      expect(trace.lines).toHaveLength(14)
+      expect(trace.isTrace).toBe(true)
+      expect(trace.lines.at(-1).text).toBe('ValueError: boom from c')
+    })
+
+    it('bumps an unleveled trace head to error and closes on the trailing stdout', () => {
+      expect(groups[0].level).toBe('error')
+      expect(groups[1].head.text).toBe('starting')
+    })
+  })
+
+  describe('Node error', () => {
+    const groups = groupEntries(parse(NODE_ERR), true)
+    const trace = groups.find((g) => g.head && g.head.text === 'Error: boom from c')
+
+    it('folds the 4-space at-frames under the bare Error head', () => {
+      expect(trace).toBeTruthy()
+      expect(trace.isTrace).toBe(true)
+      expect(trace.level).toBe('error')
+      expect(trace.lines.some((l) => l.text === '    at c ([eval]:1:56)')).toBe(true)
+    })
+
+    it('does not fold the Node.js footer into the trace', () => {
+      const footer = groups.find((g) => g.head && g.head.text === 'Node.js v26.3.1')
+      expect(footer).toBeTruthy()
+      expect(footer.lines).toHaveLength(1)
+    })
+  })
+
+  describe('Java exception', () => {
+    const groups = groupEntries(parse(JAVA_TRACE), true)
+
+    it('folds the tab-indented frames and the Caused by chain into one group', () => {
+      expect(groups).toHaveLength(2)
+      const trace = groups[1]
+      expect(trace.head.text).toContain('IllegalStateException')
+      expect(trace.isTrace).toBe(true)
+      expect(trace.level).toBe('error')
+      expect(trace.lines).toHaveLength(15)
+      expect(trace.lines.some((l) => l.text === 'Caused by: java.lang.RuntimeException: root cause')).toBe(true)
+    })
+  })
+
+  describe('SIGQUIT goroutine dump (no panic head)', () => {
+    it('opens a Go trace on a bare goroutine line and folds its frames', () => {
+      const groups = groupEntries([
+        mk('goroutine 1 [running]:'),
+        mk('main.f(...)'),
+        mk('\t/m.go:9'),
+      ], true)
+      expect(groups).toHaveLength(1)
+      expect(groups[0].isTrace).toBe(true)
+      expect(groups[0].goTrace).toBe(true)
+      expect(groups[0].lines).toHaveLength(3)
+    })
+  })
+
+  describe('negatives', () => {
+    it('does not fold a flush-left paren line with no open trace', () => {
+      const groups = groupEntries([mk('server listening'), mk('connect(addr)')], true)
+      expect(groups).toHaveLength(2)
+    })
+
+    it('does not fold a flush-left line under a non-Go (bare Error) head', () => {
+      // GO_FRAME is Go-gated, so a `)`-line is not consulted under an `Error:` head.
+      const groups = groupEntries([
+        mk('Error: cannot reach upstream'),
+        mk('falling back to cache (stale)'),
+      ], true)
+      expect(groups).toHaveLength(2)
+      expect(groups[0].isTrace).toBe(true)
+      expect(groups[0].lines).toHaveLength(1)
+    })
+
+    it('closes a trace on the first plain line after it', () => {
+      const groups = groupEntries([
+        mk('panic: x'),
+        mk('goroutine 1 [running]:'),
+        mk('main.f(...)'),
+        mk('server resumed'),
+      ], true)
+      expect(groups).toHaveLength(2)
+      expect(groups[0].lines).toHaveLength(3)
+      expect(groups[1].head.text).toBe('server resumed')
+    })
+
+    it('never folds an unambiguous frame across pods (samePod guard)', () => {
+      const groups = groupEntries([
+        mk('panic: boom', 'pod-a'),
+        mk('\tat App.c(App.java:2)', 'pod-b'),
+      ], true)
+      expect(groups).toHaveLength(2)
+    })
+
+    it('emits one group per entry when disabled', () => {
+      const entries = parse(GO_PANIC)
+      const groups = groupEntries(entries, false)
+      expect(groups).toHaveLength(entries.length)
+      expect(groups.every((g) => g.lines.length === 1)).toBe(true)
+    })
+
+    it('does not swallow an unrelated untimestamped line', () => {
+      // A lone untimestamped non-frame following a plain head is its own entry.
+      const groups = groupEntries([mk('ok'), { ...parseLogLine('retry later', null), pod: '' }], true)
+      expect(groups).toHaveLength(2)
+    })
+
+    it('does not fold an indented at/File line with no open trace', () => {
+      // Without a recognized head the frames stay separate, so a stray indented
+      // line like "  at startup" can never collapse into the previous log.
+      const groups = groupEntries([mk('cache ready'), mk('  at startup: warm')], true)
+      expect(groups).toHaveLength(2)
+    })
+  })
+
+  describe('extended head and marker coverage', () => {
+    it('recognizes a bracketed Node error-code head and folds its frames', () => {
+      const groups = groupEntries([
+        mk('TypeError [ERR_INVALID_ARG_TYPE]: bad arg'),
+        mk('    at parse (node:internal/x:1:2)'),
+        mk('    at run (node:internal/y:3:4)'),
+      ], true)
+      expect(groups).toHaveLength(1)
+      expect(groups[0].isTrace).toBe(true)
+      expect(groups[0].level).toBe('error')
+      expect(groups[0].lines).toHaveLength(3)
+    })
+
+    it('folds a suffix-less Python final (KeyboardInterrupt) into the trace', () => {
+      const groups = groupEntries([
+        mk('Traceback (most recent call last):'),
+        mk('  File "<string>", line 1, in <module>'),
+        mk('KeyboardInterrupt'),
+      ], true)
+      expect(groups).toHaveLength(1)
+      expect(groups[0].lines).toHaveLength(3)
+      expect(groups[0].lines.at(-1).text).toBe('KeyboardInterrupt')
+    })
+
+    it('folds a fully-qualified Java throwable final into the trace', () => {
+      const groups = groupEntries([
+        mk('Exception in thread "main" java.lang.RuntimeException: wrap'),
+        mk('\tat App.run(App.java:9)'),
+        mk('java.lang.OutOfMemoryError: heap'),
+      ], true)
+      expect(groups).toHaveLength(1)
+      expect(groups[0].lines).toHaveLength(3)
+    })
+  })
+})
+
+describe('parseLogLine', () => {
+  it('preserves a frame\'s leading tab after stripping the timestamp', () => {
+    const entry = parseLogLine('2026-06-20T10:00:00.000000000Z \t/m.go:2', null)
+    expect(entry.text).toBe('\t/m.go:2')
+    expect(entry.ts).toBe('2026-06-20T10:00:00.000000000Z')
+  })
+
+  it('preserves leading spaces of an indented frame', () => {
+    const entry = parseLogLine('2026-06-20T10:00:00.000000000Z     at c ([eval]:1:56)', null)
+    expect(entry.text).toBe('    at c ([eval]:1:56)')
+  })
+
+  it('parses a plain head line and leaves a non-timestamped line untimestamped', () => {
+    expect(parseLogLine('2026-06-20T10:00:00.000000000Z hello', null).text).toBe('hello')
+    const cont = parseLogLine('  some continuation', null)
+    expect(cont.ts).toBe('')
+    expect(cont.text).toBe('  some continuation')
+  })
+})

--- a/web/src/utils/logGroup.test.js
+++ b/web/src/utils/logGroup.test.js
@@ -4,6 +4,7 @@
 import { describe, it, expect } from 'vitest'
 import { groupEntries } from './logGroup'
 import { parseLogLine } from '../components/dashboards/workload/WorkloadLogsViewer'
+import { detectLevel } from './logLevel'
 
 // The fixtures below are verbatim `kubectl logs --timestamps` output captured from
 // throwaway pods on a containerd cluster (the same wire format the backend serves
@@ -94,15 +95,21 @@ const JAVA_TRACE = [
   '2026-06-20T10:31:05.434411215Z \tat jdk.compiler/com.sun.tools.javac.launcher.Main.main(Main.java:135)',
 ]
 
+// withLevel attaches the detected level to a parsed entry, mirroring what the
+// viewer's formattedLines does in production: parseLogLine no longer computes the
+// level (it's formatted-only now), so the unit tests — which feed groupEntries
+// directly, bypassing formattedLines — must supply it for the trace level bump.
+const withLevel = (e) => ({ ...e, level: detectLevel(e.text) })
+
 // parse turns a fixture (array of raw payload lines) into log entries via the
 // production parser, single-pod (no pod tags).
-const parse = (lines) => lines.map((l) => parseLogLine(l, null))
+const parse = (lines) => lines.map((l) => withLevel(parseLogLine(l, null)))
 
 // mk builds a single timestamped entry for the constructed (non-fixture) cases.
 let seq = 0
 const mk = (text, pod = '') => {
   const ts = `2026-06-20T11:00:${String(seq++ % 60).padStart(2, '0')}.000000000Z`
-  return { ...parseLogLine(`${ts} ${text}`, null), pod }
+  return { ...withLevel(parseLogLine(`${ts} ${text}`, null)), pod }
 }
 
 describe('groupEntries', () => {
@@ -237,7 +244,7 @@ describe('groupEntries', () => {
 
     it('does not swallow an unrelated untimestamped line', () => {
       // A lone untimestamped non-frame following a plain head is its own entry.
-      const groups = groupEntries([mk('ok'), { ...parseLogLine('retry later', null), pod: '' }], true)
+      const groups = groupEntries([mk('ok'), { ...withLevel(parseLogLine('retry later', null)), pod: '' }], true)
       expect(groups).toHaveLength(2)
     })
 
@@ -291,7 +298,7 @@ describe('groupEntries — unstructured bursts', () => {
   const T0 = Date.parse('2026-06-20T11:00:00.000Z')
   const be = (text, offsetMs, structured, pod = '') => {
     const iso = new Date(T0 + offsetMs).toISOString()
-    return { ...parseLogLine(`${iso} ${text}`, null), pod, podId: pod, structured }
+    return { ...withLevel(parseLogLine(`${iso} ${text}`, null)), pod, podId: pod, structured }
   }
 
   it('groups a co-timestamped curl -v dump into one unstructured run', () => {
@@ -385,7 +392,7 @@ describe('groupEntries — container scoping', () => {
   let cseq = 0
   const ce = (text, container, pod = '') => {
     const ts = `2026-06-20T12:00:${String(cseq++ % 60).padStart(2, '0')}.000000000Z`
-    return { ...parseLogLine(`${ts} ${text}`, null), container, pod, podId: pod }
+    return { ...withLevel(parseLogLine(`${ts} ${text}`, null)), container, pod, podId: pod }
   }
 
   it('folds a trace within one container', () => {
@@ -431,7 +438,7 @@ describe('groupEntries — container scoping', () => {
   it('an orphan continuation (no container) inherits its predecessor and folds in', () => {
     const groups = groupEntries([
       ce('panic: boom', 'app'),
-      { ...parseLogLine('  at frame', null), container: '', pod: '' },
+      { ...withLevel(parseLogLine('  at frame', null)), container: '', pod: '' },
     ], true)
     expect(groups).toHaveLength(1)
     expect(groups[0].lines).toHaveLength(2)
@@ -442,7 +449,7 @@ describe('groupEntries — container scoping', () => {
     // different containers must not join one run.
     const T0 = Date.parse('2026-06-20T12:30:00.000Z')
     const bc = (text, offsetMs, container) => ({
-      ...parseLogLine(`${new Date(T0 + offsetMs).toISOString()} ${text}`, null),
+      ...withLevel(parseLogLine(`${new Date(T0 + offsetMs).toISOString()} ${text}`, null)),
       container, pod: '', podId: '', structured: false,
     })
     const groups = groupEntries([

--- a/web/src/utils/logLevel.js
+++ b/web/src/utils/logLevel.js
@@ -83,6 +83,11 @@ const LEADING_LEVEL = /^([a-z]+)[:\t]/
 // the uppercase TEXT_LEVEL misses it); read the level from the 2nd tab field when
 // the 1st is an ISO-8601 or epoch timestamp.
 const ZAP_TS = /^(?:\d{4}-\d{2}-\d{2}T[\d:.]+(?:Z|[+-]\d{2}:?\d{2})?|\d{9,}(?:\.\d+)?)$/
+// NLog default layout "<longdate>|<LEVEL>|<logger>|<msg>": the level sits between
+// pipes, which TEXT_LEVEL's boundary classes exclude, so read it from the 2nd pipe
+// field. Anchored to a leading longdate so a free-form "result|ERROR|stack" (no
+// timestamp) is not misread as a level.
+const NLOG_LEVEL = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[.,]\d+\|([A-Za-z]+)\|/
 // A bracketed level token, any case, e.g. nginx "[error]", Envoy/Istio
 // "[warning]", MySQL "[Warning]", structlog "[info     ]", Elasticsearch "[INFO ]".
 // Global so multi-bracket lines (Envoy "[16][warning][config]") are scanned.
@@ -91,10 +96,20 @@ const BRACKET_LEVEL = /[[(]\s*([a-zA-Z]+)\s*[\])]/g
 // match. The leading `.` boundary catches Monolog's "channel.LEVEL:" prefix
 // (PHP); the trailing `/` catches Celery's "[ERROR/MainProcess]"; the short
 // codes (INF/WRN/ERR/FTL/DBG/VRB/TRC/PNC) catch Serilog/zerolog console output,
-// and FINE/FINER/FINEST cover java.util.logging.
-const TEXT_LEVEL = /(?:^|[\s[(.])(TRACE|TRC|DEBUG|DBG|INFO|INF|WARN(?:ING)?|WRN|ERROR|ERR|FATAL|FTL|SEVERE|CRITICAL|NOTICE|PANIC|PNC|VRB|FINEST|FINER|FINE)(?:[\s\]):/]|$)/
+// FINE/FINER/FINEST cover java.util.logging, and ALERT/EMERGENCY cover Monolog's
+// upper PSR-3 levels.
+const TEXT_LEVEL = /(?:^|[\s[(.])(TRACE|TRC|DEBUG|DBG|INFO|INF|WARN(?:ING)?|WRN|ERROR|ERR|FATAL|FTL|SEVERE|CRITICAL|NOTICE|PANIC|PNC|VRB|FINEST|FINER|FINE|ALERT|EMERGENCY)(?:[\s\]):/]|$)/
 
-function fromString(s) {
+/**
+ * fromString - normalize a logger's level word/short-code (any case) to one of
+ * LEVELS, or null when unrecognized. Backs both the pill's detection cascade and
+ * the in-body level tint in logFormat.js, so a level word maps the same way in
+ * both places.
+ *
+ * @param {string} s - The level token (e.g. "WARNING", "VRB", "crit")
+ * @returns {string|null} A value from LEVELS, or null
+ */
+export function fromString(s) {
   return STRING_ALIAS[s.toLowerCase()] || null
 }
 
@@ -177,6 +192,15 @@ export function detectLevel(text) {
     const parts = text.split('\t')
     if (parts.length >= 2 && ZAP_TS.test(parts[0])) {
       const lvl = fromString(parts[1])
+      if (lvl) return lvl
+    }
+  }
+
+  // NLog default layout: longdate-led, level in the 2nd pipe field.
+  if (text.indexOf('|') !== -1) {
+    const nl = NLOG_LEVEL.exec(text)
+    if (nl) {
+      const lvl = fromString(nl[1])
       if (lvl) return lvl
     }
   }

--- a/web/src/utils/logLevel.js
+++ b/web/src/utils/logLevel.js
@@ -78,6 +78,11 @@ const KLOG = /^([IWEF])\d{4}\s/
 // console formatters of winston (Node, "error: msg"), .NET
 // Microsoft.Extensions.Logging ("warn: Category[0]"), and zap's console encoder.
 const LEADING_LEVEL = /^([a-z]+)[:\t]/
+// zap console encoder: "<ts>\t<level>\t...". zap leads with its own timestamp
+// (so LEADING_LEVEL can't see the level) and defaults to a lowercase level (so
+// the uppercase TEXT_LEVEL misses it); read the level from the 2nd tab field when
+// the 1st is an ISO-8601 or epoch timestamp.
+const ZAP_TS = /^(?:\d{4}-\d{2}-\d{2}T[\d:.]+(?:Z|[+-]\d{2}:?\d{2})?|\d{9,}(?:\.\d+)?)$/
 // A bracketed level token, any case, e.g. nginx "[error]", Envoy/Istio
 // "[warning]", MySQL "[Warning]", structlog "[info     ]", Elasticsearch "[INFO ]".
 // Global so multi-bracket lines (Envoy "[16][warning][config]") are scanned.
@@ -160,11 +165,20 @@ export function detectLevel(text) {
   const k = KLOG.exec(text)
   if (k) return KLOG_CHAR[k[1]]
 
-  // Leading lowercase level token + ":"/tab (winston, .NET, zap console).
+  // Leading lowercase level token + ":"/tab (winston, .NET).
   const d = LEADING_LEVEL.exec(text)
   if (d) {
     const lvl = fromString(d[1])
     if (lvl) return lvl
+  }
+
+  // zap console encoder: timestamp-led, level in the 2nd tab field.
+  if (text.indexOf('\t') !== -1) {
+    const parts = text.split('\t')
+    if (parts.length >= 2 && ZAP_TS.test(parts[0])) {
+      const lvl = fromString(parts[1])
+      if (lvl) return lvl
+    }
   }
 
   // logfmt level=...

--- a/web/src/utils/logLevel.js
+++ b/web/src/utils/logLevel.js
@@ -1,0 +1,201 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Normalized log levels, ordered by severity. `info` is the default for lines
+// whose level cannot be determined, so every line carries a level.
+export const LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
+
+export const DEFAULT_LEVEL = 'info'
+
+// Per-level display metadata:
+// - `label`  human name (legend, menu, tooltips)
+// - `border` Tailwind border color for the timestamp pill and its separator
+//            rule (light/dark); `info` is a faint blue so every line reads as
+//            colored while staying calm, escalating through amber/red.
+// - `swatch` solid background for the legend/menu color dots
+// - `glow`   ready-to-use rgba for the latest-line border glow (--glow-color in
+//            index.css), matching the Tailwind shade noted per row.
+export const LEVEL_META = {
+  trace: { label: 'Trace', border: 'border-gray-300 dark:border-gray-600', swatch: 'bg-gray-400', glow: 'rgba(156,163,175,0.6)' }, // gray-400
+  debug: { label: 'Debug', border: 'border-slate-400 dark:border-slate-500', swatch: 'bg-slate-400', glow: 'rgba(148,163,184,0.6)' }, // slate-400
+  info: { label: 'Info', border: 'border-blue-300 dark:border-blue-700', swatch: 'bg-blue-400', glow: 'rgba(96,165,250,0.6)' }, // blue-400
+  warn: { label: 'Warn', border: 'border-amber-400 dark:border-amber-500', swatch: 'bg-amber-400', glow: 'rgba(245,158,11,0.6)' }, // amber-500
+  error: { label: 'Error', border: 'border-red-400 dark:border-red-500', swatch: 'bg-red-400', glow: 'rgba(239,68,68,0.6)' }, // red-500
+  fatal: { label: 'Fatal', border: 'border-red-600 dark:border-red-500', swatch: 'bg-red-600', glow: 'rgba(220,38,38,0.6)' } // red-600
+}
+
+// Matches ANSI SGR (color) escape sequences, e.g. "\x1b[31m".
+// eslint-disable-next-line no-control-regex
+const ANSI_SGR = /\x1b\[[0-9;]*m/g
+
+/**
+ * stripAnsi - removes ANSI color escape sequences from a log line so they don't
+ * render as garbage and don't break level detection. Cheap-guarded so plain
+ * lines (the common case) skip the replace.
+ *
+ * @param {string} text - The log line text
+ * @returns {string} The text without ANSI escapes
+ */
+export function stripAnsi(text) {
+  return text.indexOf('\x1b') === -1 ? text : text.replace(ANSI_SGR, '')
+}
+
+// String level aliases across loggers (zap, logrus, slog, klog, GCP, syslog,
+// .NET, winston, JUL). The short codes cover Serilog/zerolog u3 codes
+// (vrb/trc/dbg/inf/wrn/err/ftl/pnc) and the Microsoft.Extensions.Logging console
+// prefixes (trce/dbug/fail/crit). `silly`/`http` are winston's extra npm levels.
+const STRING_ALIAS = {
+  trace: 'trace', trc: 'trace', trce: 'trace', finest: 'trace', verbose: 'trace', vrb: 'trace', silly: 'trace',
+  debug: 'debug', dbg: 'debug', dbug: 'debug', fine: 'debug', finer: 'debug',
+  info: 'info', inf: 'info', information: 'info', informational: 'info', notice: 'info', http: 'info',
+  warn: 'warn', wrn: 'warn', warning: 'warn',
+  error: 'error', err: 'error', eror: 'error', fail: 'error', severe: 'error', dpanic: 'error',
+  fatal: 'fatal', ftl: 'fatal', pnc: 'fatal', critical: 'fatal', crit: 'fatal', panic: 'fatal',
+  alert: 'fatal', emergency: 'fatal', emerg: 'fatal'
+}
+
+// MongoDB logv2 single-char severity codes (F/E/W/I/D; D1..D5 = debug verbosity).
+const SEVERITY_CHAR = { F: 'fatal', E: 'error', W: 'warn', I: 'info', D: 'debug' }
+
+// klog/glog leading severity character.
+const KLOG_CHAR = { I: 'info', W: 'warn', E: 'error', F: 'fatal' }
+
+// JSON level field names, in priority order, read from the parsed top-level
+// object (not a raw substring scan, so a nested or message field can't shadow
+// the real level). `level_name` covers Monolog (PHP); `@l`/`@level` Serilog CLEF
+// and hclog (Terraform/Vault/Consul/Nomad). ECS nested `log.level` and MongoDB's
+// logv2 `s` code are handled separately in levelFromObject.
+const JSON_FIELDS = ['level', 'severity', 'lvl', 'log.level', 'level_name', '@level', '@l']
+// Fallback for a line that starts with `{` but is not strict JSON (e.g. a
+// truncated line): best-effort first level field, string or numeric.
+const JSON_LEVEL_FALLBACK = /"(?:@level|@l|level_name|level|severity|lvl|log\.level)"\s*:\s*(?:"([^"]+)"|(-?\d+))/i
+// logfmt level=value; the trailing (?!\w) rejects partial captures such as
+// `level=error_code` (which would otherwise yield "error").
+const LOGFMT_LEVEL = /(?:^|\s)(?:level|lvl|severity)=["']?([a-zA-Z]+)["']?(?!\w)/
+// klog: leading severity char + MMDD.
+const KLOG = /^([IWEF])\d{4}\s/
+// A lowercase level token at line start followed by `:` or a tab. Covers the
+// console formatters of winston (Node, "error: msg"), .NET
+// Microsoft.Extensions.Logging ("warn: Category[0]"), and zap's console encoder.
+const LEADING_LEVEL = /^([a-z]+)[:\t]/
+// A bracketed level token, any case, e.g. nginx "[error]", Envoy/Istio
+// "[warning]", MySQL "[Warning]", structlog "[info     ]", Elasticsearch "[INFO ]".
+// Global so multi-bracket lines (Envoy "[16][warning][config]") are scanned.
+const BRACKET_LEVEL = /[[(]\s*([a-zA-Z]+)\s*[\])]/g
+// Plain text: an uppercase level token, bounded so mid-message "error" doesn't
+// match. The leading `.` boundary catches Monolog's "channel.LEVEL:" prefix
+// (PHP); the trailing `/` catches Celery's "[ERROR/MainProcess]"; the short
+// codes (INF/WRN/ERR/FTL/DBG/VRB/TRC/PNC) catch Serilog/zerolog console output,
+// and FINE/FINER/FINEST cover java.util.logging.
+const TEXT_LEVEL = /(?:^|[\s[(.])(TRACE|TRC|DEBUG|DBG|INFO|INF|WARN(?:ING)?|WRN|ERROR|ERR|FATAL|FTL|SEVERE|CRITICAL|NOTICE|PANIC|PNC|VRB|FINEST|FINER|FINE)(?:[\s\]):/]|$)/
+
+function fromString(s) {
+  return STRING_ALIAS[s.toLowerCase()] || null
+}
+
+// fromSeverityChar maps a MongoDB logv2 severity code to a normalized level:
+// F/E/W/I, or D with an optional debug verbosity digit (D, D1..D5).
+function fromSeverityChar(s) {
+  return /^(?:[FEWI]|D[1-5]?)$/.test(s) ? SEVERITY_CHAR[s[0]] : null
+}
+
+// syslog/RFC 5424 severities 0..7 mapped to normalized levels.
+const SYSLOG_LEVELS = ['fatal', 'fatal', 'fatal', 'error', 'warn', 'info', 'info', 'debug']
+
+// Numeric levels: pino/bunyan use 10..60 (multiples of ten, same order as
+// LEVELS); syslog uses 0..7. zap emits negatives for debug/trace.
+function fromNumber(n) {
+  if (n < 0) return 'debug'
+  if (n % 10 === 0 && n >= 10 && n <= 60) return LEVELS[n / 10 - 1]
+  if (n >= 0 && n <= 7) return SYSLOG_LEVELS[n]
+  return null
+}
+
+// levelFromObject reads the severity from a parsed JSON log object: the known
+// fields in priority order, then ECS nested `log.level`, then MongoDB's
+// single-char `s`. Reads only top-level keys, so a nested or message field
+// never shadows the real level. Returns null when none resolve.
+function levelFromObject(obj) {
+  if (!obj || typeof obj !== 'object') return null
+  for (const f of JSON_FIELDS) {
+    const v = obj[f]
+    if (v == null) continue
+    const lvl = typeof v === 'number' ? fromNumber(v) : typeof v === 'string' ? fromString(v) : null
+    if (lvl) return lvl
+  }
+  if (obj.log && typeof obj.log.level === 'string') {
+    const lvl = fromString(obj.log.level)
+    if (lvl) return lvl
+  }
+  if (typeof obj.s === 'string') return fromSeverityChar(obj.s)
+  return null
+}
+
+/**
+ * detectLevel - determine the normalized severity of a log line across the
+ * common formats (JSON, klog, logfmt, bracketed and plain text). Runs a cheap
+ * cascade, cheapest checks first, and falls back to the default `info`.
+ *
+ * @param {string} text - The log line text (timestamp and ANSI already stripped)
+ * @returns {string} A value from LEVELS
+ */
+export function detectLevel(text) {
+  if (!text) return DEFAULT_LEVEL
+
+  // JSON: parse the object and read known level fields, top-level only. A line
+  // that looks like JSON is classified solely by its fields — never by message
+  // content — so it does not fall through to the text matchers below.
+  if (text[0] === '{') {
+    let lvl
+    try {
+      lvl = levelFromObject(JSON.parse(text))
+    } catch {
+      const m = JSON_LEVEL_FALLBACK.exec(text)
+      lvl = m ? (m[1] != null ? fromString(m[1]) : fromNumber(Number(m[2]))) : null
+    }
+    return lvl || DEFAULT_LEVEL
+  }
+
+  // klog/glog severity prefix.
+  const k = KLOG.exec(text)
+  if (k) return KLOG_CHAR[k[1]]
+
+  // Leading lowercase level token + ":"/tab (winston, .NET, zap console).
+  const d = LEADING_LEVEL.exec(text)
+  if (d) {
+    const lvl = fromString(d[1])
+    if (lvl) return lvl
+  }
+
+  // logfmt level=...
+  if (text.indexOf('=') !== -1) {
+    const lf = LOGFMT_LEVEL.exec(text)
+    if (lf) {
+      const lvl = fromString(lf[1])
+      if (lvl) return lvl
+    }
+  }
+
+  // Bracketed level token, any case (nginx, Envoy/Istio, MySQL, structlog).
+  // Scan only the leading segment, before the first quote or `=`, so a stray
+  // "[error]" inside a message or logfmt value is not treated as the level.
+  if (text.indexOf('[') !== -1 || text.indexOf('(') !== -1) {
+    const cut = text.search(/["'=]/)
+    const head = cut === -1 ? text : text.slice(0, cut)
+    BRACKET_LEVEL.lastIndex = 0
+    let b
+    while ((b = BRACKET_LEVEL.exec(head)) !== null) {
+      const lvl = fromString(b[1])
+      if (lvl) return lvl
+    }
+  }
+
+  // Plain text uppercase level token.
+  const t = TEXT_LEVEL.exec(text)
+  if (t) {
+    const lvl = fromString(t[1])
+    if (lvl) return lvl
+  }
+
+  return DEFAULT_LEVEL
+}

--- a/web/src/utils/logLevel.test.js
+++ b/web/src/utils/logLevel.test.js
@@ -1,0 +1,194 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect } from 'vitest'
+import { detectLevel, stripAnsi, LEVELS, LEVEL_META } from './logLevel'
+
+describe('detectLevel', () => {
+  it('defaults to info for empty or plain unmarked lines', () => {
+    expect(detectLevel('')).toBe('info')
+    expect(detectLevel('reconciliation finished in 1.2s')).toBe('info')
+  })
+
+  describe('JSON', () => {
+    it('reads string level fields and their aliases', () => {
+      expect(detectLevel('{"level":"error","msg":"boom"}')).toBe('error')
+      expect(detectLevel('{"severity":"WARNING","msg":"x"}')).toBe('warn')
+      expect(detectLevel('{"lvl":"err"}')).toBe('error')
+      expect(detectLevel('{"level":"dpanic"}')).toBe('error')
+      expect(detectLevel('{"log.level":"debug"}')).toBe('debug')
+      expect(detectLevel('{"level_name":"ERROR","message":"boom"}')).toBe('error')
+      expect(detectLevel('{"@t":"2026-06-16T10:00:00Z","@l":"Error","@m":"boom"}')).toBe('error')
+      expect(detectLevel('{"@level":"info","@message":"started","@module":"vault"}')).toBe('info')
+    })
+
+    it('reads MongoDB logv2 single-char severity codes', () => {
+      expect(detectLevel('{"t":{"$date":"2026-06-16T10:00:00Z"},"s":"E","c":"NETWORK","msg":"x"}')).toBe('error')
+      expect(detectLevel('{"t":{},"s":"W","c":"STORAGE","msg":"x"}')).toBe('warn')
+      expect(detectLevel('{"t":{},"s":"I","c":"NETWORK","msg":"x"}')).toBe('info')
+      expect(detectLevel('{"t":{},"s":"D2","c":"INDEX","msg":"x"}')).toBe('debug')
+      expect(detectLevel('{"t":{},"s":"F","c":"CONTROL","msg":"x"}')).toBe('fatal')
+    })
+
+    it('keeps scanning past an unmappable numeric level to a later string field', () => {
+      // Monolog JsonFormatter emits numeric "level":400 before "level_name".
+      expect(detectLevel('{"message":"boom","context":{},"level":400,"level_name":"ERROR"}')).toBe('error')
+    })
+
+    it('does not treat an arbitrary string "s" field as a severity code', () => {
+      expect(detectLevel('{"s":"running","level":"warn"}')).toBe('warn')
+      // A real severity-shaped "s" must not shadow an explicit level field.
+      expect(detectLevel('{"s":"E","level":"info"}')).toBe('info')
+    })
+
+    it('reads only the top-level level, ignoring nested objects', () => {
+      expect(detectLevel('{"payload":{"level":"error"},"level":"info"}')).toBe('info')
+    })
+
+    it('reads the ECS nested log.level object', () => {
+      expect(detectLevel('{"log":{"level":"warn"},"message":"slow"}')).toBe('warn')
+    })
+
+    it('does not classify a JSON line by its message content', () => {
+      expect(detectLevel('{"msg":"user typed [error]"}')).toBe('info')
+      expect(detectLevel('{"msg":"handled ERROR condition"}')).toBe('info')
+    })
+
+    it('does not accept out-of-range MongoDB debug verbosity codes', () => {
+      expect(detectLevel('{"t":{},"s":"E9","c":"X","msg":"y"}')).toBe('info')
+      expect(detectLevel('{"t":{},"s":"D9","c":"X","msg":"y"}')).toBe('info')
+    })
+
+    it('reads numeric pino/bunyan levels (10-60)', () => {
+      expect(detectLevel('{"level":10,"msg":"x"}')).toBe('trace')
+      expect(detectLevel('{"level":30,"msg":"x"}')).toBe('info')
+      expect(detectLevel('{"level":40}')).toBe('warn')
+      expect(detectLevel('{"level":50}')).toBe('error')
+      expect(detectLevel('{"level":60}')).toBe('fatal')
+    })
+
+    it('reads syslog numeric levels (0-7) distinct from the pino scale', () => {
+      expect(detectLevel('{"level":3}')).toBe('error')
+      expect(detectLevel('{"level":7}')).toBe('debug')
+      expect(detectLevel('{"level":0}')).toBe('fatal')
+    })
+  })
+
+  it('reads klog severity prefixes', () => {
+    expect(detectLevel('I0616 10:00:00.123456 1 controller.go:42] reconciling')).toBe('info')
+    expect(detectLevel('W0616 10:00:00.123456 1 controller.go:42] slow')).toBe('warn')
+    expect(detectLevel('E0616 10:00:00.123456 1 controller.go:42] failed')).toBe('error')
+    expect(detectLevel('F0616 10:00:00.123456 1 controller.go:42] fatal')).toBe('fatal')
+  })
+
+  it('reads logfmt level fields', () => {
+    expect(detectLevel('ts=2026-01-01 level=warn msg="slow"')).toBe('warn')
+    expect(detectLevel('level=error component=api')).toBe('error')
+  })
+
+  it('reads plain-text uppercase level tokens', () => {
+    expect(detectLevel('ERROR something broke')).toBe('error')
+    expect(detectLevel('2026-06-16 10:00:00.123  INFO 1 --- [main] c.e.App : started')).toBe('info')
+    expect(detectLevel('[WARN] disk almost full')).toBe('warn')
+    expect(detectLevel('[2026-06-16T10:00:00.000000+00:00] app.ERROR: boom [] []')).toBe('error')
+    expect(detectLevel('[2026-06-16T10:00:00.000000+00:00] request.INFO: handled [] []')).toBe('info')
+  })
+
+  it('reads .NET Microsoft.Extensions.Logging console prefixes', () => {
+    expect(detectLevel('info: Microsoft.Hosting.Lifetime[0]')).toBe('info')
+    expect(detectLevel('warn: MyApp.Worker[0]')).toBe('warn')
+    expect(detectLevel('fail: MyApp.Worker[0]')).toBe('error')
+    expect(detectLevel('crit: MyApp.Worker[0]')).toBe('fatal')
+    expect(detectLevel('dbug: MyApp.Worker[0]')).toBe('debug')
+    expect(detectLevel('trce: MyApp.Worker[0]')).toBe('trace')
+  })
+
+  it('reads Serilog u3 level codes', () => {
+    expect(detectLevel('[12:34:56 INF] Starting up')).toBe('info')
+    expect(detectLevel('[12:34:56 WRN] disk slow')).toBe('warn')
+    expect(detectLevel('[12:34:56 ERR] request failed')).toBe('error')
+    expect(detectLevel('[12:34:56 FTL] crashed')).toBe('fatal')
+    expect(detectLevel('[12:34:56 DBG] cache hit')).toBe('debug')
+    expect(detectLevel('[12:34:56 VRB] trace detail')).toBe('trace')
+  })
+
+  it('reads zerolog console codes', () => {
+    expect(detectLevel('TRC trace detail foo=bar')).toBe('trace')
+    expect(detectLevel('PNC panic recovered')).toBe('fatal')
+  })
+
+  it('reads java.util.logging plain levels', () => {
+    expect(detectLevel('FINE: cache populated')).toBe('debug')
+    expect(detectLevel('FINEST: entering method')).toBe('trace')
+  })
+
+  it('reads leading lowercase level tokens (winston, zap console)', () => {
+    expect(detectLevel('error: connection refused')).toBe('error')
+    expect(detectLevel('debug: cache miss')).toBe('debug')
+    expect(detectLevel('verbose: tracing request')).toBe('trace')
+    expect(detectLevel('warn: retrying')).toBe('warn')
+    expect(detectLevel('info\tcaller\tserver started')).toBe('info')
+  })
+
+  it('does not treat a leading prose word as a level', () => {
+    expect(detectLevel('error handling middleware registered ok')).toBe('info')
+  })
+
+  it('reads bracketed lowercase/mixed-case level tokens', () => {
+    expect(detectLevel('[error] 1#1: *1 connect() failed')).toBe('error') // nginx error_log
+    expect(detectLevel('[warn] 1#1: low on memory')).toBe('warn') // nginx
+    expect(detectLevel('[crit] 1#1: out of memory')).toBe('fatal') // nginx
+    expect(detectLevel('[16][warning][config] xds update rejected')).toBe('warn') // Envoy/Istio
+    expect(detectLevel('[16][error][upstream] connection failure')).toBe('error') // Envoy
+    expect(detectLevel('[Warning] [MY-010055] connection aborted')).toBe('warn') // MySQL
+    expect(detectLevel('[info     ] request handled    method=GET')).toBe('info') // structlog
+  })
+
+  it('does not match a non-level bracketed word', () => {
+    expect(detectLevel('[main] starting reconciler loop')).toBe('info')
+  })
+
+  it('ignores a bracketed level inside a message or logfmt value', () => {
+    expect(detectLevel('request completed message="user typed [error]"')).toBe('info')
+    expect(detectLevel('msg=processing note=[error] handled gracefully')).toBe('info')
+  })
+
+  it('does not capture a partial logfmt level value', () => {
+    expect(detectLevel('level=error_code component=api')).toBe('info')
+    expect(detectLevel('level=warn component=api')).toBe('warn')
+  })
+
+  it('reads a uppercase level token followed by a slash (Celery)', () => {
+    expect(detectLevel('[ERROR/MainProcess] task failed')).toBe('error')
+  })
+
+  it('does not match the word "error" mid-message (lowercase)', () => {
+    expect(detectLevel('handled the error gracefully and continued')).toBe('info')
+  })
+})
+
+describe('stripAnsi', () => {
+  it('removes SGR color escapes', () => {
+    expect(stripAnsi('\x1b[31merror\x1b[0m here')).toBe('error here')
+  })
+
+  it('returns plain text unchanged', () => {
+    expect(stripAnsi('no escapes here')).toBe('no escapes here')
+  })
+
+  it('lets level detection work through ANSI codes once stripped', () => {
+    expect(detectLevel(stripAnsi('\x1b[33mWARN\x1b[0m disk full'))).toBe('warn')
+  })
+})
+
+describe('metadata', () => {
+  it('has display metadata for every level', () => {
+    for (const l of LEVELS) {
+      expect(LEVEL_META[l]).toBeDefined()
+      expect(LEVEL_META[l].label).toBeTruthy()
+      expect(LEVEL_META[l].border).toBeTruthy()
+      expect(LEVEL_META[l].swatch).toBeTruthy()
+      expect(LEVEL_META[l].glow).toMatch(/^rgba\(\d+,\d+,\d+,[\d.]+\)$/)
+    }
+  })
+})

--- a/web/src/utils/logLevel.test.js
+++ b/web/src/utils/logLevel.test.js
@@ -134,6 +134,17 @@ describe('detectLevel', () => {
     expect(detectLevel('error handling middleware registered ok')).toBe('info')
   })
 
+  it('reads a zap console level from the 2nd tab field after a timestamp', () => {
+    // zap leads with its own ISO-8601 or epoch timestamp, so the level is hidden
+    // from the leading-token matcher; it is also lowercase, so the uppercase text
+    // matcher misses it. Read it from the 2nd tab field.
+    expect(detectLevel('2026-06-19T14:03:11.500Z\terror\tfoo.go:1\tboom\t{"a":1}')).toBe('error')
+    expect(detectLevel('2026-06-19T14:03:11.500Z\twarn\tcontroller\tfoo.go:1\tslow')).toBe('warn')
+    expect(detectLevel('1718805791.5\tinfo\tstarting manager')).toBe('info')
+    // A tabbed line whose 1st field is not a timestamp is not treated as zap.
+    expect(detectLevel('col1\terror\tcol3')).toBe('info')
+  })
+
   it('reads bracketed lowercase/mixed-case level tokens', () => {
     expect(detectLevel('[error] 1#1: *1 connect() failed')).toBe('error') // nginx error_log
     expect(detectLevel('[warn] 1#1: low on memory')).toBe('warn') // nginx

--- a/web/src/utils/logLevel.test.js
+++ b/web/src/utils/logLevel.test.js
@@ -176,6 +176,92 @@ describe('detectLevel', () => {
   it('does not match the word "error" mid-message (lowercase)', () => {
     expect(detectLevel('handled the error gracefully and continued')).toBe('info')
   })
+
+  // The pill carries the level for Java console lines (parseJava keeps the level
+  // word in the body but the pill still drives the at-a-glance color), so these
+  // pin detection for the Spring Boot / Log4j2 / Logback default layouts.
+  describe('Java console (pill level)', () => {
+    it('detects the level word in a Spring Boot line', () => {
+      expect(detectLevel('2025-12-18T07:25:01.584Z  INFO 132568 --- [myapp] [  main] c.e.App : up')).toBe('info')
+      expect(detectLevel('2026-06-16T10:00:00.123Z  WARN 1 --- [  main] c.e.App : slow')).toBe('warn')
+      expect(detectLevel('2026-06-16T10:00:00.123Z ERROR 1 --- [  main] c.e.App : boom')).toBe('error')
+    })
+
+    it('detects the level word in a Log4j2 / Logback line', () => {
+      expect(detectLevel('10:00:00.123 [main] INFO  com.example.Demo - started')).toBe('info')
+      expect(detectLevel('2026-06-16 10:00:00,123 [main] ERROR com.example.Demo - boom')).toBe('error')
+    })
+
+    // Known, pre-existing detectLevel limitation: BRACKET_LEVEL scans the whole
+    // head and a `(error)`/`[warn]` token inside the message is read as the level,
+    // so the pill can be wrong. parseJava mitigates this by keeping the (correctly
+    // parsed) level word in the body. This locks the current behavior.
+    it('mis-detects a parenthesized level token in a Log4j2 message (pre-existing)', () => {
+      expect(detectLevel('10:00:00.123 [main] INFO  c.e.Proxy - downstream said (error) and bailed')).toBe('error')
+    })
+
+    it('reads the level from a logstash-logback-encoder JSON line', () => {
+      expect(detectLevel('{"@timestamp":"2026-06-16T10:00:00.123Z","level":"WARN","logger_name":"c.e.X","thread_name":"main","message":"slow","stack_trace":"java.lang.X\\n\\tat c.e.X"}')).toBe('warn')
+    })
+
+    it('reads the ECS flat log.level from a Log4j2 ECS-layout JSON line', () => {
+      expect(detectLevel('{"@timestamp":"2026-06-16T10:00:00.123Z","log.level":"ERROR","message":"boom"}')).toBe('error')
+    })
+  })
+
+  describe('.NET console (pill level)', () => {
+    it('detects the Serilog u3 code via TEXT_LEVEL', () => {
+      expect(detectLevel('[14:30:00 INF] starting')).toBe('info')
+      expect(detectLevel('[14:30:00 ERR] failed')).toBe('error')
+      expect(detectLevel('[14:30:00 VRB] trace it')).toBe('trace')
+      expect(detectLevel('[14:30:00 FTL] dead')).toBe('fatal')
+    })
+
+    it('detects the NLog level from the 2nd pipe field (dedicated branch)', () => {
+      expect(detectLevel('2024-01-15 10:30:00.0000|INFO|MyApp.Program|up')).toBe('info')
+      expect(detectLevel('2024-01-15 10:30:00.0000|ERROR|MyApp.Svc|boom')).toBe('error')
+      expect(detectLevel('2024-01-15 10:30:00.0000|FATAL|MyApp.Svc|dead')).toBe('fatal')
+    })
+
+    it('does not read a level from a free-form pipe line (no leading longdate)', () => {
+      expect(detectLevel('result|ERROR|stack trace follows')).toBe('info')
+    })
+
+    it('reads the Serilog CLEF level, defaulting to info when @l is omitted', () => {
+      expect(detectLevel('{"@t":"2026-06-16T10:00:00.123Z","@l":"Warning","@m":"slow"}')).toBe('warn')
+      // CLEF omits @l for Information, so an info-level event has no level field.
+      expect(detectLevel('{"@t":"2026-06-16T10:00:00.123Z","@m":"hello"}')).toBe('info')
+    })
+  })
+
+  describe('scripting console (pill level)', () => {
+    it('detects Python logging (custom format and gunicorn/uvicorn)', () => {
+      expect(detectLevel('2024-01-15 10:30:00,123 - myapp - WARNING - disk almost full')).toBe('warn')
+      expect(detectLevel('[2024-01-15 10:30:00 +0000] [8] [ERROR] Worker failed')).toBe('error')
+      expect(detectLevel('INFO:     Started server process [1]')).toBe('info')
+      expect(detectLevel('CRITICAL: Application startup failed. Exiting.')).toBe('fatal')
+    })
+
+    it('detects Ruby Logger severity labels', () => {
+      expect(detectLevel('I, [2024-01-15T10:30:00.123456 #1]  INFO -- : Started')).toBe('info')
+      expect(detectLevel('F, [2024-01-15T10:30:00.123456 #1] FATAL -- app: boom')).toBe('fatal')
+    })
+
+    it('treats Ruby ANY (UNKNOWN) as the default info — ANY is deliberately not a level token', () => {
+      // Intentional: adding ANY to TEXT_LEVEL would mis-detect the common word "ANY"
+      // in ordinary messages. The viewer renders the ANY level word muted to match.
+      expect(detectLevel('A, [2024-01-15T10:30:00.123456 #1]  ANY -- : unknown-level')).toBe('info')
+      expect(detectLevel('the query accepts ANY value as input')).toBe('info')
+    })
+
+    it('detects PHP Monolog levels, including ALERT/EMERGENCY', () => {
+      expect(detectLevel('[2024-01-15T10:30:00+00:00] app.ERROR: failed [] []')).toBe('error')
+      expect(detectLevel('[2024-01-15 10:30:00] app.CRITICAL: dead [] []')).toBe('fatal')
+      expect(detectLevel('[2024-01-15 10:30:00] app.ALERT: failover triggered [] []')).toBe('fatal')
+      expect(detectLevel('[2024-01-15 10:30:00] app.EMERGENCY: site is down [] []')).toBe('fatal')
+      expect(detectLevel('[2024-01-15 10:30:00] app.NOTICE: deprecation [] []')).toBe('info')
+    })
+  })
 })
 
 describe('stripAnsi', () => {

--- a/web/src/utils/logSettings.js
+++ b/web/src/utils/logSettings.js
@@ -7,13 +7,24 @@ import { writeLocalStorage } from './storage'
 // LocalStorage key holding the log viewer settings as a single JSON object.
 const STORAGE_KEY = 'log-viewer'
 
-// Selectable limits for the number of log lines to fetch from the backend. Also
-// the allow-list used to validate a persisted `tail` value.
-export const LINE_LIMITS = [100, 500, 1000, 5000]
+// Selectable values for the number of log lines to fetch from the backend, used
+// both to render the toggle group and to validate a persisted `tail` value. The
+// maximum matches the backend's maxLogTailLines cap and the viewer's
+// MAX_BUFFER_LINES.
+export const TAIL_LINES = [100, 500, 1000, 2000, 5000]
+
+// Selectable monospace font sizes for the log body. `key` is persisted, `px` is
+// applied via the --logs-font-size CSS variable on the log body container.
+export const FONT_SIZES = [
+  { key: 'sm', label: 'Small', px: 11 },
+  { key: 'md', label: 'Medium', px: 12 },
+  { key: 'lg', label: 'Large', px: 14 }
+]
+const FONT_SIZE_KEYS = FONT_SIZES.map((f) => f.key)
 
 // Default log viewer settings, used on first load and as the per-field fallback
 // when a stored value is missing or invalid.
-export const DEFAULT_LOG_SETTINGS = { follow: true, formatted: true, tail: 100 }
+export const DEFAULT_LOG_SETTINGS = { follow: true, formatted: true, tail: 100, fontSize: 'md' }
 
 /**
  * Read the log viewer settings from localStorage, validating each field and
@@ -21,7 +32,7 @@ export const DEFAULT_LOG_SETTINGS = { follow: true, formatted: true, tail: 100 }
  * object still loads (unknown fields are dropped, missing ones defaulted), so the
  * shape can evolve without a version flag.
  *
- * @returns {{follow: boolean, formatted: boolean, tail: number}} The settings
+ * @returns {{follow: boolean, formatted: boolean, tail: number, fontSize: string}} The settings
  */
 export const getLogSettingsFromStorage = () => {
   try {
@@ -31,7 +42,8 @@ export const getLogSettingsFromStorage = () => {
     return {
       follow: typeof o.follow === 'boolean' ? o.follow : DEFAULT_LOG_SETTINGS.follow,
       formatted: typeof o.formatted === 'boolean' ? o.formatted : DEFAULT_LOG_SETTINGS.formatted,
-      tail: LINE_LIMITS.includes(o.tail) ? o.tail : DEFAULT_LOG_SETTINGS.tail
+      tail: TAIL_LINES.includes(o.tail) ? o.tail : DEFAULT_LOG_SETTINGS.tail,
+      fontSize: FONT_SIZE_KEYS.includes(o.fontSize) ? o.fontSize : DEFAULT_LOG_SETTINGS.fontSize
     }
   } catch {
     return { ...DEFAULT_LOG_SETTINGS }
@@ -41,8 +53,8 @@ export const getLogSettingsFromStorage = () => {
 // Reactive signal for the log viewer settings, seeded from localStorage.
 export const logSettings = signal(getLogSettingsFromStorage())
 
-// Persist the settings to localStorage whenever they change. Only the three known
-// keys are written (the signal never carries unknown fields), so the stored object
+// Persist the settings to localStorage whenever they change. Only the known keys
+// are written (the signal never carries unknown fields), so the stored object
 // stays clean.
 effect(() => {
   writeLocalStorage(STORAGE_KEY, JSON.stringify(logSettings.value))

--- a/web/src/utils/logSettings.js
+++ b/web/src/utils/logSettings.js
@@ -1,0 +1,59 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { signal, effect } from '@preact/signals'
+import { writeLocalStorage } from './storage'
+
+// LocalStorage key holding the log viewer settings as a single JSON object.
+const STORAGE_KEY = 'log-viewer'
+
+// Selectable limits for the number of log lines to fetch from the backend. Also
+// the allow-list used to validate a persisted `tail` value.
+export const LINE_LIMITS = [100, 500, 1000, 5000]
+
+// Default log viewer settings, used on first load and as the per-field fallback
+// when a stored value is missing or invalid.
+export const DEFAULT_LOG_SETTINGS = { follow: true, formatted: true, tail: 100 }
+
+/**
+ * Read the log viewer settings from localStorage, validating each field and
+ * falling back to its default when missing or invalid. A partial or older stored
+ * object still loads (unknown fields are dropped, missing ones defaulted), so the
+ * shape can evolve without a version flag.
+ *
+ * @returns {{follow: boolean, formatted: boolean, tail: number}} The settings
+ */
+export const getLogSettingsFromStorage = () => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return { ...DEFAULT_LOG_SETTINGS }
+    const o = JSON.parse(stored)
+    return {
+      follow: typeof o.follow === 'boolean' ? o.follow : DEFAULT_LOG_SETTINGS.follow,
+      formatted: typeof o.formatted === 'boolean' ? o.formatted : DEFAULT_LOG_SETTINGS.formatted,
+      tail: LINE_LIMITS.includes(o.tail) ? o.tail : DEFAULT_LOG_SETTINGS.tail
+    }
+  } catch {
+    return { ...DEFAULT_LOG_SETTINGS }
+  }
+}
+
+// Reactive signal for the log viewer settings, seeded from localStorage.
+export const logSettings = signal(getLogSettingsFromStorage())
+
+// Persist the settings to localStorage whenever they change. Only the three known
+// keys are written (the signal never carries unknown fields), so the stored object
+// stays clean.
+effect(() => {
+  writeLocalStorage(STORAGE_KEY, JSON.stringify(logSettings.value))
+})
+
+/**
+ * Reset the log viewer settings to their defaults. The change persists via the
+ * effect above. An already-open viewer is unaffected — it seeds its state once on
+ * mount (via peek, no subscription) — so the reset applies the next time the
+ * viewer is opened. Used by the "Clear local storage" action.
+ */
+export function resetLogSettings() {
+  logSettings.value = { ...DEFAULT_LOG_SETTINGS }
+}

--- a/web/src/utils/logSettings.js
+++ b/web/src/utils/logSettings.js
@@ -23,8 +23,9 @@ export const FONT_SIZES = [
 const FONT_SIZE_KEYS = FONT_SIZES.map((f) => f.key)
 
 // Default log viewer settings, used on first load and as the per-field fallback
-// when a stored value is missing or invalid.
-export const DEFAULT_LOG_SETTINGS = { follow: true, formatted: true, tail: 100, fontSize: 'md' }
+// when a stored value is missing or invalid. `fields` is the JSON field-selection
+// expression (see fieldMatcher); empty shows all fields.
+export const DEFAULT_LOG_SETTINGS = { follow: true, formatted: true, tail: 100, fontSize: 'md', fields: '' }
 
 /**
  * Read the log viewer settings from localStorage, validating each field and
@@ -43,7 +44,8 @@ export const getLogSettingsFromStorage = () => {
       follow: typeof o.follow === 'boolean' ? o.follow : DEFAULT_LOG_SETTINGS.follow,
       formatted: typeof o.formatted === 'boolean' ? o.formatted : DEFAULT_LOG_SETTINGS.formatted,
       tail: TAIL_LINES.includes(o.tail) ? o.tail : DEFAULT_LOG_SETTINGS.tail,
-      fontSize: FONT_SIZE_KEYS.includes(o.fontSize) ? o.fontSize : DEFAULT_LOG_SETTINGS.fontSize
+      fontSize: FONT_SIZE_KEYS.includes(o.fontSize) ? o.fontSize : DEFAULT_LOG_SETTINGS.fontSize,
+      fields: typeof o.fields === 'string' ? o.fields : DEFAULT_LOG_SETTINGS.fields
     }
   } catch {
     return { ...DEFAULT_LOG_SETTINGS }

--- a/web/src/utils/logSettings.test.js
+++ b/web/src/utils/logSettings.test.js
@@ -1,0 +1,93 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import {
+  logSettings,
+  DEFAULT_LOG_SETTINGS,
+  LINE_LIMITS,
+  getLogSettingsFromStorage,
+  resetLogSettings
+} from './logSettings'
+
+describe('logSettings utilities', () => {
+  beforeEach(() => {
+    logSettings.value = { ...DEFAULT_LOG_SETTINGS }
+    global.localStorageMock.getItem.mockReset()
+    global.localStorageMock.setItem.mockClear()
+  })
+
+  describe('exports', () => {
+    it('defaults to follow on, formatted, 100 lines', () => {
+      expect(DEFAULT_LOG_SETTINGS).toEqual({ follow: true, formatted: true, tail: 100 })
+    })
+
+    it('exposes the selectable line limits', () => {
+      expect(LINE_LIMITS).toEqual([100, 500, 1000, 5000])
+    })
+  })
+
+  describe('getLogSettingsFromStorage', () => {
+    it('returns the defaults when nothing is stored', () => {
+      global.localStorageMock.getItem.mockReturnValue(null)
+      expect(getLogSettingsFromStorage()).toEqual(DEFAULT_LOG_SETTINGS)
+    })
+
+    it('returns a fresh copy of the defaults, not the shared object', () => {
+      global.localStorageMock.getItem.mockReturnValue(null)
+      expect(getLogSettingsFromStorage()).not.toBe(DEFAULT_LOG_SETTINGS)
+    })
+
+    it('reads a valid stored object', () => {
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: false, formatted: false, tail: 500 }))
+      expect(getLogSettingsFromStorage()).toEqual({ follow: false, formatted: false, tail: 500 })
+    })
+
+    it('falls back per field, keeping the valid ones, when a field is invalid', () => {
+      // tail 250 is not in LINE_LIMITS, so only tail defaults; follow/formatted kept.
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: false, formatted: true, tail: 250 }))
+      expect(getLogSettingsFromStorage()).toEqual({ follow: false, formatted: true, tail: 100 })
+    })
+
+    it('defaults a non-boolean follow/formatted', () => {
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: 'yes', formatted: 1, tail: 1000 }))
+      expect(getLogSettingsFromStorage()).toEqual({ follow: true, formatted: true, tail: 1000 })
+    })
+
+    it('defaults the missing fields of a partial object', () => {
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ formatted: false }))
+      expect(getLogSettingsFromStorage()).toEqual({ follow: true, formatted: false, tail: 100 })
+    })
+
+    it('drops unknown fields', () => {
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: true, formatted: true, tail: 100, extra: 'x' }))
+      expect(getLogSettingsFromStorage()).toEqual(DEFAULT_LOG_SETTINGS)
+    })
+
+    it('returns the defaults on malformed JSON', () => {
+      global.localStorageMock.getItem.mockReturnValue('{not json')
+      expect(getLogSettingsFromStorage()).toEqual(DEFAULT_LOG_SETTINGS)
+    })
+  })
+
+  describe('persistence', () => {
+    it('writes the settings to localStorage when they change', () => {
+      logSettings.value = { follow: false, formatted: false, tail: 5000 }
+      expect(global.localStorageMock.setItem).toHaveBeenCalledWith(
+        'log-viewer',
+        JSON.stringify({ follow: false, formatted: false, tail: 5000 })
+      )
+    })
+  })
+
+  describe('resetLogSettings', () => {
+    it('restores the defaults and persists them', () => {
+      logSettings.value = { follow: false, formatted: false, tail: 500 }
+      resetLogSettings()
+      expect(logSettings.value).toEqual(DEFAULT_LOG_SETTINGS)
+      expect(global.localStorageMock.setItem).toHaveBeenLastCalledWith(
+        'log-viewer',
+        JSON.stringify(DEFAULT_LOG_SETTINGS)
+      )
+    })
+  })
+})

--- a/web/src/utils/logSettings.test.js
+++ b/web/src/utils/logSettings.test.js
@@ -4,7 +4,8 @@
 import {
   logSettings,
   DEFAULT_LOG_SETTINGS,
-  LINE_LIMITS,
+  TAIL_LINES,
+  FONT_SIZES,
   getLogSettingsFromStorage,
   resetLogSettings
 } from './logSettings'
@@ -17,12 +18,17 @@ describe('logSettings utilities', () => {
   })
 
   describe('exports', () => {
-    it('defaults to follow on, formatted, 100 lines', () => {
-      expect(DEFAULT_LOG_SETTINGS).toEqual({ follow: true, formatted: true, tail: 100 })
+    it('defaults to follow on, formatted, 100 lines, medium font', () => {
+      expect(DEFAULT_LOG_SETTINGS).toEqual({ follow: true, formatted: true, tail: 100, fontSize: 'md' })
     })
 
-    it('exposes the selectable line limits', () => {
-      expect(LINE_LIMITS).toEqual([100, 500, 1000, 5000])
+    it('exposes the selectable tail line values', () => {
+      expect(TAIL_LINES).toEqual([100, 500, 1000, 2000, 5000])
+    })
+
+    it('exposes the selectable font sizes', () => {
+      expect(FONT_SIZES.map(f => f.key)).toEqual(['sm', 'md', 'lg'])
+      expect(FONT_SIZES.every(f => typeof f.label === 'string' && typeof f.px === 'number')).toBe(true)
     })
   })
 
@@ -38,28 +44,34 @@ describe('logSettings utilities', () => {
     })
 
     it('reads a valid stored object', () => {
-      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: false, formatted: false, tail: 500 }))
-      expect(getLogSettingsFromStorage()).toEqual({ follow: false, formatted: false, tail: 500 })
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: false, formatted: false, tail: 500, fontSize: 'lg' }))
+      expect(getLogSettingsFromStorage()).toEqual({ follow: false, formatted: false, tail: 500, fontSize: 'lg' })
+    })
+
+    it('accepts the 2000 tail value', () => {
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: true, formatted: true, tail: 2000, fontSize: 'md' }))
+      expect(getLogSettingsFromStorage().tail).toBe(2000)
     })
 
     it('falls back per field, keeping the valid ones, when a field is invalid', () => {
-      // tail 250 is not in LINE_LIMITS, so only tail defaults; follow/formatted kept.
-      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: false, formatted: true, tail: 250 }))
-      expect(getLogSettingsFromStorage()).toEqual({ follow: false, formatted: true, tail: 100 })
+      // tail 250 is not one of TAIL_LINES and fontSize 'xl' is unknown, so both
+      // default; follow/formatted kept.
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: false, formatted: true, tail: 250, fontSize: 'xl' }))
+      expect(getLogSettingsFromStorage()).toEqual({ follow: false, formatted: true, tail: 100, fontSize: 'md' })
     })
 
     it('defaults a non-boolean follow/formatted', () => {
-      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: 'yes', formatted: 1, tail: 1000 }))
-      expect(getLogSettingsFromStorage()).toEqual({ follow: true, formatted: true, tail: 1000 })
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: 'yes', formatted: 1, tail: 1000, fontSize: 'sm' }))
+      expect(getLogSettingsFromStorage()).toEqual({ follow: true, formatted: true, tail: 1000, fontSize: 'sm' })
     })
 
     it('defaults the missing fields of a partial object', () => {
       global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ formatted: false }))
-      expect(getLogSettingsFromStorage()).toEqual({ follow: true, formatted: false, tail: 100 })
+      expect(getLogSettingsFromStorage()).toEqual({ follow: true, formatted: false, tail: 100, fontSize: 'md' })
     })
 
     it('drops unknown fields', () => {
-      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: true, formatted: true, tail: 100, extra: 'x' }))
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: true, formatted: true, tail: 100, fontSize: 'md', extra: 'x' }))
       expect(getLogSettingsFromStorage()).toEqual(DEFAULT_LOG_SETTINGS)
     })
 
@@ -71,10 +83,10 @@ describe('logSettings utilities', () => {
 
   describe('persistence', () => {
     it('writes the settings to localStorage when they change', () => {
-      logSettings.value = { follow: false, formatted: false, tail: 5000 }
+      logSettings.value = { follow: false, formatted: false, tail: 5000, fontSize: 'lg' }
       expect(global.localStorageMock.setItem).toHaveBeenCalledWith(
         'log-viewer',
-        JSON.stringify({ follow: false, formatted: false, tail: 5000 })
+        JSON.stringify({ follow: false, formatted: false, tail: 5000, fontSize: 'lg' })
       )
     })
   })

--- a/web/src/utils/logSettings.test.js
+++ b/web/src/utils/logSettings.test.js
@@ -18,8 +18,8 @@ describe('logSettings utilities', () => {
   })
 
   describe('exports', () => {
-    it('defaults to follow on, formatted, 100 lines, medium font', () => {
-      expect(DEFAULT_LOG_SETTINGS).toEqual({ follow: true, formatted: true, tail: 100, fontSize: 'md' })
+    it('defaults to follow on, formatted, 100 lines, medium font, no field filter', () => {
+      expect(DEFAULT_LOG_SETTINGS).toEqual({ follow: true, formatted: true, tail: 100, fontSize: 'md', fields: '' })
     })
 
     it('exposes the selectable tail line values', () => {
@@ -44,8 +44,13 @@ describe('logSettings utilities', () => {
     })
 
     it('reads a valid stored object', () => {
-      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: false, formatted: false, tail: 500, fontSize: 'lg' }))
-      expect(getLogSettingsFromStorage()).toEqual({ follow: false, formatted: false, tail: 500, fontSize: 'lg' })
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: false, formatted: false, tail: 500, fontSize: 'lg', fields: 'msg|error' }))
+      expect(getLogSettingsFromStorage()).toEqual({ follow: false, formatted: false, tail: 500, fontSize: 'lg', fields: 'msg|error' })
+    })
+
+    it('defaults a non-string fields to an empty filter', () => {
+      global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: true, formatted: true, tail: 100, fontSize: 'md', fields: 123 }))
+      expect(getLogSettingsFromStorage().fields).toBe('')
     })
 
     it('accepts the 2000 tail value', () => {
@@ -57,17 +62,17 @@ describe('logSettings utilities', () => {
       // tail 250 is not one of TAIL_LINES and fontSize 'xl' is unknown, so both
       // default; follow/formatted kept.
       global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: false, formatted: true, tail: 250, fontSize: 'xl' }))
-      expect(getLogSettingsFromStorage()).toEqual({ follow: false, formatted: true, tail: 100, fontSize: 'md' })
+      expect(getLogSettingsFromStorage()).toEqual({ follow: false, formatted: true, tail: 100, fontSize: 'md', fields: '' })
     })
 
     it('defaults a non-boolean follow/formatted', () => {
       global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ follow: 'yes', formatted: 1, tail: 1000, fontSize: 'sm' }))
-      expect(getLogSettingsFromStorage()).toEqual({ follow: true, formatted: true, tail: 1000, fontSize: 'sm' })
+      expect(getLogSettingsFromStorage()).toEqual({ follow: true, formatted: true, tail: 1000, fontSize: 'sm', fields: '' })
     })
 
     it('defaults the missing fields of a partial object', () => {
       global.localStorageMock.getItem.mockReturnValue(JSON.stringify({ formatted: false }))
-      expect(getLogSettingsFromStorage()).toEqual({ follow: true, formatted: false, tail: 100, fontSize: 'md' })
+      expect(getLogSettingsFromStorage()).toEqual({ follow: true, formatted: false, tail: 100, fontSize: 'md', fields: '' })
     })
 
     it('drops unknown fields', () => {

--- a/web/src/utils/navHistory.js
+++ b/web/src/utils/navHistory.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { signal, effect } from '@preact/signals'
+import { writeLocalStorage } from './storage'
 
 // LocalStorage key for navigation history
 const STORAGE_KEY = 'nav-history'
@@ -48,7 +49,7 @@ export const navHistory = signal(getNavHistoryFromStorage())
 
 // Sync navigation history to localStorage whenever it changes
 effect(() => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(navHistory.value))
+  writeLocalStorage(STORAGE_KEY, JSON.stringify(navHistory.value))
 })
 
 /**

--- a/web/src/utils/pods.js
+++ b/web/src/utils/pods.js
@@ -1,0 +1,91 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Shared helpers for summarizing a workload's pods. Used by the workload
+// pipeline panel and the inline workload details panel so both report pod
+// readiness and phase breakdowns identically.
+
+/**
+ * Check if a pod is truly ready using the Kubernetes Ready condition.
+ * Falls back to checking the pod phase when podStatus is not available.
+ * @param {object} pod - Pod object with status and optional podStatus
+ * @returns {boolean} true if the pod is ready
+ */
+export function isPodReady(pod) {
+  // Use the Ready condition from podStatus when available (detail endpoint)
+  if (pod.podStatus?.conditions) {
+    return pod.podStatus.conditions.some(c => c.type === 'Ready' && c.status === 'True')
+  }
+  // Fallback: treat Running/Succeeded as ready when podStatus is not available
+  return pod.status === 'Running' || pod.status === 'Succeeded'
+}
+
+/**
+ * Compute the aggregated pod status.
+ * For CronJobs, success means all pods succeeded (no failures).
+ * For other workloads, uses the Kubernetes Ready condition to determine readiness.
+ * @param {Array} pods - Array of pod objects with status field
+ * @param {boolean} isCronJob - Whether the parent workload is a CronJob
+ * @returns {string} Aggregated status: Ready, Failed, Progressing, or Unknown
+ */
+export function getPodAggregateStatus(pods, isCronJob) {
+  if (!pods || pods.length === 0) return 'Unknown'
+  const hasAnyFailed = pods.some(p => p.status === 'Failed')
+  if (hasAnyFailed) return 'Failed'
+  if (isCronJob) {
+    const allCompleted = pods.every(p => p.status === 'Succeeded')
+    if (allCompleted) return 'Ready'
+  } else {
+    if (pods.every(p => isPodReady(p))) return 'Ready'
+  }
+  return 'Progressing'
+}
+
+/**
+ * Build a human-readable summary of pod phases (e.g. "2 running", "1 running, 1 pending").
+ * Groups pods by lowercase phase and joins counts with commas.
+ * @param {Array} pods - Array of pod objects with status field
+ * @returns {string} Phase summary string
+ */
+export function getPodPhaseSummary(pods) {
+  if (!pods || pods.length === 0) return ''
+  const counts = {}
+  for (const pod of pods) {
+    const phase = (pod.status || 'Unknown').toLowerCase()
+    counts[phase] = (counts[phase] || 0) + 1
+  }
+  return Object.entries(counts)
+    .map(([phase, count]) => `${count} ${phase}`)
+    .join(', ')
+}
+
+/**
+ * Summarize a workload's pods into a status plus display strings.
+ * @param {Array} pods - Array of pod objects with name and status
+ * @param {string} kind - The workload kind (Deployment, CronJob, etc.)
+ * @returns {{ status: string, total: number, primary: string, detail: string }}
+ *   status: aggregate status for coloring; total: pod count;
+ *   primary: e.g. "2/3 ready" or "1/2 completed"; detail: phase breakdown.
+ */
+export function summarizePods(pods, kind) {
+  const isCronJob = kind === 'CronJob'
+  const total = pods?.length || 0
+  const status = getPodAggregateStatus(pods, isCronJob)
+
+  if (total === 0) {
+    return {
+      status,
+      total,
+      primary: isCronJob ? 'No active pods' : 'Scaled to zero',
+      detail: '0 pods'
+    }
+  }
+
+  if (isCronJob) {
+    const completed = pods.filter(p => p.status === 'Succeeded' || p.status === 'Failed').length
+    return { status, total, primary: `${completed}/${total} completed`, detail: getPodPhaseSummary(pods) }
+  }
+
+  const ready = pods.filter(p => isPodReady(p)).length
+  return { status, total, primary: `${ready}/${total} ready`, detail: getPodPhaseSummary(pods) }
+}

--- a/web/src/utils/pods.test.js
+++ b/web/src/utils/pods.test.js
@@ -1,0 +1,84 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect } from 'vitest'
+import { isPodReady, getPodAggregateStatus, getPodPhaseSummary, summarizePods } from './pods'
+
+const readyPod = (name) => ({ name, status: 'Running', podStatus: { conditions: [{ type: 'Ready', status: 'True' }] } })
+const notReadyPod = (name) => ({ name, status: 'Running', podStatus: { conditions: [{ type: 'Ready', status: 'False' }] } })
+
+describe('isPodReady', () => {
+  it('uses the Ready condition when podStatus is present', () => {
+    expect(isPodReady(readyPod('a'))).toBe(true)
+    expect(isPodReady(notReadyPod('a'))).toBe(false)
+  })
+
+  it('falls back to the phase when podStatus is absent', () => {
+    expect(isPodReady({ name: 'a', status: 'Running' })).toBe(true)
+    expect(isPodReady({ name: 'a', status: 'Succeeded' })).toBe(true)
+    expect(isPodReady({ name: 'a', status: 'Pending' })).toBe(false)
+  })
+})
+
+describe('getPodAggregateStatus', () => {
+  it('returns Unknown for no pods', () => {
+    expect(getPodAggregateStatus([], false)).toBe('Unknown')
+    expect(getPodAggregateStatus(undefined, false)).toBe('Unknown')
+  })
+
+  it('returns Failed when any pod failed', () => {
+    expect(getPodAggregateStatus([readyPod('a'), { name: 'b', status: 'Failed' }], false)).toBe('Failed')
+  })
+
+  it('returns Ready when all pods are ready', () => {
+    expect(getPodAggregateStatus([readyPod('a'), readyPod('b')], false)).toBe('Ready')
+  })
+
+  it('returns Progressing when some pods are not ready', () => {
+    expect(getPodAggregateStatus([readyPod('a'), notReadyPod('b')], false)).toBe('Progressing')
+  })
+
+  it('treats all-succeeded CronJob pods as Ready', () => {
+    expect(getPodAggregateStatus([{ name: 'a', status: 'Succeeded' }], true)).toBe('Ready')
+  })
+})
+
+describe('getPodPhaseSummary', () => {
+  it('groups and counts phases', () => {
+    expect(getPodPhaseSummary([readyPod('a'), readyPod('b')])).toBe('2 running')
+    expect(getPodPhaseSummary([readyPod('a'), { name: 'b', status: 'Pending' }])).toBe('1 running, 1 pending')
+  })
+
+  it('returns an empty string for no pods', () => {
+    expect(getPodPhaseSummary([])).toBe('')
+  })
+})
+
+describe('summarizePods', () => {
+  it('reports ready count for apps workloads', () => {
+    const s = summarizePods([readyPod('a'), notReadyPod('b')], 'Deployment')
+    expect(s.primary).toBe('1/2 ready')
+    expect(s.detail).toBe('2 running')
+    expect(s.status).toBe('Progressing')
+    expect(s.total).toBe(2)
+  })
+
+  it('reports completed count for CronJobs', () => {
+    const s = summarizePods([{ name: 'a', status: 'Succeeded' }, { name: 'b', status: 'Running' }], 'CronJob')
+    expect(s.primary).toBe('1/2 completed')
+    expect(s.detail).toBe('1 succeeded, 1 running')
+  })
+
+  it('reports scaled-to-zero for empty apps workloads', () => {
+    const s = summarizePods([], 'Deployment')
+    expect(s.primary).toBe('Scaled to zero')
+    expect(s.detail).toBe('0 pods')
+    expect(s.total).toBe(0)
+  })
+
+  it('reports no active pods for empty CronJobs', () => {
+    const s = summarizePods(undefined, 'CronJob')
+    expect(s.primary).toBe('No active pods')
+    expect(s.detail).toBe('0 pods')
+  })
+})

--- a/web/src/utils/routing.js
+++ b/web/src/utils/routing.js
@@ -3,6 +3,22 @@
 
 import { useEffect, useRef } from 'preact/hooks'
 import { useLocation } from 'preact-iso'
+import { workloadKinds } from './constants'
+
+/**
+ * Builds the dashboard URL for a Kubernetes object, routing workload kinds
+ * (Deployment/StatefulSet/DaemonSet/CronJob) to the workload dashboard and all
+ * other kinds to the resource dashboard.
+ *
+ * @param {string} kind - Object kind
+ * @param {string} namespace - Object namespace
+ * @param {string} name - Object name
+ * @returns {string} Dashboard path
+ */
+export function getDashboardUrl(kind, namespace, name) {
+  const base = workloadKinds.includes(kind) ? 'workload' : 'resource'
+  return `/${base}/${encodeURIComponent(kind)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`
+}
 
 /**
  * Serializes filter object to URL query string

--- a/web/src/utils/routing.js
+++ b/web/src/utils/routing.js
@@ -44,6 +44,29 @@ export function serializeFilters(filters) {
 }
 
 /**
+ * Returns the current URL (path + query string + hash) with a single query
+ * parameter set or, when value is falsy, removed. All other existing params, the
+ * path, and the hash are preserved (the hash carries the detail-panel tab state).
+ * Used to make a view's open state shareable via the address bar without disturbing
+ * other filters, e.g.
+ * `window.history.replaceState(null, '', urlWithParam('logs', podName))`.
+ *
+ * @param {string} name - Query parameter name
+ * @param {string} [value] - Value to set; when falsy the parameter is removed
+ * @returns {string} The relative URL (pathname + optional query string + hash)
+ */
+export function urlWithParam(name, value) {
+  const params = new URLSearchParams(window.location.search)
+  if (value) {
+    params.set(name, value)
+  } else {
+    params.delete(name)
+  }
+  const queryString = params.toString()
+  return `${window.location.pathname}${queryString ? `?${queryString}` : ''}${window.location.hash}`
+}
+
+/**
  * Custom hook that restores filter signals from URL query params on mount
  * Runs once on component mount, reads URL and sets signal values
  *

--- a/web/src/utils/routing.test.js
+++ b/web/src/utils/routing.test.js
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/preact'
 import { signal } from '@preact/signals'
-import { serializeFilters } from './routing'
+import { serializeFilters, urlWithParam } from './routing'
 
 describe('serializeFilters', () => {
   it('should serialize simple filter object to query string', () => {
@@ -59,6 +59,52 @@ describe('serializeFilters', () => {
   it('should handle numeric string values', () => {
     const filters = { limit: '10', offset: '0' }
     expect(serializeFilters(filters)).toBe('limit=10&offset=0')
+  })
+})
+
+describe('urlWithParam', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/')
+  })
+
+  it('adds a param to a path with no existing query', () => {
+    window.history.replaceState(null, '', '/workload/Deployment/apps/podinfo')
+    expect(urlWithParam('logs', 'podinfo-abc')).toBe('/workload/Deployment/apps/podinfo?logs=podinfo-abc')
+  })
+
+  it('preserves existing params when adding a new one', () => {
+    window.history.replaceState(null, '', '/workload/Deployment/apps/podinfo?tab=pods')
+    expect(urlWithParam('logs', 'all')).toBe('/workload/Deployment/apps/podinfo?tab=pods&logs=all')
+  })
+
+  it('overwrites an existing value for the same param', () => {
+    window.history.replaceState(null, '', '/p?logs=old')
+    expect(urlWithParam('logs', 'new')).toBe('/p?logs=new')
+  })
+
+  it('removes the param when the value is falsy, keeping others', () => {
+    window.history.replaceState(null, '', '/p?tab=pods&logs=podinfo-abc')
+    expect(urlWithParam('logs', null)).toBe('/p?tab=pods')
+  })
+
+  it('drops the query string entirely when removing the only param', () => {
+    window.history.replaceState(null, '', '/p?logs=podinfo-abc')
+    expect(urlWithParam('logs', null)).toBe('/p')
+  })
+
+  it('URL-encodes the value', () => {
+    window.history.replaceState(null, '', '/p')
+    expect(urlWithParam('q', 'a b&c')).toBe('/p?q=a+b%26c')
+  })
+
+  it('preserves the hash (detail-panel tab state) when setting a param', () => {
+    window.history.replaceState(null, '', '/p#workload-pods')
+    expect(urlWithParam('logs', 'app-abc')).toBe('/p?logs=app-abc#workload-pods')
+  })
+
+  it('preserves the hash when removing a param', () => {
+    window.history.replaceState(null, '', '/p?logs=app-abc#workload-pods')
+    expect(urlWithParam('logs', null)).toBe('/p#workload-pods')
   })
 })
 

--- a/web/src/utils/status.js
+++ b/web/src/utils/status.js
@@ -134,6 +134,27 @@ export function getEventBadgeClass(type) {
 }
 
 /**
+ * Get badge class for Kubernetes container states.
+ * Maps container state labels to appropriate badge styling.
+ * @param {string} stateLabel - Container state label (Running, Waiting, Terminated, Completed)
+ * @returns {string} Tailwind CSS classes for the badge
+ */
+export function getContainerStateBadgeClass(stateLabel) {
+  switch (stateLabel) {
+  case 'Running':
+    return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400'
+  case 'Waiting':
+    return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400'
+  case 'Completed':
+    return 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400'
+  case 'Terminated':
+    return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+  default:
+    return 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400'
+  }
+}
+
+/**
  * Get solid background color class for resource status bars/charts.
  * @param {string} status - Status value (Ready, Failed, Progressing, Suspended, Unknown)
  * @returns {string} Tailwind CSS classes for the background

--- a/web/src/utils/status.js
+++ b/web/src/utils/status.js
@@ -193,13 +193,61 @@ export function getEventBarColor(type) {
 }
 
 /**
+ * Normalize a status value to the Flux vocabulary (Ready/Failed/Progressing/
+ * Suspended/Unknown) used by status charts, filters, and borders. Kubernetes workload
+ * kstatus values are mapped to their Flux equivalents (Current/Idle -> Ready,
+ * InProgress -> Progressing, Terminating -> Suspended); Flux statuses and any
+ * unrecognized value pass through unchanged. Keep this in sync with
+ * getWorkloadStatusBadgeClass so badges, borders, and charts stay consistent.
+ * @param {string} status - Status value
+ * @returns {string} Status value in the Flux vocabulary
+ */
+export function normalizeToFluxStatus(status) {
+  switch (status) {
+  case 'Current':
+  case 'Idle':
+    return 'Ready'
+  case 'InProgress':
+    return 'Progressing'
+  case 'Terminating':
+    return 'Suspended'
+  default:
+    return status
+  }
+}
+
+/**
+ * Get dot color class for a Flux resource status.
+ * Aligns with resourceStatuses in constants.js; unknown/empty falls back to gray.
+ * @param {string} status - Status value (Ready, Failed, Progressing, Suspended, Unknown)
+ * @returns {string} Tailwind background color class for a status dot
+ */
+export function getStatusDotClass(status) {
+  switch (status) {
+  case 'Ready':
+    return 'bg-green-500'
+  case 'Failed':
+    return 'bg-red-500'
+  case 'Progressing':
+    return 'bg-blue-500'
+  case 'Suspended':
+    return 'bg-yellow-500'
+  default:
+    return 'bg-gray-500'
+  }
+}
+
+/**
  * Get border color class for resource status.
  * Uses semantic color classes (border-success, border-danger, etc.) for consistency.
- * @param {string} status - Status value (Ready, Failed, Progressing, Suspended, Unknown)
+ * Accepts both Flux resource statuses and Kubernetes workload kstatus values
+ * (normalized via normalizeToFluxStatus), so workload favorites render a border
+ * consistent with their status badge.
+ * @param {string} status - Status value
  * @returns {string} Tailwind CSS classes for the border
  */
 export function getStatusBorderClass(status) {
-  switch (status) {
+  switch (normalizeToFluxStatus(status)) {
   case 'Ready':
     return 'border-success'
   case 'Failed':

--- a/web/src/utils/status.test.js
+++ b/web/src/utils/status.test.js
@@ -9,6 +9,7 @@ import {
   getHistoryStatusBadgeClass,
   getHistoryDotClass,
   getEventBadgeClass,
+  getContainerStateBadgeClass,
   getStatusBarColor,
   getEventBarColor,
   getStatusBorderClass,
@@ -209,6 +210,40 @@ describe('status utilities', () => {
     it('should include dark mode classes', () => {
       expect(getEventBadgeClass('Normal')).toContain('dark:bg-green-900/30')
       expect(getEventBadgeClass('Warning')).toContain('dark:bg-red-900/30')
+    })
+  })
+
+  describe('getContainerStateBadgeClass', () => {
+    it('should return blue for Running state', () => {
+      expect(getContainerStateBadgeClass('Running')).toContain('bg-blue-100')
+      expect(getContainerStateBadgeClass('Running')).toContain('text-blue-800')
+    })
+
+    it('should return yellow for Waiting state', () => {
+      expect(getContainerStateBadgeClass('Waiting')).toContain('bg-yellow-100')
+      expect(getContainerStateBadgeClass('Waiting')).toContain('text-yellow-800')
+    })
+
+    it('should return red for Terminated state', () => {
+      expect(getContainerStateBadgeClass('Terminated')).toContain('bg-red-100')
+      expect(getContainerStateBadgeClass('Terminated')).toContain('text-red-800')
+    })
+
+    it('should return cyan for Completed state', () => {
+      expect(getContainerStateBadgeClass('Completed')).toContain('bg-cyan-100')
+      expect(getContainerStateBadgeClass('Completed')).toContain('text-cyan-800')
+    })
+
+    it('should return gray for unknown state', () => {
+      expect(getContainerStateBadgeClass('Unknown')).toContain('bg-gray-100')
+      expect(getContainerStateBadgeClass('Unknown')).toContain('text-gray-800')
+    })
+
+    it('should include dark mode classes', () => {
+      expect(getContainerStateBadgeClass('Running')).toContain('dark:bg-blue-900/30')
+      expect(getContainerStateBadgeClass('Waiting')).toContain('dark:bg-yellow-900/30')
+      expect(getContainerStateBadgeClass('Terminated')).toContain('dark:bg-red-900/30')
+      expect(getContainerStateBadgeClass('Completed')).toContain('dark:bg-cyan-900/30')
     })
   })
 

--- a/web/src/utils/status.test.js
+++ b/web/src/utils/status.test.js
@@ -13,6 +13,8 @@ import {
   getStatusBarColor,
   getEventBarColor,
   getStatusBorderClass,
+  getStatusDotClass,
+  normalizeToFluxStatus,
   cleanStatus
 } from './status'
 
@@ -291,6 +293,42 @@ describe('status utilities', () => {
     })
   })
 
+  describe('getStatusDotClass', () => {
+    it('should map Flux statuses to dot colors', () => {
+      expect(getStatusDotClass('Ready')).toBe('bg-green-500')
+      expect(getStatusDotClass('Failed')).toBe('bg-red-500')
+      expect(getStatusDotClass('Progressing')).toBe('bg-blue-500')
+      expect(getStatusDotClass('Suspended')).toBe('bg-yellow-500')
+    })
+
+    it('should fall back to gray for unknown or empty status', () => {
+      expect(getStatusDotClass('Unknown')).toBe('bg-gray-500')
+      expect(getStatusDotClass('')).toBe('bg-gray-500')
+      expect(getStatusDotClass(undefined)).toBe('bg-gray-500')
+    })
+  })
+
+  describe('normalizeToFluxStatus', () => {
+    it('should map healthy workload kstatus values to Ready', () => {
+      expect(normalizeToFluxStatus('Current')).toBe('Ready')
+      expect(normalizeToFluxStatus('Idle')).toBe('Ready')
+    })
+
+    it('should map InProgress to Progressing and Terminating to Suspended', () => {
+      expect(normalizeToFluxStatus('InProgress')).toBe('Progressing')
+      expect(normalizeToFluxStatus('Terminating')).toBe('Suspended')
+    })
+
+    it('should pass through Flux vocab and unrecognized values unchanged', () => {
+      expect(normalizeToFluxStatus('Ready')).toBe('Ready')
+      expect(normalizeToFluxStatus('Failed')).toBe('Failed')
+      expect(normalizeToFluxStatus('Progressing')).toBe('Progressing')
+      expect(normalizeToFluxStatus('Suspended')).toBe('Suspended')
+      expect(normalizeToFluxStatus('Unknown')).toBe('Unknown')
+      expect(normalizeToFluxStatus('SomethingElse')).toBe('SomethingElse')
+    })
+  })
+
   describe('getStatusBorderClass', () => {
     it('should return success border for Ready status', () => {
       expect(getStatusBorderClass('Ready')).toBe('border-success')
@@ -306,6 +344,13 @@ describe('status utilities', () => {
 
     it('should return info border for Progressing status', () => {
       expect(getStatusBorderClass('Progressing')).toBe('border-info')
+    })
+
+    it('should translate workload kstatus values to matching borders', () => {
+      expect(getStatusBorderClass('Current')).toBe('border-success')
+      expect(getStatusBorderClass('Idle')).toBe('border-success')
+      expect(getStatusBorderClass('InProgress')).toBe('border-info')
+      expect(getStatusBorderClass('Terminating')).toBe('border-warning')
     })
 
     it('should return gray border for Unknown status', () => {

--- a/web/src/utils/storage.js
+++ b/web/src/utils/storage.js
@@ -1,0 +1,36 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Guarded wrappers around Web Storage writes. A storage-disabled environment —
+// notably Safari private mode, where setItem throws QuotaExceededError because the
+// quota is zero — must never break rendering or a user action, so write failures
+// are swallowed. Reads are unaffected: getItem returns null when storage is
+// unavailable, which the callers already handle.
+
+/**
+ * Write a value to localStorage, ignoring failures (private mode / quota exceeded).
+ *
+ * @param {string} key - The storage key
+ * @param {string} value - The already-serialized string value
+ */
+export function writeLocalStorage(key, value) {
+  try {
+    localStorage.setItem(key, value)
+  } catch {
+    // Storage unavailable or full — skip persisting rather than break the app.
+  }
+}
+
+/**
+ * Write a value to sessionStorage, ignoring failures (private mode / quota exceeded).
+ *
+ * @param {string} key - The storage key
+ * @param {string} value - The already-serialized string value
+ */
+export function writeSessionStorage(key, value) {
+  try {
+    window.sessionStorage.setItem(key, value)
+  } catch {
+    // Storage unavailable or full — skip persisting rather than break the app.
+  }
+}

--- a/web/src/utils/storage.test.js
+++ b/web/src/utils/storage.test.js
@@ -1,0 +1,50 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { writeLocalStorage, writeSessionStorage } from './storage'
+
+describe('storage write guards', () => {
+  beforeEach(() => {
+    global.localStorageMock.setItem.mockReset()
+    window.sessionStorage.clear()
+  })
+
+  describe('writeLocalStorage', () => {
+    it('writes through to localStorage.setItem', () => {
+      writeLocalStorage('k', 'v')
+      expect(global.localStorageMock.setItem).toHaveBeenCalledWith('k', 'v')
+    })
+
+    it('swallows a throwing setItem (Safari private mode / quota)', () => {
+      global.localStorageMock.setItem.mockImplementation(() => {
+        throw new Error('QuotaExceededError')
+      })
+      expect(() => writeLocalStorage('k', 'v')).not.toThrow()
+    })
+  })
+
+  describe('writeSessionStorage', () => {
+    it('writes through to sessionStorage', () => {
+      writeSessionStorage('k', 'v')
+      expect(window.sessionStorage.getItem('k')).toBe('v')
+    })
+
+    it('swallows a throwing setItem (Safari private mode / quota)', () => {
+      const original = window.sessionStorage
+      Object.defineProperty(window, 'sessionStorage', {
+        value: { setItem: () => { throw new Error('QuotaExceededError') } },
+        configurable: true,
+        writable: true
+      })
+      try {
+        expect(() => writeSessionStorage('k', 'v')).not.toThrow()
+      } finally {
+        Object.defineProperty(window, 'sessionStorage', {
+          value: original,
+          configurable: true,
+          writable: true
+        })
+      }
+    })
+  })
+})

--- a/web/src/utils/theme.js
+++ b/web/src/utils/theme.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { signal, effect } from '@preact/signals'
+import { writeLocalStorage } from './storage'
 
 // Theme modes
 export const themes = {
@@ -42,7 +43,7 @@ effect(() => {
   }
 
   // Save to localStorage
-  localStorage.setItem('theme', mode)
+  writeLocalStorage('theme', mode)
 
   // Apply to document
   if (appliedTheme.value === themes.dark) {

--- a/web/src/utils/useDismiss.js
+++ b/web/src/utils/useDismiss.js
@@ -1,0 +1,39 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useEffect, useRef } from 'preact/hooks'
+
+/**
+ * useDismiss - closes a popup (dropdown, menu) on an outside mousedown or the
+ * Escape key, but only while `active`. The latest `onDismiss` is read from a
+ * ref so the listeners are attached once per open/close, not on every render.
+ *
+ * @param {object} ref - Ref to the popup container element
+ * @param {Function} onDismiss - Called to close the popup
+ * @param {boolean} active - Whether the popup is open (listeners attach only then)
+ */
+export function useDismiss(ref, onDismiss, active) {
+  const cb = useRef(onDismiss)
+  cb.current = onDismiss
+
+  useEffect(() => {
+    if (!active) return
+    const onClick = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) cb.current()
+    }
+    const onKey = (e) => {
+      if (e.key === 'Escape') {
+        // Stop the Escape from bubbling to outer handlers (e.g. a modal that
+        // also closes on Escape), so it only dismisses this popup.
+        e.stopPropagation()
+        cb.current()
+      }
+    }
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [ref, active])
+}

--- a/web/src/utils/useDismiss.test.js
+++ b/web/src/utils/useDismiss.test.js
@@ -1,0 +1,63 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/preact'
+import { useRef } from 'preact/hooks'
+import { useDismiss } from './useDismiss'
+
+// Minimal harness: a panel that dismisses via the hook.
+function Panel({ active, onDismiss }) {
+  const ref = useRef(null)
+  useDismiss(ref, onDismiss, active)
+  return (
+    <div>
+      <div ref={ref} data-testid="panel">inside</div>
+      <button data-testid="outside">outside</button>
+    </div>
+  )
+}
+
+describe('useDismiss', () => {
+  afterEach(cleanup)
+
+  it('dismisses on an outside mousedown while active', () => {
+    const onDismiss = vi.fn()
+    render(<Panel active={true} onDismiss={onDismiss} />)
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dismiss on a mousedown inside the panel', () => {
+    const onDismiss = vi.fn()
+    render(<Panel active={true} onDismiss={onDismiss} />)
+    fireEvent.mouseDown(screen.getByTestId('panel'))
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('dismisses on Escape while active', () => {
+    const onDismiss = vi.fn()
+    render(<Panel active={true} onDismiss={onDismiss} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops Escape from reaching outer handlers', () => {
+    const onDismiss = vi.fn()
+    const outer = vi.fn()
+    window.addEventListener('keydown', outer)
+    render(<Panel active={true} onDismiss={onDismiss} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+    expect(outer).not.toHaveBeenCalled()
+    window.removeEventListener('keydown', outer)
+  })
+
+  it('does not listen while inactive', () => {
+    const onDismiss = vi.fn()
+    render(<Panel active={false} onDismiss={onDismiss} />)
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/utils/version.js
+++ b/web/src/utils/version.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { signal } from '@preact/signals'
+import { writeLocalStorage } from './storage'
 
 // localStorage keys
 const VERSION_STORAGE_KEY = 'flux-operator-version'
@@ -35,7 +36,7 @@ export function getOrCreateUUID() {
   let uuid = localStorage.getItem(UUID_STORAGE_KEY)
   if (!uuid) {
     uuid = crypto.randomUUID()
-    localStorage.setItem(UUID_STORAGE_KEY, uuid)
+    writeLocalStorage(UUID_STORAGE_KEY, uuid)
   }
   return uuid
 }
@@ -71,7 +72,7 @@ export async function checkForUpdates(version, fluxVersion, env = import.meta.en
     const data = await response.json()
 
     // Persist successful response to localStorage
-    localStorage.setItem(UPDATE_INFO_STORAGE_KEY, JSON.stringify(data))
+    writeLocalStorage(UPDATE_INFO_STORAGE_KEY, JSON.stringify(data))
 
     // Update the signal
     updateInfo.value = data
@@ -115,7 +116,7 @@ export function checkVersionChange(newVersion, fluxVersion) {
   const hasCachedInfoForVersion = cachedUpdateInfo?.current === newVersion
 
   // Store the new version
-  localStorage.setItem(VERSION_STORAGE_KEY, newVersion)
+  writeLocalStorage(VERSION_STORAGE_KEY, newVersion)
 
   // Check for updates if we don't have cached info for this specific version
   if (!hasCachedInfoForVersion) {


### PR DESCRIPTION
This PR extends the Flux Web UI with:
- dedicated workload search page and dashboard with deploy pipeline graph
- log viewer with streaming, log level filtering and multi-pod multi-container aggregation 
- add support for workload kinds in Favorites and Quick Search
- ⚠️  remove workload actions+pods from the Resource dashboard and link to Workload dashboard

Security & RBAC changes:
- workloads search results are subject to namespace access (same as the resources search)
- workload dashboard runs under impersonation (same access control as the resource  dashboard)
- log queries run under impersonation (users need RBAC granting `get` for `pods/log`)

### Workload Dashboard

Dedicated dashboard for Deployment, StatefulSet, DaemonSet and CronJob.

- Action bar: `reconcile` / `pull` / `suspend/resume` | `rollout restart` / `run job` / `view logs`
- Pipeline graph: `source` -> `reconciler` -> `workload` -> `pods`
- Workload panel: `overview` | `pods` | `events` | `spec` | `status`
   - Overview: rollout strategy, cron expression, service account, ports, last action
   - Pods: list with rollout status, per-container image and error detection (actions: view logs and delete pod)
   - Spec/Status: view as YAML
- Reconciler panel: `overview` | `source` | `events`

---

<img width="1020" height="864" alt="Screenshot 2026-06-20 at 10 41 17" src="https://github.com/user-attachments/assets/36ef1724-1244-42d4-9d25-bb80537967b9" />


### Workload Log Viewer

Dedicated view for tailing, filtering and following pod logs. Comes with a builtin parser for popular logging frameworks including log level detection and stack trace grouping.

Toolbar:
- Follow/Snapshot (toggle)
- Format/Raw (toggle)
- Settings (persisted in local storage)
   - Select number of lines to tail
   - Select font size
   - JSON fields selector
- Search with support for exclusions e.g. `!debug` (textbox)
- Select pods - defaults to all (dropdown)
- Select container including previous ones (dropdown)
- Select level (dropdown)
- Download raw logs (link)
- Full screen (toggle)

Listing modes:
- Formatted: pretty print with timestamps, log level, stack trace grouping, burst grouping
  - Go — klog/glog, zap (console encoder), logfmt (logrus text, go-kit/log, slog TextHandler)
  - Java — Spring Boot, Log4j2, Logback (default console layouts, log4net, log4j-style)
  - .NET — Serilog Console sink, NLog default layout
  - Python — common logging format, gunicorn, uvicorn
  - Ruby — Logger default format
  - PHP — Monolog default LineFormatter
  - JSON — generic objects/arrays, logstash-logback-encoder, Log4j2 ECS, Serilog CLEF, MEL JSON console
- Raw: continuous stream of wrapped log lines

---

<img width="887" height="725" alt="Screenshot 2026-06-22 at 05 53 27" src="https://github.com/user-attachments/assets/90dced8f-ad00-4bbf-b466-2bdb835b6692" />


### Refs

- closes: #697
- closes: #567