### PR TITLE
ci: release pipeline hardening

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -17,7 +17,29 @@ env:
   IMAGE: ghcr.io/${{ github.repository }}-preview
 
 jobs:
+  branch-build-web:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - name: Build frontend
+        run: make web-ci-install web-build
+      - name: Upload frontend assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: web-dist-${{ github.sha }}
+          path: web/dist/
+          retention-days: 1
+          if-no-files-found: error
   branch-build-push:
+    needs: [branch-build-web]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -30,14 +52,11 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.26.x
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Download frontend assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          node-version: 24
-          cache: 'npm'
-          cache-dependency-path: web/package-lock.json
-      - name: Build frontend
-        run: make web-ci-install web-build
+          name: web-dist-${{ github.sha }}
+          path: web/dist/
       - name: Prepare
         id: prep
         run: |

--- a/.github/workflows/push-manifests.yaml
+++ b/.github/workflows/push-manifests.yaml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Kustomize
-        uses: fluxcd/pkg/actions/kustomize@main
       - name: Setup Flux
         uses: fluxcd/flux2/action@04acaec6161ac4fb1a82ffafa88901c03271d34f #v2.8.6
       - name: Prepare

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,10 +71,10 @@ jobs:
         with:
           go-version: 1.26.x
           cache: false
-      - name: Setup Kustomize
-        uses: fluxcd/pkg/actions/kustomize@main
-      - name: Setup Flux
+      - name: Setup Flux CLI
         uses: fluxcd/flux2/action@04acaec6161ac4fb1a82ffafa88901c03271d34f #v2.8.6
+      - name: Setup Flux Schema CLI
+        uses: fluxcd/flux-schema/actions/setup@c90d3f83707614d21c20226183a9e714d8ba9626 # v0.3.0
       - name: Setup Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - name: Prepare
@@ -156,18 +156,11 @@ jobs:
         shell: bash
         run: |
           mkdir -p bin/release
-          kustomize build config/default > bin/release/install.yaml
-          kustomize build config/crd > bin/release/crds.yaml
-      - name: Generate OpenAPI JSON schemas from CRDs
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: fluxcd/pkg/actions/crdjsonschema@1bfcca47168cb6d2d7dfdc5b35d8b379a773976d # main
-        with:
-          crd: bin/release/crds.yaml
-          output: schemas
-      - name: Archive the OpenAPI JSON schemas
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          tar -czvf bin/release/crd-schemas.tar.gz -C schemas .
+          kubectl kustomize config/default > bin/release/install.yaml
+          kubectl kustomize config/crd > bin/release/crds.yaml
+          flux-schema extract crd bin/release/crds.yaml \
+          --output-format '{{ .Kind }}-{{ .GroupPrefix }}-{{ .Version }}.json' \
+          --output-archive bin/release/crd-schemas.tar.gz
       - name: Create release
         if: startsWith(github.ref, 'refs/tags/v')
         id: run-goreleaser

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,8 +28,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'npm'
-          cache-dependency-path: web/package-lock.json
+          package-manager-cache: false
       - name: Prepare
         id: prep
         run: |
@@ -63,14 +62,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
       - name: Disk Cleanup
         uses: ./.github/actions/runner-cleanup
-      - name: Unshallow
-        run: git fetch --prune --unshallow
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.26.x
+          cache: false
       - name: Setup Kustomize
         uses: fluxcd/pkg/actions/kustomize@main
       - name: Setup Flux

--- a/hack/build-dist-manifests.sh
+++ b/hack/build-dist-manifests.sh
@@ -19,11 +19,11 @@ fatal() {
 
 rm -rf ${DEST_DIR}
 mkdir -p ${DEST_DIR}/flux-operator
-kustomize build config/default > ${DEST_DIR}/flux-operator/install.yaml
+kubectl kustomize config/default > ${DEST_DIR}/flux-operator/install.yaml
 info "operator manifests generated to disto/flux-operator"
 
 mkdir -p ${DEST_DIR}/flux-operator-mcp
-kustomize build config/mcp > ${DEST_DIR}/flux-operator-mcp/install.yaml
+kubectl kustomize config/mcp > ${DEST_DIR}/flux-operator-mcp/install.yaml
 info "MCP server manifests generated to disto/flux-operator-mcp"
 
 mkdir -p ${DEST_DIR}/flux


### PR DESCRIPTION
Hardening of the release pipeline:
- disable caching of npm packages and Go modules
- isolate web ui build operations on a runner with read-only access
- replace the kustomize install action with `kubectl kustomize` (preinstalled on the runners)
- migrate to flux-schema for OpenAPI JSON schema generation