### PR TITLE
web: support auth URL params for oauth2

### DIFF
--- a/api/v1/webconfig_types.go
+++ b/api/v1/webconfig_types.go
@@ -175,6 +175,14 @@ type OAuth2AuthenticationSpec struct {
 	// +optional
 	Scopes []string `json:"scopes"`
 
+	// AuthURLParams is a map of additional query parameters
+	// to include in the authorization URL when redirecting
+	// the user to the OAuth2 provider for authentication.
+	// This can be used to set provider-specific parameters,
+	// such as "access_type=offline" and "prompt=consent".
+	// +optional
+	AuthURLParams map[string]string `json:"authURLParams"`
+
 	// IssuerURL is used for OIDC provider discovery.
 	// Required for the OIDC provider.
 	// Used only by the OIDC provider.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -697,6 +697,13 @@ func (in *OAuth2AuthenticationSpec) DeepCopyInto(out *OAuth2AuthenticationSpec) 
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AuthURLParams != nil {
+		in, out := &in.AuthURLParams, &out.AuthURLParams
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.ClaimsProcessorSpec.DeepCopyInto(&out.ClaimsProcessorSpec)
 }
 

--- a/docs/web/web-config-api.md
+++ b/docs/web/web-config-api.md
@@ -76,6 +76,44 @@ spec:
       clientSecret: flux-web-client-secret
       issuerURL: https://dex.example.com
 
+      # Custom scopes to request instead of the defaults.
+      # Each provider may have different default scopes.
+      scopes: # Optional
+        - groups
+        - email
+
+      # Map of additional query parameters to include in
+      # the authorization URL when redirecting the user to
+      # the OAuth2 provider for authentication. This can be
+      # used to set provider-specific parameters, such as
+      # "access_type=offline" and "prompt=consent".
+      authURLParams: # Optional
+        access_type: offline
+        prompt: consent
+
+      # CEL expressions to extract information from the ID token claims
+      # into named variables that can be reused in other expressions.
+      variables: # Optional
+        - name: username
+          expression: "claims.sub"
+
+      # CEL expressions that validate the ID token claims and extracted
+      # variables. Each expression must return the type bool.
+      validations: # Optional
+        - expression: "size(claims.groups) > 0"
+          message: "user must belong to at least one group"
+
+      # CEL expressions to extract user profile information
+      # from the ID token claims and extracted variables.
+      profile: # Optional
+        name: "claims.name"
+
+      # CEL expressions that extract the username and groups
+      # for Kubernetes RBAC impersonation.
+      impersonation: # Optional
+        username: "claims.email"
+        groups: "claims.groups"
+
   # User actions (optional)
   userActions:
     # Send audit events to Kubernetes and Flux's notification-controller.
@@ -160,6 +198,14 @@ spec:
       scopes:
         - groups
         - email
+
+      # Optional: map of additional query parameters to include in
+      # the authorization URL when redirecting the user to the OAuth2
+      # provider for authentication. This can be used to set
+      # provider-specific parameters.
+      authURLParams:
+        access_type: offline
+        prompt: consent
 ```
 
 The default scopes requested are `openid`, `offline_access`, `profile`, `email` and `groups`.
@@ -319,6 +365,29 @@ spec:
       clientID: flux-web
       clientSecret: my-client-secret
       issuerURL: https://dex.example.com
+```
+
+### OIDC with Authorization URL Parameters
+
+This example configures additional query parameters for the authorization URL,
+useful for provider-specific settings such as forcing offline access and consent
+prompts:
+
+```yaml
+apiVersion: web.fluxcd.controlplane.io/v1
+kind: Config
+spec:
+  baseURL: https://flux-web.example.com
+  authentication:
+    type: OAuth2
+    oauth2:
+      provider: OIDC
+      clientID: flux-web
+      clientSecret: my-client-secret
+      issuerURL: https://accounts.google.com
+      authURLParams:
+        access_type: offline
+        prompt: consent
 ```
 
 ### OIDC with Custom Session Duration

--- a/internal/web/auth/oauth2.go
+++ b/internal/web/auth/oauth2.go
@@ -123,11 +123,18 @@ func (o *oauth2Authenticator) serveAuthorize(w http.ResponseWriter, r *http.Requ
 	setSecureCookie(w, cookieNameOAuth2LoginState, cookiePathOAuth2LoginState,
 		state, cookieDurationShortLived, !o.conf.Insecure)
 
-	// Redirect to authorization URL.
-	authCodeURL := oauth2Conf.AuthCodeURL(state,
+	// Build authorization code URL.
+	authCodeOpts := []oauth2.AuthCodeOption{
 		oauth2.SetAuthURLParam("code_challenge", pkceChallenge),
 		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
-		oauth2.SetAuthURLParam("nonce", nonce))
+		oauth2.SetAuthURLParam("nonce", nonce),
+	}
+	for k, v := range o.conf.Authentication.OAuth2.AuthURLParams {
+		authCodeOpts = append(authCodeOpts, oauth2.SetAuthURLParam(k, v))
+	}
+	authCodeURL := oauth2Conf.AuthCodeURL(state, authCodeOpts...)
+
+	// Redirect to authorization URL.
 	http.Redirect(w, r, authCodeURL, http.StatusSeeOther)
 }
 

--- a/internal/web/auth/oauth2_test.go
+++ b/internal/web/auth/oauth2_test.go
@@ -449,12 +449,16 @@ func TestVerifyTokenAndSetStorageOrLogErrorOptions(t *testing.T) {
 
 // mockOAuth2Provider is a test double for oauth2Provider.
 type mockOAuth2Provider struct {
+	conf    *oauth2.Config
 	details *user.Details
 	storage *authStorage
 	err     error
 }
 
 func (m *mockOAuth2Provider) config() (*oauth2.Config, error) {
+	if m.conf != nil {
+		return m.conf, nil
+	}
 	return &oauth2.Config{}, nil
 }
 
@@ -468,6 +472,91 @@ func (m *mockOAuth2Provider) verifyAccessToken(ctx context.Context, accessToken 
 
 func (m *mockOAuth2Provider) verifyToken(ctx context.Context, token *oauth2.Token, nonce ...string) (*user.Details, *authStorage, error) {
 	return m.details, m.storage, m.err
+}
+
+func TestServeAuthorize_AuthURLParams(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		authURLParams  map[string]string
+		expectParams   map[string]string
+		unexpectParams []string
+	}{
+		{
+			name:          "includes custom auth URL params in redirect",
+			authURLParams: map[string]string{"access_type": "offline", "prompt": "consent"},
+			expectParams:  map[string]string{"access_type": "offline", "prompt": "consent"},
+		},
+		{
+			name:          "includes single auth URL param",
+			authURLParams: map[string]string{"prompt": "login"},
+			expectParams:  map[string]string{"prompt": "login"},
+		},
+		{
+			name:           "no custom params when authURLParams is nil",
+			authURLParams:  nil,
+			unexpectParams: []string{"access_type", "prompt"},
+		},
+		{
+			name:           "no custom params when authURLParams is empty",
+			authURLParams:  map[string]string{},
+			unexpectParams: []string{"access_type", "prompt"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			auth := newTestOAuth2Authenticator(t)
+			auth.conf = &fluxcdv1.WebConfigSpec{
+				BaseURL:  "https://flux-web.example.com",
+				Insecure: true,
+				Authentication: &fluxcdv1.AuthenticationSpec{
+					OAuth2: &fluxcdv1.OAuth2AuthenticationSpec{
+						Provider:      "OIDC",
+						ClientID:      "test-client-id",
+						ClientSecret:  "test-client-secret-for-testing-purposes",
+						AuthURLParams: tt.authURLParams,
+					},
+				},
+			}
+			auth.provider = &mockOAuth2Provider{
+				conf: &oauth2.Config{
+					Endpoint: oauth2.Endpoint{
+						AuthURL: "https://auth.example.com/authorize",
+					},
+				},
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/oauth2/authorize", nil)
+			rec := httptest.NewRecorder()
+
+			auth.serveAuthorize(rec, req)
+
+			g.Expect(rec.Code).To(Equal(http.StatusSeeOther))
+
+			location := rec.Header().Get("Location")
+			g.Expect(location).NotTo(BeEmpty())
+
+			redirectURL, err := url.Parse(location)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			query := redirectURL.Query()
+
+			// Standard PKCE and nonce params should always be present.
+			g.Expect(query.Get("code_challenge")).NotTo(BeEmpty())
+			g.Expect(query.Get("code_challenge_method")).To(Equal("S256"))
+			g.Expect(query.Get("nonce")).NotTo(BeEmpty())
+
+			// Check expected custom params.
+			for k, v := range tt.expectParams {
+				g.Expect(query.Get(k)).To(Equal(v), "expected param %s=%s", k, v)
+			}
+
+			// Check unexpected params are absent.
+			for _, k := range tt.unexpectParams {
+				g.Expect(query.Has(k)).To(BeFalse(), "unexpected param %s", k)
+			}
+		})
+	}
 }
 
 func TestVerifyTokenAndSetStorageOrLogError_SessionStart(t *testing.T) {


### PR DESCRIPTION
Closes: #738

Adding also docs for every missing field in the `Config API` section.

This PR introduces the field `.spec.authentication.oauth2.authURLParams` in the Web Config API to support custom parameters for the OAuth2 authorization URL the Web UI redirects users to for authentication:

```yaml
apiVersion: web.fluxcd.controlplane.io/v1
kind: Config
spec:
  baseURL: https://flux-web.example.com
  authentication:
    type: OAuth2
    oauth2:
      provider: OIDC
      clientID: flux-web
      clientSecret: my-client-secret
      issuerURL: https://accounts.google.com
      authURLParams:
        access_type: offline
        prompt: consent
```