### PR TITLE
rset: Watch `convertKubeConfigFrom` Secrets

### DIFF
--- a/docs/api/v1/resourceset.md
+++ b/docs/api/v1/resourceset.md
@@ -543,6 +543,10 @@ and the CA certificate from the first cluster entry, and populates the
 If the ConfigMap template already contains `address` or `ca.crt` fields,
 the existing values are preserved and not overwritten.
 
+To trigger an immediate reconciliation of the ResourceSet when the referenced
+kubeconfig Secret changes, you can set the `reconcile.fluxcd.io/watch: Enabled`
+label on the Secret.
+
 Example using a custom Secret key:
 
 ```yaml

--- a/internal/controller/resourceset_manager.go
+++ b/internal/controller/resourceset_manager.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -167,6 +168,8 @@ func (r *ResourceSetReconciler) requestsForResourceSetInputProviders(
 // considered dependent if either:
 //   - it applied a ConfigMap or Secret that uses the triggering object
 //     as a copyFrom source, or
+//   - it applied a ConfigMap that uses the triggering Secret as a
+//     convertKubeConfigFrom source, or
 //   - its status.externalChecksumRefs lists the triggering object.
 func (r *ResourceSetReconciler) requestsForConfigMapsOrSecrets(ctx context.Context,
 	obj client.Object) []reconcile.Request {
@@ -225,6 +228,44 @@ func (r *ResourceSetReconciler) requestsForConfigMapsOrSecrets(ctx context.Conte
 			Namespace: objLabels[fluxcdv1.OwnerLabelResourceSetNamespace],
 		}
 		resourceSets[rset] = struct{}{}
+	}
+
+	// When the trigger is a Secret, match applied ConfigMaps whose
+	// convertKubeConfigFrom annotation references it. The annotation
+	// value may be 'namespace/name' or 'namespace/name:key'.
+	if objKind == kindSecret {
+		var appliedConfigMaps metav1.PartialObjectMetadataList
+		appliedConfigMaps.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind(kindConfigMap))
+		if err := r.List(ctx, &appliedConfigMaps, listOpts...); err != nil {
+			log.Error(err, "failed to list ConfigMaps applied by ResourceSets",
+				"eventTrigger", map[string]any{
+					"kind":      objKind,
+					"name":      obj.GetName(),
+					"namespace": obj.GetNamespace(),
+				})
+		} else {
+			for _, appliedObject := range appliedConfigMaps.Items {
+				convertFrom := appliedObject.GetAnnotations()[fluxcdv1.ConvertKubeConfigFromAnnotation]
+				if convertFrom == "" {
+					continue
+				}
+				nameRef := convertFrom
+				if colonIdx := strings.LastIndex(convertFrom, ":"); colonIdx > 0 {
+					if slashIdx := strings.Index(convertFrom, "/"); slashIdx > 0 && colonIdx > slashIdx {
+						nameRef = convertFrom[:colonIdx]
+					}
+				}
+				if nameRef != objKey {
+					continue
+				}
+				objLabels := appliedObject.GetLabels()
+				rset := types.NamespacedName{
+					Name:      objLabels[fluxcdv1.OwnerLabelResourceSetName],
+					Namespace: objLabels[fluxcdv1.OwnerLabelResourceSetNamespace],
+				}
+				resourceSets[rset] = struct{}{}
+			}
+		}
 	}
 
 	// Match ResourceSets whose status.externalChecksumRefs contains the

--- a/internal/controller/resourceset_manager_test.go
+++ b/internal/controller/resourceset_manager_test.go
@@ -190,6 +190,40 @@ func TestResourceSetReconciler_requestsForConfigMapsOrSecrets(t *testing.T) {
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
+	// Create ConfigMap with ResourceSet owner labels and a convertKubeConfigFrom
+	// annotation using the plain 'namespace/name' form.
+	err = testEnv.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-kubeconfig-plain",
+			Namespace: ns.Name,
+			Annotations: map[string]string{
+				fluxcdv1.ConvertKubeConfigFromAnnotation: "kc-ns/kc-secret",
+			},
+			Labels: map[string]string{
+				fluxcdv1.OwnerLabelResourceSetName:      "rset-kc",
+				fluxcdv1.OwnerLabelResourceSetNamespace: "rset-kc-ns",
+			},
+		},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Create ConfigMap with ResourceSet owner labels and a convertKubeConfigFrom
+	// annotation using the 'namespace/name:key' form.
+	err = testEnv.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-kubeconfig-keyed",
+			Namespace: ns.Name,
+			Annotations: map[string]string{
+				fluxcdv1.ConvertKubeConfigFromAnnotation: "kc-ns/kc-secret-keyed:myKey",
+			},
+			Labels: map[string]string{
+				fluxcdv1.OwnerLabelResourceSetName:      "rset-kc-keyed",
+				fluxcdv1.OwnerLabelResourceSetNamespace: "rset-kc-ns",
+			},
+		},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
 	// Create ConfigMap without ResourceSet owner labels.
 	err = testEnv.Create(ctx, &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -355,6 +389,49 @@ func TestResourceSetReconciler_requestsForConfigMapsOrSecrets(t *testing.T) {
 					Namespace: ns.Name,
 				},
 			}},
+		},
+		{
+			name: "Secret referenced by convertKubeConfigFrom annotation",
+			obj: &metav1.PartialObjectMetadata{
+				TypeMeta: secretTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kc-secret",
+					Namespace: "kc-ns",
+				},
+			},
+			expectedRequests: []reconcile.Request{{
+				NamespacedName: client.ObjectKey{
+					Name:      "rset-kc",
+					Namespace: "rset-kc-ns",
+				},
+			}},
+		},
+		{
+			name: "Secret referenced by convertKubeConfigFrom annotation with key suffix",
+			obj: &metav1.PartialObjectMetadata{
+				TypeMeta: secretTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kc-secret-keyed",
+					Namespace: "kc-ns",
+				},
+			},
+			expectedRequests: []reconcile.Request{{
+				NamespacedName: client.ObjectKey{
+					Name:      "rset-kc-keyed",
+					Namespace: "rset-kc-ns",
+				},
+			}},
+		},
+		{
+			name: "ConfigMap trigger does not match convertKubeConfigFrom",
+			obj: &metav1.PartialObjectMetadata{
+				TypeMeta: cmTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kc-secret",
+					Namespace: "kc-ns",
+				},
+			},
+			expectedRequests: nil,
 		},
 		{
 			name: "ConfigMap not referenced by any checksumFrom",


### PR DESCRIPTION
React immediately for kubeconfig conversions. Same label as always for ConfigMaps and Secrets: `reconcile.fluxcd.io/watch: Enabled`.