### PR TITLE
operator:  Add `insecure: true` to ResourceSetInputProvider `OCIArtifactTag`. 

### DIFF
--- a/api/v1/resourcesetinputprovider_types.go
+++ b/api/v1/resourcesetinputprovider_types.go
@@ -51,7 +51,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="!self.type.startsWith('AzureDevOps') || self.url.startsWith('http')", message="spec.url must start with 'http://' or 'https://' when spec.type is a Git provider"
 // +kubebuilder:validation:XValidation:rule="!self.type.endsWith('ArtifactTag') || self.url.startsWith('oci')", message="spec.url must start with 'oci://' when spec.type is an OCI provider"
 // +kubebuilder:validation:XValidation:rule="self.type != 'ExternalService' || self.url.startsWith('http')", message="spec.url must start with 'http://' or 'https://' when spec.type is 'ExternalService'"
-// +kubebuilder:validation:XValidation:rule="!has(self.insecure) || !self.insecure || self.type == 'ExternalService'", message="spec.insecure can only be set when spec.type is 'ExternalService'"
+// +kubebuilder:validation:XValidation:rule="!has(self.insecure) || !self.insecure || self.type == 'ExternalService' || self.type == 'OCIArtifactTag'", message="spec.insecure can only be set when spec.type is 'ExternalService' or 'OCIArtifactTag'"
 // +kubebuilder:validation:XValidation:rule="self.type != 'ExternalService' || !self.url.startsWith('http://') || (has(self.insecure) && self.insecure)", message="spec.url must use 'https://' unless spec.insecure is true"
 // +kubebuilder:validation:XValidation:rule="!has(self.serviceAccountName) || self.type.startsWith('AzureDevOps') || self.type.endsWith('ArtifactTag')", message="cannot specify spec.serviceAccountName when spec.type is not one of AzureDevOps* or *ArtifactTag"
 // +kubebuilder:validation:XValidation:rule="!has(self.certSecretRef) || !(self.url == 'Static' || self.type.startsWith('AzureDevOps') || (self.type.endsWith('ArtifactTag') && self.type != 'OCIArtifactTag'))", message="cannot specify spec.certSecretRef when spec.type is one of Static, AzureDevOps*, ACRArtifactTag, ECRArtifactTag or GARArtifactTag"
@@ -102,8 +102,8 @@ type ResourceSetInputProviderSpec struct {
 	// +optional
 	CertSecretRef *meta.LocalObjectReference `json:"certSecretRef,omitempty"`
 
-	// Insecure allows connecting to an ExternalService provider over
-	// plain HTTP without TLS. When not set, the URL must use HTTPS.
+	// Insecure allows connecting to an ExternalService or OCIArtifactTag provider
+	// over plain HTTP without TLS. When not set, the URL must use HTTPS.
 	// +optional
 	Insecure bool `json:"insecure,omitempty"`
 

--- a/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
@@ -135,8 +135,8 @@ spec:
                 type: object
               insecure:
                 description: |-
-                  Insecure allows connecting to an ExternalService provider over
-                  plain HTTP without TLS. When not set, the URL must use HTTPS.
+                  Insecure allows connecting to an ExternalService or OCIArtifactTag provider
+                  over plain HTTP without TLS. When not set, the URL must use HTTPS.
                 type: boolean
               schedule:
                 description: Schedule defines the schedules for the input provider
@@ -253,7 +253,9 @@ spec:
                 is 'ExternalService'
               rule: self.type != 'ExternalService' || self.url.startsWith('http')
             - message: spec.insecure can only be set when spec.type is 'ExternalService'
-              rule: '!has(self.insecure) || !self.insecure || self.type == ''ExternalService'''
+                or 'OCIArtifactTag'
+              rule: '!has(self.insecure) || !self.insecure || self.type == ''ExternalService''
+                || self.type == ''OCIArtifactTag'''
             - message: spec.url must use 'https://' unless spec.insecure is true
               rule: self.type != 'ExternalService' || !self.url.startsWith('http://')
                 || (has(self.insecure) && self.insecure)

--- a/docs/api/v1/resourcesetinputprovider.md
+++ b/docs/api/v1/resourcesetinputprovider.md
@@ -201,9 +201,11 @@ When using plain HTTP (without TLS), the `.spec.insecure` field must be set to `
 
 ### Insecure
 
-The `.spec.insecure` field is optional and can only be set when `.spec.type` is `ExternalService`.
-When set to `true`, it allows connecting to the external service over plain HTTP without TLS.
-If not set or set to `false`, the URL must use the `https://` scheme.
+The `.spec.insecure` field is optional and can only be set when `.spec.type` is `ExternalService`
+or `OCIArtifactTag`. When set to `true`, it allows connecting over plain HTTP without TLS.
+For `ExternalService`, the URL may use `http://` instead of `https://`.
+For `OCIArtifactTag`, insecure HTTP connections to the OCI registry are allowed.
+If not set or set to `false`, connections use HTTPS/TLS.
 
 ### Filter
 

--- a/internal/controller/resourcesetinputprovider_controller_externalservice_test.go
+++ b/internal/controller/resourcesetinputprovider_controller_externalservice_test.go
@@ -781,5 +781,5 @@ func TestResourceSetInputProviderReconciler_ExternalService_InsecureOnNonExterna
 	g.Expect(conditions.IsReady(obj)).To(BeFalse())
 	g.Expect(conditions.IsStalled(obj)).To(BeTrue())
 	g.Expect(conditions.GetReason(obj, meta.ReadyCondition)).To(Equal(fluxcdv1.ReasonInvalidSpec))
-	g.Expect(conditions.GetMessage(obj, meta.StalledCondition)).To(ContainSubstring("spec.insecure can only be set"))
+	g.Expect(conditions.GetMessage(obj, meta.StalledCondition)).To(ContainSubstring("spec.insecure can only be set when spec.type is 'ExternalService' or 'OCIArtifactTag'"))
 }


### PR DESCRIPTION
Closes #720 

Adding `insecure: true` to ResourceSetInputProvider `OCIArtifactTag`. 

This is implemented how the oci source controller does, where TLS will be used for every case unless `insecure: true` is set and there is no TLS config added as well. 

[oci-e2e-logs.txt](https://github.com/user-attachments/files/25589870/oci-e2e-logs.txt)
[insecure-oci-e2e.sh](https://github.com/user-attachments/files/25589876/insecure-oci-e2e.sh)
