### PR TITLE
web: reframe zero trust as principle of least privilege

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ The project is structured as a Go module with the following components:
 - Run individual tests when debugging, run the full test suite when done
 - Replace `interface{}` with `any` type alias
 - Use `go doc` to read func signatures in external packages
-- Always keep docs/web/web-zero-trust-rbac.md updated after every change you make
+- Always keep docs/web/web-least-privilege-rbac.md updated after every change you make
 
 ## Development Commands for AI Agents
 

--- a/api/v1/webconfig_types.go
+++ b/api/v1/webconfig_types.go
@@ -55,7 +55,7 @@ const (
 	// UserActionsAccessFineGrained configures GitOps actions to be performed
 	// using the Flux Operator Web UI's own privileges, requiring the user to
 	// hold only the custom per-action verb (e.g. suspend). This enables
-	// stricter Zero Trust setups.
+	// stricter least-privilege setups.
 	UserActionsAccessFineGrained = "FineGrained"
 )
 
@@ -340,7 +340,7 @@ type UserActionsSpec struct {
 	// When set to "FineGrained", an action requires only the custom per-action
 	// RBAC verb. The action itself is performed using the Flux Operator Web UI's
 	// own privileges instead of impersonating the user. This enables stricter
-	// Zero Trust setups where a user can be granted access to a single action
+	// least-privilege setups where a user can be granted access to a single action
 	// (e.g. only "suspend") without also gaining the broader native verbs.
 	// +kubebuilder:validation:Enum=Impersonated;FineGrained
 	// +optional

--- a/api/v1/webconfig_types.go
+++ b/api/v1/webconfig_types.go
@@ -4,6 +4,9 @@
 package v1
 
 import (
+	"maps"
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -43,7 +46,7 @@ const (
 	// UserActionDeletePods is the delete user action for pods of workloads
 	// managed by Flux. This constant is not used for RBAC checks, and is
 	// only used for sinalizing to the frontend that the user can delete
-	// pods of a workload. Should not be added to the AllUserActions list.
+	// pods of a workload. Should not be added to the userActions map.
 	UserActionDeletePods = "deletePods"
 
 	// UserActionsAccessImpersonated configures GitOps actions to be performed
@@ -66,14 +69,18 @@ var (
 		AuthenticationTypeOAuth2,
 	}
 
-	// AllUserActions lists all possible user actions.
-	AllUserActions = []string{
-		UserActionReconcile,
-		UserActionSuspend,
-		UserActionResume,
-		UserActionDownload,
-		UserActionRestart,
-		UserActionDelete,
+	// userActions is the single source of truth for all GitOps user actions.
+	// The map key is the custom RBAC verb. Because this is a map literal, the Go
+	// compiler rejects any duplicate verb at build time, which guarantees that no
+	// two actions can share a verb. This invariant is what makes FineGrained
+	// access safe: each verb unlocks exactly one action.
+	userActions = map[string]struct{}{
+		UserActionReconcile: {},
+		UserActionSuspend:   {},
+		UserActionResume:    {},
+		UserActionDownload:  {},
+		UserActionRestart:   {},
+		UserActionDelete:    {},
 	}
 
 	// AllUserActionsAccessModes lists all possible user actions access modes.
@@ -82,6 +89,18 @@ var (
 		UserActionsAccessFineGrained,
 	}
 )
+
+// AllUserActions returns all supported user action verbs, sorted, derived from
+// the userActions source of truth.
+func AllUserActions() []string {
+	return slices.Sorted(maps.Keys(userActions))
+}
+
+// IsUserAction reports whether the given verb is a supported user action.
+func IsUserAction(verb string) bool {
+	_, ok := userActions[verb]
+	return ok
+}
 
 // WebConfig is the Flux Status Page configuration.
 type WebConfig struct {

--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -479,7 +479,7 @@ Use cases:
 - **Cloud workload identity**: Each tenant namespace has service accounts bound to cloud IAM roles
 - **Secret management**: Different service accounts for decryption operations (e.g. SOPS with cloud KMS)
 - **Multi-cluster**: Separate service accounts for accessing remote clusters via cloud IAM
-- **Zero-trust**: Prevent controllers from accessing resources outside their intended scope
+- **Least privilege**: Prevent controllers from accessing resources outside their intended scope
 
 See the complete workload identity documentation for CNCF Flux
 [here](https://fluxcd.io/flux/integrations/).

--- a/docs/web/web-config-api.md
+++ b/docs/web/web-config-api.md
@@ -342,7 +342,7 @@ are authorized and performed. It accepts two values:
 - `FineGrained`: an action requires **only** the custom per-action verb
   (e.g. `suspend`). The action itself is performed using the Flux Operator
   web UI application's own privileges instead of impersonating the user.
-  This enables stricter Zero Trust setups where a user can be granted access
+  This enables stricter least-privilege setups where a user can be granted access
   to a single action without also gaining the broader native verbs.
 
 When `FineGrained` is enabled, the per-action custom verb is still checked

--- a/docs/web/web-least-privilege-rbac.md
+++ b/docs/web/web-least-privilege-rbac.md
@@ -1,9 +1,9 @@
 ---
-title: Flux Web UI RBAC Minimization & Zero Trust
+title: Flux Web UI RBAC Minimization & Least Privilege
 description: Transparency documentation for all elevated system privileges in the Flux Web UI backend.
 ---
 
-# Flux Web UI RBAC Minimization & Zero Trust
+# Flux Web UI RBAC Minimization & Least Privilege
 
 The Flux Web UI backend enforces strict
 [Role-Based Access Control](web-user-management.md#role-based-access-control)
@@ -19,7 +19,7 @@ system fulfills these critical internal requirements without exposing
 sensitive data.
 
 By relying on the system to safely handle these internal operations,
-administrators can enforce a much stricter Zero Trust posture.
+administrators can enforce a much stricter least-privilege posture.
 
 ## Guiding Principles
 
@@ -29,7 +29,7 @@ administrators can enforce a much stricter Zero Trust posture.
    ConfigMap data, or any other sensitive content to the user.
 3. **RBAC Minimization.** Each usage of elevated system privileges exists because it enables a
    specific, high-value feature that significantly decreases the permissions
-   that users would otherwise require, improving support for Zero Trust.
+   that users would otherwise require, improving support for the principle of least privilege.
 
 ---
 
@@ -50,7 +50,7 @@ The privileged client is used solely to query this index for Jobs owned
 by the CronJob; the resulting Pod statuses (name, phase, timestamps) are
 returned to the user without exposing any sensitive pod spec data.
 
-**Zero Trust benefit:**
+**Least privilege benefit:**
 Without this internal usage, users would need explicit read permissions on all Jobs and Pods just to see their scheduled workloads running. By handling this internally, we limit the user's required RBAC to just the CronJob itself while still providing critical observability.
 
 ---
@@ -72,7 +72,7 @@ is used for this single discovery call because the REST mapper is a
 cluster-level metadata operation that does not read any actual resource
 data.
 
-**Zero Trust benefit:**
+**Least privilege benefit:**
 API discovery is a metadata-only operation that returns no workload data,
 no secrets, and no resource content. If we required the user to have
 explicit RBAC permissions for API discovery, every user role would need
@@ -97,7 +97,7 @@ using the privileged client. It then reads the FluxInstance to find the
 notification-controller address and emits a Kubernetes Event tied to the
 managing Flux resource.
 
-**Zero Trust benefit:**
+**Least privilege benefit:**
 Audit is a security feature, not a user-facing data feature. The user has
 already been authorized to perform the action itself (via their own RBAC). By using the system client, we guarantee that every auditable action produces a complete, traceable event regardless of the acting user's read permissions. Administrators don't need to weaken audit coverage or inflate user RBAC just to ensure logs are written. No data from the privileged reads is returned to the user.
 
@@ -117,7 +117,7 @@ workload. It then looks up the Flux resource managing that workload so
 the audit event is associated with the correct Flux resource. This entire
 chain traversal uses the privileged client.
 
-**Zero Trust benefit:**
+**Least privilege benefit:**
 The user has already been authorized to delete the Pod, which is a
 destructive action with a higher privilege bar than reading. Walking the
 owner chain to produce a meaningful audit trail is an internal task that
@@ -141,7 +141,7 @@ single report object. This report is built periodically on a background
 goroutine and cached. When a user requests the report, the cached data
 is filtered to show only the namespaces the user has access to.
 
-**Zero Trust benefit:**
+**Least privilege benefit:**
 The report is the backbone of the Web UI dashboard. Building it requires
 cross-namespace visibility that no single user is guaranteed to have —
 especially in multi-tenant clusters. The privileged scan produces **aggregated statistics only**
@@ -164,7 +164,7 @@ client is used because the Metrics API call and the pod spec read target
 the operator's own namespace (typically `flux-system`), which users may
 not have access to.
 
-**Zero Trust benefit:**
+**Least privilege benefit:**
 Flux controller health is a cluster-wide concern visible to all dashboard
 users, regardless of their namespace-scoped permissions. Showing CPU and
 memory utilization of Flux controllers helps users understand whether Flux itself is under resource pressure. The metrics data contains no sensitive information. By fetching this internally, administrators are not forced to break namespace isolation by granting everyone read access to the `flux-system` namespace.
@@ -181,8 +181,8 @@ The system performs the actual `patch` operation on the target resource, as long
 **How it works:**
 Normally, GitOps actions are executed by patching the object using the user's impersonated client, which requires the user to hold the native Kubernetes `patch` verb. When fine-grained access control is enabled, the backend verifies that the user holds the specific custom verb for the action, and if so, it uses the privileged client to perform the patch operation, removing the need for user impersonation during the patch.
 
-**Zero Trust benefit:**
-This feature is crucial for Zero Trust security scenarios. If users were required to have the native `patch` verb to suspend or resume resources, they could potentially bypass the Web UI and perform unauthorized modifications via `kubectl` or other SSO-integrated tools. By handling the patch internally, cluster administrators can assign restrictive, fine-grained access policies ensuring tenants can solely perform permitted actions.
+**Least privilege benefit:**
+This feature is crucial for least-privilege security scenarios. If users were required to have the native `patch` verb to suspend or resume resources, they could potentially bypass the Web UI and perform unauthorized modifications via `kubectl` or other SSO-integrated tools. By handling the patch internally, cluster administrators can assign restrictive, fine-grained access policies ensuring tenants can solely perform permitted actions.
 
 ---
 
@@ -196,7 +196,7 @@ The system lists all namespaces to determine which ones the user is permitted to
 **How it works:**
 To populate the namespace filter dropdown and filter the main dashboard statistics, the backend needs to know which namespaces the user is allowed to see. It uses the system client to list all namespaces, and then performs a `SelfSubjectAccessReview` for the user to check if they have `get` permissions on `ResourceSets` in each namespace. If they do, the namespace's existence is revealed to the user in the UI.
 
-**Zero Trust benefit:**
+**Least privilege benefit:**
 Users do not need cluster-wide `list` permissions on namespaces just to populate the UI dropdown. The system determines what the user is allowed to see internally, keeping user permissions tightly scoped to only the resources they actively manage. This preserves strict multi-tenant boundaries by removing the need for broad, cluster-level namespace access.
 
 ---

--- a/docs/web/web-user-management.md
+++ b/docs/web/web-user-management.md
@@ -15,7 +15,7 @@ and Kubernetes Role-Based Access Control (RBAC) policies.
 
 For a detailed overview of the Web UI's security model and every case where
 the backend uses elevated privileges, see the
-[Flux Web UI RBAC Minimization & Zero Trust](web-zero-trust-rbac.md) transparency page.
+[Flux Web UI RBAC Minimization & Least Privilege](web-least-privilege-rbac.md) transparency page.
 
 ## Anonymous Access
 

--- a/internal/web/action_access_test.go
+++ b/internal/web/action_access_test.go
@@ -36,7 +36,7 @@ func fineGrainedConfig() *fluxcdv1.WebConfigSpec {
 
 // grantUserActionVerb creates a ClusterRole/Binding that grants the given user
 // the custom action verbs on resourcesets (get, list and the action verbs) but
-// deliberately NOT the native patch verb. This models a Zero Trust setup where
+// deliberately NOT the native patch verb. This models a least-privilege setup where
 // a user is granted only the right to trigger an action.
 func grantUserActionVerb(t *testing.T, g *WithT, username string, verbs ...string) {
 	t.Helper()

--- a/internal/web/config/user_actions_validation_test.go
+++ b/internal/web/config/user_actions_validation_test.go
@@ -111,7 +111,7 @@ func TestAllUserActions(t *testing.T) {
 	g := NewWithT(t)
 
 	// Verify AllUserActions contains the expected actions
-	g.Expect(fluxcdv1.AllUserActions).To(ConsistOf(
+	g.Expect(fluxcdv1.AllUserActions()).To(ConsistOf(
 		fluxcdv1.UserActionReconcile,
 		fluxcdv1.UserActionSuspend,
 		fluxcdv1.UserActionResume,
@@ -119,5 +119,5 @@ func TestAllUserActions(t *testing.T) {
 		fluxcdv1.UserActionRestart,
 		fluxcdv1.UserActionDelete,
 	))
-	g.Expect(fluxcdv1.AllUserActions).To(HaveLen(6))
+	g.Expect(fluxcdv1.AllUserActions()).To(HaveLen(6))
 }

--- a/internal/web/config/validation.go
+++ b/internal/web/config/validation.go
@@ -235,7 +235,7 @@ func ValidateUserActionsSpec(u *fluxcdv1.UserActionsSpec) error {
 		if _, exists := auditedActions[action]; exists {
 			return fmt.Errorf("duplicate audit action: '%s'", action)
 		}
-		if !slices.Contains(fluxcdv1.AllUserActions, action) && action != "*" {
+		if !fluxcdv1.IsUserAction(action) && action != "*" {
 			return fmt.Errorf("invalid audit action: '%s'", action)
 		}
 		auditedActions[action] = struct{}{}

--- a/internal/web/resource.go
+++ b/internal/web/resource.go
@@ -225,7 +225,7 @@ func (h *Handler) GetResource(ctx context.Context, kind, name, namespace string)
 	// List which actions the user can perform on this resource.
 	if h.conf.UserActionsEnabled() {
 		var actions []string
-		for _, action := range fluxcdv1.AllUserActions {
+		for _, action := range fluxcdv1.AllUserActions() {
 			canAct, err := h.kubeClient.CanActOnResource(ctx, action, gvk.Group, kindInfo.Plural, namespace, name)
 			if err != nil {
 				log.FromContext(ctx).Error(err, "failed to check custom RBAC for action",

--- a/internal/web/resource_action.go
+++ b/internal/web/resource_action.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
-	"slices"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -67,7 +66,7 @@ func (h *Handler) ActionHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Validate action type
-	if !slices.Contains(fluxcdv1.AllUserActions, actionReq.Action) {
+	if !fluxcdv1.IsUserAction(actionReq.Action) {
 		http.Error(w, "Invalid action. Must be one of: reconcile, suspend, resume", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
Follow up for #883 and #882

Preview: https://github.com/controlplaneio-fluxcd/flux-operator/blob/reframe-least-privilege/docs/web/web-least-privilege-rbac.md

Also refactor user actions to enforce at compile time that they are fine-grained: no two operations use the same RBAC verb unless they are distinguished by the target resource type (e.g. `restart` for `Deployment` and `restart` for `CronJob`).