### PR TITLE
mcp: Remove the hints from `get_kubernetes_resources` tool

### DIFF
--- a/cmd/mcp/toolbox/get_resource.go
+++ b/cmd/mcp/toolbox/get_resource.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
 
 const (
@@ -76,45 +74,5 @@ func (m *Manager) HandleGetKubernetesResources(ctx context.Context, request *mcp
 		return NewToolResultError("No resources found")
 	}
 
-	return NewToolResultText(result + m.GetFluxTip(input.Kind))
-}
-
-func (m *Manager) GetFluxTip(kind string) string {
-	switch kind {
-	case fluxcdv1.FluxGitRepositoryKind, fluxcdv1.FluxBucketKind, fluxcdv1.FluxOCIRepositoryKind:
-		return `
-If asked for recommendations:
-1. Check if the interval is less than 1 minute and if so, recommend to increase it to one minute.
-2. Check if the GitRepository has ref.branch set and if so, recommend to set ref.name to refs/heads/<branch name>.
-3. Check if the GitRepository has ref.tag set and if so, recommend to set ref.name to refs/tags/<tag name>.
-`
-	case fluxcdv1.FluxKustomizationKind:
-		return `
-If asked for recommendations:
-1. Check if the Kustomization interval is less than 10 minutes and if so, recommend to increase it.
-   Explain that the Kustomization interval is for detecting drift in cluster and undo kubectl edits.
-   The interval set in the source (GitRepository, OCIRepository or Bucket) of the Kustomization
-   is for detecting changes in upstream, and that one can be set to a lower value.
-2. Check if the Kustomization has a retryInterval and if not, recommend to add it.
-3. Check if the Kustomization has wait set to true and if so, recommend to set a timeout value.
-4. Check if the Kustomization has prune set to true and if so, recommend to set spec.deletionPolicy to Delete.
-5. Check if the Kustomization has force set to true and if so, recommend to remove it.
-   Explain that force recreates resources and can cause downtime,
-   it should be used only in emergencies when patching fails due to immutable field changes.
-`
-	case fluxcdv1.FluxHelmReleaseKind:
-		return `
-If asked for recommendations:
-1. Check if the interval is less than 10 minutes and if so, recommend to increase it.
-   Explain that the HelmRelease interval is for detecting drift in cluster.
-   The interval set in the source (OCIRepository, HelmRepository) of the HelmRelease
-   is for detecting changes in upstream Helm chart, and that one can be set to a lower value.
-2. Check if the HelmRelease has releaseName set and if not, recommend to add it.
-3. Check if the HelmRelease has targetNamespace set, if so check if storageNamespace is set to the same value.
-   If not, recommend to set storageNamespace to the same value as targetNamespace.
-4. Check if postRenderers are set, if any of the patches have a namespace set in the target, recommend to remove it.
-`
-	default:
-		return ""
-	}
+	return NewToolResultText(result)
 }

