### PR TITLE
cmd: Implement distro mirror command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,16 @@ deploy: generate kustomize ## Deploy flux-operator to the K8s cluster specified 
 undeploy: kustomize ## Delete flux-operator from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
+.PHONY: docker-registry-up
+docker-registry-up: ## Create a local docker registry if it doesn't exist.
+	@docker inspect flux-operator-registry > /dev/null 2>&1 || \
+	docker run -d --restart=always -p "5050:5000" --name flux-operator-registry registry:3 > /dev/null
+	@echo "Registry running at localhost:5050"
+
+.PHONY: docker-registry-down
+docker-registry-down: ## Stop and remove the local docker registry if it exists.
+	@docker rm -f flux-operator-registry > /dev/null 2>&1 || true
+
 ##@ Release
 
 NEXT_VERSION ?= ""

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -388,6 +388,41 @@ it is recommended to follow the [installation guide](https://fluxcd.control-plan
     - `--certificate-oidc-issuer`: OIDC issuer for signature verification.
     - `--trusted-root`: Path to a `trusted_root.json` file for offline signature verification.
 
+### Distro Mirror Command
+
+The `flux-operator distro mirror` command copies a complete Flux distribution
+(controller images and optionally the Flux Operator image and Helm chart)
+from the upstream registries to a destination registry. This is intended for users
+running Flux in air-gapped or private-registry environments.
+
+This command performs the following steps:
+
+1. Pulls the Flux distribution manifests OCI artifact to read the image list.
+2. Resolves the requested version against the available distribution releases.
+3. Mirrors every controller image and (optionally) the Flux Operator image
+   and Helm chart to the destination registry.
+
+Authentication for the destination registry uses the local Docker config file.
+The source registry (`ghcr.io`) can be authenticated with `--pull-token` or
+`--pull-token-stdin`, otherwise the Docker config is used as well.
+
+- `flux-operator distro mirror <destination>`: Mirrors the Flux distribution to a destination registry.
+  The destination is a positional argument, e.g. `registry.example.com/flux`.
+    - `--version`: Flux distribution version, e.g. `2.8.5` or `2.8.x` (default `2.x`).
+    - `--components`: Comma-separated list of components to mirror (defaults to all controllers,
+      plus `source-watcher` for Flux 2.7+).
+    - `--variant`: Distribution variant (`upstream-alpine`, `enterprise-alpine`,
+      `enterprise-distroless`, `enterprise-distroless-fips`). Default `upstream-alpine`.
+    - `--include-operator-image`: Also mirror the Flux Operator container image (default `true`).
+    - `--include-operator-chart`: Also mirror the Flux Operator Helm chart (default `true`).
+    - `--immutable`: Treat destination tags as immutable (default `false`). When set,
+      existing tags are never overwritten; new images are pushed under a unique tag
+      suffix (`<tag>-<unix-timestamp>`).
+    - `--pull-token`: GHCR token for the source registry (used as a basic-auth password).
+    - `--pull-token-stdin`: Read the GHCR token for the source registry from stdin
+      (mutually exclusive with `--pull-token`).
+    - `--dry-run`: List source→destination pairs without writing anything.
+
 ### Uninstall Command
 
 The `flux-operator uninstall` command safely removes the Flux Operator and Flux instance from the cluster.

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -422,6 +422,7 @@ The source registry (`ghcr.io`) can be authenticated with `--pull-token` or
     - `--pull-token-stdin`: Read the GHCR token for the source registry from stdin
       (mutually exclusive with `--pull-token`).
     - `--dry-run`: List source→destination pairs without writing anything.
+    - `--verify`: Verify the cosign signatures of the images before mirroring.
 
 ### Uninstall Command
 

--- a/cmd/cli/distro_mirror.go
+++ b/cmd/cli/distro_mirror.go
@@ -1,0 +1,442 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/spf13/cobra"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/builder"
+)
+
+var distroMirrorCmd = &cobra.Command{
+	Use:   "mirror <destination>",
+	Short: "Mirror the Flux distribution to a destination registry",
+	Long: `The distro mirror command copies a complete Flux distribution from the
+upstream registries to a destination registry. This is intended for users
+running Flux in air-gapped or private-registry environments.
+
+The command performs the following steps:
+  1. Pulls the Flux distribution manifests OCI artifact to read the image list.
+  2. Resolves the requested version against the available distribution releases.
+  3. Mirrors every controller image and (optionally) the Flux Operator image
+     and Helm chart to the destination registry.
+
+Authentication for the destination registry uses the local Docker config file.
+The source registry (ghcr.io) can be authenticated with --pull-token or
+--pull-token-stdin, otherwise the Docker config is used as well.`,
+	Example: `  # Mirror the latest Flux 2.x distribution to a private registry
+  flux-operator distro mirror registry.example.com/flux
+
+  # Mirror a specific Flux version
+  flux-operator distro mirror registry.example.com/flux --version 2.8.x
+
+  # Mirror the enterprise distroless variant
+  echo "${GITHUB_TOKEN}" | flux-operator distro mirror registry.example.com/flux \
+    --variant enterprise-distroless \
+    --pull-token-stdin
+
+  # List the source/destination pairs without copying images
+  flux-operator distro mirror registry.example.com/flux --dry-run
+
+  # Mirror only a subset of controllers
+  flux-operator distro mirror registry.example.com/flux \
+    --components source-controller,kustomize-controller,helm-controller
+
+  # Mirror to an immutable registry (push by digest with a unique tag suffix)
+  flux-operator distro mirror registry.example.com/flux --immutable
+
+  # Mirror without the Flux Operator image and chart (controllers only)
+  flux-operator distro mirror registry.example.com/flux \
+    --include-operator-image=false \
+    --include-operator-chart=false
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: distroMirrorCmdRun,
+}
+
+type distroMirrorFlags struct {
+	version              string
+	components           []string
+	variant              string
+	includeOperatorImage bool
+	includeOperatorChart bool
+	dryRun               bool
+	immutable            bool
+	pullToken            string
+	pullTokenStdin       bool
+}
+
+var distroMirrorArgs = distroMirrorFlags{
+	version:              "2.x",
+	variant:              builder.UpstreamAlpine,
+	includeOperatorImage: true,
+	includeOperatorChart: true,
+}
+
+const (
+	distroMirrorSrcRegistry       = "ghcr.io"
+	distroMirrorManifestsArtifact = "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
+	distroMirrorOperatorRepo      = "ghcr.io/controlplaneio-fluxcd/flux-operator"
+	distroMirrorChartRepo         = "ghcr.io/controlplaneio-fluxcd/charts/flux-operator"
+	// distroMirrorMinTimeout is the minimum operation timeout. The default
+	// rootArgs.timeout (1m) is too short to pull the manifests artifact and
+	// copy every controller image, so we floor it.
+	distroMirrorMinTimeout = 10 * time.Minute
+)
+
+// distroMirrorVariantRegistry maps a distribution variant to its source registry.
+var distroMirrorVariantRegistry = map[string]string{
+	builder.UpstreamAlpine:           "ghcr.io/fluxcd",
+	builder.EnterpriseAlpine:         "ghcr.io/controlplaneio-fluxcd/alpine",
+	builder.EnterpriseDistroless:     "ghcr.io/controlplaneio-fluxcd/distroless",
+	builder.EnterpriseDistrolessFIPS: "ghcr.io/controlplaneio-fluxcd/distroless-fips",
+}
+
+func init() {
+	distroMirrorCmd.Flags().StringVar(&distroMirrorArgs.version, "version", distroMirrorArgs.version,
+		"Flux distribution version, e.g. 2.8.5 or 2.8.x")
+	distroMirrorCmd.Flags().StringSliceVar(&distroMirrorArgs.components, "components", nil,
+		"comma-separated list of components to mirror (defaults to all controllers, plus source-watcher for Flux 2.7+)")
+	distroMirrorCmd.Flags().StringVar(&distroMirrorArgs.variant, "variant", distroMirrorArgs.variant,
+		"distribution variant: upstream-alpine, enterprise-alpine, enterprise-distroless, enterprise-distroless-fips")
+	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.includeOperatorImage, "include-operator-image", distroMirrorArgs.includeOperatorImage,
+		"also mirror the Flux Operator container image")
+	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.includeOperatorChart, "include-operator-chart", distroMirrorArgs.includeOperatorChart,
+		"also mirror the Flux Operator Helm chart")
+	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.dryRun, "dry-run", false,
+		"list source→destination pairs without writing anything")
+	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.immutable, "immutable", distroMirrorArgs.immutable,
+		"treat destination tags as immutable; never overwrite, copy by digest to a unique tag instead")
+	distroMirrorCmd.Flags().StringVar(&distroMirrorArgs.pullToken, "pull-token", "",
+		"GHCR token for the source registry (basic-auth password)")
+	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.pullTokenStdin, "pull-token-stdin", false,
+		"read the GHCR token for the source registry from stdin")
+
+	distroCmd.AddCommand(distroMirrorCmd)
+}
+
+func distroMirrorCmdRun(_ *cobra.Command, args []string) error {
+	dstPrefix := strings.TrimSuffix(strings.TrimPrefix(args[0], "oci://"), "/")
+	if dstPrefix == "" {
+		return errors.New("destination registry is required")
+	}
+
+	srcRegistry, ok := distroMirrorVariantRegistry[distroMirrorArgs.variant]
+	if !ok {
+		return fmt.Errorf("unsupported variant %q, must be one of: %s",
+			distroMirrorArgs.variant,
+			strings.Join(slices.Sorted(maps.Keys(distroMirrorVariantRegistry)), ", "))
+	}
+
+	// --pull-token and --pull-token-stdin are mutually exclusive.
+	pullToken := distroMirrorArgs.pullToken
+	if distroMirrorArgs.pullTokenStdin {
+		if pullToken != "" {
+			return errors.New("--pull-token and --pull-token-stdin are mutually exclusive")
+		}
+		var input string
+		if _, err := fmt.Scan(&input); err != nil {
+			return fmt.Errorf("unable to read pull token from stdin: %w", err)
+		}
+		pullToken = input
+	}
+
+	keychain := buildMirrorKeychain(distroMirrorSrcRegistry, pullToken)
+	ctx, cancel := context.WithTimeout(context.Background(), max(rootArgs.timeout, distroMirrorMinTimeout))
+	defer cancel()
+	craneOpts := []crane.Option{
+		crane.WithContext(ctx),
+		crane.WithAuthFromKeychain(keychain),
+	}
+
+	rootCmd.Println(`◎`, "Pulling distribution manifests from", distroMirrorManifestsArtifact)
+	tmpDir, err := builder.MkdirTempAbs("", "flux-mirror")
+	if err != nil {
+		return fmt.Errorf("failed to create tmp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if _, err := builder.PullArtifact(ctx, distroMirrorManifestsArtifact, tmpDir, keychain); err != nil {
+		return fmt.Errorf("failed to pull distribution manifests: %w", err)
+	}
+
+	ver, err := builder.MatchVersion(filepath.Join(tmpDir, "flux"), distroMirrorArgs.version)
+	if err != nil {
+		return fmt.Errorf("failed to resolve version: %w", err)
+	}
+
+	components, err := resolveMirrorComponents(distroMirrorArgs.components, ver)
+	if err != nil {
+		return err
+	}
+
+	opts := builder.MakeDefaultOptions()
+	opts.Version = ver
+	opts.Variant = distroMirrorArgs.variant
+	opts.Registry = srcRegistry
+	opts.Components = components
+
+	images, err := builder.ExtractComponentImagesWithDigest(filepath.Join(tmpDir, "flux-images"), opts)
+	if err != nil {
+		return fmt.Errorf("failed to extract component images: %w", err)
+	}
+
+	jobs := buildMirrorJobs(images, dstPrefix,
+		distroMirrorArgs.includeOperatorImage,
+		distroMirrorArgs.includeOperatorChart)
+
+	rootCmd.Printf("◎ Mirroring Flux %s (%s) to %s\n", ver, distroMirrorArgs.variant, dstPrefix)
+
+	var copied, skipped, byDigest int
+	for _, j := range jobs {
+		result, err := runMirrorJob(j, distroMirrorArgs.immutable, distroMirrorArgs.dryRun, craneOpts)
+		if err != nil {
+			return err
+		}
+		switch result.action {
+		case mirrorCopied:
+			rootCmd.Printf("→ %s → %s (copied)\n", result.src, result.dst)
+			copied++
+		case mirrorOverwritten:
+			rootCmd.Printf("→ %s → %s (overwritten)\n", result.src, result.dst)
+			copied++
+		case mirrorByDigest:
+			rootCmd.Printf("→ %s → %s (copied by digest)\n", result.src, result.dst)
+			byDigest++
+		case mirrorSkipped:
+			rootCmd.Printf("≡ %s (skipped: %s)\n", result.dst, result.reason)
+			skipped++
+		case mirrorDryRun:
+			rootCmd.Printf("✎ %s → %s (dry-run)\n", result.src, result.dst)
+		}
+	}
+
+	if distroMirrorArgs.dryRun {
+		rootCmd.Printf("✔ Dry-run complete: %d image(s) would be processed\n", len(jobs))
+		return nil
+	}
+	rootCmd.Printf("✔ Mirror complete: %d copied, %d skipped, %d copied by digest\n",
+		copied, skipped, byDigest)
+	return nil
+}
+
+// resolveMirrorComponents returns the user-supplied components if non-empty,
+// otherwise the default controller set augmented with source-watcher when the
+// resolved version supports it. The result is validated against AllComponents
+// and against the version constraint for source-watcher.
+func resolveMirrorComponents(input []string, ver string) ([]string, error) {
+	v, err := semver.NewVersion(ver)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version %q: %w", ver, err)
+	}
+
+	if len(input) == 0 {
+		// All controllers; source-watcher only exists in Flux >= 2.7.
+		out := slices.DeleteFunc(slices.Clone(builder.AllComponents), func(c string) bool {
+			return c == fluxcdv1.FluxSourceWatcher
+		})
+		if v.Minor() >= 7 {
+			out = append(out, fluxcdv1.FluxSourceWatcher)
+		}
+		return out, nil
+	}
+
+	for _, c := range input {
+		if !slices.Contains(builder.AllComponents, c) {
+			return nil, fmt.Errorf("invalid component %q", c)
+		}
+		if c == fluxcdv1.FluxSourceWatcher && v.Minor() < 7 {
+			return nil, fmt.Errorf("%s is only supported in Flux versions >= 2.7.0", fluxcdv1.FluxSourceWatcher)
+		}
+	}
+	return input, nil
+}
+
+// mirrorJob describes a single image to mirror.
+type mirrorJob struct {
+	srcRepo string // e.g. ghcr.io/fluxcd/source-controller
+	dstRepo string // e.g. registry.example.com/flux/source-controller
+	tag     string // e.g. v1.6.2
+	digest  string // src digest (sha256:...) — empty when not pre-resolved
+}
+
+func (j mirrorJob) src() string { return j.srcRepo + ":" + j.tag }
+func (j mirrorJob) dst() string { return j.dstRepo + ":" + j.tag }
+
+// buildMirrorJobs constructs the ordered list of mirror jobs from the
+// extracted component images, optionally including the Flux Operator
+// container image and Helm chart.
+func buildMirrorJobs(images []builder.ComponentImage, dstPrefix string, includeOperatorImage, includeOperatorChart bool) []mirrorJob {
+	jobs := make([]mirrorJob, 0, len(images)+2)
+	for _, img := range images {
+		jobs = append(jobs, mirrorJob{
+			srcRepo: img.Repository,
+			dstRepo: dstPrefix + "/" + path.Base(img.Repository),
+			tag:     img.Tag,
+			digest:  img.Digest,
+		})
+	}
+
+	// Operator image is published with a "v" prefix (e.g. v0.46.0),
+	// Helm chart is published without it (e.g. 0.46.0).
+	bareVersion := strings.TrimPrefix(VERSION, "v")
+
+	if includeOperatorImage {
+		jobs = append(jobs, mirrorJob{
+			srcRepo: distroMirrorOperatorRepo,
+			dstRepo: dstPrefix + "/flux-operator",
+			tag:     "v" + bareVersion,
+		})
+	}
+
+	if includeOperatorChart {
+		jobs = append(jobs, mirrorJob{
+			srcRepo: distroMirrorChartRepo,
+			dstRepo: dstPrefix + "/charts/flux-operator",
+			tag:     bareVersion,
+		})
+	}
+
+	return jobs
+}
+
+// mirrorAction describes the outcome of a mirror job.
+type mirrorAction int
+
+const (
+	mirrorCopied mirrorAction = iota
+	mirrorOverwritten
+	mirrorByDigest
+	mirrorSkipped
+	mirrorDryRun
+)
+
+// mirrorResult is the result of executing a single mirror job.
+type mirrorResult struct {
+	action mirrorAction
+	src    string // src ref actually used (may be "<repo>@<digest>")
+	dst    string // dst ref actually written (may differ from j.dst() in immutable mode)
+	reason string // human-readable reason for skip
+}
+
+// runMirrorJob copies a single image to the destination registry, honoring the
+// immutable and dry-run flags. The function is idempotent: if the destination
+// already holds the source digest under the requested tag, the job is skipped.
+//
+// The source digest is resolved lazily: jobs that don't carry a pre-resolved
+// digest only pay the extra round trip when the destination tag exists and we
+// need to compare. The common first-mirror path (dst returns 404) avoids it.
+func runMirrorJob(j mirrorJob, immutable, dryRun bool, craneOpts []crane.Option) (mirrorResult, error) {
+	src, dst := j.src(), j.dst()
+	if dryRun {
+		return mirrorResult{action: mirrorDryRun, src: src, dst: dst}, nil
+	}
+
+	desc, err := crane.Head(dst, craneOpts...)
+	switch {
+	case isNotFound(err):
+		if err := crane.Copy(src, dst, craneOpts...); err != nil {
+			return mirrorResult{}, fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+		}
+		return mirrorResult{action: mirrorCopied, src: src, dst: dst}, nil
+	case err != nil:
+		return mirrorResult{}, fmt.Errorf("failed to head %s: %w", dst, err)
+	}
+
+	srcDigest := j.digest
+	if srcDigest == "" {
+		d, err := crane.Digest(src, craneOpts...)
+		if err != nil {
+			return mirrorResult{}, fmt.Errorf("failed to resolve digest for %s: %w", src, err)
+		}
+		srcDigest = d
+	}
+
+	if desc.Digest.String() == srcDigest {
+		return mirrorResult{action: mirrorSkipped, src: src, dst: dst, reason: "up-to-date"}, nil
+	}
+
+	if !immutable {
+		if err := crane.Copy(src, dst, craneOpts...); err != nil {
+			return mirrorResult{}, fmt.Errorf("failed to copy %s to %s: %w", src, dst, err)
+		}
+		return mirrorResult{action: mirrorOverwritten, src: src, dst: dst}, nil
+	}
+
+	// Immutable mode: don't touch the existing tag. Skip entirely if the
+	// source digest is already stored under any tag at the destination.
+	if _, err := crane.Digest(j.dstRepo+"@"+srcDigest, craneOpts...); err == nil {
+		return mirrorResult{action: mirrorSkipped, src: src, dst: dst, reason: "digest already present"}, nil
+	} else if !isNotFound(err) {
+		return mirrorResult{}, fmt.Errorf("failed to check digest %s@%s: %w", j.dstRepo, srcDigest, err)
+	}
+
+	srcByDigest := j.srcRepo + "@" + srcDigest
+	uniqueDst := fmt.Sprintf("%s:%s-%d", j.dstRepo, j.tag, time.Now().Unix())
+	if err := crane.Copy(srcByDigest, uniqueDst, craneOpts...); err != nil {
+		return mirrorResult{}, fmt.Errorf("failed to copy %s to %s: %w", srcByDigest, uniqueDst, err)
+	}
+	return mirrorResult{action: mirrorByDigest, src: srcByDigest, dst: uniqueDst}, nil
+}
+
+// isNotFound returns true when err is a transport.Error with HTTP 404.
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var terr *transport.Error
+	if errors.As(err, &terr) {
+		return terr.StatusCode == 404
+	}
+	return false
+}
+
+// buildMirrorKeychain returns a keychain that authenticates the given source
+// registry hostname with the supplied token (as a basic-auth password) and
+// falls back to the default Docker config keychain for everything else.
+func buildMirrorKeychain(srcRegistry, token string) authn.Keychain {
+	if token == "" {
+		return authn.DefaultKeychain
+	}
+	src := &mirrorTokenKeychain{
+		registry: srcRegistry,
+		auth: authn.FromConfig(authn.AuthConfig{
+			Username: "flux",
+			Password: token,
+		}),
+	}
+	return authn.NewMultiKeychain(src, authn.DefaultKeychain)
+}
+
+// mirrorTokenKeychain authenticates a single registry hostname with a static
+// authenticator and returns anonymous credentials for everything else. It is
+// chained with the default keychain via authn.NewMultiKeychain.
+type mirrorTokenKeychain struct {
+	registry string
+	auth     authn.Authenticator
+}
+
+// Resolve implements authn.Keychain.
+func (k *mirrorTokenKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	if target.RegistryStr() == k.registry {
+		return k.auth, nil
+	}
+	return authn.Anonymous, nil
+}

--- a/cmd/cli/distro_mirror.go
+++ b/cmd/cli/distro_mirror.go
@@ -22,7 +22,9 @@ import (
 	"github.com/spf13/cobra"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/agentops"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/builder"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/cosign"
 )
 
 var distroMirrorCmd = &cobra.Command{
@@ -47,9 +49,10 @@ The source registry (ghcr.io) can be authenticated with --pull-token or
   # Mirror a specific Flux version
   flux-operator distro mirror registry.example.com/flux --version 2.8.x
 
-  # Mirror the enterprise distroless variant
+  # Verify signatures and mirror the enterprise distroless variant
   echo "${GITHUB_TOKEN}" | flux-operator distro mirror registry.example.com/flux \
     --variant enterprise-distroless \
+    --verify \
     --pull-token-stdin
 
   # List the source/destination pairs without copying images
@@ -81,6 +84,7 @@ type distroMirrorFlags struct {
 	immutable            bool
 	pullToken            string
 	pullTokenStdin       bool
+	verify               bool
 }
 
 var distroMirrorArgs = distroMirrorFlags{
@@ -128,6 +132,8 @@ func init() {
 		"GHCR token for the source registry (basic-auth password)")
 	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.pullTokenStdin, "pull-token-stdin", false,
 		"read the GHCR token for the source registry from stdin")
+	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.verify, "verify", false,
+		"verify the cosign signature of the images before mirroring")
 
 	distroCmd.AddCommand(distroMirrorCmd)
 }
@@ -196,6 +202,22 @@ func distroMirrorCmdRun(_ *cobra.Command, args []string) error {
 	images, err := builder.ExtractComponentImagesWithDigest(filepath.Join(tmpDir, "flux-images"), opts)
 	if err != nil {
 		return fmt.Errorf("failed to extract component images: %w", err)
+	}
+
+	if distroMirrorArgs.verify {
+		rootCmd.Println(`◎`, "Verifying signatures...")
+		for _, img := range images {
+			pinnedRef := img.Repository + "@" + img.Digest
+			certIdentityRegexp := fmt.Sprintf(`^https://github\.com/%s/.*$`, agentops.DeriveGitHubOwner(img.Repository))
+			if err := cosign.VerifyArtifact(ctx, pinnedRef,
+				certIdentityRegexp,
+				cosign.DefaultCertOIDCIssuer,
+				"",
+				keychain); err != nil {
+				return fmt.Errorf("signature verification failed for %s: %w", pinnedRef, err)
+			}
+			rootCmd.Printf("✔ %s\n", pinnedRef)
+		}
 	}
 
 	jobs := buildMirrorJobs(images, dstPrefix,

--- a/cmd/cli/distro_mirror_test.go
+++ b/cmd/cli/distro_mirror_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	. "github.com/onsi/gomega"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/builder"
+)
+
+func TestDistroMirror_FlagValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		expectError string
+	}{
+		{
+			name:        "missing destination arg",
+			args:        []string{"distro", "mirror"},
+			expectError: "accepts 1 arg",
+		},
+		{
+			name:        "unknown variant",
+			args:        []string{"distro", "mirror", "localhost:5050", "--variant", "bogus"},
+			expectError: "unsupported variant",
+		},
+		{
+			name:        "pull-token and pull-token-stdin are mutually exclusive",
+			args:        []string{"distro", "mirror", "localhost:5050", "--pull-token", "abc", "--pull-token-stdin"},
+			expectError: "mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			_, err := executeCommand(tt.args)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tt.expectError))
+		})
+	}
+}
+
+func TestDistroMirror_VariantRegistryMap(t *testing.T) {
+	g := NewWithT(t)
+
+	// Every advertised variant must have a source registry mapping.
+	for _, v := range []string{
+		builder.UpstreamAlpine,
+		builder.EnterpriseAlpine,
+		builder.EnterpriseDistroless,
+		builder.EnterpriseDistrolessFIPS,
+	} {
+		_, ok := distroMirrorVariantRegistry[v]
+		g.Expect(ok).To(BeTrue(), "variant %q has no source registry mapping", v)
+	}
+
+	g.Expect(distroMirrorVariantRegistry[builder.UpstreamAlpine]).To(Equal("ghcr.io/fluxcd"))
+	g.Expect(distroMirrorVariantRegistry[builder.EnterpriseAlpine]).To(Equal("ghcr.io/controlplaneio-fluxcd/alpine"))
+	g.Expect(distroMirrorVariantRegistry[builder.EnterpriseDistroless]).To(Equal("ghcr.io/controlplaneio-fluxcd/distroless"))
+	g.Expect(distroMirrorVariantRegistry[builder.EnterpriseDistrolessFIPS]).To(Equal("ghcr.io/controlplaneio-fluxcd/distroless-fips"))
+}
+
+func TestDistroMirror_ResolveComponents(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []string
+		version     string
+		expect      []string
+		expectError string
+	}{
+		{
+			name:    "default for 2.6.x has no source-watcher",
+			version: "v2.6.4",
+			expect: []string{
+				"source-controller",
+				"kustomize-controller",
+				"helm-controller",
+				"notification-controller",
+				"image-reflector-controller",
+				"image-automation-controller",
+			},
+		},
+		{
+			name:    "default for 2.7.x includes source-watcher",
+			version: "v2.7.0",
+			expect: []string{
+				"source-controller",
+				"kustomize-controller",
+				"helm-controller",
+				"notification-controller",
+				"image-reflector-controller",
+				"image-automation-controller",
+				"source-watcher",
+			},
+		},
+		{
+			name:    "explicit subset is preserved",
+			input:   []string{"source-controller", "helm-controller"},
+			version: "v2.8.5",
+			expect:  []string{"source-controller", "helm-controller"},
+		},
+		{
+			name:        "invalid component is rejected",
+			input:       []string{"bogus-controller"},
+			version:     "v2.8.5",
+			expectError: "invalid component",
+		},
+		{
+			name:        "source-watcher rejected on 2.6.x",
+			input:       []string{"source-watcher"},
+			version:     "v2.6.4",
+			expectError: "source-watcher is only supported",
+		},
+		{
+			name:        "invalid version is rejected",
+			input:       nil,
+			version:     "not-a-version",
+			expectError: "failed to parse version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			out, err := resolveMirrorComponents(tt.input, tt.version)
+			if tt.expectError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectError))
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(out).To(Equal(tt.expect))
+		})
+	}
+}
+
+func TestDistroMirror_BuildJobs(t *testing.T) {
+	g := NewWithT(t)
+
+	images := []builder.ComponentImage{
+		{
+			Name:       "source-controller",
+			Repository: "ghcr.io/fluxcd/source-controller",
+			Tag:        "v1.6.2",
+			Digest:     "sha256:aaaa",
+		},
+		{
+			Name:       "kustomize-controller",
+			Repository: "ghcr.io/fluxcd/kustomize-controller",
+			Tag:        "v1.6.1",
+			Digest:     "sha256:bbbb",
+		},
+	}
+
+	// Save and override VERSION so the operator/chart job tags are deterministic.
+	origVersion := VERSION
+	VERSION = "0.46.0"
+	defer func() { VERSION = origVersion }()
+
+	jobs := buildMirrorJobs(images, "registry.example.com/flux", true, true)
+	g.Expect(jobs).To(HaveLen(4)) // 2 controllers + operator + chart
+
+	// Controllers
+	g.Expect(jobs[0].srcRepo).To(Equal("ghcr.io/fluxcd/source-controller"))
+	g.Expect(jobs[0].dstRepo).To(Equal("registry.example.com/flux/source-controller"))
+	g.Expect(jobs[0].tag).To(Equal("v1.6.2"))
+	g.Expect(jobs[0].digest).To(Equal("sha256:aaaa"))
+	g.Expect(jobs[0].src()).To(Equal("ghcr.io/fluxcd/source-controller:v1.6.2"))
+	g.Expect(jobs[0].dst()).To(Equal("registry.example.com/flux/source-controller:v1.6.2"))
+
+	g.Expect(jobs[1].src()).To(Equal("ghcr.io/fluxcd/kustomize-controller:v1.6.1"))
+	g.Expect(jobs[1].dst()).To(Equal("registry.example.com/flux/kustomize-controller:v1.6.1"))
+
+	// Operator
+	g.Expect(jobs[2].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/flux-operator:v0.46.0"))
+	g.Expect(jobs[2].dst()).To(Equal("registry.example.com/flux/flux-operator:v0.46.0"))
+	g.Expect(jobs[2].digest).To(BeEmpty())
+
+	// Chart (published without the "v" prefix)
+	g.Expect(jobs[3].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/charts/flux-operator:0.46.0"))
+	g.Expect(jobs[3].dst()).To(Equal("registry.example.com/flux/charts/flux-operator:0.46.0"))
+	g.Expect(jobs[3].tag).To(Equal("0.46.0"))
+	g.Expect(jobs[3].digest).To(BeEmpty())
+
+	// Without chart
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", true, false)
+	g.Expect(jobs).To(HaveLen(3))
+	for _, j := range jobs {
+		g.Expect(j.dst()).ToNot(ContainSubstring("/charts/"))
+	}
+
+	// Without operator image (chart only)
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, true)
+	g.Expect(jobs).To(HaveLen(3)) // 2 controllers + chart
+	for _, j := range jobs {
+		g.Expect(j.dst()).ToNot(Equal("registry.example.com/flux/flux-operator:v0.46.0"))
+	}
+	g.Expect(jobs[2].dst()).To(Equal("registry.example.com/flux/charts/flux-operator:0.46.0"))
+
+	// Controllers only
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, false)
+	g.Expect(jobs).To(HaveLen(2)) // 2 controllers, no operator, no chart
+}
+
+func TestDistroMirror_BuildJobsHandlesNestedSourceRegistry(t *testing.T) {
+	g := NewWithT(t)
+
+	// Enterprise variants live under ghcr.io/controlplaneio-fluxcd/<variant>/<component>.
+	// path.Base() must extract just the component name.
+	images := []builder.ComponentImage{
+		{
+			Name:       "source-controller",
+			Repository: "ghcr.io/controlplaneio-fluxcd/distroless/source-controller",
+			Tag:        "v1.6.2",
+			Digest:     "sha256:cccc",
+		},
+	}
+
+	origVersion := VERSION
+	VERSION = "0.46.0"
+	defer func() { VERSION = origVersion }()
+
+	jobs := buildMirrorJobs(images, "registry.example.com/flux", true, false)
+	g.Expect(jobs).To(HaveLen(2)) // 1 controller + operator
+	g.Expect(jobs[0].dst()).To(Equal("registry.example.com/flux/source-controller:v1.6.2"))
+}
+
+func TestDistroMirror_OperatorTagStripsVPrefix(t *testing.T) {
+	g := NewWithT(t)
+
+	origVersion := VERSION
+	defer func() { VERSION = origVersion }()
+
+	// Both with and without "v" prefix should produce the same tag.
+	for _, v := range []string{"0.46.0", "v0.46.0"} {
+		VERSION = v
+		jobs := buildMirrorJobs(nil, "r.example.com", true, false)
+		g.Expect(jobs).To(HaveLen(1)) // operator only
+		g.Expect(jobs[0].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/flux-operator:v0.46.0"))
+		g.Expect(jobs[0].dst()).To(Equal("r.example.com/flux-operator:v0.46.0"))
+	}
+}
+
+func TestDistroMirror_DryRunSkipsRegistry(t *testing.T) {
+	g := NewWithT(t)
+
+	job := mirrorJob{
+		srcRepo: "ghcr.io/fluxcd/source-controller",
+		dstRepo: "registry.example.com/flux/source-controller",
+		tag:     "v1.6.2",
+	}
+	res, err := runMirrorJob(job, false, true, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res.action).To(Equal(mirrorDryRun))
+	g.Expect(res.src).To(Equal(job.src()))
+	g.Expect(res.dst).To(Equal(job.dst()))
+}
+
+func TestDistroMirror_IsNotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(isNotFound(nil)).To(BeFalse())
+	g.Expect(isNotFound(errors.New("boom"))).To(BeFalse())
+
+	g.Expect(isNotFound(&transport.Error{StatusCode: 404})).To(BeTrue())
+	g.Expect(isNotFound(&transport.Error{StatusCode: 500})).To(BeFalse())
+
+	// Wrapped error is also recognized.
+	g.Expect(isNotFound(errors.Join(errors.New("ctx"), &transport.Error{StatusCode: 404}))).To(BeTrue())
+}
+
+func TestDistroMirror_BuildKeychain(t *testing.T) {
+	g := NewWithT(t)
+
+	// No token → DefaultKeychain.
+	g.Expect(buildMirrorKeychain("ghcr.io", "")).To(Equal(authn.DefaultKeychain))
+
+	// With token → multi-keychain that resolves the source registry to the
+	// static authenticator and other registries to anonymous (chained with
+	// DefaultKeychain).
+	kc := buildMirrorKeychain("ghcr.io", "secret")
+	g.Expect(kc).ToNot(BeNil())
+
+	srcRef, err := name.NewRepository("ghcr.io/fluxcd/source-controller")
+	g.Expect(err).ToNot(HaveOccurred())
+	auth, err := kc.Resolve(srcRef)
+	g.Expect(err).ToNot(HaveOccurred())
+	cfg, err := auth.Authorization()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cfg.Username).To(Equal("flux"))
+	g.Expect(cfg.Password).To(Equal("secret"))
+
+	// A non-source registry resolves to anonymous (or whatever DefaultKeychain returns for it).
+	otherRef, err := name.NewRepository("other.example.com/foo/bar")
+	g.Expect(err).ToNot(HaveOccurred())
+	otherAuth, err := kc.Resolve(otherRef)
+	g.Expect(err).ToNot(HaveOccurred())
+	otherCfg, err := otherAuth.Authorization()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(otherCfg.Password).ToNot(Equal("secret"))
+}

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -207,7 +207,8 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 		if err := cosign.VerifyArtifact(ctx, artifactURL,
 			installArgs.certIdentityRegexp,
 			installArgs.certOIDCIssuer,
-			installArgs.trustedRoot); err != nil {
+			installArgs.trustedRoot,
+			authn.DefaultKeychain); err != nil {
 			return fmt.Errorf("artifact signature verification failed: %w", err)
 		}
 		rootCmd.Println(`✔`, "Artifact signature verified successfully")

