### PR TITLE
docs: Use Flux CLI commands in guides

### DIFF
--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -266,11 +266,11 @@ and must be of type `kubernetes.io/dockerconfigjson`.
 Example generating a secret for the ControlPlane enterprise registry:
 
 ```sh
-kubectl create secret docker-registry flux-enterprise-auth \
-  --namespace flux-system \
-  --docker-server=ghcr.io \
-  --docker-username=flux \
-  --docker-password=$ENTERPRISE_TOKEN
+echo $ENTERPRISE_TOKEN | flux-operator create secret registry flux-enterprise-auth \
+  --namespace=flux-system \
+  --server=ghcr.io \
+  --username=flux \
+  --password-stdin
 ```
 
 #### Distribution artifact
@@ -695,12 +695,11 @@ stringData:
   password: "git-token"
 ```
 
-To generate the secret with the Flux CLI:
+To generate the secret with the Flux Operator CLI:
 
 ```sh
-flux create secret git git-token-auth \
-  --namespace flux-system \
-  --url=https://gitlab.com/my-group/my-fleet.git \
+flux-operator create secret basic-auth git-token-auth \
+  --namespace=flux-system \
   --username=git-username \
   --password=git-token
 ```
@@ -738,13 +737,13 @@ stringData:
     github.com ecdsa-sha2-nistp256 AAAA...  
 ```
 
-To generate the secret with the Flux CLI:
+To generate the secret with the Flux Operator CLI:
 
 ```sh
-flux create secret git git-ssh-auth \
-  --namespace flux-system \
-  --url=ssh://git@github.com/my-org/my-fleet.git \
-  --private-key-file=my-private.key
+flux-operator create secret ssh git-ssh-auth \
+  --namespace=flux-system \
+  --private-key-file=my-private.key \
+  --knownhosts-file=./known_hosts
 ```
 
 #### Sync from OCI over HTTP/S
@@ -775,12 +774,12 @@ data:
   .dockerconfigjson: "base64-encoded-docker-config"
 ```
 
-To generate the secret with the Flux CLI:
+To generate the secret with the Flux Operator CLI:
 
 ```sh
-flux create secret oci oci-token-auth \
-  --namespace flux-system \
-  --url=ghcr.io \
+flux-operator create secret registry oci-token-auth \
+  --namespace=flux-system \
+  --server=ghcr.io \
   --username=ghcr-username \
   --password=ghcr-token
 ```

--- a/docs/api/v1/resourcesetinputprovider.md
+++ b/docs/api/v1/resourcesetinputprovider.md
@@ -474,7 +474,7 @@ ID corresponding to the owner using the GitHub API.
 The GitHub App ID and Installation ID are integer numbers, so remember to quote them in the secret
 if using the `stringData` field as all values in this field must be strings.
 
-A simpler alternative is creating the secret using the Flux CLI command `flux create secret githubapp`.
+A simpler alternative is creating the secret using the `flux-operator create secret githubapp` command.
 
 ### TLS certificate configuration
 

--- a/docs/guides/instance/instance-controllers.md
+++ b/docs/guides/instance/instance-controllers.md
@@ -89,11 +89,11 @@ To access the ControlPlane registry, the `flux-enterprise-auth` Kubernetes secre
 created in the `flux-system` namespace and should contain the credentials to pull the enterprise images:
 
 ```shell
-kubectl create secret docker-registry flux-enterprise-auth \
-  --namespace flux-system \
-  --docker-server=ghcr.io \
-  --docker-username=flux \
-  --docker-password=$ENTERPRISE_TOKEN
+echo $ENTERPRISE_TOKEN | flux-operator create secret registry flux-enterprise-auth \
+  --namespace=flux-system \
+  --server=ghcr.io \
+  --username=flux \
+  --password-stdin
 ```
 
 ## Custom configuration

--- a/docs/guides/instance/instance-sync.md
+++ b/docs/guides/instance/instance-sync.md
@@ -40,10 +40,10 @@ If the source repository is private, the Kubernetes secret must be created in th
 and should contain the credentials to clone the repository:
 
 ```shell
-flux create secret git flux-system \
-  --url=https://gitlab.com/my-org/my-fleet.git \
+echo $GITLAB_TOKEN | flux-operator create secret basic-auth flux-system \
+  --namespace=flux-system \
   --username=git \
