### PR TITLE
cli: Add migrate owner command to clean up stale managed fields

### DIFF
--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -114,6 +114,7 @@ const (
 
 // Flux controller names.
 const (
+	FluxOperator                  = "flux-operator"
 	FluxSourceController          = "source-controller"
 	FluxKustomizeController       = "kustomize-controller"
 	FluxHelmController            = "helm-controller"

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -181,33 +181,6 @@ Arguments:
 - `-n, --namespace`: Specifies the namespace scope of the command.
 - `--wait`: On resume, waits for the reconciliation to complete before returning.
 
-### Migrate Commands
-
-The `flux-operator migrate` commands are used to migrate the managed fields of
-Kubernetes resources to a new API version. This is useful when a CRD introduces
-a new storage version that adds defaulted fields, which can otherwise cause
-server-side applies to fail with `field not declared in schema` errors for
-field managers whose entries are still pinned to the old API version.
-
-The migration rewrites the `apiVersion` of every `metadata.managedFields` entry
-on every listed resource, across all field managers.
-
-The following command is available:
-
-- `flux-operator migrate resources`: Migrates the managed fields of the
-  specified Kubernetes resources to the given API version.
-
-Arguments:
-
-- `--api-version`: The target API version in the format `group/version` (required).
-- `--kind`: The kind of resources to migrate (required).
-- `-n, --namespace`: Specifies the namespace scope of the command.
-- `-A, --all-namespaces`: Migrates resources in all namespaces.
-- `--dry-run`: Lists the resources that need migration without patching them.
-
-Before patching, the command verifies that the target version is present in the
-CRD's `status.storedVersions` field and fails otherwise.
-
 ### Delete Commands
 
 The `flux-operator delete` commands are used to delete the Flux Operator resources from the cluster.
@@ -274,6 +247,27 @@ Arguments:
 
 - `-n, --namespace`: Specifies the namespace scope of the command.
 - `--timeout`: The length of time to wait before giving up (default 1m).
+
+### Migrate Commands
+
+The `flux-operator migrate` commands are used to clean up the managed fields of Kubernetes resources.
+
+The following commands are available:
+
+- `flux-operator migrate owner <kind>/<name>`: Cleans up stale managed fields entries left on resources
+  owned by the given Flux applier (`HelmRelease`, `Kustomization`, `ResourceSet`, or `FluxInstance`),
+  so that the current applier becomes the sole Flux field-owner on each resource.
+    - `-n, --namespace`: Specifies the namespace of the applier.
+    - `--dry-run`: Lists the stale managers that would be stripped without patching resources.
+- `flux-operator migrate resources`: Migrates the managed fields of the specified Kubernetes resources
+  to the given API version. This resolves `field not declared in schema` errors after a CRD introduces
+  a new storage version with defaulted fields. Before patching, the command verifies that the target
+  version is present in the CRD's `status.storedVersions` field.
+    - `--api-version`: The target API version in the format `group/version` (required).
+    - `--kind`: The kind of resources to migrate (required).
+    - `-n, --namespace`: Specifies the namespace scope of the command.
+    - `-A, --all-namespaces`: Migrates resources in all namespaces.
+    - `--dry-run`: Lists the resources that need migration without patching them.
 
 ### Create Secret Commands
 

--- a/cmd/cli/migrate.go
+++ b/cmd/cli/migrate.go
@@ -9,7 +9,7 @@ import (
 
 var migrateCmd = &cobra.Command{
 	Use:   "migrate",
-	Short: "Migrate Kubernetes resources",
+	Short: "Migrate Kubernetes resources managed fields",
 }
 
 func init() {

--- a/cmd/cli/migrate_owner.go
+++ b/cmd/cli/migrate_owner.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/fluxcd/pkg/ssa"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/inventory"
+)
+
+var migrateOwnerCmd = &cobra.Command{
+	Use:     "owner [<kind>/<name>]",
+	Aliases: []string{"ownership"},
+	Short:   "Clean up stale Flux managed fields on resources owned by the given Flux applier",
+	Long: `The migrate owner command takes a Flux applier resource (HelmRelease, Kustomization,
+ResourceSet, or FluxInstance) and removes stale managed fields entries left behind
+by OTHER Flux field managers on every resource listed in its status.inventory.
+This is intended to resolve post-migration issues where a field set by a previous
+Flux applier is retained even after the resource is reassigned to a new applier.`,
+	Example: `  # Clean up stale Flux managers on resources owned by a HelmRelease
+  flux-operator -n monitoring migrate owner hr/kube-prom-stack
+
+  # Dry-run: list the stale managers that would be stripped
+  flux-operator -n flux-system migrate owner ks/apps --dry-run
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: migrateOwnerCmdRun,
+}
+
+type migrateOwnerFlags struct {
+	dryRun bool
+}
+
+var migrateOwnerArgs migrateOwnerFlags
+
+func init() {
+	migrateOwnerCmd.Flags().BoolVar(&migrateOwnerArgs.dryRun, "dry-run", false,
+		"List the stale managers that would be stripped without patching resources.")
+	migrateCmd.AddCommand(migrateOwnerCmd)
+}
+
+var allFluxManagers = []ssa.FieldManager{
+	{Name: fluxcdv1.FluxKustomizeController, OperationType: metav1.ManagedFieldsOperationApply, ExactMatch: true},
+	{Name: fluxcdv1.FluxHelmController, OperationType: metav1.ManagedFieldsOperationApply, ExactMatch: true},
+	// helm-controller (Helm v3 compat) uses Update instead of Apply
+	{Name: fluxcdv1.FluxHelmController, OperationType: metav1.ManagedFieldsOperationUpdate, ExactMatch: true},
+	{Name: fluxcdv1.FluxOperator, OperationType: metav1.ManagedFieldsOperationApply, ExactMatch: true},
+}
+
+func kindToManager(kind string) (string, error) {
+	switch kind {
+	case fluxcdv1.FluxHelmReleaseKind:
+		return fluxcdv1.FluxHelmController, nil
+	case fluxcdv1.FluxKustomizationKind:
+		return fluxcdv1.FluxKustomizeController, nil
+	case fluxcdv1.ResourceSetKind, fluxcdv1.FluxInstanceKind:
+		return fluxcdv1.FluxOperator, nil
+	default:
+		return "", fmt.Errorf("unsupported kind %q, must be one of: %s, %s, %s, %s",
+			kind,
+			fluxcdv1.FluxHelmReleaseKind,
+			fluxcdv1.FluxKustomizationKind,
+			fluxcdv1.ResourceSetKind,
+			fluxcdv1.FluxInstanceKind)
+	}
+}
+
+func staleFluxManagers(currentOwner string) []ssa.FieldManager {
+	stale := make([]ssa.FieldManager, 0, len(allFluxManagers)-1)
+	for _, m := range allFluxManagers {
+		if m.Name == currentOwner {
+			continue
+		}
+		stale = append(stale, m)
+	}
+	return stale
+}
+
+func migrateOwnerCmdRun(cmd *cobra.Command, args []string) error {
+	owner, err := getObjectByKindName(args)
+	if err != nil {
+		return err
+	}
+
+	currentOwner, err := kindToManager(owner.GetKind())
+	if err != nil {
+		return err
+	}
+	staleMgrs := staleFluxManagers(currentOwner)
+
+	entries, err := inventory.FromUnstructured(owner)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("%s/%s/%s has no status.inventory entries (requires Flux v2.8+ for HelmRelease)",
+			owner.GetKind(), owner.GetNamespace(), owner.GetName())
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	kubeClient, err := newKubeClient()
+	if err != nil {
+		return fmt.Errorf("unable to create kube client: %w", err)
+	}
+
+	var cleaned, failures int
+
+	for _, ref := range entries {
+		target, err := getInventoryEntry(ctx, kubeClient, ref)
+		if err != nil {
+			rootCmd.Printf("✗ %s: failed to get resource: %v\n", ref.ID, err)
+			failures++
+			continue
+		}
+
+		qualified := ssautil.FmtUnstructured(target)
+
+		// On HelmRelease targets, preserve the helm-controller Update manager
+		// to avoid revoking ownership of status and finalizers.
+		targetStaleMgrs := staleMgrs
+		if target.GetKind() == fluxcdv1.FluxHelmReleaseKind {
+			targetStaleMgrs = make([]ssa.FieldManager, 0, len(staleMgrs))
+			for _, m := range staleMgrs {
+				if m.Name == fluxcdv1.FluxHelmController && m.OperationType == metav1.ManagedFieldsOperationUpdate {
+					continue
+				}
+				targetStaleMgrs = append(targetStaleMgrs, m)
+			}
+		}
+
+		patches := ssa.PatchRemoveFieldsManagers(target, targetStaleMgrs)
+		if len(patches) == 0 {
+			rootCmd.Printf("• %s already clean\n", qualified)
+			continue
+		}
+
+		removed := removedManagerNames(target.GetManagedFields(), targetStaleMgrs)
+
+		if migrateOwnerArgs.dryRun {
+			rootCmd.Printf("◎ %s would strip managers [%s]\n", qualified, strings.Join(removed, ", "))
+			cleaned++
+			continue
+		}
+
+		patchBytes, err := json.Marshal(patches)
+		if err != nil {
+			rootCmd.Printf("✗ %s: failed to marshal patch: %v\n", qualified, err)
+			failures++
+			continue
+		}
+
+		if err := kubeClient.Patch(ctx, target, client.RawPatch(types.JSONPatchType, patchBytes)); err != nil {
+			rootCmd.Printf("✗ %s: failed to strip managers: %v\n", qualified, err)
+			failures++
+			continue
+		}
+
+		rootCmd.Printf("✔ %s stripped managers [%s]\n", qualified, strings.Join(removed, ", "))
+		cleaned++
+	}
+
+	total := len(entries)
+	if migrateOwnerArgs.dryRun {
+		rootCmd.Printf("✔ %d/%d resources need cleanup (current owner: %s)\n", cleaned, total, currentOwner)
+		return nil
+	}
+
+	rootCmd.Printf("✔ cleaned %d/%d resources (current owner: %s)\n", cleaned, total, currentOwner)
+
+	if failures > 0 && cleaned == 0 {
+		return fmt.Errorf("failed to process any resource (%d errors)", failures)
+	}
+	return nil
+}
+
+func getInventoryEntry(ctx context.Context, kubeClient client.Client, ref fluxcdv1.ResourceRef) (*unstructured.Unstructured, error) {
+	obj, err := inventory.EntryToUnstructured(ref)
+	if err != nil {
+		return nil, err
+	}
+	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func removedManagerNames(entries []metav1.ManagedFieldsEntry, stale []ssa.FieldManager) []string {
+	seen := map[string]struct{}{}
+	for _, e := range entries {
+		for _, s := range stale {
+			if e.Manager == s.Name && e.Operation == s.OperationType {
+				seen[e.Manager] = struct{}{}
+			}
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/cli/migrate_owner_test.go
+++ b/cmd/cli/migrate_owner_test.go
@@ -1,0 +1,402 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+const kubectlFieldManager = "kubectl"
+
+func TestKindToManager(t *testing.T) {
+	tests := []struct {
+		kind        string
+		expected    string
+		expectError bool
+	}{
+		{kind: fluxcdv1.FluxHelmReleaseKind, expected: fluxcdv1.FluxHelmController},
+		{kind: fluxcdv1.FluxKustomizationKind, expected: fluxcdv1.FluxKustomizeController},
+		{kind: fluxcdv1.ResourceSetKind, expected: fluxcdv1.FluxOperator},
+		{kind: fluxcdv1.FluxInstanceKind, expected: fluxcdv1.FluxOperator},
+		{kind: "ConfigMap", expectError: true},
+		{kind: "", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := kindToManager(tt.kind)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(got).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestStaleFluxManagers(t *testing.T) {
+	g := NewWithT(t)
+
+	// Current owner's entries (both Apply and Update) must be excluded.
+	stale := staleFluxManagers(fluxcdv1.FluxHelmController)
+	for _, m := range stale {
+		g.Expect(m.Name).ToNot(Equal(fluxcdv1.FluxHelmController))
+		g.Expect(m.ExactMatch).To(BeTrue())
+	}
+	g.Expect(stale).To(HaveLen(len(allFluxManagers) - 2))
+
+	all := staleFluxManagers("unknown-manager")
+	g.Expect(all).To(HaveLen(len(allFluxManagers)))
+}
+
+type managedField struct {
+	manager   string
+	operation metav1.ManagedFieldsOperationType
+}
+
+// seedManagedFields replaces the managedFields on obj with the given entries
+// via a JSON patch. This emulates a resource that has accumulated entries
+// from several Flux appliers over time.
+func seedManagedFields(ctx context.Context, g *WithT, obj client.Object, fields []managedField) {
+	entries := make([]metav1.ManagedFieldsEntry, 0, len(fields))
+	for _, f := range fields {
+		entries = append(entries, metav1.ManagedFieldsEntry{
+			Manager:    f.manager,
+			Operation:  f.operation,
+			APIVersion: "v1",
+			FieldsType: "FieldsV1",
+			FieldsV1: &metav1.FieldsV1{
+				Raw: []byte(`{"f:metadata":{"f:labels":{}}}`),
+			},
+		})
+	}
+	patch := []map[string]any{
+		{"op": "replace", "path": "/metadata/managedFields", "value": entries},
+	}
+	raw, err := json.Marshal(patch)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(testClient.Patch(ctx, obj, client.RawPatch(types.JSONPatchType, raw))).To(Succeed())
+}
+
+func applyFields(managers ...string) []managedField {
+	out := make([]managedField, 0, len(managers))
+	for _, m := range managers {
+		out = append(out, managedField{manager: m, operation: metav1.ManagedFieldsOperationApply})
+	}
+	return out
+}
+
+// inventoryIDForConfigMap formats a ResourceRef ID for a namespaced core/v1 ConfigMap.
+func inventoryIDForConfigMap(namespace, name string) string {
+	return fmt.Sprintf("%s_%s__ConfigMap", namespace, name)
+}
+
+// setResourceSetInventory writes the given configmap references as the
+// ResourceSet's status.inventory.entries.
+func setResourceSetInventory(ctx context.Context, g *WithT, rs *fluxcdv1.ResourceSet, cmRefs []fluxcdv1.ResourceRef) {
+	rs.Status.Inventory = &fluxcdv1.ResourceInventory{Entries: cmRefs}
+	g.Expect(testClient.Status().Update(ctx, rs)).To(Succeed())
+}
+
+func configMapManagers(ctx context.Context, g *WithT, namespace, name string) []string {
+	cm := &corev1.ConfigMap{}
+	g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, cm)).To(Succeed())
+	seen := map[string]struct{}{}
+	for _, e := range cm.GetManagedFields() {
+		seen[e.Manager] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	return out
+}
+
+func TestMigrateOwnerCmd_UnsupportedKind(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "migrate-owner-unsupported")
+	g.Expect(err).ToNot(HaveOccurred())
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "target", Namespace: ns.Name},
+	}
+	g.Expect(testClient.Create(ctx, cm)).To(Succeed())
+
+	kubeconfigArgs.Namespace = &ns.Name
+	_, err = executeCommand([]string{"migrate", "owner", "configmap/target"})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("unsupported kind"))
+}
+
+func TestMigrateOwnerCmd_MissingInventory(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "migrate-owner-noinv")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	rs := newResourceSet(ns.Name)
+	g.Expect(testClient.Create(ctx, rs)).To(Succeed())
+
+	kubeconfigArgs.Namespace = &ns.Name
+	_, err = executeCommand([]string{"migrate", "owner", "rset/owner"})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("no status.inventory entries"))
+}
+
+func TestMigrateOwnerCmd_ResourceSet(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "migrate-owner-rset")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cmName := "app-config"
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns.Name},
+		Data:       map[string]string{"key": "value"},
+	}
+	g.Expect(testClient.Create(ctx, cm)).To(Succeed())
+	seedManagedFields(ctx, g, cm, []managedField{
+		{manager: fluxcdv1.FluxOperator, operation: metav1.ManagedFieldsOperationApply},
+		{manager: fluxcdv1.FluxHelmController, operation: metav1.ManagedFieldsOperationApply},
+		// helm-controller also writes Update entries; both variants must be stripped.
+		{manager: fluxcdv1.FluxHelmController, operation: metav1.ManagedFieldsOperationUpdate},
+		{manager: fluxcdv1.FluxKustomizeController, operation: metav1.ManagedFieldsOperationApply},
+		{manager: kubectlFieldManager, operation: metav1.ManagedFieldsOperationUpdate},
+	})
+
+	rs := newResourceSet(ns.Name)
+	g.Expect(testClient.Create(ctx, rs)).To(Succeed())
+	setResourceSetInventory(ctx, g, rs, []fluxcdv1.ResourceRef{{
+		ID: inventoryIDForConfigMap(ns.Name, cmName), Version: "v1",
+	}})
+
+	kubeconfigArgs.Namespace = &ns.Name
+	output, err := executeCommand([]string{"migrate", "owner", "rset/owner"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("stripped managers"))
+	g.Expect(output).To(ContainSubstring(fluxcdv1.FluxHelmController))
+	g.Expect(output).To(ContainSubstring(fluxcdv1.FluxKustomizeController))
+	g.Expect(output).To(ContainSubstring("cleaned 1/1 resources"))
+
+	cm = &corev1.ConfigMap{}
+	g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: cmName}, cm)).To(Succeed())
+	for _, e := range cm.GetManagedFields() {
+		g.Expect(e.Manager).ToNot(Equal(fluxcdv1.FluxHelmController))
+		g.Expect(e.Manager).ToNot(Equal(fluxcdv1.FluxKustomizeController))
+	}
+	remaining := configMapManagers(ctx, g, ns.Name, cmName)
+	g.Expect(remaining).To(ContainElement(fluxcdv1.FluxOperator))
+	g.Expect(remaining).To(ContainElement(kubectlFieldManager))
+}
+
+func TestMigrateOwnerCmd_FluxInstance(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "migrate-owner-fi")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cmName := "fi-config"
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns.Name},
+	}
+	g.Expect(testClient.Create(ctx, cm)).To(Succeed())
+	seedManagedFields(ctx, g, cm, applyFields(fluxcdv1.FluxOperator, fluxcdv1.FluxKustomizeController))
+
+	fi := newFluxInstance(ns.Name)
+	g.Expect(testClient.Create(ctx, fi)).To(Succeed())
+	t.Cleanup(func() { _ = testClient.Delete(context.Background(), fi) })
+	fi.Status.Inventory = &fluxcdv1.ResourceInventory{Entries: []fluxcdv1.ResourceRef{{
+		ID: inventoryIDForConfigMap(ns.Name, cmName), Version: "v1",
+	}}}
+	g.Expect(testClient.Status().Update(ctx, fi)).To(Succeed())
+
+	kubeconfigArgs.Namespace = &ns.Name
+	output, err := executeCommand([]string{"migrate", "owner", "fluxinstance/flux"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("stripped managers"))
+
+	remaining := configMapManagers(ctx, g, ns.Name, cmName)
+	g.Expect(remaining).To(ContainElement(fluxcdv1.FluxOperator))
+	g.Expect(remaining).ToNot(ContainElement(fluxcdv1.FluxKustomizeController))
+}
+
+func TestMigrateOwnerCmd_AlreadyClean(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "migrate-owner-clean")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cmName := "clean"
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns.Name},
+	}
+	g.Expect(testClient.Create(ctx, cm)).To(Succeed())
+	seedManagedFields(ctx, g, cm, applyFields(fluxcdv1.FluxOperator, kubectlFieldManager))
+
+	rs := newResourceSet(ns.Name)
+	g.Expect(testClient.Create(ctx, rs)).To(Succeed())
+	setResourceSetInventory(ctx, g, rs, []fluxcdv1.ResourceRef{{
+		ID: inventoryIDForConfigMap(ns.Name, cmName), Version: "v1",
+	}})
+
+	kubeconfigArgs.Namespace = &ns.Name
+	output, err := executeCommand([]string{"migrate", "owner", "rset/owner"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("already clean"))
+
+	remaining := configMapManagers(ctx, g, ns.Name, cmName)
+	g.Expect(remaining).To(ContainElement(fluxcdv1.FluxOperator))
+	g.Expect(remaining).To(ContainElement(kubectlFieldManager))
+}
+
+func TestMigrateOwnerCmd_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "migrate-owner-dryrun")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cmName := "dry"
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns.Name},
+	}
+	g.Expect(testClient.Create(ctx, cm)).To(Succeed())
+	seedManagedFields(ctx, g, cm, applyFields(fluxcdv1.FluxOperator, fluxcdv1.FluxHelmController))
+
+	rs := newResourceSet(ns.Name)
+	g.Expect(testClient.Create(ctx, rs)).To(Succeed())
+	setResourceSetInventory(ctx, g, rs, []fluxcdv1.ResourceRef{{
+		ID: inventoryIDForConfigMap(ns.Name, cmName), Version: "v1",
+	}})
+
+	kubeconfigArgs.Namespace = &ns.Name
+	output, err := executeCommand([]string{"migrate", "owner", "rset/owner", "--dry-run"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("would strip managers"))
+	g.Expect(output).To(ContainSubstring(fluxcdv1.FluxHelmController))
+	g.Expect(output).To(ContainSubstring("1/1 resources need cleanup"))
+
+	// Dry-run must not mutate the target.
+	remaining := configMapManagers(ctx, g, ns.Name, cmName)
+	g.Expect(remaining).To(ContainElement(fluxcdv1.FluxHelmController))
+}
+
+func TestMigrateOwnerCmd_FreesOrphanedDataKeys(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "migrate-owner-data")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cmName := "app-data"
+
+	// flux-kustomize-controller applies the ConfigMap with two data keys.
+	ksApply := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: ns.Name,
+		},
+		Data: map[string]string{
+			"kept":   "v1",
+			"orphan": "v2",
+		},
+	}
+	g.Expect(testClient.Patch(ctx, ksApply, client.Apply,
+		client.ForceOwnership, client.FieldOwner(fluxcdv1.FluxKustomizeController))).To(Succeed())
+
+	// flux-operator takes ownership of both keys via a force apply so the
+	// new owner is authoritative before migrate runs.
+	foApply := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: ns.Name,
+		},
+		Data: map[string]string{
+			"kept":   "v1",
+			"orphan": "v2",
+		},
+	}
+	g.Expect(testClient.Patch(ctx, foApply, client.Apply,
+		client.ForceOwnership, client.FieldOwner(fluxcdv1.FluxOperator))).To(Succeed())
+
+	rs := newResourceSet(ns.Name)
+	g.Expect(testClient.Create(ctx, rs)).To(Succeed())
+	setResourceSetInventory(ctx, g, rs, []fluxcdv1.ResourceRef{{
+		ID: inventoryIDForConfigMap(ns.Name, cmName), Version: "v1",
+	}})
+
+	kubeconfigArgs.Namespace = &ns.Name
+	_, err = executeCommand([]string{"migrate", "owner", "rset/owner"})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// After the stale manager is stripped and the current owner reapplies
+	// its desired state, the orphan data key must be deleted.
+	foReapply := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: ns.Name,
+		},
+		Data: map[string]string{"kept": "v1"},
+	}
+	g.Expect(testClient.Patch(ctx, foReapply, client.Apply,
+		client.ForceOwnership, client.FieldOwner(fluxcdv1.FluxOperator))).To(Succeed())
+
+	cm := &corev1.ConfigMap{}
+	g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: cmName}, cm)).To(Succeed())
+	g.Expect(cm.Data).To(HaveLen(1))
+	g.Expect(cm.Data).To(HaveKeyWithValue("kept", "v1"))
+	g.Expect(cm.Data).ToNot(HaveKey("orphan"))
+}
+
+func newResourceSet(namespace string) *fluxcdv1.ResourceSet {
+	return &fluxcdv1.ResourceSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: namespace},
+		Spec: fluxcdv1.ResourceSetSpec{
+			ResourcesTemplate: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: placeholder`,
+		},
+	}
+}
+
+func newFluxInstance(namespace string) *fluxcdv1.FluxInstance {
+	return &fluxcdv1.FluxInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "flux", Namespace: namespace},
+		Spec: fluxcdv1.FluxInstanceSpec{
+			Distribution: fluxcdv1.Distribution{
+				Version:  "2.x",
+				Registry: "ghcr.io/fluxcd",
+			},
+		},
+	}
+}

