### PR TITLE
operator: introduce support for `aws` provider with `GitRepository` sync

### DIFF
--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -296,7 +296,8 @@ type Sync struct {
 
 	// Provider specifies OIDC provider for source authentication.
 	// For OCIRepository and Bucket the provider can be set to 'aws', 'azure' or 'gcp'.
-	// for GitRepository the accepted value can be set to 'azure' or 'github'.
+	// For GitRepository the provider can be set to 'aws' (requires Flux 2.9 or later),
+	// 'azure' or 'github'.
 	// To disable OIDC authentication the provider can be set to 'generic' or left empty.
 	// +kubebuilder:validation:Enum=generic;aws;azure;gcp;github
 	// +optional

--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -250,6 +250,9 @@ type Kustomize struct {
 	Patches []kustomize.Patch `json:"patches,omitempty"`
 }
 
+// Sync defines the source and path for the Flux instance synchronization.
+// +kubebuilder:validation:XValidation:rule="!has(self.provider) || self.provider != 'gcp' || self.kind == 'OCIRepository' || self.kind == 'Bucket'",message="sync.provider 'gcp' is only supported for OCIRepository and Bucket"
+// +kubebuilder:validation:XValidation:rule="!has(self.provider) || self.provider != 'github' || self.kind == 'GitRepository'",message="sync.provider 'github' is only supported for GitRepository"
 type Sync struct {
 	// Name is the name of the Flux source and kustomization resources.
 	// When not specified, the name is set to the namespace name of the FluxInstance.

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -403,6 +403,14 @@ spec:
                 - ref
                 - url
                 type: object
+                x-kubernetes-validations:
+                - message: sync.provider 'gcp' is only supported for OCIRepository
+                    and Bucket
+                  rule: '!has(self.provider) || self.provider != ''gcp'' || self.kind
+                    == ''OCIRepository'' || self.kind == ''Bucket'''
+                - message: sync.provider 'github' is only supported for GitRepository
+                  rule: '!has(self.provider) || self.provider != ''github'' || self.kind
+                    == ''GitRepository'''
               wait:
                 default: true
                 description: |-

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -368,7 +368,8 @@ spec:
                     description: |-
                       Provider specifies OIDC provider for source authentication.
                       For OCIRepository and Bucket the provider can be set to 'aws', 'azure' or 'gcp'.
-                      for GitRepository the accepted value can be set to 'azure' or 'github'.
+                      For GitRepository the provider can be set to 'aws' (requires Flux 2.9 or later),
+                      'azure' or 'github'.
                       To disable OIDC authentication the provider can be set to 'generic' or left empty.
                     enum:
                     - generic

--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -660,7 +660,8 @@ Sync fields:
 - `pullSecret`: The name of the Kubernetes secret that contains the credentials to pull the source repository. This field is optional.
 - `provider`: The provider name used for OIDC-based authentication.
    Supported values are `aws`, `azure` and `gcp` for `OCIRepository`/`Bucket`,
-   and `azure` or `github` for `GitRepository`. This field is optional.
+   and `aws` (requires Flux 2.9 or later), `azure` or `github` for `GitRepository`.
+   This field is optional.
 - `interval`: The sync interval. This field is optional, when not set the default is `1m`.
 - `name`: The name of the generated Flux source and Kustomization objects.
    This field is optional, when not set the default is the FluxInstance namespace name.

--- a/internal/builder/sync.go
+++ b/internal/builder/sync.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package builder
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/fluxcd/pkg/auth/aws"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+// ValidateSync validates the sync options against the Flux version in the
+// Options struct, returning an error when the configuration is not supported.
+func (o *Options) ValidateSync() error {
+	if o.Sync == nil {
+		return nil
+	}
+
+	if o.Sync.Kind == fluxcdv1.FluxGitRepositoryKind && o.Sync.Provider == aws.ProviderName {
+		version, err := semver.NewVersion(o.Version)
+		if err != nil {
+			return fmt.Errorf("failed to parse Flux version '%s': %w", o.Version, err)
+		}
+		ok, err := checkVersionAgainstConstraint(version, ">= 2.9.0")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("sync.provider 'aws' for GitRepository requires Flux version >= 2.9.0, got '%s'", o.Version)
+		}
+	}
+
+	return nil
+}

--- a/internal/builder/sync_test.go
+++ b/internal/builder/sync_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/fluxcd/pkg/auth/aws"
+	. "github.com/onsi/gomega"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestValidateSync(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        string
+		sync           *Sync
+		expectError    bool
+		expectErrorMsg string
+	}{
+		{
+			name:    "no sync is valid",
+			version: "2.8.0",
+			sync:    nil,
+		},
+		{
+			name:    "GitRepository with github provider is valid on older versions",
+			version: "2.6.0",
+			sync:    &Sync{Kind: fluxcdv1.FluxGitRepositoryKind, Provider: "github"},
+		},
+		{
+			name:    "GitRepository with aws provider is valid on 2.9.0",
+			version: "2.9.0",
+			sync:    &Sync{Kind: fluxcdv1.FluxGitRepositoryKind, Provider: aws.ProviderName},
+		},
+		{
+			name:    "GitRepository with aws provider is valid on 2.10.0",
+			version: "2.10.0",
+			sync:    &Sync{Kind: fluxcdv1.FluxGitRepositoryKind, Provider: aws.ProviderName},
+		},
+		{
+			name:           "GitRepository with aws provider is rejected on 2.8.0",
+			version:        "2.8.0",
+			sync:           &Sync{Kind: fluxcdv1.FluxGitRepositoryKind, Provider: aws.ProviderName},
+			expectError:    true,
+			expectErrorMsg: "requires Flux version >= 2.9.0",
+		},
+		{
+			name:    "OCIRepository with aws provider is valid on older versions",
+			version: "2.6.0",
+			sync:    &Sync{Kind: fluxcdv1.FluxOCIRepositoryKind, Provider: aws.ProviderName},
+		},
+		{
+			name:    "Bucket with aws provider is valid on older versions",
+			version: "2.6.0",
+			sync:    &Sync{Kind: fluxcdv1.FluxBucketKind, Provider: aws.ProviderName},
+		},
+		{
+			name:           "invalid version returns error when validating aws GitRepository",
+			version:        "not-a-version",
+			sync:           &Sync{Kind: fluxcdv1.FluxGitRepositoryKind, Provider: aws.ProviderName},
+			expectError:    true,
+			expectErrorMsg: "failed to parse Flux version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			opts := MakeDefaultOptions()
+			opts.Version = tt.version
+			opts.Sync = tt.sync
+
+			err := opts.ValidateSync()
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tt.expectErrorMsg != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.expectErrorMsg))
+				}
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+}

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -403,6 +403,10 @@ func (r *FluxInstanceReconciler) build(ctx context.Context,
 			Path:       obj.Spec.Sync.Path,
 			Provider:   obj.Spec.Sync.Provider,
 		}
