### PR TITLE
ci: Attest release assets on GitHub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,8 @@ jobs:
       contents: write # for creating the GitHub release.
       id-token: write # for creating OIDC tokens for signing.
       packages: write # for pushing and signing container images.
+      attestations: write # for GitHub Attestations.
+      artifact-metadata: write # for GitHub SLSA provenance.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -145,6 +147,11 @@ jobs:
           args: release --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attest release assets
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-checksums: ./dist/flux-operator_${{ steps.prep.outputs.VERSION }}_checksums.txt
       - name: Generate SLSA metadata
         id: slsa
         run: |
@@ -225,8 +232,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: "VERSION=${{ steps.prep.outputs.VERSION }}"
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-        with:
-          cosign-release: v2.6.1 # TODO: remove after Flux 2.8 with support for cosign v3
       - name: Sign images
         env:
           COSIGN_EXPERIMENTAL: 1
@@ -285,8 +290,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: "VERSION=${{ steps.prep.outputs.VERSION }}"
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-        with:
-          cosign-release: v2.6.1 # TODO: remove after Flux 2.8 with support for cosign v3
       - name: Sign images
         env:
           COSIGN_EXPERIMENTAL: 1


### PR DESCRIPTION
Attest release assets using [actions/attest](https://github.com/actions/attest)