### PR TITLE
cli: Add migrate command for managed fields API version

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -181,6 +181,33 @@ Arguments:
 - `-n, --namespace`: Specifies the namespace scope of the command.
 - `--wait`: On resume, waits for the reconciliation to complete before returning.
 
+### Migrate Commands
+
+The `flux-operator migrate` commands are used to migrate the managed fields of
+Kubernetes resources to a new API version. This is useful when a CRD introduces
+a new storage version that adds defaulted fields, which can otherwise cause
+server-side applies to fail with `field not declared in schema` errors for
+field managers whose entries are still pinned to the old API version.
+
+The migration rewrites the `apiVersion` of every `metadata.managedFields` entry
+on every listed resource, across all field managers.
+
+The following command is available:
+
+- `flux-operator migrate resources`: Migrates the managed fields of the
+  specified Kubernetes resources to the given API version.
+
+Arguments:
+
+- `--api-version`: The target API version in the format `group/version` (required).
+- `--kind`: The kind of resources to migrate (required).
+- `-n, --namespace`: Specifies the namespace scope of the command.
+- `-A, --all-namespaces`: Migrates resources in all namespaces.
+- `--dry-run`: Lists the resources that need migration without patching them.
+
+Before patching, the command verifies that the target version is present in the
+CRD's `status.storedVersions` field and fails otherwise.
+
 ### Delete Commands
 
 The `flux-operator delete` commands are used to delete the Flux Operator resources from the cluster.
@@ -345,6 +372,42 @@ The following commands are available:
     - `--sign`: Sign the artifact with cosign keyless (default `false`).
     - `--output, -o`: Output format (`json`).
 
+### Distro Mirror Command
+
+The `flux-operator distro mirror` command copies a complete Flux distribution
+(controller images and optionally the Flux Operator image and Helm chart)
+from the upstream registries to a destination registry. This is intended for users
+running Flux in air-gapped or private-registry environments.
+
+This command performs the following steps:
+
+1. Pulls the Flux distribution manifests OCI artifact to read the image list.
+2. Resolves the requested version against the available distribution releases.
+3. Mirrors every controller image and (optionally) the Flux Operator image
+   and Helm chart to the destination registry.
+
+Authentication for the destination registry uses the local Docker config file.
+The source registry (`ghcr.io`) can be authenticated with `--pull-token` or
+`--pull-token-stdin`, otherwise the Docker config is used as well.
+
+- `flux-operator distro mirror <destination>`: Mirrors the Flux distribution to a destination registry.
+  The destination is a positional argument, e.g. `registry.example.com/flux`.
+    - `--version`: Flux distribution version, e.g. `2.8.5` or `2.8.x` (default `2.x`).
+    - `--components`: Comma-separated list of components to mirror (defaults to all controllers,
+      plus `source-watcher` for Flux 2.7+).
+    - `--variant`: Distribution variant (`upstream-alpine`, `enterprise-alpine`,
+      `enterprise-distroless`, `enterprise-distroless-fips`). Default `upstream-alpine`.
+    - `--include-operator-image`: Also mirror the Flux Operator container image (default `true`).
+    - `--include-operator-chart`: Also mirror the Flux Operator Helm chart (default `true`).
+    - `--immutable`: Treat destination tags as immutable (default `false`). When set,
+      existing tags are never overwritten; new images are pushed under a unique tag
+      suffix (`<tag>-<unix-timestamp>`).
+    - `--pull-token`: GHCR token for the source registry (used as a basic-auth password).
+    - `--pull-token-stdin`: Read the GHCR token for the source registry from stdin
+      (mutually exclusive with `--pull-token`).
+    - `--dry-run`: List source→destination pairs without writing anything.
+    - `--verify`: Verify the cosign signatures of the images before mirroring.
+
 ### Install Command
 
 The `flux-operator install` command provides a quick way to bootstrap a Kubernetes cluster with the Flux Operator and a Flux instance.