--- a/cmd/cli/migrate_resources.go
+++ b/cmd/cli/migrate_resources.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/fluxcd/pkg/ssa"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
 	"github.com/spf13/cobra"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,46 +127,41 @@ func migrateResourcesCmdRun(cmd *cobra.Command, args []string) error {
 
 	for i := range list.Items {
 		u := &list.Items[i]
-		name := u.GetName()
-		namespace := u.GetNamespace()
-		qualified := name
-		if namespace != "" {
-			qualified = namespace + "/" + name
-		}
+		qualified := ssautil.FmtUnstructured(u)
 
 		patches, err := ssa.PatchMigrateToVersion(u, migrateResourcesArgs.apiVersion)
 		if err != nil {
-			rootCmd.Printf("✗ %s %s: failed to build migration patch: %v\n", gvk.Kind, qualified, err)
+			rootCmd.Printf("✗ %s: failed to build migration patch: %v\n", qualified, err)
 			failures++
 			continue
 		}
 		if len(patches) == 0 {
-			rootCmd.Printf("• %s %s already at %s\n", gvk.Kind, qualified, migrateResourcesArgs.apiVersion)
+			rootCmd.Printf("• %s already at %s\n", qualified, migrateResourcesArgs.apiVersion)
 			continue
 		}
 
 		if migrateResourcesArgs.dryRun {
 			managers := staleManagers(u.GetManagedFields(), migrateResourcesArgs.apiVersion)
-			rootCmd.Printf("◎ %s %s needs migration (managers: %s)\n",
-				gvk.Kind, qualified, strings.Join(managers, ", "))
+			rootCmd.Printf("◎ %s needs migration (managers: %s)\n",
+				qualified, strings.Join(managers, ", "))
 			migrated++
 			continue
 		}
 
 		patchBytes, err := json.Marshal(patches)
 		if err != nil {
-			rootCmd.Printf("✗ %s %s: failed to marshal patch: %v\n", gvk.Kind, qualified, err)
+			rootCmd.Printf("✗ %s: failed to marshal patch: %v\n", qualified, err)
 			failures++
 			continue
 		}
 
 		if err := kubeClient.Patch(ctx, u, client.RawPatch(types.JSONPatchType, patchBytes)); err != nil {
-			rootCmd.Printf("✗ %s %s: failed to migrate: %v\n", gvk.Kind, qualified, err)
+			rootCmd.Printf("✗ %s: failed to migrate: %v\n", qualified, err)
 			failures++
 			continue
 		}
 
-		rootCmd.Printf("✔ %s %s migrated to %s\n", gvk.Kind, qualified, migrateResourcesArgs.apiVersion)
+		rootCmd.Printf("✔ %s migrated to %s\n", qualified, migrateResourcesArgs.apiVersion)
 		migrated++
 	}
 

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -184,6 +184,7 @@ func resetCmdArgs() {
 
 	// Migrate commands
 	migrateResourcesArgs = migrateResourcesFlags{}
+	migrateOwnerArgs = migrateOwnerFlags{}
 
 	// Patch commands
 	patchInstanceArgs = patchInstanceFlags{version: "main", components: nil}

--- a/internal/inventory/reader.go
+++ b/internal/inventory/reader.go
@@ -26,6 +26,40 @@ import (
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
 
+// FromUnstructured extracts the inventory entries from the status of a Kubernetes
+// object. This function is suitable for the following kinds: Flux HelmRelease (v2.8+),
+// Kustomization, ResourceSet, and FluxInstance. It returns an empty slice when no
+// inventory is present.
+func FromUnstructured(obj *unstructured.Unstructured) ([]fluxcdv1.ResourceRef, error) {
+	result := make([]fluxcdv1.ResourceRef, 0)
+
+	entries, exists, err := unstructured.NestedSlice(obj.Object, "status", "inventory", "entries")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read status.inventory.entries: %w", err)
+	}
+	if !exists || len(entries) == 0 {
+		return result, nil
+	}
+
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, found := entryMap["id"].(string)
+		if !found {
+			continue
+		}
+		v, found := entryMap["v"].(string)
+		if !found {
+			continue
+		}
+		result = append(result, fluxcdv1.ResourceRef{ID: id, Version: v})
+	}
+
+	return result, nil
+}
+
 // FromStatusOf inspects the status of a Kubernetes object and extracts the
 // inventory entries from it. This function is suitable for the following kinds:
 // Flux Kustomization, ResourceSet, and FluxInstance.
@@ -34,8 +68,6 @@ func FromStatusOf(
 	kubeClient client.Client,
 	ref fluxcdv1.ResourceRef,
 ) ([]fluxcdv1.ResourceRef, error) {
-	result := make([]fluxcdv1.ResourceRef, 0)
-
 	obj, err := EntryToUnstructured(ref)
 	if err != nil {
 		return nil, err
@@ -51,24 +83,7 @@ func FromStatusOf(
 		return nil, fmt.Errorf("failed to get %s/%s: %w", obj.GetKind(), objKey.String(), err)
 	}
 
-	// If the object has a status.inventory.entries field, extract the entries.
-	if entries, exists, _ := unstructured.NestedSlice(obj.Object, "status", "inventory", "entries"); exists && len(entries) > 0 {
-		for _, entry := range entries {
-			if entryMap, ok := entry.(map[string]any); ok {
-				id, found := entryMap["id"].(string)
-				if !found {
-					continue
-				}
-				v, found := entryMap["v"].(string)
-				if !found {
-					continue
-				}
-				result = append(result, fluxcdv1.ResourceRef{ID: id, Version: v})
-			}
-		}
-	}
-
-	return result, nil
+	return FromUnstructured(obj)
 }
 
 // HelmStorage is a struct used to decode the Helm storage secret.
@@ -112,21 +127,10 @@ func FromHelmRelease(
 	}
 
 	// Check for status.inventory.entries first (Flux v2.8+)
-	if entries, exists, _ := unstructured.NestedSlice(hrObj.Object, "status", "inventory", "entries"); exists && len(entries) > 0 {
-		for _, entry := range entries {
-			if entryMap, ok := entry.(map[string]any); ok {
-				id, found := entryMap["id"].(string)
-				if !found {
-					continue
-				}
-				v, found := entryMap["v"].(string)
-				if !found {
-					continue
-				}
-				result = append(result, fluxcdv1.ResourceRef{ID: id, Version: v})
-			}
-		}
-		return result, nil
+	if statusEntries, err := FromUnstructured(hrObj); err != nil {
+		return nil, err
+	} else if len(statusEntries) > 0 {
+		return statusEntries, nil
 	}
 
 	// Fallback to Helm storage secret for older versions of Flux


### PR DESCRIPTION
The migrate owner command takes a Flux applier resource (`HelmRelease`, `Kustomization`, `ResourceSet`, or `FluxInstance`) and removes stale managed fields entries left behind by *other* Flux field managers on every resource listed in its `status.inventory`. This is intended to resolve post-migration issues where a field set by a previous Flux applier is retained even after the resource is reassigned to a new applier.

Example for migrating the managed fields of podinfo resources after helm-controller takes ownership from kustomize-controller:

```bash
flux-operator -n apps migrate owner hr/podinfo --dry-run
```

Transferring ownership workflow:

1. A Flux Kustomization named `podinfo` reconciles the  `podinfo` Deployment, Service, etc
2. We suspend the `podinfo` Kustomization and we delete it from source
3. We wait for Flux to sync it, the `podinfo` Deployment, Service, etc are left in the cluster
4. We add a HelmRelease for `podinfo`, helm-controller becomes the co-owner of the Deployment, Service, etc
5. We run `flux-operator -n apps migrate owner hr/podinfo `
6. From this moment on, helm-controller is the sole owner of podinfo and can remove fields from the Deployment, Service, etc


Note that this command requires Flux 2.8+

Closes: #740