### PR TITLE
mcp: strip kubectl last-applied annotation

### DIFF
--- a/cmd/mcp/k8s/export.go
+++ b/cmd/mcp/k8s/export.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -65,6 +66,12 @@ func (k *Client) Export(ctx context.Context,
 		if err := k.Client.List(ctx, &list, listOpts...); err == nil {
 			for _, item := range list.Items {
 				unstructured.RemoveNestedField(item.Object, "metadata", "managedFields")
+
+				// Remove the kubectl last-applied annotation as it contains a full copy of the object.
+				unstructured.RemoveNestedField(item.Object, "metadata", "annotations", corev1.LastAppliedConfigAnnotation)
+				if annotations, found, _ := unstructured.NestedStringMap(item.Object, "metadata", "annotations"); found && len(annotations) == 0 {
+					unstructured.RemoveNestedField(item.Object, "metadata", "annotations")
+				}
 
 				// Mask values in Kubernetes Secret
 				if item.GetKind() == "Secret" && maskSecrets {

--- a/cmd/mcp/k8s/export_test.go
+++ b/cmd/mcp/k8s/export_test.go
@@ -32,6 +32,10 @@ func TestExport(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "flux-system",
 			Namespace: "flux-system",
+			Annotations: map[string]string{
+				corev1.LastAppliedConfigAnnotation: `{"apiVersion":"v1","kind":"Secret","data":{"password":"cGFzc3dvcmQ="}}`,
+				"example.com/owner":                "flux",
+			},
 		},
 		Data: map[string][]byte{
 			"username": []byte("flux"),
@@ -116,6 +120,7 @@ func TestExport(t *testing.T) {
 	tests := []struct {
 		testName    string
 		matchResult string
+		missResults []string
 		matchErr    string
 		emptyResult bool
 
@@ -145,6 +150,7 @@ func TestExport(t *testing.T) {
 		{
 			testName:    "mask secret",
 			matchResult: "password: '****'",
+			missResults: []string{"cGFzc3dvcmQ=", "last-applied-configuration"},
 
 			apiVersion:  "v1",
 			kind:        "Secret",
@@ -153,6 +159,14 @@ func TestExport(t *testing.T) {
 		{
 			testName:    "unmask secret",
 			matchResult: "password: cGFzc3dvcmQ=",
+
+			apiVersion: "v1",
+			kind:       "Secret",
+		},
+		{
+			testName:    "remove kubectl annotation",
+			matchResult: "example.com/owner: flux",
+			missResults: []string{"last-applied-configuration"},
 
 			apiVersion: "v1",
 			kind:       "Secret",
@@ -196,6 +210,10 @@ func TestExport(t *testing.T) {
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(result).To(ContainSubstring(tt.matchResult))
+			}
+
+			for _, missResult := range tt.missResults {
+				g.Expect(result).NotTo(ContainSubstring(missResult))
 			}
 
 			if tt.emptyResult {


### PR DESCRIPTION
Trim the kubectl last-applied annotation from MCP tool responses to avoid duplicating the response size.