### PR TITLE
rset: Add `includeEmptyProviders` option to `Permute` `inputStrategy`

### DIFF
--- a/api/v1/resourceset_types.go
+++ b/api/v1/resourceset_types.go
@@ -83,6 +83,7 @@ type ResourceSetSpec struct {
 // InputStrategySpec defines how the inputs are combined when multiple
 // input provider objects are used. Defaults to flattening all inputs
 // from all providers into a single list of input sets.
+// +kubebuilder:validation:XValidation:rule="!has(self.includeEmptyProviders) || self.name == 'Permute'",message="includeEmptyProviders only applies when name is Permute"
 type InputStrategySpec struct {
 	// Name defines how the inputs are combined when multiple
 	// input provider objects are used. Supported values are:
@@ -100,6 +101,15 @@ type InputStrategySpec struct {
 	// +kubebuilder:validation:Enum=Flatten;Permute
 	// +required
 	Name string `json:"name,omitempty"`
+
+	// IncludeEmptyProviders controls how input providers that export no
+	// inputs are treated. Only applies when Name is Permute. When true, if
+	// any provider has zero inputs the resulting permutation set is empty
+	// (mathematically correct Cartesian product behavior). When false or
+	// unset (default), providers with zero inputs are silently skipped and
+	// the remaining providers still permute among themselves.
+	// +optional
+	IncludeEmptyProviders bool `json:"includeEmptyProviders,omitempty"`
 }
 
 // GetInputStrategy returns the input strategy name.
@@ -108,6 +118,15 @@ func (in *ResourceSet) GetInputStrategy() string {
 		return InputStrategyFlatten
 	}
 	return in.Spec.InputStrategy.Name
+}
+
+// GetIncludeEmptyProviders returns whether providers with zero exported inputs
+// should be kept when combining inputs. Defaults to false.
+func (in *ResourceSet) GetIncludeEmptyProviders() bool {
+	if in.Spec.InputStrategy == nil {
+		return false
+	}
+	return in.Spec.InputStrategy.Name == InputStrategyPermute && in.Spec.InputStrategy.IncludeEmptyProviders
 }
 
 // InputProviderReference defines a reference to an input provider resource

--- a/config/crd/bases/fluxcd.controlplane.io_resourcesets.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_resourcesets.yaml
@@ -110,6 +110,15 @@ spec:
                   input provider objects are used. Defaults to flattening all inputs
                   from all providers into a single list of input sets.
                 properties:
+                  includeEmptyProviders:
+                    description: |-
+                      IncludeEmptyProviders controls how input providers that export no
+                      inputs are treated. Only applies when Name is Permute. When true, if
+                      any provider has zero inputs the resulting permutation set is empty
+                      (mathematically correct Cartesian product behavior). When false or
+                      unset (default), providers with zero inputs are silently skipped and
+                      the remaining providers still permute among themselves.
+                    type: boolean
                   name:
                     description: |-
                       Name defines how the inputs are combined when multiple
@@ -132,6 +141,9 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: includeEmptyProviders only applies when name is Permute
+                  rule: '!has(self.includeEmptyProviders) || self.name == ''Permute'''
               inputs:
                 description: Inputs contains the list of ResourceSet inputs.
                 items:

--- a/docs/api/v1/resourceset.md
+++ b/docs/api/v1/resourceset.md
@@ -205,6 +205,10 @@ The `.spec.inputStrategy` field has the following subfields:
 - `.name`: The name of the input strategy. If `.spec.inputStrategy` is not set, the behavior
   matches setting `.spec.inputStrategy.name` to `Flatten`. Supported values are `Flatten` and
   `Permute`.
+- `.includeEmptyProviders`: Only applies when `.name` is `Permute`. When set to `true`, if any
+  input provider exports zero inputs the resulting permutation set is empty (mathematically
+  correct Cartesian product behavior). When `false` or unset (default), providers with zero
+  inputs are silently skipped and the remaining providers still permute among themselves.
 
 When `.spec.inputStrategy.name` is set to `Permute`, the resulting inputs are the Cartesian product
 of the input sets from each selected `ResourceSetInputProvider` object, and from the `ResourceSet`

--- a/internal/controller/resourceset_controller_test.go
+++ b/internal/controller/resourceset_controller_test.go
@@ -430,6 +430,46 @@ func TestResourceSetInputsFromValidation(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("at least one of name or selector must be set for input provider references"))
 }
 