@@ -387,42 +450,6 @@ it is recommended to follow the [installation guide](https://fluxcd.control-plan
     - `--certificate-identity-regexp`: Certificate identity regexp for signature verification.
     - `--certificate-oidc-issuer`: OIDC issuer for signature verification.
     - `--trusted-root`: Path to a `trusted_root.json` file for offline signature verification.
-
-### Distro Mirror Command
-
-The `flux-operator distro mirror` command copies a complete Flux distribution
-(controller images and optionally the Flux Operator image and Helm chart)
-from the upstream registries to a destination registry. This is intended for users
-running Flux in air-gapped or private-registry environments.
-
-This command performs the following steps:
-
-1. Pulls the Flux distribution manifests OCI artifact to read the image list.
-2. Resolves the requested version against the available distribution releases.
-3. Mirrors every controller image and (optionally) the Flux Operator image
-   and Helm chart to the destination registry.
-
-Authentication for the destination registry uses the local Docker config file.
-The source registry (`ghcr.io`) can be authenticated with `--pull-token` or
-`--pull-token-stdin`, otherwise the Docker config is used as well.
-
-- `flux-operator distro mirror <destination>`: Mirrors the Flux distribution to a destination registry.
-  The destination is a positional argument, e.g. `registry.example.com/flux`.
-    - `--version`: Flux distribution version, e.g. `2.8.5` or `2.8.x` (default `2.x`).
-    - `--components`: Comma-separated list of components to mirror (defaults to all controllers,
-      plus `source-watcher` for Flux 2.7+).
-    - `--variant`: Distribution variant (`upstream-alpine`, `enterprise-alpine`,
-      `enterprise-distroless`, `enterprise-distroless-fips`). Default `upstream-alpine`.
-    - `--include-operator-image`: Also mirror the Flux Operator container image (default `true`).
-    - `--include-operator-chart`: Also mirror the Flux Operator Helm chart (default `true`).
-    - `--immutable`: Treat destination tags as immutable (default `false`). When set,
-      existing tags are never overwritten; new images are pushed under a unique tag
-      suffix (`<tag>-<unix-timestamp>`).
-    - `--pull-token`: GHCR token for the source registry (used as a basic-auth password).
-    - `--pull-token-stdin`: Read the GHCR token for the source registry from stdin
-      (mutually exclusive with `--pull-token`).
-    - `--dry-run`: List source→destination pairs without writing anything.
-    - `--verify`: Verify the cosign signatures of the images before mirroring.
 
 ### Uninstall Command
 

--- a/cmd/cli/migrate.go
+++ b/cmd/cli/migrate.go
@@ -1,0 +1,17 @@
+// Copyright 2025 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Migrate Kubernetes resources",
+}
+
+func init() {
+	rootCmd.AddCommand(migrateCmd)
+}