--- a/docs/mcp/mcp-config.md
+++ b/docs/mcp/mcp-config.md
@@ -51,7 +51,7 @@ export KUBECONFIG=$HOME/.kube/config
 flux-operator-mcp serve --transport http --port 8080
 ```
 
-To connect to the server from VS Code, use the following configuration:
+To connect to the server over http, use the following configuration:
 
 ```json
 {
@@ -78,7 +78,7 @@ export KUBECONFIG=$HOME/.kube/config
 flux-operator-mcp serve --transport sse --port 8080
 ```
 
-To connect to the server from VS Code, use the following configuration:
+To connect to the server over sse, use the following configuration:
 
 ```json
 {
@@ -231,7 +231,7 @@ To connect to the server, start port forwarding with:
 kubectl port-forward -n flux-system svc/flux-operator-mcp 9090:9090
 ```
 
-Then, in your VS Code settings, add:
+Then, in your AI settings, add:
 
 ```json
 {

--- a/docs/mcp/mcp-install.md
+++ b/docs/mcp/mcp-install.md
@@ -55,18 +55,13 @@ using any of the following transport modes:
 - Server-Sent Events (`sse`)
 - Streamable HTTP (`http`)
 
-See the [Configuration Options](mcp-config.md) for more details on how to set up the server
-in different modes.
-
-### Claude, Cursor, and Windsurf
-
-Add the following configuration to your AI assistant's settings to enable the Flux MCP Server:
+Add the following configuration to your AI assistant's settings to use the Flux MCP Server over stdio:
 
 ```json
 {
  "mcpServers": {
    "flux-operator-mcp": {
-     "command": "/path/to/flux-operator-mcp",
+     "command": "flux-operator-mcp",
      "args": ["serve"],
      "env": {
        "KUBECONFIG": "/path/to/.kube/config"
@@ -76,41 +71,19 @@ Add the following configuration to your AI assistant's settings to enable the Fl
 }
 ```
 
-Replace `/path/to/flux-operator-mcp` with the actual path to the binary
-and `/path/to/.kube/config` with the path to your kubeconfig file.
+Replace `/path/to/.kube/config` with the path to your kubeconfig file.
+To determine the correct path, you can run: `echo $HOME/.kube/config`.
 
-To determine the correct paths for the binary and kubeconfig, you can use the following commands:
+For Codex, you can run:
 
 ```shell
-which flux-operator-mcp
-echo $HOME/.kube/config
+codex mcp add flux-operator-mcp \
+  --env KUBECONFIG=$HOME/.kube/config \
+  -- flux-operator-mcp serve
 ```
 
-### VS Code Copilot Chat
-
-Add the following configuration to your VS Code settings:
-
-```json
-{
- "mcp": {
-   "servers": {
-     "flux-operator-mcp": {
-       "command": "/path/to/flux-operator-mcp",
-       "args": ["serve"],
-       "env": {
-         "KUBECONFIG": "/path/to/.kube/config"
-       }
-     }
-   }
- },
- "chat.mcp.enabled": true
-}
-```
-
-Replace `/path/to/flux-operator-mcp` with the actual path to the binary
-and `/path/to/.kube/config` with the path to your kubeconfig file.
-
-When using GitHub Copilot Chat, enable Agent mode to access the Flux MCP tools.
+See the [Configuration Options](mcp-config.md) for more details on how to set up the server
+in different modes.
 
 ## Testing Your Installation
 

--- a/docs/mcp/mcp-prompting.md
+++ b/docs/mcp/mcp-prompting.md
@@ -27,6 +27,28 @@ It is recommended to enhance the instructions with relevant information about yo
 AI assistant understand your context better. For example, Kubernetes distribution, Cloud provider,
 what type of applications are deployed, how secrets are managed.
 
+## AI Agent Skills
+
+For agents that support the [Agent Skills Open Standard](https://agentskills.io/specification),
+the Flux project maintains the official [GitOps Agent Skills](https://github.com/fluxcd/agent-skills)
+which give coding agents deep expertise in Flux CD, Kubernetes, and GitOps best practices.
+
+The skill relevant to the Flux MCP is **gitops-cluster-debug**, which helps
+troubleshoot live Kubernetes clusters using the MCP Server. This skill follows dedicated
+workflows for HelmRelease, Kustomization, and ResourceSet debugging, and produces a root
+cause analysis report with a dependency chain and prioritized remediation steps.
+
+The fastest way to install the skills is with the [Flux Operator CLI](cli.md).
+Navigate to your GitOps repository root and run:
+
+```shell
+flux-operator skills install ghcr.io/fluxcd/agent-skills --agent claude-code
+```
+
+The skills work across compatible agents including Claude Code, Codex, Gemini, and GitHub Copilot.
+For other agents and installation methods,
+refer to the [agent-skills README](https://github.com/fluxcd/agent-skills#install).
+
 ## Prompting Strategies
 
 For the best experience with the Flux MCP Server [tools](tools.md):


### PR DESCRIPTION
Remove the trailing instructions from the MCP response, point users to the Flux Agent Skills which are way better than the in-line hints.

Fix: #884