+
+		if err := options.ValidateSync(); err != nil {
+			return nil, err
+		}
 	}
 
 	if obj.Spec.Kustomize != nil && len(obj.Spec.Kustomize.Patches) > 0 {

--- a/internal/controller/fluxinstance_controller_test.go
+++ b/internal/controller/fluxinstance_controller_test.go
@@ -116,6 +116,76 @@ func TestFluxInstanceReconciler_CELValidation(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "sync.provider 'gcp' is rejected for GitRepository",
+			obj: func(t *testing.T) *fluxcdv1.FluxInstance {
+				spec := getDefaultFluxSpec(t)
+				spec.Sync = &fluxcdv1.Sync{
+					Kind:     fluxcdv1.FluxGitRepositoryKind,
+					URL:      "https://github.com/org/repo",
+					Path:     "./",
+					Ref:      "refs/heads/main",
+					Provider: "gcp",
+				}
+				return &fluxcdv1.FluxInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "flux"},
+					Spec:       spec,
+				}
+			},
+			expectedErr: "sync.provider 'gcp' is only supported for OCIRepository and Bucket",
+		},
+		{
+			name: "sync.provider 'github' is rejected for OCIRepository",
+			obj: func(t *testing.T) *fluxcdv1.FluxInstance {
+				spec := getDefaultFluxSpec(t)
+				spec.Sync = &fluxcdv1.Sync{
+					Kind:     fluxcdv1.FluxOCIRepositoryKind,
+					URL:      "oci://registry/repo",
+					Path:     "./",
+					Ref:      "latest",
+					Provider: "github",
+				}
+				return &fluxcdv1.FluxInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "flux"},
+					Spec:       spec,
+				}
+			},
+			expectedErr: "sync.provider 'github' is only supported for GitRepository",
+		},
+		{
+			name: "sync.provider 'gcp' is accepted for OCIRepository",
+			obj: func(t *testing.T) *fluxcdv1.FluxInstance {
+				spec := getDefaultFluxSpec(t)
+				spec.Sync = &fluxcdv1.Sync{
+					Kind:     fluxcdv1.FluxOCIRepositoryKind,
+					URL:      "oci://registry/repo",
+					Path:     "./",
+					Ref:      "latest",
+					Provider: "gcp",
+				}
+				return &fluxcdv1.FluxInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "flux"},
+					Spec:       spec,
+				}
+			},
+		},
+		{
+			name: "sync.provider 'github' is accepted for GitRepository",
+			obj: func(t *testing.T) *fluxcdv1.FluxInstance {
+				spec := getDefaultFluxSpec(t)
+				spec.Sync = &fluxcdv1.Sync{
+					Kind:     fluxcdv1.FluxGitRepositoryKind,
+					URL:      "https://github.com/org/repo",
+					Path:     "./",
+					Ref:      "refs/heads/main",
+					Provider: "github",
+				}
+				return &fluxcdv1.FluxInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "flux"},
+					Spec:       spec,
+				}
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)


### PR DESCRIPTION
Flux 2.9 comes with support for the `aws` provider in the `GitRepository` API: https://github.com/fluxcd/flux2/issues/5866

I'm also enforcing the `.provider` versus `.kind` compatibility matrix, which was not being enforced before. Users can lock themselves out if they apply an invalid source for the sync.