### PR TITLE
[web-ui] Change reconciler to resource in user-facing places

### DIFF
--- a/web/src/components/dashboards/cluster/OverallStatusPanel.jsx
+++ b/web/src/components/dashboards/cluster/OverallStatusPanel.jsx
@@ -85,7 +85,7 @@ export function OverallStatusPanel({ report }) {
         bgColor: 'bg-yellow-50',
         borderColor: 'border-warning',
         title: 'Degraded Performance',
-        message: `${failingReconcilers} reconciler${failingReconcilers !== 1 ? 's' : ''} failing`
+        message: `${failingReconcilers} resource${failingReconcilers !== 1 ? 's' : ''} failing`
       }
     }
 

--- a/web/src/components/dashboards/cluster/OverallStatusPanel.test.jsx
+++ b/web/src/components/dashboards/cluster/OverallStatusPanel.test.jsx
@@ -191,7 +191,7 @@ describe('OverallStatusPanel', () => {
 
       expect(screen.queryByText('Major Outage')).not.toBeInTheDocument()
       expect(screen.getByText('Degraded Performance')).toBeInTheDocument()
-      expect(screen.getByText('5 reconcilers failing')).toBeInTheDocument()
+      expect(screen.getByText('5 resources failing')).toBeInTheDocument()
     })
 
     it('should be clickable in major outage state', () => {
@@ -345,7 +345,7 @@ describe('OverallStatusPanel', () => {
       render(<OverallStatusPanel report={report} />)
 
       expect(screen.getByText('Degraded Performance')).toBeInTheDocument()
-      expect(screen.getByText('2 reconcilers failing')).toBeInTheDocument()
+      expect(screen.getByText('2 resources failing')).toBeInTheDocument()
     })
 
     it('should show correct singular for one failure', () => {
@@ -362,7 +362,7 @@ describe('OverallStatusPanel', () => {
 
       render(<OverallStatusPanel report={report} />)
 
-      expect(screen.getByText('1 reconciler failing')).toBeInTheDocument()
+      expect(screen.getByText('1 resource failing')).toBeInTheDocument()
     })
 
     it('should be clickable in degraded state', () => {
@@ -639,7 +639,7 @@ describe('OverallStatusPanel', () => {
 
       // Should count only the 2 from Kustomization
       expect(screen.getByText('Degraded Performance')).toBeInTheDocument()
-      expect(screen.getByText('2 reconcilers failing')).toBeInTheDocument()
+      expect(screen.getByText('2 resources failing')).toBeInTheDocument()
     })
 
     it('should handle reconcilers with null/undefined failing count', () => {
@@ -675,7 +675,7 @@ describe('OverallStatusPanel', () => {
 
       render(<OverallStatusPanel report={report} />)
 
-      expect(screen.getByText('5 reconcilers failing')).toBeInTheDocument()
+      expect(screen.getByText('5 resources failing')).toBeInTheDocument()
     })
 
     it('should correctly calculate when all reconcilers are completely broken', () => {
@@ -715,7 +715,7 @@ describe('OverallStatusPanel', () => {
 
       // Should be degraded with 3 failing
       expect(screen.getByText('Degraded Performance')).toBeInTheDocument()
-      expect(screen.getByText('3 reconcilers failing')).toBeInTheDocument()
+      expect(screen.getByText('3 resources failing')).toBeInTheDocument()
     })
   })
 })

--- a/web/src/components/dashboards/cluster/ReconcilersPanel.jsx
+++ b/web/src/components/dashboards/cluster/ReconcilersPanel.jsx
@@ -221,7 +221,7 @@ export function ReconcilersPanel({ reconcilers }) {
       >
         <div class="flex items-center justify-between">
           <div>
-            <h3 class="text-base sm:text-lg font-semibold text-gray-900 dark:text-white">Flux Reconcilers</h3>
+            <h3 class="text-base sm:text-lg font-semibold text-gray-900 dark:text-white">Flux Resources</h3>
             <div class="flex items-center space-x-4 mt-1">
               <p class="text-sm text-gray-600 dark:text-gray-400">
                 {installedKinds.size} CRDs • {totalResources} resources

--- a/web/src/components/dashboards/cluster/ReconcilersPanel.test.jsx
+++ b/web/src/components/dashboards/cluster/ReconcilersPanel.test.jsx
@@ -48,7 +48,7 @@ describe('ReconcilersPanel', () => {
     it('should render component title', () => {
       render(<ReconcilersPanel reconcilers={mockReconcilers} />)
 
-      expect(screen.getByText('Flux Reconcilers')).toBeInTheDocument()
+      expect(screen.getByText('Flux Resources')).toBeInTheDocument()
     })
 
     it('should show total CRD count', () => {
@@ -89,7 +89,7 @@ describe('ReconcilersPanel', () => {
     it('should render expand/collapse toggle', () => {
       render(<ReconcilersPanel reconcilers={mockReconcilers} />)
 
-      const toggle = screen.getByRole('button', { name: /Flux Reconcilers/i })
+      const toggle = screen.getByRole('button', { name: /Flux Resources/i })
       expect(toggle).toBeInTheDocument()
     })
 
@@ -304,7 +304,7 @@ describe('ReconcilersPanel', () => {
       expect(screen.getByText('Kustomization')).toBeInTheDocument()
 
       // Click toggle to collapse
-      const toggle = screen.getByRole('button', { name: /Flux Reconcilers/i })
+      const toggle = screen.getByRole('button', { name: /Flux Resources/i })
       fireEvent.click(toggle)
 
       // Cards should be hidden
@@ -314,7 +314,7 @@ describe('ReconcilersPanel', () => {
     it('should toggle grid visibility when clicked multiple times', () => {
       render(<ReconcilersPanel reconcilers={mockReconcilers} />)
 
-      const toggle = screen.getByRole('button', { name: /Flux Reconcilers/i })
+      const toggle = screen.getByRole('button', { name: /Flux Resources/i })
 
       // Get initial state
       const initiallyVisible = screen.queryByText('Kustomization') !== null
@@ -337,7 +337,7 @@ describe('ReconcilersPanel', () => {
     it('should rotate chevron icon when toggled', () => {
       render(<ReconcilersPanel reconcilers={mockReconcilers} />)
 
-      const toggle = screen.getByRole('button', { name: /Flux Reconcilers/i })
+      const toggle = screen.getByRole('button', { name: /Flux Resources/i })
       const chevron = toggle.querySelector('svg')
 
       // Get initial rotation state
@@ -625,7 +625,7 @@ describe('ReconcilersPanel', () => {
     it('should handle empty reconcilers array', () => {
       render(<ReconcilersPanel reconcilers={[]} />)
 
-      expect(screen.getByText('Flux Reconcilers')).toBeInTheDocument()
+      expect(screen.getByText('Flux Resources')).toBeInTheDocument()
       // Shows 0 CRDs when none are installed, and 0 resources
       expect(screen.getByText(/0 CRDs/)).toBeInTheDocument()
       expect(screen.getByText(/0 resources/)).toBeInTheDocument()

--- a/web/src/components/search/StatusChart.jsx
+++ b/web/src/components/search/StatusChart.jsx
@@ -159,7 +159,7 @@ export function StatusChart({ items, loading, mode = 'events', onBarClick }) {
             <span>Loading...</span>
           ) : (
             <span>
-              {mode === 'events' ? 'Reconcile events: ' : 'Reconcilers: '}
+              {mode === 'events' ? 'Reconcile events: ' : 'Resources: '}
               <span class="font-semibold text-gray-900 dark:text-gray-100">
                 {items && items.length > 0 ? items.length : 0}
               </span>

--- a/web/src/components/search/StatusChart.test.jsx
+++ b/web/src/components/search/StatusChart.test.jsx
@@ -532,7 +532,7 @@ describe('StatusChart', () => {
       )
 
       // Should show total reconciliations count
-      expect(container.textContent).toContain('Reconcilers:')
+      expect(container.textContent).toContain('Resources:')
       expect(container.textContent).toContain('15')
     })
 


### PR DESCRIPTION
I'd like to propose making this change, I think "resource" is a better user-facing word than "reconciler". Also, not all Flux resources are really reconcilers, we have stateless resources like Alert and Provider.