### PR TITLE
operator: change OLM base image to `ubi8-micro`

### DIFF
--- a/config/olm/build/Dockerfile
+++ b/config/olm/build/Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION
 
 FROM --platform=${BUILDPLATFORM} ghcr.io/controlplaneio-fluxcd/flux-operator:${VERSION} AS distroless
-FROM --platform=${BUILDPLATFORM} registry.access.redhat.com/ubi8/ubi-minimal
+FROM --platform=${BUILDPLATFORM} registry.access.redhat.com/ubi8-micro
 
 ### Required OpenShift Labels
 LABEL name="flux-operator" \
@@ -22,5 +22,7 @@ COPY config/data/ /data/
 # Copy the operator binary.
 COPY --from=distroless flux-operator .
 
-# Run the operator as the default user.
+# Run the operator as the nobody user.
+USER 65534:65534
+
 ENTRYPOINT ["/flux-operator"]


### PR DESCRIPTION
This change drastically reduces the amount of CVEs in the base image. We don't expect breaking changes from this as Flux Operator does not shell out to anything.

```
  ┌─────────┬──────────┬───────────────────┬──────────────────┐
  │ Scanner │ Severity │ ubi-minimal (old) │ ubi8-micro (new) │
  ├─────────┼──────────┼───────────────────┼──────────────────┤
  │ Trivy   │ HIGH     │ 4                 │ 0                │
  ├─────────┼──────────┼───────────────────┼──────────────────┤
  │ Trivy   │ MEDIUM   │ 81                │ 16               │
  ├─────────┼──────────┼───────────────────┼──────────────────┤
  │ Trivy   │ LOW      │ 114               │ 25               │
  ├─────────┼──────────┼───────────────────┼──────────────────┤
  │ Grype   │ High     │ 4                 │ 0                │
  ├─────────┼──────────┼───────────────────┼──────────────────┤
  │ Grype   │ Medium   │ 82                │ 16               │
  ├─────────┼──────────┼───────────────────┼──────────────────┤
  │ Grype   │ Low      │ 111               │ 25               │
  └─────────┴──────────┴───────────────────┴──────────────────┘
```