### PR TITLE
mcp: ensure tool schemas include "properties" for OpenAI compatibility

### DIFF
--- a/cmd/mcp/toolbox/manager.go
+++ b/cmd/mcp/toolbox/manager.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
@@ -57,8 +58,25 @@ type toolRecorder struct {
 	tools []string
 }
 
+// emptyObjectSchema is a JSON Schema with an explicit empty "properties" field.
+// OpenAI's function calling API requires "properties" to be present even when
+// empty, but the MCP Go SDK's jsonschema.ForType omits it for struct{} types,
+// producing {"type":"object"} without "properties".
+var emptyObjectSchema = &jsonschema.Schema{
+	Type:       "object",
+	Properties: map[string]*jsonschema.Schema{},
+}
+
 // addTool adds a tool to the MCP server and records it.
+// Tools without an explicit InputSchema get the emptyObjectSchema to ensure
+// the serialized JSON always includes "properties", which is required by
+// OpenAI's function calling API.
 func addTool[In, Out any](s *mcp.Server, r *toolRecorder, t *mcp.Tool, h mcp.ToolHandlerFor[In, Out]) {
+	if t.InputSchema == nil {
+		t.InputSchema = emptyObjectSchema
+	} else if schema, ok := t.InputSchema.(*jsonschema.Schema); ok && schema.Properties == nil {
+		schema.Properties = map[string]*jsonschema.Schema{}
+	}
 	mcp.AddTool(s, t, h)
 	r.tools = append(r.tools, t.Name)
 }

--- a/cmd/mcp/toolbox/manager_test.go
+++ b/cmd/mcp/toolbox/manager_test.go
@@ -4,6 +4,8 @@
 package toolbox
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -41,6 +43,48 @@ func TestManager_RegisterToolsDoesNotPanic(t *testing.T) {
 		"get_kubeconfig_contexts",
 		"set_kubeconfig_context",
 	}))
+}
+
+func TestManager_ToolSchemasIncludeProperties(t *testing.T) {
+	g := NewWithT(t)
+
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "flux-operator-mcp",
+		Version: "test-version",
+	}, &mcp.ServerOptions{
+		HasTools: true,
+	})
+
+	manager := NewManager(nil, 0, false, false, nil)
+	manager.RegisterTools(server, false)
+
+	ctx := context.Background()
+	st, ct := mcp.NewInMemoryTransports()
+	_, err := server.Connect(ctx, st, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "test-client",
+		Version: "test-version",
+	}, nil)
+	session, err := client.Connect(ctx, ct, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	result, err := session.ListTools(ctx, &mcp.ListToolsParams{})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	for _, tool := range result.Tools {
+		raw, err := json.Marshal(tool.InputSchema)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to marshal schema for tool %s", tool.Name)
+
+		var schema map[string]any
+		err = json.Unmarshal(raw, &schema)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to unmarshal schema for tool %s", tool.Name)
+
+		g.Expect(schema).To(HaveKey("properties"),
+			"tool %s schema is missing 'properties' field (required by OpenAI function calling API): %s",
+			tool.Name, string(raw))
+	}
 }
 
 func TestManager_RegisterSpecificTools(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/google/go-containerregistry v0.21.5
 	github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20260414223304-7a662782a11f
 	github.com/google/go-github/v81 v81.0.0
+	github.com/google/jsonschema-go v0.4.2
 	github.com/google/uuid v1.6.0
 	github.com/gosimple/slug v1.15.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
@@ -150,7 +151,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-github/v82 v82.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect


### PR DESCRIPTION
## Summary

OpenAI's function calling API requires the `"properties"` field to be present in tool input schemas, even when empty. The MCP Go SDK's `jsonschema.ForType` omits it for `struct{}` input types, producing `{"type":"object"}` without a `"properties"` key.

This causes MCP clients using OpenAI models (e.g., GPT-4o, GPT-5.5) to reject the tool schemas with:

```
Invalid schema for function 'mcp_flux_get_flux_instance': In context=(), object schema missing properties
```

### Affected tools

The three tools with `struct{}` input (no parameters):
- `get_flux_instance`
- `get_kubernetes_api_versions`
- `get_kubeconfig_contexts`

### Fix

Normalize tool input schemas in the `addTool` wrapper so that all tools always serialize with an explicit `"properties"` field. This covers both:
- Tools with no parameters (`struct{}` input → `InputSchema` is nil at registration time)
- Tools whose `*jsonschema.Schema` has a nil `Properties` map

Before:
```json
{"type":"object"}
```

After:
```json
{"type":"object","properties":{}}
```

### Test

Added `TestManager_ToolSchemasIncludeProperties` that:
1. Registers all tools on an in-memory MCP server
2. Connects a client and lists tools
3. Verifies every tool's `inputSchema` JSON contains the `"properties"` key

### Related

- Root cause is in the upstream `jsonschema-go` library which uses `omitempty` on `Properties`, but this fix is self-contained and doesn't require SDK changes.
- Affects any MCP client that forwards tool schemas to OpenAI's API (PicoClaw, custom integrations, etc.)


Made with [Cursor](https://cursor.com)