+func TestResourceSetInputStrategyValidation(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// includeEmptyProviders=true with name=Permute is accepted.
+	err = testEnv.Create(ctx, &fluxcdv1.ResourceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "permute-include-empty",
+			Namespace: ns.Name,
+		},
+		Spec: fluxcdv1.ResourceSetSpec{
+			InputStrategy: &fluxcdv1.InputStrategySpec{
+				Name:                  fluxcdv1.InputStrategyPermute,
+				IncludeEmptyProviders: true,
+			},
+		},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// includeEmptyProviders=true with name=Flatten is rejected by CEL.
+	err = testEnv.Create(ctx, &fluxcdv1.ResourceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flatten-include-empty",
+			Namespace: ns.Name,
+		},
+		Spec: fluxcdv1.ResourceSetSpec{
+			InputStrategy: &fluxcdv1.InputStrategySpec{
+				Name:                  fluxcdv1.InputStrategyFlatten,
+				IncludeEmptyProviders: true,
+			},
+		},
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("includeEmptyProviders only applies when name is Permute"))
+}
+
 func TestResourceSetReconciler_LabelSelector(t *testing.T) {
 	g := NewWithT(t)
 	reconciler := getResourceSetReconciler(t)

--- a/internal/inputs/combine.go
+++ b/internal/inputs/combine.go
@@ -53,7 +53,11 @@ func Combine(rset *fluxcdv1.ResourceSet, providerMap map[ProviderKey]fluxcdv1.In
 	case fluxcdv1.InputStrategyFlatten:
 		combiner = NewFlattener()
 	case fluxcdv1.InputStrategyPermute:
-		combiner = NewPermuter()
+		var opts []PermuterOption
+		if rset.GetIncludeEmptyProviders() {
+			opts = append(opts, WithIncludeEmptyProviders())
+		}
+		combiner = NewPermuter(opts...)
 	default:
 		return nil, fmt.Errorf("unknown input strategy: '%s'", strategy)
 	}

--- a/internal/inputs/combine_test.go
+++ b/internal/inputs/combine_test.go
@@ -160,6 +160,104 @@ func TestCombine(t *testing.T) {
 		g.Expect(string(b)).To(MatchYAML(permuted))
 	})
 