--- a/cmd/cli/migrate_resources.go
+++ b/cmd/cli/migrate_resources.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/fluxcd/pkg/ssa"
+	"github.com/spf13/cobra"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var migrateResourcesCmd = &cobra.Command{
+	Use:     "resources",
+	Aliases: []string{"resource"},
+	Short:   "Migrate the managed fields of Kubernetes resources to a new API version",
+	Example: `  # Migrate all ExternalSecret resources to v1 across all namespaces
+  flux-operator migrate resources --api-version=external-secrets.io/v1 --kind=ExternalSecret -A
+
+  # List resources that need migration without patching them
+  flux-operator migrate resources --api-version=external-secrets.io/v1 --kind=ExternalSecret -A --dry-run
+
+  # Migrate resources in a specific namespace
+  flux-operator -n apps migrate resources --api-version=external-secrets.io/v1 --kind=ExternalSecret
+`,
+	Args: cobra.NoArgs,
+	RunE: migrateResourcesCmdRun,
+}
+
+type migrateResourcesFlags struct {
+	apiVersion    string
+	kind          string
+	allNamespaces bool
+	dryRun        bool
+}
+
+var migrateResourcesArgs migrateResourcesFlags
+
+func init() {
+	migrateResourcesCmd.Flags().StringVar(&migrateResourcesArgs.apiVersion, "api-version", "",
+		"The target API version in the format group/version, e.g., external-secrets.io/v1 (required).")
+	migrateResourcesCmd.Flags().StringVar(&migrateResourcesArgs.kind, "kind", "",
+		"The kind of resources to migrate, e.g., ExternalSecret (required).")
+	migrateResourcesCmd.Flags().BoolVarP(&migrateResourcesArgs.allNamespaces, "all-namespaces", "A", false,
+		"Migrate resources in all namespaces.")
+	migrateResourcesCmd.Flags().BoolVar(&migrateResourcesArgs.dryRun, "dry-run", false,
+		"List the resources that need migration without patching them.")
+	migrateCmd.AddCommand(migrateResourcesCmd)
+}
+
+func migrateResourcesCmdRun(cmd *cobra.Command, args []string) error {
+	if migrateResourcesArgs.apiVersion == "" {
+		return fmt.Errorf("--api-version is required")
+	}
+	if migrateResourcesArgs.kind == "" {
+		return fmt.Errorf("--kind is required")
+	}
+
+	gv, err := schema.ParseGroupVersion(migrateResourcesArgs.apiVersion)
+	if err != nil {
+		return fmt.Errorf("invalid --api-version %q: %w", migrateResourcesArgs.apiVersion, err)
+	}
+	if gv.Group == "" {
+		return fmt.Errorf("invalid --api-version %q: group is required", migrateResourcesArgs.apiVersion)
+	}
+	gvk := gv.WithKind(migrateResourcesArgs.kind)
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client: %w", err)
+	}
+
+	mapper, err := kubeconfigArgs.ToRESTMapper()
+	if err != nil {
+		return fmt.Errorf("unable to create REST mapper: %w", err)
+	}
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return fmt.Errorf("unable to resolve REST mapping for %s: %w", gvk.String(), err)
+	}
+
+	crdName := mapping.Resource.Resource + "." + gvk.Group
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := kubeClient.Get(ctx, client.ObjectKey{Name: crdName}, crd); err != nil {
+		return fmt.Errorf("unable to get CRD %s: %w", crdName, err)
+	}
+
+	if !slices.Contains(crd.Status.StoredVersions, gvk.Version) {
+		return fmt.Errorf("version %q is not a stored version of CRD %s (stored versions: %s)",
+			gvk.Version, crdName, strings.Join(crd.Status.StoredVersions, ", "))
+	}
+
+	list := unstructured.UnstructuredList{
+		Object: map[string]any{
+			"apiVersion": migrateResourcesArgs.apiVersion,
+			"kind":       gvk.Kind + "List",
+		},
+	}
+	lsOpts := &client.ListOptions{}
+	if !migrateResourcesArgs.allNamespaces {
+		lsOpts.Namespace = *kubeconfigArgs.Namespace
+	}
+	if err := kubeClient.List(ctx, &list, lsOpts); err != nil {
+		return fmt.Errorf("unable to list resources for %s: %w", gvk.String(), err)
+	}
+
+	if len(list.Items) == 0 {
+		return fmt.Errorf("no resources of kind %s found", gvk.Kind)
+	}
+
+	var migrated, failures int
+
+	for i := range list.Items {
+		u := &list.Items[i]
+		name := u.GetName()
+		namespace := u.GetNamespace()
+		qualified := name
+		if namespace != "" {
+			qualified = namespace + "/" + name
+		}
+
+		patches, err := ssa.PatchMigrateToVersion(u, migrateResourcesArgs.apiVersion)
+		if err != nil {
+			rootCmd.Printf("✗ %s %s: failed to build migration patch: %v\n", gvk.Kind, qualified, err)
+			failures++
+			continue
+		}
+		if len(patches) == 0 {
+			rootCmd.Printf("• %s %s already at %s\n", gvk.Kind, qualified, migrateResourcesArgs.apiVersion)
+			continue
+		}
+
+		if migrateResourcesArgs.dryRun {
+			managers := staleManagers(u.GetManagedFields(), migrateResourcesArgs.apiVersion)
+			rootCmd.Printf("◎ %s %s needs migration (managers: %s)\n",
+				gvk.Kind, qualified, strings.Join(managers, ", "))
+			migrated++
+			continue
+		}
+
+		patchBytes, err := json.Marshal(patches)
+		if err != nil {
+			rootCmd.Printf("✗ %s %s: failed to marshal patch: %v\n", gvk.Kind, qualified, err)
+			failures++
+			continue
+		}
+
+		if err := kubeClient.Patch(ctx, u, client.RawPatch(types.JSONPatchType, patchBytes)); err != nil {
+			rootCmd.Printf("✗ %s %s: failed to migrate: %v\n", gvk.Kind, qualified, err)
+			failures++
+			continue
+		}
+
+		rootCmd.Printf("✔ %s %s migrated to %s\n", gvk.Kind, qualified, migrateResourcesArgs.apiVersion)
+		migrated++
+	}
+
+	if migrateResourcesArgs.dryRun {
+		rootCmd.Printf("✔ %d/%d resources need migration to %s\n",
+			migrated, len(list.Items), migrateResourcesArgs.apiVersion)
+		return nil
+	}
+
+	rootCmd.Printf("✔ migrated %d/%d resources to %s\n",
+		migrated, len(list.Items), migrateResourcesArgs.apiVersion)
+
+	if failures > 0 && migrated == 0 {
+		return fmt.Errorf("failed to migrate any resources (%d errors)", failures)
+	}
+
+	return nil
+}
+
+func staleManagers(entries []metav1.ManagedFieldsEntry, targetAPIVersion string) []string {
+	seen := map[string]struct{}{}
+	for _, e := range entries {
+		if e.APIVersion != targetAPIVersion {
+			seen[e.Manager] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/cli/migrate_resources_test.go
+++ b/cmd/cli/migrate_resources_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	migrateTestGroup    = "migrate.example.com"
+	migrateTestKind     = "Widget"
+	migrateTestPlural   = "widgets"
+	migrateTestCRDName  = migrateTestPlural + "." + migrateTestGroup
+	migrateTestOldVer   = "v1beta1"
+	migrateTestNewVer   = "v1"
+	migrateFieldManager = "migrate-test"
+)
+
+func installMigrateTestCRD(ctx context.Context, g *WithT) func() {
+	preserve := true
+	schemaProps := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"spec": {
+				Type:                   "object",
+				XPreserveUnknownFields: &preserve,
+			},
+		},
+	}
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: migrateTestCRDName},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: migrateTestGroup,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   migrateTestPlural,
+				Singular: "widget",
+				Kind:     migrateTestKind,
+				ListKind: migrateTestKind + "List",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    migrateTestOldVer,
+					Served:  true,
+					Storage: false,
+					Schema:  &apiextensionsv1.CustomResourceValidation{OpenAPIV3Schema: schemaProps},
+				},
+				{
+					Name:    migrateTestNewVer,
+					Served:  true,
+					Storage: true,
+					Schema:  &apiextensionsv1.CustomResourceValidation{OpenAPIV3Schema: schemaProps},
+				},
+			},
+		},
+	}
+	g.Expect(testClient.Create(ctx, crd)).To(Succeed())
+
+	// Wait until the CRD is established and the API is discoverable.
+	listGVK := schema.GroupVersionKind{Group: migrateTestGroup, Version: migrateTestNewVer, Kind: migrateTestKind + "List"}
+	g.Eventually(func() error {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(listGVK)
+		return testClient.List(ctx, list)
+	}, timeout, "500ms").Should(Succeed())
+
+	return func() {
+		_ = testClient.Delete(context.Background(), crd)
+	}
+}
+
+// createStaleWidget creates a Widget at newVer and then rewrites every
+// managed-fields entry's apiVersion to oldVer via a JSON patch, emulating
+// a resource whose field managers are still pinned to the old API version.
+func createStaleWidget(ctx context.Context, g *WithT, namespace, name string) {
+	widget := &unstructured.Unstructured{}
+	widget.SetGroupVersionKind(schema.GroupVersionKind{Group: migrateTestGroup, Version: migrateTestNewVer, Kind: migrateTestKind})
+	widget.SetNamespace(namespace)
+	widget.SetName(name)
+	g.Expect(unstructured.SetNestedField(widget.Object, "bar", "spec", "foo")).To(Succeed())
+
+	g.Expect(testClient.Patch(ctx, widget, client.Apply,
+		client.ForceOwnership, client.FieldOwner(migrateFieldManager))).To(Succeed())
+
+	// Rewrite every managed-fields entry's apiVersion to the old version
+	// to simulate a stale state.
+	g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(widget), widget)).To(Succeed())
+	entries := widget.GetManagedFields()
+	g.Expect(entries).ToNot(BeEmpty())
+	oldAPIVersion := migrateTestGroup + "/" + migrateTestOldVer
+	for i := range entries {
+		entries[i].APIVersion = oldAPIVersion
+	}
+	widget.SetManagedFields(entries)
+	g.Expect(testClient.Update(ctx, widget)).To(Succeed())
+}
+
+func getWidgetManagedFieldsVersions(ctx context.Context, g *WithT, namespace, name string) []string {
+	widget := &unstructured.Unstructured{}
+	widget.SetGroupVersionKind(schema.GroupVersionKind{Group: migrateTestGroup, Version: migrateTestNewVer, Kind: migrateTestKind})
+	widget.SetNamespace(namespace)
+	widget.SetName(name)
+	g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(widget), widget)).To(Succeed())
+	versions := make([]string, 0, len(widget.GetManagedFields()))
+	for _, e := range widget.GetManagedFields() {
+		versions = append(versions, e.APIVersion)
+	}
+	return versions
+}
+
+func TestMigrateResourcesCmd(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cleanup := installMigrateTestCRD(ctx, g)
+	t.Cleanup(cleanup)
+
+	newAPIVersion := migrateTestGroup + "/" + migrateTestNewVer
+	oldAPIVersion := migrateTestGroup + "/" + migrateTestOldVer
+
+	t.Run("missing --api-version", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand([]string{"migrate", "resources", "--kind", migrateTestKind})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("--api-version is required"))
+	})
+
+	t.Run("missing --kind", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand([]string{"migrate", "resources", "--api-version", newAPIVersion})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("--kind is required"))
+	})
+
+	t.Run("unknown kind", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand([]string{
+			"migrate", "resources",
+			"--api-version", newAPIVersion,
+			"--kind", "NotAKind",
+			"-A",
+		})
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("version not in storedVersions", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := executeCommand([]string{
+			"migrate", "resources",
+			"--api-version", migrateTestGroup + "/v9",
+			"--kind", migrateTestKind,
+			"-A",
+		})
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("no resources found", func(t *testing.T) {
+		g := NewWithT(t)
+		ns, err := testEnv.CreateNamespace(ctx, "migrate-empty")
+		g.Expect(err).ToNot(HaveOccurred())
+		kubeconfigArgs.Namespace = &ns.Name
+		_, err = executeCommand([]string{
+			"migrate", "resources",
+			"--api-version", newAPIVersion,
+			"--kind", migrateTestKind,
+		})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("no resources of kind"))
+	})
+
+	t.Run("dry-run reports but does not patch", func(t *testing.T) {
+		g := NewWithT(t)
+		ns, err := testEnv.CreateNamespace(ctx, "migrate-dryrun")
+		g.Expect(err).ToNot(HaveOccurred())
+		kubeconfigArgs.Namespace = &ns.Name
+		createStaleWidget(ctx, g, ns.Name, "widget-a")
+
+		output, err := executeCommand([]string{
+			"migrate", "resources",
+			"--api-version", newAPIVersion,
+			"--kind", migrateTestKind,
+			"--dry-run",
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("widget-a needs migration"))
+		g.Expect(output).To(ContainSubstring("1/1 resources need migration"))
+
+		// Verify the server-side managed fields were NOT rewritten.
+		versions := getWidgetManagedFieldsVersions(ctx, g, ns.Name, "widget-a")
+		g.Expect(versions).To(ContainElement(oldAPIVersion))
+		g.Expect(versions).ToNot(ContainElement(newAPIVersion))
+	})
+
+	t.Run("migrates stale resources in namespace", func(t *testing.T) {
+		g := NewWithT(t)
+		ns, err := testEnv.CreateNamespace(ctx, "migrate-ns")
+		g.Expect(err).ToNot(HaveOccurred())
+		kubeconfigArgs.Namespace = &ns.Name
+		createStaleWidget(ctx, g, ns.Name, "widget-b")
+
+		output, err := executeCommand([]string{
+			"migrate", "resources",
+			"--api-version", newAPIVersion,
+			"--kind", migrateTestKind,
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("widget-b migrated"))
+		g.Expect(output).To(ContainSubstring("migrated 1/1 resources"))
+
+		versions := getWidgetManagedFieldsVersions(ctx, g, ns.Name, "widget-b")
+		g.Expect(versions).ToNot(BeEmpty())
+		for _, v := range versions {
+			g.Expect(v).To(Equal(newAPIVersion))
+		}
+	})
+
+	t.Run("migrates across all namespaces", func(t *testing.T) {
+		g := NewWithT(t)
+		nsA, err := testEnv.CreateNamespace(ctx, "migrate-all-a")
+		g.Expect(err).ToNot(HaveOccurred())
+		nsB, err := testEnv.CreateNamespace(ctx, "migrate-all-b")
+		g.Expect(err).ToNot(HaveOccurred())
+		createStaleWidget(ctx, g, nsA.Name, "widget-a")
+		createStaleWidget(ctx, g, nsB.Name, "widget-b")
+
+		output, err := executeCommand([]string{
+			"migrate", "resources",
+			"--api-version", newAPIVersion,
+			"--kind", migrateTestKind,
+			"-A",
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(output).To(ContainSubstring("widget-a migrated"))
+		g.Expect(output).To(ContainSubstring("widget-b migrated"))
+
+		for _, n := range []struct{ ns, name string }{{nsA.Name, "widget-a"}, {nsB.Name, "widget-b"}} {
+			versions := getWidgetManagedFieldsVersions(ctx, g, n.ns, n.name)
+			for _, v := range versions {
+				g.Expect(v).To(Equal(newAPIVersion))
+			}
+		}
+	})
+}

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -182,6 +182,9 @@ func resetCmdArgs() {
 	// Diff commands
 	diffYAMLArgs = diffYAMLFlags{output: "json-patch-yaml"}
 
+	// Migrate commands
+	migrateResourcesArgs = migrateResourcesFlags{}
+
 	// Patch commands
 	patchInstanceArgs = patchInstanceFlags{version: "main", components: nil}
 	fluxControllerBaseURL = "https://github.com/fluxcd"


### PR DESCRIPTION
Add command to migrate the managed fields of Kubernetes resources to a new API version.

Example usage:

```shell
flux-operator migrate resources \
--api-version=external-secrets.io/v1 \
--kind=ExternalSecret \
--all-namespaces \
--dry-run
```

xref: https://github.com/fluxcd/flux2/issues/5715