### PR TITLE
rset: Watch external references from `checksumFrom`

### DIFF
--- a/api/v1/resourceset_types.go
+++ b/api/v1/resourceset_types.go
@@ -205,6 +205,14 @@ type ResourceSetStatus struct {
 	// +optional
 	LastAppliedRevision string `json:"lastAppliedRevision,omitempty"`
 
+	// ExternalChecksumRefs lists the ConfigMap and Secret references
+	// discovered in checksumFrom annotations on the last reconciliation
+	// that point to objects not rendered by this ResourceSet. Each entry
+	// has the form "Kind/namespace/name". It is used to trigger a
+	// reconciliation when one of the referenced objects changes.
+	// +optional
+	ExternalChecksumRefs []string `json:"externalChecksumRefs,omitempty"`
+
 	// History contains the reconciliation history of the ResourceSet
 	// as a list of snapshots ordered by the last reconciled time.
 	History History `json:"history,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1332,6 +1332,11 @@ func (in *ResourceSetStatus) DeepCopyInto(out *ResourceSetStatus) {
 		*out = new(ResourceInventory)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExternalChecksumRefs != nil {
+		in, out := &in.ExternalChecksumRefs, &out.ExternalChecksumRefs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.History != nil {
 		in, out := &in.History, &out.History
 		*out = make(History, len(*in))

--- a/config/crd/bases/fluxcd.controlplane.io_resourcesets.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_resourcesets.yaml
@@ -310,6 +310,16 @@ spec:
                   - type
                   type: object
                 type: array
+              externalChecksumRefs:
+                description: |-
+                  ExternalChecksumRefs lists the ConfigMap and Secret references
+                  discovered in checksumFrom annotations on the last reconciliation
+                  that point to objects not rendered by this ResourceSet. Each entry
+                  has the form "Kind/namespace/name". It is used to trigger a
+                  reconciliation when one of the referenced objects changes.
+                items:
+                  type: string
+                type: array
               history:
                 description: |-
                   History contains the reconciliation history of the ResourceSet

--- a/internal/controller/resourceset_controller.go
+++ b/internal/controller/resourceset_controller.go
@@ -486,9 +486,11 @@ func (r *ResourceSetReconciler) apply(ctx context.Context,
 		return "", err
 	}
 
-	if err := r.computeChecksumsFromAnnotations(ctx, kubeClient, objects); err != nil {
+	externalRefs, err := r.computeChecksumsFromAnnotations(ctx, kubeClient, objects)
+	if err != nil {
 		return "", err
 	}
+	obj.Status.ExternalChecksumRefs = externalRefs
 
 	if err := normalize.UnstructuredList(objects); err != nil {
 		return "", err

--- a/internal/controller/resourceset_controller_configs.go
+++ b/internal/controller/resourceset_controller_configs.go
@@ -203,15 +203,20 @@ func (r *ResourceSetReconciler) convertKubeConfigResources(
 // about-to-be-applied data rather than any absent or stale cluster state.
 // Repeated references to the same source within a single reconciliation
 // are fetched at most once.
+//
+// It returns the sorted list of external references resolved from the
+// cluster, so the caller can persist them on the ResourceSet status and
+// trigger reconciliation when any of them changes. In-set references are
+// omitted because their changes already change the applied digest.
 func (r *ResourceSetReconciler) computeChecksumsFromAnnotations(ctx context.Context,
-	kubeClient client.Client, objects []*unstructured.Unstructured) error {
+	kubeClient client.Client, objects []*unstructured.Unstructured) ([]string, error) {
 	cr := newChecksumResolver(ctx, kubeClient, objects)
 	for i := range objects {
 		if err := cr.walk(objects[i].Object); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return cr.externalRefs(), nil
 }
 
 // checksumResolver resolves checksumFrom references during a single
@@ -224,6 +229,7 @@ type checksumResolver struct {
 	client    client.Client
 	rendered  map[string]*unstructured.Unstructured
 	canonical map[string]map[string][]byte
+	external  map[string]struct{}
 }
 
 func newChecksumResolver(ctx context.Context, c client.Client,
@@ -239,7 +245,23 @@ func newChecksumResolver(ctx context.Context, c client.Client,
 		client:    c,
 		rendered:  rendered,
 		canonical: make(map[string]map[string][]byte),
+		external:  make(map[string]struct{}),
 	}
+}
+
+// externalRefs returns the sorted list of references that were resolved
+// from the cluster (not from the in-set rendered slice). Used by the
+// caller to persist the dependency set on the ResourceSet status.
+func (cr *checksumResolver) externalRefs() []string {
+	if len(cr.external) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(cr.external))
+	for k := range cr.external {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // checksumRefKey builds the canonical "Kind/namespace/name" string used to
@@ -346,6 +368,7 @@ func (cr *checksumResolver) data(kind, ns, name string) (map[string][]byte, erro
 		d, err = canonicalFromUnstructured(u)
 	} else {
 		d, err = cr.fetchCanonical(kind, ns, name)
+		cr.external[key] = struct{}{}
 	}
 	if err != nil {
 		return nil, err

--- a/internal/controller/resourceset_controller_configs.go
+++ b/internal/controller/resourceset_controller_configs.go
@@ -210,9 +210,9 @@ func (r *ResourceSetReconciler) convertKubeConfigResources(
 // omitted because their changes already change the applied digest.
 func (r *ResourceSetReconciler) computeChecksumsFromAnnotations(ctx context.Context,
 	kubeClient client.Client, objects []*unstructured.Unstructured) ([]string, error) {
-	cr := newChecksumResolver(ctx, kubeClient, objects)
+	cr := newChecksumResolver(kubeClient, objects)
 	for i := range objects {
-		if err := cr.walk(objects[i].Object); err != nil {
+		if err := cr.walk(ctx, objects[i].Object); err != nil {
 			return nil, err
 		}
 	}
@@ -225,14 +225,13 @@ func (r *ResourceSetReconciler) computeChecksumsFromAnnotations(ctx context.Cont
 // data (not from an absent or stale cluster copy), and caches canonical
 // data per reference so repeated references fetch at most once.
 type checksumResolver struct {
-	ctx       context.Context
 	client    client.Client
 	rendered  map[string]*unstructured.Unstructured
 	canonical map[string]map[string][]byte
 	external  map[string]struct{}
 }
 
-func newChecksumResolver(ctx context.Context, c client.Client,
+func newChecksumResolver(c client.Client,
 	objects []*unstructured.Unstructured) *checksumResolver {
 	rendered := make(map[string]*unstructured.Unstructured)
 	for _, o := range objects {
@@ -241,7 +240,6 @@ func newChecksumResolver(ctx context.Context, c client.Client,
 		}
 	}
 	return &checksumResolver{
-		ctx:       ctx,
 		client:    c,
 		rendered:  rendered,
 		canonical: make(map[string]map[string][]byte),
@@ -279,13 +277,13 @@ func checksumRefKey(kind, namespace, name string) string {
 // Kubernetes ObjectMeta locations such as metadata.annotations,
 // spec.template.metadata.annotations and
 // spec.jobTemplate.spec.template.metadata.annotations.
-func (cr *checksumResolver) walk(node any) error {
+func (cr *checksumResolver) walk(ctx context.Context, node any) error {
 	switch v := node.(type) {
 	case map[string]any:
 		if metaMap, ok := v["metadata"].(map[string]any); ok {
 			if ann, ok := metaMap["annotations"].(map[string]any); ok {
 				if raw, ok := ann[fluxcdv1.ChecksumFromAnnotation].(string); ok && raw != "" {
-					sum, err := cr.resolve(raw)
+					sum, err := cr.resolve(ctx, raw)
 					if err != nil {
 						return err
 					}
@@ -294,13 +292,13 @@ func (cr *checksumResolver) walk(node any) error {
 			}
 		}
 		for _, val := range v {
-			if err := cr.walk(val); err != nil {
+			if err := cr.walk(ctx, val); err != nil {
 				return err
 			}
 		}
 	case []any:
 		for _, item := range v {
-			if err := cr.walk(item); err != nil {
+			if err := cr.walk(ctx, item); err != nil {
 				return err
 			}
 		}
@@ -311,7 +309,7 @@ func (cr *checksumResolver) walk(node any) error {
 // resolve parses a comma-separated list of ConfigMap/Secret references,
 // resolves each one via data(), and returns a "sha256:<hex>" digest over
 // the combined null-delimited input.
-func (cr *checksumResolver) resolve(refs string) (string, error) {
+func (cr *checksumResolver) resolve(ctx context.Context, refs string) (string, error) {
 	var buf bytes.Buffer
 	for ref := range strings.SplitSeq(refs, ",") {
 		ref = strings.TrimSpace(ref)
@@ -329,7 +327,7 @@ func (cr *checksumResolver) resolve(refs string) (string, error) {
 				kind, fluxcdv1.ChecksumFromAnnotation)
 		}
 
-		data, err := cr.data(kind, ns, name)
+		data, err := cr.data(ctx, kind, ns, name)
 		if err != nil {
 			return "", err
 		}
@@ -355,7 +353,7 @@ func (cr *checksumResolver) resolve(refs string) (string, error) {
 // ConfigMap or Secret, pulling from the in-set rendered slice when
 // available and falling back to the cluster. Results are cached so
 // repeated references within a single reconcile resolve at most once.
-func (cr *checksumResolver) data(kind, ns, name string) (map[string][]byte, error) {
+func (cr *checksumResolver) data(ctx context.Context, kind, ns, name string) (map[string][]byte, error) {
 	key := checksumRefKey(kind, ns, name)
 	if d, ok := cr.canonical[key]; ok {
 		return d, nil
@@ -367,7 +365,7 @@ func (cr *checksumResolver) data(kind, ns, name string) (map[string][]byte, erro
 	if u, ok := cr.rendered[key]; ok {
 		d, err = canonicalFromUnstructured(u)
 	} else {
-		d, err = cr.fetchCanonical(kind, ns, name)
+		d, err = cr.fetchCanonical(ctx, kind, ns, name)
 		cr.external[key] = struct{}{}
 	}
 	if err != nil {
@@ -379,12 +377,12 @@ func (cr *checksumResolver) data(kind, ns, name string) (map[string][]byte, erro
 
 // fetchCanonical issues a cluster Get for the referenced ConfigMap or
 // Secret and returns its data as a canonical map[string][]byte.
-func (cr *checksumResolver) fetchCanonical(kind, ns, name string) (map[string][]byte, error) {
+func (cr *checksumResolver) fetchCanonical(ctx context.Context, kind, ns, name string) (map[string][]byte, error) {
 	nn := types.NamespacedName{Namespace: ns, Name: name}
 	switch kind {
 	case kindConfigMap:
 		cm := &corev1.ConfigMap{}
-		if err := cr.client.Get(cr.ctx, nn, cm); err != nil {
+		if err := cr.client.Get(ctx, nn, cm); err != nil {
 			return nil, fmt.Errorf("failed to resolve %s reference ConfigMap/%s/%s: %w",
 				fluxcdv1.ChecksumFromAnnotation, ns, name, err)
 		}
@@ -396,7 +394,7 @@ func (cr *checksumResolver) fetchCanonical(kind, ns, name string) (map[string][]
 		return out, nil
 	case kindSecret:
 		secret := &corev1.Secret{}
-		if err := cr.client.Get(cr.ctx, nn, secret); err != nil {
+		if err := cr.client.Get(ctx, nn, secret); err != nil {
 			return nil, fmt.Errorf("failed to resolve %s reference Secret/%s/%s: %w",
 				fluxcdv1.ChecksumFromAnnotation, ns, name, err)
 		}

--- a/internal/controller/resourceset_controller_configs_test.go
+++ b/internal/controller/resourceset_controller_configs_test.go
@@ -819,19 +819,19 @@ func TestResourceSetReconciler_ChecksumFromCanonicalParity(t *testing.T) {
 
 	refs := fmt.Sprintf("ConfigMap/%s/parity-cm", ns.Name)
 
-	clusterSum, err := newChecksumResolver(ctx, testClient, nil).resolve(refs)
+	clusterSum, err := newChecksumResolver(testClient, nil).resolve(ctx, refs)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(clusterSum).To(HavePrefix("sha256:"))
 
 	// Empty refs from trailing, leading, or doubled commas are ignored.
 	for _, variant := range []string{refs + ",", "," + refs, refs + ",,", ",," + refs + ",,"} {
-		sum, err := newChecksumResolver(ctx, testClient, nil).resolve(variant)
+		sum, err := newChecksumResolver(testClient, nil).resolve(ctx, variant)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(sum).To(Equal(clusterSum))
 	}
 
-	inSetSum, err := newChecksumResolver(ctx, testClient,
-		[]*unstructured.Unstructured{renderedCM}).resolve(refs)
+	inSetSum, err := newChecksumResolver(testClient,
+		[]*unstructured.Unstructured{renderedCM}).resolve(ctx, refs)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(inSetSum).To(Equal(clusterSum))
 
@@ -865,11 +865,11 @@ func TestResourceSetReconciler_ChecksumFromCanonicalParity(t *testing.T) {
 	}, "stringData")).To(Succeed())
 
 	secretRefs := fmt.Sprintf("Secret/%s/parity-secret", ns.Name)
-	clusterSecretSum, err := newChecksumResolver(ctx, testClient, nil).resolve(secretRefs)
+	clusterSecretSum, err := newChecksumResolver(testClient, nil).resolve(ctx, secretRefs)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	inSetSecretSum, err := newChecksumResolver(ctx, testClient,
-		[]*unstructured.Unstructured{renderedSecret}).resolve(secretRefs)
+	inSetSecretSum, err := newChecksumResolver(testClient,
+		[]*unstructured.Unstructured{renderedSecret}).resolve(ctx, secretRefs)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(inSetSecretSum).To(Equal(clusterSecretSum))
 }

--- a/internal/controller/resourceset_controller_configs_test.go
+++ b/internal/controller/resourceset_controller_configs_test.go
@@ -591,6 +591,13 @@ spec:
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(conditions.GetReason(result, meta.ReadyCondition)).To(BeIdenticalTo(meta.ReconciliationSucceededReason))
 
+	// Both references are resolved from the cluster, so they are tracked
+	// as external dependencies to drive watch-based reconciliation.
+	g.Expect(result.Status.ExternalChecksumRefs).To(ConsistOf(
+		fmt.Sprintf("ConfigMap/%s/app-config", ns.Name),
+		fmt.Sprintf("Secret/%s/app-secret", ns.Name),
+	))
+
 	// Verify the applied Deployment has both checksumFrom and checksum
 	// annotations on its pod template.
 	resultDep := &appsv1.Deployment{}
@@ -733,6 +740,10 @@ spec:
 	err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(conditions.GetReason(result, meta.ReadyCondition)).To(BeIdenticalTo(meta.ReconciliationSucceededReason))
+
+	// The only reference is resolved from the in-set pending data, so the
+	// ResourceSet declares no external dependencies.
+	g.Expect(result.Status.ExternalChecksumRefs).To(BeEmpty())
 
 	// The checksum must be set even though the ConfigMap did not exist
 	// in the cluster when reconciliation started.

--- a/internal/controller/resourceset_manager.go
+++ b/internal/controller/resourceset_manager.go
@@ -162,10 +162,12 @@ func (r *ResourceSetReconciler) requestsForResourceSetInputProviders(
 	return reqs
 }
 
-// requestsForConfigMapsOrSecrets lists the metadata of all ConfigMaps or Secrets created
-// by ResourceSets (depending on the kind of the object that triggered the event), and for
-// each ResourceSet being referenced in a copyFrom annotation, a reconcile.Request is
-// included in the returned slice.
+// requestsForConfigMapsOrSecrets enqueues ResourceSets that depend on the
+// ConfigMap or Secret that triggered the event. A ResourceSet is
+// considered dependent if either:
+//   - it applied a ConfigMap or Secret that uses the triggering object
+//     as a copyFrom source, or
+//   - its status.externalChecksumRefs lists the triggering object.
 func (r *ResourceSetReconciler) requestsForConfigMapsOrSecrets(ctx context.Context,
 	obj client.Object) []reconcile.Request {
 
@@ -174,6 +176,9 @@ func (r *ResourceSetReconciler) requestsForConfigMapsOrSecrets(ctx context.Conte
 	// Compute object metadata.
 	objKind := obj.GetObjectKind().GroupVersionKind().Kind
 	objKey := client.ObjectKeyFromObject(obj).String()
+	objRef := objKind + "/" + objKey
+
+	resourceSets := make(map[types.NamespacedName]struct{})
 
 	// List the metadata of all objects of the same kind that were created by
 	// ResourceSets. The WatchesMetadata call in SetupWithManager causes
@@ -208,8 +213,7 @@ func (r *ResourceSetReconciler) requestsForConfigMapsOrSecrets(ctx context.Conte
 	}
 
 	// Match listed objects with the object that triggered the event
-	// to generate a list of reconcile.Requests.
-	resourceSets := make(map[types.NamespacedName]struct{})
+	// via the copyFrom annotation.
 	for _, appliedObject := range appliedObjects.Items {
 		copyFrom := appliedObject.GetAnnotations()[fluxcdv1.CopyFromAnnotation]
 		if copyFrom != objKey {
@@ -222,6 +226,29 @@ func (r *ResourceSetReconciler) requestsForConfigMapsOrSecrets(ctx context.Conte
 		}
 		resourceSets[rset] = struct{}{}
 	}
+
+	// Match ResourceSets whose status.externalChecksumRefs contains the
+	// triggering object. The ResourceSet informer is a full-object cache,
+	// so this List hits memory rather than the API server.
+	var rsetList fluxcdv1.ResourceSetList
+	if err := r.List(ctx, &rsetList, client.UnsafeDisableDeepCopy); err != nil {
+		log.Error(err, "failed to list ResourceSets for checksum ref match",
+			"eventTrigger", map[string]any{
+				"kind":      objKind,
+				"name":      obj.GetName(),
+				"namespace": obj.GetNamespace(),
+			})
+	} else {
+		for _, rs := range rsetList.Items {
+			for _, ref := range rs.Status.ExternalChecksumRefs {
+				if ref == objRef {
+					resourceSets[types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}] = struct{}{}
+					break
+				}
+			}
+		}
+	}
+
 	reqs := make([]reconcile.Request, 0, len(resourceSets))
 	for rset := range resourceSets {
 		reqs = append(reqs, reconcile.Request{NamespacedName: rset})

--- a/internal/controller/resourceset_manager_test.go
+++ b/internal/controller/resourceset_manager_test.go
@@ -214,6 +214,32 @@ func TestResourceSetReconciler_requestsForConfigMapsOrSecrets(t *testing.T) {
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
+	// Create a ResourceSet whose status references an external ConfigMap
+	// and an external Secret via checksumFrom.
+	rsetWithRefs := &fluxcdv1.ResourceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rset-with-external-refs",
+			Namespace: ns.Name,
+		},
+	}
+	err = testEnv.Create(ctx, rsetWithRefs)
+	g.Expect(err).NotTo(HaveOccurred())
+	rsetWithRefs.Status.ExternalChecksumRefs = []string{
+		"ConfigMap/external-ns/external-cm",
+		"Secret/external-ns/external-secret",
+	}
+	err = testEnv.Status().Update(ctx, rsetWithRefs)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Create a second ResourceSet with no external refs.
+	err = testEnv.Create(ctx, &fluxcdv1.ResourceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rset-without-external-refs",
+			Namespace: ns.Name,
+		},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
 	// TypeMetas.
 	cmTypeMeta := metav1.TypeMeta{
 		APIVersion: corev1.SchemeGroupVersion.String(),
@@ -294,6 +320,49 @@ func TestResourceSetReconciler_requestsForConfigMapsOrSecrets(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "secret-without-labels",
 					Namespace: ns.Name,
+				},
+			},
+			expectedRequests: nil,
+		},
+		{
+			name: "ConfigMap referenced by checksumFrom in status",
+			obj: &metav1.PartialObjectMetadata{
+				TypeMeta: cmTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "external-cm",
+					Namespace: "external-ns",
+				},
+			},
+			expectedRequests: []reconcile.Request{{
+				NamespacedName: client.ObjectKey{
+					Name:      "rset-with-external-refs",
+					Namespace: ns.Name,
+				},
+			}},
+		},
+		{
+			name: "Secret referenced by checksumFrom in status",
+			obj: &metav1.PartialObjectMetadata{
+				TypeMeta: secretTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "external-secret",
+					Namespace: "external-ns",
+				},
+			},
+			expectedRequests: []reconcile.Request{{
+				NamespacedName: client.ObjectKey{
+					Name:      "rset-with-external-refs",
+					Namespace: ns.Name,
+				},
+			}},
+		},
+		{
+			name: "ConfigMap not referenced by any checksumFrom",
+			obj: &metav1.PartialObjectMetadata{
+				TypeMeta: cmTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unreferenced-cm",
+					Namespace: "external-ns",
 				},
 			},
 			expectedRequests: nil,


### PR DESCRIPTION
Also removing `ctx` from the `checksumResolver` struct.