--- a/cmd/cli/skills_install.go
+++ b/cmd/cli/skills_install.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/spf13/cobra"
 
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/agentops"
@@ -124,7 +125,7 @@ func skillsInstallCmdRun(cmd *cobra.Command, args []string) error {
 	// Verify the artifact signature using the digest-pinned reference.
 	if skillsInstallArgs.verify {
 		rootCmd.Println(`◎`, "Verifying artifact signature...")
-		if err := cosign.VerifyArtifact(ctx, pinnedURL, oidcSubjectRegex, oidcIssuer, skillsInstallArgs.verifyTrustedRoot); err != nil {
+		if err := cosign.VerifyArtifact(ctx, pinnedURL, oidcSubjectRegex, oidcIssuer, skillsInstallArgs.verifyTrustedRoot, authn.DefaultKeychain); err != nil {
 			return fmt.Errorf("signature verification failed: %w", err)
 		}
 		rootCmd.Println(`✔`, "Artifact signature verified")

--- a/cmd/cli/skills_update.go
+++ b/cmd/cli/skills_update.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/spf13/cobra"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
@@ -243,7 +244,7 @@ func verifySource(ctx context.Context, src fluxcdv1.AgentCatalogSource, pinnedUR
 	}
 
 	rootCmd.Println(`◎`, fmt.Sprintf("Verifying %s...", ociURL))
-	if err := cosign.VerifyArtifact(ctx, pinnedURL, oidcSubjectRegex, oidcIssuer, skillsUpdateArgs.verifyTrustedRoot); err != nil {
+	if err := cosign.VerifyArtifact(ctx, pinnedURL, oidcSubjectRegex, oidcIssuer, skillsUpdateArgs.verifyTrustedRoot, authn.DefaultKeychain); err != nil {
 		return fmt.Errorf("signature verification failed for %s: %w", ociURL, err)
 	}
 	rootCmd.Println(`✔`, "Artifact signature verified")

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -204,4 +204,10 @@ func resetCmdArgs() {
 		outputPath: ".",
 		overwrite:  false,
 	}
+	distroMirrorArgs = distroMirrorFlags{
+		version:              "2.x",
+		variant:              "upstream-alpine",
+		includeOperatorImage: true,
+		includeOperatorChart: true,
+	}
 }

--- a/internal/cosign/verify.go
+++ b/internal/cosign/verify.go
@@ -40,12 +40,18 @@ const (
 // When trustedRootPath is set, the trusted root is loaded from the given file
 // and TUF is bypassed entirely, enabling offline verification with no network
 // calls beyond the OCI registry.
-func VerifyArtifact(ctx context.Context, ociRef string, certIdentityRegexp string, certOIDCIssuer string, trustedRootPath string) error {
+// When keychain is nil, authn.DefaultKeychain is used to resolve registry
+// credentials for fetching the artifact descriptor, referrers index, and
+// sigstore bundle.
+func VerifyArtifact(ctx context.Context, ociRef string, certIdentityRegexp string, certOIDCIssuer string, trustedRootPath string, keychain authn.Keychain) error {
 	if certIdentityRegexp == "" {
 		return fmt.Errorf("certificate identity regexp must not be empty")
 	}
 	if certOIDCIssuer == "" {
 		return fmt.Errorf("certificate OIDC issuer must not be empty")
+	}
+	if keychain == nil {
+		keychain = authn.DefaultKeychain
 	}
 
 	// Strip oci:// prefix if present.
@@ -57,14 +63,14 @@ func VerifyArtifact(ctx context.Context, ociRef string, certIdentityRegexp strin
 		return fmt.Errorf("parsing reference %q: %w", ociRef, err)
 	}
 
-	desc, err := remote.Get(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx))
+	desc, err := remote.Get(ref, remote.WithAuthFromKeychain(keychain), remote.WithContext(ctx))
 	if err != nil {
 		return fmt.Errorf("fetching descriptor for %q: %w", ociRef, err)
 	}
 
 	repo := ref.Context()
 	digest := repo.Digest(desc.Digest.String())
-	remoteOpts := []remote.Option{remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx)}
+	remoteOpts := []remote.Option{remote.WithAuthFromKeychain(keychain), remote.WithContext(ctx)}
 
 	// Query referrers for sigstore bundles.
 	idx, err := remote.Referrers(digest, remoteOpts...)

--- a/internal/cosign/verify_test.go
+++ b/internal/cosign/verify_test.go
@@ -30,6 +30,7 @@ func TestVerifyArtifact(t *testing.T) {
 			ghActionsIdentity,
 			ghActionsIssuer,
 			"",
+			nil,
 		)
 		g.Expect(err).ToNot(HaveOccurred())
 	})
@@ -45,6 +46,7 @@ func TestVerifyArtifact(t *testing.T) {
 			ghActionsIdentity,
 			ghActionsIssuer,
 			"",
+			nil,
 		)
 		g.Expect(err).ToNot(HaveOccurred())
 	})