+	t.Run("permutes skipping empty providers by default", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rset := rset.DeepCopy()
+		rset.Spec.InputStrategy = &fluxcdv1.InputStrategySpec{
+			Name: fluxcdv1.InputStrategyPermute,
+		}
+
+		emptyRsip := map[inputs.ProviderKey]fluxcdv1.InputProvider{
+			{
+				GVK: schema.GroupVersionKind{
+					Group:   fluxcdv1.GroupVersion.Group,
+					Version: fluxcdv1.GroupVersion.Version,
+					Kind:    fluxcdv1.ResourceSetInputProviderKind,
+				},
+				Name:      "rsip",
+				Namespace: "default",
+			}: &fluxcdv1.ResourceSetInputProvider{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: fluxcdv1.GroupVersion.String(),
+					Kind:       fluxcdv1.ResourceSetInputProviderKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rsip",
+					Namespace: "default",
+				},
+				Status: fluxcdv1.ResourceSetInputProviderStatus{
+					ExportedInputs: nil,
+				},
+			},
+		}
+
+		c, err := inputs.Combine(rset, emptyRsip)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// The empty provider is silently skipped, so only rset's 2 inputs
+		// contribute to the permutations.
+		g.Expect(c).To(HaveLen(2))
+	})
+
+	t.Run("permutes to empty when includeEmptyProviders is true and a provider is empty", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rset := rset.DeepCopy()
+		rset.Spec.InputStrategy = &fluxcdv1.InputStrategySpec{
+			Name:                  fluxcdv1.InputStrategyPermute,
+			IncludeEmptyProviders: true,
+		}
+
+		emptyRsip := map[inputs.ProviderKey]fluxcdv1.InputProvider{
+			{
+				GVK: schema.GroupVersionKind{
+					Group:   fluxcdv1.GroupVersion.Group,
+					Version: fluxcdv1.GroupVersion.Version,
+					Kind:    fluxcdv1.ResourceSetInputProviderKind,
+				},
+				Name:      "rsip",
+				Namespace: "default",
+			}: &fluxcdv1.ResourceSetInputProvider{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: fluxcdv1.GroupVersion.String(),
+					Kind:       fluxcdv1.ResourceSetInputProviderKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rsip",
+					Namespace: "default",
+				},
+				Status: fluxcdv1.ResourceSetInputProviderStatus{
+					ExportedInputs: nil,
+				},
+			},
+		}
+
+		c, err := inputs.Combine(rset, emptyRsip)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Cartesian product with an empty set is empty.
+		g.Expect(c).To(BeEmpty())
+	})
+
+	t.Run("permutes with all providers non-empty is unaffected by includeEmptyProviders", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rset := rset.DeepCopy()
+		rset.Spec.InputStrategy = &fluxcdv1.InputStrategySpec{
+			Name:                  fluxcdv1.InputStrategyPermute,
+			IncludeEmptyProviders: true,
+		}
+
+		c, err := inputs.Combine(rset, rsip)
+
+		g.Expect(err).NotTo(HaveOccurred())
+
+		b, err := yaml.Marshal(c)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(string(b)).To(MatchYAML(permuted))
+	})
+
 	t.Run("errors on unknown input strategy", func(t *testing.T) {
 		g := NewWithT(t)
 


### PR DESCRIPTION
## Summary

This adds an optional `.spec.inputStrategy.includeEmptyProviders` field to the `ResourceSet`, which changes how the `Permute` strategy handles providers that export zero inputs.

By default, empty providers are silently skipped and the remaining providers still permute among themselves. When `includeEmptyProviders: true`, the strategy behaves as a strict Cartesian product - if any provider exports zero inputs, the result is zero permutations.

## Motivation

I ran into this while experimenting with the `GitHubPullRequest` providers. The setup was a `ResourceSet` combining a dynamic PR provider with a static one holding shared defaults (`driftDetection`, `install`, `upgrade`, etc.) via `Permute`:

```yaml
inputStrategy:
  name: Permute
inputsFrom:
  - name: myapp-pull-requests      # dynamic, may have 0 entries
  - name: helmrelease-defaults     # static, always 1 entry
```

When there were no labeled PRs, the dynamic provider returned zero inputs. The remaining (static) provider then permuted by itself, which produced one render set that didn't have the PR-specific fields the template referenced. The result was that the `ResourceSet` ends up in an error state (`map has no entry for key "hello_pull_requests"`) until the first PR appears.

Mathematically, anything x empty set = empty set, so the expected behavior for "no PRs -> nothing to render" should be zero renders and no error. That's what `includeEmptyProviders: true` gives you.

## API

- New field: `.spec.inputStrategy.includeEmptyProviders` (`*bool`, optional, default `false`)
- CEL rule rejects the field unless `name == 'Permute'` (error: `includeEmptyProviders only applies when name is Permute`)
- Default behavior is unchanged - opt-in only

## Implementation

The underlying `WithIncludeEmptyProviders()` permuter option already existed and was tested in `internal/inputs/permuter_test.go`; this PR just wires it through from the CRD via `Combine()` in `internal/inputs/combine.go`.

## Tests

- Added three subtests to `TestCombine` covering the new flag path:
  - empty provider is skipped by default
  - empty provider causes zero results when `includeEmptyProviders: true`
  - flag is a no-op when all providers have inputs
- Added `TestResourceSetInputStrategyValidation` exercising the CEL rule via `testEnv.Create`
- All existing tests still pass, no changes to default behavior
