### PR TITLE
web: set npm min release age to 2 weeks

### DIFF
--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,3 @@
+# Mitigates supply-chain attacks by refusing to install package versions
+# published less than 2 weeks ago. Requires npm >= 11.5.0.
+min-release-age=20160


### PR DESCRIPTION
Prevent updating npm packages locally that are newer than 2 weeks.