@@ -63,6 +65,7 @@ func TestVerifyArtifact(t *testing.T) {
 			ghActionsIdentity,
 			ghActionsIssuer,
 			trustedRootPath,
+			nil,
 		)
 		g.Expect(err).ToNot(HaveOccurred())
 	})
@@ -78,6 +81,7 @@ func TestVerifyArtifact(t *testing.T) {
 			`^wrong-identity@example\.com$`,
 			ghActionsIssuer,
 			"",
+			nil,
 		)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("signature verification failed"))
@@ -94,6 +98,7 @@ func TestVerifyArtifact(t *testing.T) {
 			ghActionsIdentity,
 			"https://wrong-issuer.example.com",
 			"",
+			nil,
 		)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("signature verification failed"))
@@ -110,6 +115,7 @@ func TestVerifyArtifact(t *testing.T) {
 			"",
 			ghActionsIssuer,
 			"",
+			nil,
 		)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("certificate identity regexp must not be empty"))
@@ -126,6 +132,7 @@ func TestVerifyArtifact(t *testing.T) {
 			ghActionsIdentity,
 			"",
 			"",
+			nil,
 		)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("certificate OIDC issuer must not be empty"))
@@ -142,6 +149,7 @@ func TestVerifyArtifact(t *testing.T) {
 			ghActionsIdentity,
 			ghActionsIssuer,
 			"/nonexistent/trusted_root.json",
+			nil,
 		)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("loading trusted root"))
