### PR TITLE
mcp: add support for retrieving previous container logs

### DIFF
--- a/cmd/mcp/k8s/logs.go
+++ b/cmd/mcp/k8s/logs.go
@@ -15,11 +15,13 @@ import (
 )
 
 // GetLogs retrieves the logs for a specific pod container in the given namespace.
-func (k *Client) GetLogs(ctx context.Context, pod, container, namespace string, limit int64) (*unstructured.Unstructured, error) {
+// If previous is true, the logs from the previous container instance are returned.
+func (k *Client) GetLogs(ctx context.Context, pod, container, namespace string, limit int64, previous bool) (*unstructured.Unstructured, error) {
 	podLogOpts := corev1.PodLogOptions{
 		Container:  container,
 		TailLines:  &limit,
-		LimitBytes: new(int64(64 * 1024)),
+		LimitBytes: new(int64(256 * 1024)), // 256 KiB cap
+		Previous:   previous,
 	}
 
 	clientset, err := kubernetes.NewForConfig(k.cfg)

--- a/cmd/mcp/toolbox/get_logs.go
+++ b/cmd/mcp/toolbox/get_logs.go
@@ -28,6 +28,7 @@ type getKubernetesLogsInput struct {
 	ContainerName string  `json:"container_name" jsonschema:"The name of the container."`
 	PodNamespace  string  `json:"pod_namespace" jsonschema:"The namespace of the pod."`
 	Limit         float64 `json:"limit,omitempty" jsonschema:"The maximum number of log lines to return. Defaults to 100."`
+	Previous      bool    `json:"previous,omitempty" jsonschema:"Return logs from the previous container instance. Defaults to false."`
 }
 
 // HandleGetKubernetesLogs is the handler function for the get_kubernetes_logs tool.
@@ -58,7 +59,7 @@ func (m *Manager) HandleGetKubernetesLogs(ctx context.Context, request *mcp.Call
 		return NewToolResultErrorFromErr("Failed to get Kubernetes client", err)
 	}
 
-	result, err := kubeClient.GetLogs(ctx, input.PodName, input.ContainerName, input.PodNamespace, limit)
+	result, err := kubeClient.GetLogs(ctx, input.PodName, input.ContainerName, input.PodNamespace, limit, input.Previous)
 	if err != nil {
 		return NewToolResultError(err.Error())
 	}

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -55,6 +55,7 @@ Retrieves logs from Kubernetes pods, allowing AI assistants to analyze applicati
 - `pod_namespace` (required): The namespace of the pod
 - `container_name` (required): The name of the container
 - `limit` (optional): Maximum number of log lines to return (default: 100)
+- `previous` (optional): Return logs from the previous container instance (default: false)
 
 **Output:**
 


### PR DESCRIPTION
Add `previous` arg to `get_kubernetes_logs` tool and increase the max response to 256 KiB