### PR TITLE
web: make namespace filtering docs link work on the whole text

### DIFF
--- a/web/src/components/dashboards/cluster/ClusterPage.jsx
+++ b/web/src/components/dashboards/cluster/ClusterPage.jsx
@@ -27,17 +27,18 @@ function NoNamespaceAccessWarning({ userInfo }) {
             Limited Access
           </h3>
           <p class="mt-1 text-sm text-yellow-700 dark:text-yellow-300">
-            You don't have access to any namespaces. Contact your administrator to grant your group the necessary permissions.
             <a
               href={namespaceFilteringDocUrl}
               target="_blank"
               rel="noopener noreferrer"
               onClick={(e) => e.stopPropagation()}
-              class="inline-flex items-center align-middle text-yellow-700 underline decoration-yellow-500/70 underline-offset-2 transition-colors hover:text-yellow-800 dark:text-yellow-300 dark:hover:text-yellow-200"
+              class="inline-flex items-center gap-1 align-middle transition-colors hover:text-yellow-800 dark:hover:text-yellow-200"
               title="Namespace filtering documentation"
-              aria-label="Namespace filtering documentation"
             >
-              <svg class="ml-px h-4 w-4 flex-shrink-0 relative -top-px" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <span>
+                You don't have access to any namespaces. Contact your administrator to grant your group the necessary permissions.
+              </span>
+              <svg class="h-4 w-4 flex-shrink-0 relative -top-px" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
               </svg>
             </a>

--- a/web/src/components/dashboards/cluster/ClusterPage.test.jsx
+++ b/web/src/components/dashboards/cluster/ClusterPage.test.jsx
@@ -285,8 +285,7 @@ describe('ClusterPage', () => {
       render(<ClusterPage spec={spec} />)
 
       expect(screen.getByText('Limited Access')).toBeInTheDocument()
-      expect(screen.getByText(/Contact your administrator/)).toBeInTheDocument()
-      const docLink = screen.getByRole('link', { name: 'Namespace filtering documentation' })
+      const docLink = screen.getByRole('link', { name: /You don't have access to any namespaces\. Contact your administrator to grant your group the necessary permissions\./ })
       expect(docLink).toHaveAttribute('href', namespaceFilteringDocUrl)
       expect(docLink).toHaveAttribute('target', '_blank')
       expect(docLink).toHaveAttribute('rel', 'noopener noreferrer')


### PR DESCRIPTION
Nothing changes visually, except that the whole text line prior to the icon is now also part of the link.