@@ -158,6 +166,7 @@ func TestVerifyArtifact(t *testing.T) {
 			cosign.DefaultCertIdentityRegexp,
 			cosign.DefaultCertOIDCIssuer,
 			"",
+			nil,
 		)
 		g.Expect(err).To(HaveOccurred())
 	})


### PR DESCRIPTION
The `flux-operator distro mirror` command copies a complete Flux distribution (controller images and optionally the Flux Operator image and Helm chart) from the upstream registries to a destination registry. This is intended for users running Flux in air-gapped or private-registry environments.

Examples:

```sh
  # Mirror the latest Flux 2.x distribution to a private registry
  flux-operator distro mirror registry.example.com/flux

  # Mirror a specific Flux version
  flux-operator distro mirror registry.example.com/flux --version 2.8.x

  # Verify signatures and mirror the enterprise distroless variant
  echo "${GITHUB_TOKEN}" | flux-operator distro mirror registry.example.com/flux \
    --variant enterprise-distroless \
    --verify \
    --pull-token-stdin

  # List the source/destination pairs without copying images
  flux-operator distro mirror registry.example.com/flux --dry-run

  # Mirror only a subset of controllers
  flux-operator distro mirror registry.example.com/flux \
    --components source-controller,kustomize-controller,helm-controller

  # Mirror to an immutable registry (push by digest with a unique tag suffix)
  flux-operator distro mirror registry.example.com/flux --immutable

  # Mirror without the Flux Operator image and chart (controllers only)
  flux-operator distro mirror registry.example.com/flux \
    --include-operator-image=false \
    --include-operator-chart=false
```

Closes: #632