### PR TITLE
feat(web): add one click filtering on status bar

### DIFF
--- a/web/src/components/search/EventList.jsx
+++ b/web/src/components/search/EventList.jsx
@@ -223,7 +223,14 @@ export function EventList() {
         </div>
 
         {/* Status Chart */}
-        <StatusChart items={eventsData.value} loading={eventsLoading.value} mode="events" />
+        <StatusChart
+          items={eventsData.value}
+          loading={eventsLoading.value}
+          mode="events"
+          onBarClick={(status) => {
+            selectedEventSeverity.value = selectedEventSeverity.value === status ? '' : status
+          }}
+        />
 
         {/* Error State */}
         {eventsError.value && (

--- a/web/src/components/search/ResourceList.jsx
+++ b/web/src/components/search/ResourceList.jsx
@@ -274,7 +274,14 @@ export function ResourceList() {
         </div>
 
         {/* Status Chart */}
-        <StatusChart items={resourcesData.value} loading={resourcesLoading.value} mode="resources" />
+        <StatusChart
+          items={resourcesData.value}
+          loading={resourcesLoading.value}
+          mode="resources"
+          onBarClick={(status) => {
+            selectedResourceStatus.value = selectedResourceStatus.value === status ? '' : status
+          }}
+        />
 
         {/* Error State */}
         {resourcesError.value && (

--- a/web/src/components/search/StatusChart.jsx
+++ b/web/src/components/search/StatusChart.jsx
@@ -72,7 +72,7 @@ function getBarColor(status, mode) {
  * - Shows placeholder bar during loading
  * - Tooltip on hover with count and percentage
  */
-export function StatusChart({ items, loading, mode = 'events' }) {
+export function StatusChart({ items, loading, mode = 'events', onBarClick }) {
   const [hoveredBar, setHoveredBar] = useState(null)
   const [animationComplete, setAnimationComplete] = useState(false)
 
@@ -227,12 +227,14 @@ export function StatusChart({ items, loading, mode = 'events' }) {
                 style={{ flex: `0 0 ${bar.percentage}%` }}
                 onMouseEnter={() => setHoveredBar(index)}
                 onMouseLeave={() => setHoveredBar(null)}
+                onClick={() => onBarClick?.(bar.status)}
+                role={onBarClick ? 'button' : undefined}
               >
                 {/* Gray background */}
                 <div class={`h-full ${grayClass}`}>
                   {/* Colored fill overlay - animates from left to right on initial load */}
                   <div
-                    class={`h-full transition-opacity duration-200 ${colorClass} hover:opacity-80 cursor-pointer`}
+                    class={`h-full transition-opacity duration-200 ${colorClass}${onBarClick ? ' hover:opacity-80 cursor-pointer' : ''}`}
                     style={{
                       width: '100%',
                       animation: !animationComplete ? 'fillRight 0.8s ease-out both' : 'none',

--- a/web/src/components/search/StatusChart.test.jsx
+++ b/web/src/components/search/StatusChart.test.jsx
@@ -484,6 +484,35 @@ describe('StatusChart', () => {
     })
   })
 
+  describe('Click Handling', () => {
+    it('calls onBarClick with status when bar is clicked', () => {
+      const normalEvents = createMockEvents(7, 'Normal')
+      const warningEvents = createMockEvents(3, 'Warning')
+      const onBarClick = vi.fn()
+
+      const { container } = render(
+        <StatusChart items={[...normalEvents, ...warningEvents]} loading={false} mode="events" onBarClick={onBarClick} />
+      )
+
+      const bars = container.querySelectorAll('.relative.group')
+      fireEvent.click(bars[0])
+      expect(onBarClick).toHaveBeenCalledWith('Normal')
+
+      fireEvent.click(bars[1])
+      expect(onBarClick).toHaveBeenCalledWith('Warning')
+    })
+
+    it('does not crash when onBarClick is not provided', () => {
+      const events = createMockEvents(5, 'Normal')
+      const { container } = render(
+        <StatusChart items={events} loading={false} mode="events" />
+      )
+
+      const bars = container.querySelectorAll('.relative.group')
+      expect(() => fireEvent.click(bars[0])).not.toThrow()
+    })
+  })
+
   describe('Header with Totals and Stats', () => {
     it('renders header with total count for events', () => {
       const events = createMockEvents(10)


### PR DESCRIPTION
Hello

On first run I wanted to click on the bar but it was doing nothing. I think it would be great to make easier to filter via 1 click.




https://github.com/user-attachments/assets/c9e736a6-fbda-40c9-8991-960b254aad66