-  --password=$GITLAB_TOKEN
+  --password-stdin
 ```
 
 ## Sync from a Git Repository using GitHub App auth
@@ -80,17 +80,18 @@ The Kubernetes secret must be created in the `flux-system` namespace
 and should contain the GitHub App private key:
 
 ```shell
-flux create secret githubapp flux-system \
+flux-operator create secret githubapp flux-system \
+  --namespace=flux-system \
   --app-id=1 \
   --app-installation-id=2 \
-  --app-private-key=./path/to/private-key-file.pem
+  --app-private-key-file=./path/to/private-key-file.pem
 ```
 
 !!! tip "GitHub App Support"
 
     Note that GitHub App support was added in Flux v2.5.0 and Flux Operator v0.16.0.
     For more information on how to create a GitHub App see the
-    Flux [GitRepository API reference](https://fluxcd.io/flux/components/source/gitrepositories/#github). 
+    Flux [GitRepository API reference](https://fluxoperator.dev/docs/crd/gitrepository/#github). 
 
 
 ## Sync from an Azure DevOps Repository using AKS Workload Identity
@@ -150,7 +151,7 @@ spec:
 
     Note that Azure DevOps Workload Identity support was added in Flux v2.5.0 and Flux Operator v0.18.0.
     For more information on how to configure Azure DevOps Workload Identity see the
-    Flux [GitRepository API reference](https://fluxcd.io/flux/components/source/gitrepositories/#azure). 
+    Flux [GitRepository API reference](https://fluxoperator.dev/docs/crd/gitrepository/#azure). 
 
 ## Sync from a Container Registry
 
@@ -180,11 +181,11 @@ in the same namespace where the `FluxInstance` is deployed,
 and be of type `kubernetes.io/dockerconfigjson`:
 
 ```shell
-flux create secret oci flux-system \
-  --namespace flux-system \
-  --url=ghcr.io \
+echo $GITHUB_TOKEN | flux-operator create secret registry flux-system \
+  --namespace=flux-system \
+  --server=ghcr.io \
   --username=flux \
-  --password=$GITHUB_TOKEN
+  --password-stdin
 ```
 
 ## Sync from a Container Registry using Workload Identity

--- a/docs/guides/operator/operator-migration.md
+++ b/docs/guides/operator/operator-migration.md
@@ -91,6 +91,39 @@ Running the trace command should result in a "Not managed by Flux" message:
 flux trace kustomization flux-system
 ```
 
+## Git credentials rotation
+
+If you wish to rotate the Git credentials used by Flux, you can
+overwrite the existing pull secret using the [Flux Operator CLI](cli.md).
+
+SSH credentials:
+
+```shell
+flux-operator create secret ssh flux-system \
+  --namespace=flux-system \
+  --private-key-file=./path/to/private-key \
+  --knownhosts-file=./path/to/known_hosts
+```
+
+Personal access token credentials:
+
+```shell
+echo $GIT_TOKEN | flux-operator create secret basic-auth flux-system \
+  --namespace=flux-system \
+  --username=git \
+  --password-stdin
+```
+
+GitHub App credentials:
+
+```shell
+flux-operator create secret githubapp flux-system \
+  --namespace=flux-system \
+  --app-id=1 \
+  --app-installation-id=2 \
+  --app-private-key-file=./path/to/private-key-file.pem
+```
+
 ## Cleanup the repository
 
 To finalize the migration, remove the Flux manifests from the Git repository:
@@ -235,10 +268,11 @@ Create an image pull secret in the `flux-system` namespace that contains
 a GitHub token with read access to the GitHub Container Registry:
 
 ```shell
-flux create secret oci ghcr-auth \
-    --url=ghcr.io \
+echo ${GITHUB_TOKEN} | flux-operator create secret registry ghcr-auth \
+    --namespace=flux-system \
+    --server=ghcr.io \
     --username=flux \
-    --password=${GITHUB_TOKEN}
+    --password-stdin
 ```
 
 ### Update the FluxInstance to use OCI artifacts


### PR DESCRIPTION
Update all guides to Flux Operator CLI commands instead of kubectl and flux.

Add a section to the migration guide on how to rotate the Git credentials (fix: #685)