### PR TITLE
Link namespace filtering warning and docs to each other

### DIFF
--- a/docs/web/web-user-management.md
+++ b/docs/web/web-user-management.md
@@ -136,13 +136,6 @@ Flux resources in the `apps` namespace. Attempting to access resources in other
 namespaces will result in a "403 Forbidden" error. To allow the dev team to
 perform actions on their resources, you can bind them to the `flux-web-admin` role instead.
 
-!!! info "Namespace filtering"
-
-    The Web UI fiters the list of namespaces a user can pick from the dropdowns
-    based on the `get` permission assigned to their groups for the `ResourceSet` kind.
-    By default, the Flux Operator Helm chart creates a role that grants access to `ResourceSet`
-    by aggregating to `view` and `edit` roles.
-
 Users who are not part of any group with assigned permissions will only see the main dashboard,
 without access to any specific resources. The main dashboard will only display
 the readiness status of the Flux controllers.
@@ -155,6 +148,15 @@ to manage user permissions and access to resources.
 The Web UI impersonates the authenticated user when making requests to the Kubernetes API server.
 This means that the permissions granted to a user in the Web UI are determined by
 the Kubernetes RBAC policies assigned to that user or to the groups they belong to.
+
+### Namespace Filtering
+
+The Web UI fiters the list of namespaces a user can pick from the dropdowns
+based on the `get` RBAC verb assigned to their groups for the `ResourceSet`
+kind. If a user does not have `get` on `ResourceSet` in any namespaces, they
+will see the warning "Limited Access - You don't have access to any namespaces".
+This warning will go away if the user has `get` on `ResourceSet` in at least
+one namespace.
 
 ### Predefined Roles
 

--- a/web/src/components/dashboards/cluster/ClusterPage.jsx
+++ b/web/src/components/dashboards/cluster/ClusterPage.jsx
@@ -3,6 +3,7 @@
 
 import { useEffect } from 'preact/hooks'
 import { usePageMeta } from '../../../utils/meta'
+import { namespaceFilteringDocUrl } from '../../../utils/constants'
 import { addToNavHistory } from '../../../utils/navHistory'
 import { OverallStatusPanel } from './OverallStatusPanel'
 import { InfoPanel } from './InfoPanel'
@@ -27,6 +28,19 @@ function NoNamespaceAccessWarning({ userInfo }) {
           </h3>
           <p class="mt-1 text-sm text-yellow-700 dark:text-yellow-300">
             You don't have access to any namespaces. Contact your administrator to grant your group the necessary permissions.
+            <a
+              href={namespaceFilteringDocUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              class="inline-flex items-center align-middle text-yellow-700 underline decoration-yellow-500/70 underline-offset-2 transition-colors hover:text-yellow-800 dark:text-yellow-300 dark:hover:text-yellow-200"
+              title="Namespace filtering documentation"
+              aria-label="Namespace filtering documentation"
+            >
+              <svg class="ml-px h-4 w-4 flex-shrink-0 relative -top-px" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+            </a>
           </p>
           {(userInfo?.impersonation) && (userInfo?.impersonation.username || userInfo?.impersonation.groups) && (
             <p class="mt-2 text-xs text-yellow-600 dark:text-yellow-400 font-mono">

--- a/web/src/components/dashboards/cluster/ClusterPage.test.jsx
+++ b/web/src/components/dashboards/cluster/ClusterPage.test.jsx
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen } from '@testing-library/preact'
 import { ClusterPage } from './ClusterPage'
+import { namespaceFilteringDocUrl } from '../../../utils/constants'
 
 // Mock all child components
 vi.mock('./OverallStatusPanel', () => ({
@@ -285,6 +286,10 @@ describe('ClusterPage', () => {
 
       expect(screen.getByText('Limited Access')).toBeInTheDocument()
       expect(screen.getByText(/Contact your administrator/)).toBeInTheDocument()
+      const docLink = screen.getByRole('link', { name: 'Namespace filtering documentation' })
+      expect(docLink).toHaveAttribute('href', namespaceFilteringDocUrl)
+      expect(docLink).toHaveAttribute('target', '_blank')
+      expect(docLink).toHaveAttribute('rel', 'noopener noreferrer')
     })
 
     it('should show warning when namespaces is undefined', () => {

--- a/web/src/utils/constants.js
+++ b/web/src/utils/constants.js
@@ -144,6 +144,9 @@ export const fluxCRDs = [
   },
 ]
 
+// Namespace filtering docs URL.
+export const namespaceFilteringDocUrl = 'https://fluxoperator.dev/docs/web-ui/user-management/#namespace-filtering'
+
 // Flux resource kinds for dropdown (derived from fluxCRDs)
 export const fluxKinds = fluxCRDs.map(crd => crd.kind)
 


### PR DESCRIPTION
Closes: #760

* Link namespace filtering docs to warning `Limited Access`
* Link warning `Limited Access` to namespace filtering docs

<img width="1246" height="355" alt="Screenshot from 2026-03-13 09-24-10" src="https://github.com/user-attachments/assets/d262b918-20d4-41e3-9bc6-0f9387dc06bb" />
