### PR TITLE
web: limit request body size

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -77,8 +77,9 @@ func NewHandler(ctx context.Context, conf *fluxcdv1.WebConfigSpec, spaHandler ht
 	mux.HandleFunc("POST /api/v1/workloads", h.WorkloadsHandler)
 
 	// Wrap the mux with middlewares to produce the final handler.
+	// Limit request body size to 1MB to prevent abuse on POST endpoints.
 	handler := LoggingMiddleware(l, SecurityHeadersMiddleware(
-		GzipMiddleware(CacheControlMiddleware(authMiddleware(mux)))))
+		GzipMiddleware(CacheControlMiddleware(MaxBodySizeMiddleware(1<<20)(authMiddleware(mux))))))
 
 	// The report cache is the only goroutine.
 	stopped := h.startReportCache(ctx, reportInterval)

--- a/internal/web/middlewares.go
+++ b/internal/web/middlewares.go
@@ -116,6 +116,19 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// MaxBodySizeMiddleware limits the size of request bodies to prevent abuse.
+// Only applies to requests that may carry a body (POST, PUT, PATCH).
+func MaxBodySizeMiddleware(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch {
+				r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // LoggingMiddleware logs HTTP requests and responses.
 func LoggingMiddleware(logger logr.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Limit request body size to 1MB to prevent abuse on POST endpoints.