### PR TITLE
Add live object YAML editing to web UI

### DIFF
--- a/docs/web/web-least-privilege-rbac.md
+++ b/docs/web/web-least-privilege-rbac.md
@@ -228,6 +228,21 @@ Users do not need cluster-wide `list` permissions on namespaces just to populate
 
 ---
 
+## Non-elevated Live Object Editing
+
+**Where:** YAML editors on resource and workload specification tabs.
+
+**Internal operation:**
+The backend updates the submitted Kubernetes object using the authenticated user's impersonated client.
+
+**How it works:**
+The Web UI sends the edited YAML to `PUT /api/v1/object`. The backend parses the YAML, validates `apiVersion`, `kind`, and `metadata.name`, fetches the current object with the user's own Kubernetes identity, carries forward the current `resourceVersion`, strips the status subresource, and performs a normal Kubernetes `update` using that same impersonated identity. No `WithPrivileges()` path is used.
+
+**Least privilege benefit:**
+Live editing does not grant any additional capability beyond the user's native Kubernetes RBAC. Users who lack `update` permission on an object receive the Kubernetes authorization error, while users who already have update permission get an in-context editor without needing to leave the Flux Web UI.
+
+---
+
 ## Summary
 
 | # | Feature                     | Internal Operation                                 | Data Exposed to User                                                          |
@@ -240,3 +255,4 @@ Users do not need cluster-wide `list` permissions on namespaces just to populate
 | 6 | Controller metrics          | System reads metrics API                           | CPU/memory usage of Flux controllers                                          |
 | 7 | Fine-Grained GitOps Actions | System patches resource                            | None (server-side mutation only)                                              |
 | 8 | Namespace visibility        | Wrapper lists namespaces with privileged base client | Visible namespace names after RBAC filtering                                  |
+| 9 | Live object editing         | User's impersonated client updates submitted object fields | Editable YAML for objects the user can get/update                             |

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -72,6 +72,8 @@ func NewHandler(ctx context.Context, conf *fluxcdv1.WebConfigSpec, spaHandler ht
 	mux.HandleFunc("GET /api/v1/events", h.EventsHandler)
 	mux.HandleFunc("POST /api/v1/favorites", h.FavoritesHandler)
 	mux.HandleFunc("GET /api/v1/report", h.ReportHandler)
+	mux.HandleFunc("GET /api/v1/object", h.ObjectEditHandler)
+	mux.HandleFunc("PUT /api/v1/object", h.ObjectEditHandler)
 	mux.HandleFunc("GET /api/v1/resource", h.ResourceHandler)
 	mux.HandleFunc("POST /api/v1/resource/action", h.ActionHandler)
 	mux.HandleFunc("GET /api/v1/resources", h.ResourcesHandler)

--- a/internal/web/object_edit.go
+++ b/internal/web/object_edit.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/yaml"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
+)
+
+// ObjectEditRequest represents the request body for PUT /api/v1/object.
+type ObjectEditRequest struct {
+	APIVersion string `json:"apiVersion,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	Name       string `json:"name,omitempty"`
+	YAML       string `json:"yaml"`
+}
+
+// ObjectEditResponse represents the response body for PUT /api/v1/object.
+type ObjectEditResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+// ObjectEditHandler handles GET and PUT /api/v1/object requests for live Kubernetes objects.
+func (h *Handler) ObjectEditHandler(w http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+	case http.MethodGet, http.MethodHead:
+		h.ObjectGetHandler(w, req)
+	case http.MethodPut:
+		h.ObjectUpdateHandler(w, req)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// ObjectGetHandler handles GET /api/v1/object requests and returns a live Kubernetes object.
+func (h *Handler) ObjectGetHandler(w http.ResponseWriter, req *http.Request) {
+	queryParams := req.URL.Query()
+	apiVersion := queryParams.Get("apiVersion")
+	kind := queryParams.Get("kind")
+	name := queryParams.Get("name")
+	namespace := queryParams.Get("namespace")
+	if apiVersion == "" || kind == "" || name == "" {
+		http.Error(w, "Missing required parameters: apiVersion, kind, name", http.StatusBadRequest)
+		return
+	}
+
+	obj, err := h.GetObject(req.Context(), apiVersion, kind, namespace, name)
+	if err != nil {
+		log.FromContext(req.Context()).Error(err, "failed to get object")
+		switch {
+		case apierrors.IsNotFound(err):
+			http.Error(w, err.Error(), http.StatusNotFound)
+		case apierrors.IsForbidden(err):
+			perms := user.Permissions(req.Context())
+			http.Error(w, fmt.Sprintf("You do not have access to this object. User: %s, Groups: [%s]",
+				perms.Username, strings.Join(perms.Groups, ", ")), http.StatusForbidden)
+		default:
+			http.Error(w, fmt.Sprintf("Failed to get object: %v", err), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	obj.SetManagedFields(nil)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(obj.Object); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// ObjectUpdateHandler handles PUT /api/v1/object requests to update live Kubernetes objects from YAML.
+func (h *Handler) ObjectUpdateHandler(w http.ResponseWriter, req *http.Request) {
+	var editReq ObjectEditRequest
+	if err := json.NewDecoder(req.Body).Decode(&editReq); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(editReq.YAML) == "" {
+		http.Error(w, "Missing required field: yaml", http.StatusBadRequest)
+		return
+	}
+
+	updated, err := h.UpdateObjectFromYAML(req.Context(), editReq)
+	if err != nil {
+		log.FromContext(req.Context()).Error(err, "object edit failed")
+		switch {
+		case isObjectValidationError(err):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		case apierrors.IsNotFound(err):
+			http.Error(w, err.Error(), http.StatusNotFound)
+		case apierrors.IsForbidden(err):
+			perms := user.Permissions(req.Context())
+			http.Error(w, fmt.Sprintf("Permission denied. User %s cannot update %s %s/%s",
+				perms.Username, updatedKindFromErrorTarget(updated), updated.GetNamespace(), updated.GetName()), http.StatusForbidden)
+		case apierrors.IsConflict(err):
+			http.Error(w, err.Error(), http.StatusConflict)
+		case apierrors.IsInvalid(err) || apierrors.IsBadRequest(err):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		default:
+			http.Error(w, fmt.Sprintf("Object update failed: %v", err), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	resp := ObjectEditResponse{
+		Success: true,
+		Message: fmt.Sprintf("Updated %s %s/%s", updated.GetKind(), updated.GetNamespace(), updated.GetName()),
+	}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+// GetObject fetches a single Kubernetes object by apiVersion, kind, name and namespace.
+func (h *Handler) GetObject(ctx context.Context, apiVersion, kind, namespace, name string) (*unstructured.Unstructured, error) {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(apiVersion)
+	obj.SetKind(kind)
+	if err := h.kubeClient.GetClient(ctx).Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// UpdateObjectFromYAML updates an existing Kubernetes object from a user-edited YAML document.
+func (h *Handler) UpdateObjectFromYAML(ctx context.Context, req ObjectEditRequest) (*unstructured.Unstructured, error) {
+	edited := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal([]byte(req.YAML), &edited.Object); err != nil {
+		return edited, objectValidationError(fmt.Sprintf("Invalid YAML: %v", err))
+	}
+
+	if edited.GetAPIVersion() == "" {
+		return edited, objectValidationError("apiVersion is required")
+	}
+	if edited.GetKind() == "" {
+		return edited, objectValidationError("kind is required")
+	}
+	if edited.GetName() == "" {
+		return edited, objectValidationError("metadata.name is required")
+	}
+	if err := validateObjectIdentity(req, edited); err != nil {
+		return edited, err
+	}
+
+	kubeClient := h.kubeClient.GetClient(ctx)
+	current := &unstructured.Unstructured{}
+	current.SetAPIVersion(edited.GetAPIVersion())
+	current.SetKind(edited.GetKind())
+	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: edited.GetNamespace(), Name: edited.GetName()}, current); err != nil {
+		return edited, err
+	}
+
+	updated := mergeEditedObject(current, edited)
+	if err := kubeClient.Update(ctx, updated); err != nil {
+		return updated, err
+	}
+
+	return updated, nil
+}
+
+func validateObjectIdentity(req ObjectEditRequest, edited *unstructured.Unstructured) error {
+	if req.APIVersion != "" && req.APIVersion != edited.GetAPIVersion() {
+		return objectValidationError("apiVersion cannot be changed")
+	}
+	if req.Kind != "" && req.Kind != edited.GetKind() {
+		return objectValidationError("kind cannot be changed")
+	}
+	if req.Namespace != "" && req.Namespace != edited.GetNamespace() {
+		return objectValidationError("metadata.namespace cannot be changed")
+	}
+	if req.Name != "" && req.Name != edited.GetName() {
+		return objectValidationError("metadata.name cannot be changed")
+	}
+	return nil
+}
+
+func mergeEditedObject(current, edited *unstructured.Unstructured) *unstructured.Unstructured {
+	updated := current.DeepCopy()
+	updated.SetLabels(edited.GetLabels())
+	updated.SetAnnotations(edited.GetAnnotations())
+	updated.SetFinalizers(edited.GetFinalizers())
+	updated.SetOwnerReferences(edited.GetOwnerReferences())
+
+	for key, value := range edited.Object {
+		switch key {
+		case "apiVersion", "kind", "metadata", "status":
+			continue
+		default:
+			updated.Object[key] = value
+		}
+	}
+	return updated
+}
+
+type objectValidationError string
+
+func (e objectValidationError) Error() string {
+	return string(e)
+}
+
+func isObjectValidationError(err error) bool {
+	_, ok := err.(objectValidationError)
+	return ok
+}
+
+func updatedKindFromErrorTarget(obj *unstructured.Unstructured) string {
+	if obj == nil || obj.GetKind() == "" {
+		return "object"
+	}
+	return obj.GetKind()
+}

--- a/internal/web/object_edit_test.go
+++ b/internal/web/object_edit_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestObjectEditHandler_GetConfigMap_Success(t *testing.T) {
+	g := NewWithT(t)
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-get-configmap",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"key": "value",
+		},
+	}
+	g.Expect(testClient.Create(ctx, configMap)).To(Succeed())
+	defer testClient.Delete(ctx, configMap)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/object?apiVersion=v1&kind=ConfigMap&namespace=default&name=test-get-configmap", nil)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handler.ObjectEditHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusOK))
+	var resp map[string]any
+	g.Expect(json.NewDecoder(rec.Body).Decode(&resp)).To(Succeed())
+	g.Expect(resp["kind"]).To(Equal("ConfigMap"))
+	g.Expect(resp["data"]).To(HaveKeyWithValue("key", "value"))
+}
+
+func TestObjectEditHandler_UpdateConfigMap_Success(t *testing.T) {
+	g := NewWithT(t)
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-edit-configmap",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"key": "old-value",
+		},
+	}
+	g.Expect(testClient.Create(ctx, configMap)).To(Succeed())
+	defer testClient.Delete(ctx, configMap)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	body, _ := json.Marshal(ObjectEditRequest{
+		YAML: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-edit-configmap
+  namespace: default
+data:
+  key: new-value
+`,
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/object", bytes.NewBuffer(body))
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handler.ObjectEditHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusOK))
+
+	var resp ObjectEditResponse
+	err := json.NewDecoder(rec.Body).Decode(&resp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(resp.Success).To(BeTrue())
+	g.Expect(resp.Message).To(ContainSubstring("Updated ConfigMap default/test-edit-configmap"))
+
+	var updated corev1.ConfigMap
+	g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), &updated)).To(Succeed())
+	g.Expect(updated.Data).To(HaveKeyWithValue("key", "new-value"))
+}
+
+func TestObjectEditHandler_InvalidYAML(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	body, _ := json.Marshal(ObjectEditRequest{YAML: "apiVersion: ["})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/object", bytes.NewBuffer(body))
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handler.ObjectEditHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
+	g.Expect(rec.Body.String()).To(ContainSubstring("Invalid YAML"))
+}
+
+func TestObjectEditHandler_IdentityMismatch(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	body, _ := json.Marshal(ObjectEditRequest{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Namespace:  "default",
+		Name:       "expected-name",
+		YAML: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: different-name
+  namespace: default
+`,
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/object", bytes.NewBuffer(body))
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handler.ObjectEditHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
+	g.Expect(rec.Body.String()).To(ContainSubstring("metadata.name cannot be changed"))
+}
+
+func TestObjectEditHandler_MissingIdentity(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := &Handler{
+		conf:          oauthConfig(),
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	body, _ := json.Marshal(ObjectEditRequest{
+		YAML: `apiVersion: v1
+kind: ConfigMap
+data:
+  key: value
+`,
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/object", bytes.NewBuffer(body))
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handler.ObjectEditHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
+	g.Expect(rec.Body.String()).To(ContainSubstring("metadata.name is required"))
+}

--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -18,6 +18,7 @@ import { ResourceList } from './components/search/ResourceList'
 import { WorkloadList } from './components/search/WorkloadList'
 import { ResourcePage } from './components/dashboards/resource/ResourcePage'
 import { WorkloadPage } from './components/dashboards/workload/WorkloadPage'
+import { ObjectPage } from './components/dashboards/object/ObjectPage'
 import { FavoritesPage } from './components/favorites/FavoritesPage'
 import { ProfilePage } from './components/user/ProfilePage'
 import { NotFoundPage } from './components/layout/NotFoundPage'
@@ -325,6 +326,7 @@ function AppContent({ spec, namespace }) {
         <Route path="/workloads" component={WorkloadList} />
         <Route path="/resource/:kind/:namespace/:name" component={ResourcePage} />
         <Route path="/workload/:kind/:namespace/:name" component={WorkloadPage} />
+        <Route path="/object/:apiVersion/:kind/:namespace/:name" component={ObjectPage} />
         <Route path="/user/profile" component={ProfilePage} />
         <Route default component={NotFoundPage} />
       </Router>

--- a/web/src/app.test.jsx
+++ b/web/src/app.test.jsx
@@ -63,7 +63,11 @@ vi.mock('./components/dashboards/workload/WorkloadPage', () => ({
   WorkloadPage: () => <div data-testid="workload-page">WorkloadPage</div>
 }))
 
-vi.mock('./components/common/NotFoundPage', () => ({
+vi.mock('./components/dashboards/object/ObjectPage', () => ({
+  ObjectPage: () => <div data-testid="object-page">ObjectPage</div>
+}))
+
+vi.mock('./components/layout/NotFoundPage', () => ({
   NotFoundPage: () => <div data-testid="not-found-page">NotFoundPage</div>
 }))
 

--- a/web/src/components/dashboards/common/yaml.jsx
+++ b/web/src/components/dashboards/common/yaml.jsx
@@ -1,8 +1,9 @@
 // Copyright 2025 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { useEffect, useMemo } from 'preact/hooks'
+import { useEffect, useMemo, useState } from 'preact/hooks'
 import { appliedTheme } from '../../../utils/theme'
+import { fetchWithMock } from '../../../utils/fetch'
 import yaml from 'js-yaml'
 import Prism from 'prismjs'
 import 'prismjs/components/prism-yaml'
@@ -94,5 +95,131 @@ export function YamlBlock({ data }) {
     <pre class="p-3 bg-gray-50 dark:bg-gray-900 rounded-md overflow-x-auto language-yaml" style="font-size: 12px; line-height: 1.5;">
       <code class="language-yaml" style="font-size: 12px;" dangerouslySetInnerHTML={{ __html: highlighted }} />
     </pre>
+  )
+}
+
+/**
+ * Editable YAML block for live Kubernetes object edits.
+ */
+export function EditableYamlBlock({ data, onSaved }) {
+  const yamlText = useMemo(() => data ? yaml.dump(data, { indent: 2, lineWidth: -1 }) : '', [data])
+  const [editing, setEditing] = useState(false)
+  const [value, setValue] = useState(yamlText)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+  const [message, setMessage] = useState(null)
+
+  useEffect(() => {
+    if (!editing) {
+      setValue(yamlText)
+    }
+  }, [yamlText, editing])
+
+  const startEditing = () => {
+    setValue(yamlText)
+    setError(null)
+    setMessage(null)
+    setEditing(true)
+  }
+
+  const cancelEditing = () => {
+    setValue(yamlText)
+    setError(null)
+    setEditing(false)
+  }
+
+  const saveYaml = async () => {
+    setSaving(true)
+    setError(null)
+    setMessage(null)
+    try {
+      const response = await fetchWithMock({
+        endpoint: '/api/v1/object',
+        mockPath: '../mock/action',
+        mockExport: 'mockObjectEdit',
+        method: 'PUT',
+        body: {
+          apiVersion: data?.apiVersion,
+          kind: data?.kind,
+          namespace: data?.metadata?.namespace || '',
+          name: data?.metadata?.name,
+          yaml: value
+        }
+      })
+      setMessage(response?.message || 'Object updated')
+      setEditing(false)
+      if (onSaved) {
+        await onSaved()
+      }
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!editing) {
+    return (
+      <div class="space-y-3">
+        <div class="flex items-center justify-between gap-3">
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            Edit applies changes to the live Kubernetes object using your RBAC identity.
+          </p>
+          <button
+            type="button"
+            onClick={startEditing}
+            class="px-3 py-1.5 text-xs font-medium rounded border border-flux-blue text-flux-blue hover:bg-blue-50 dark:border-blue-400 dark:text-blue-400 dark:hover:bg-blue-900/30"
+          >
+            Edit YAML
+          </button>
+        </div>
+        {message && (
+          <div class="p-2 rounded border border-green-200 bg-green-50 text-xs text-green-800 dark:border-green-800 dark:bg-green-900/20 dark:text-green-200">
+            {message}
+          </div>
+        )}
+        <YamlBlock data={data} />
+      </div>
+    )
+  }
+
+  return (
+    <div class="space-y-3">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <p class="text-xs text-gray-500 dark:text-gray-400">
+          Review carefully. Saving updates the live object immediately.
+        </p>
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={cancelEditing}
+            disabled={saving}
+            class="px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:text-gray-400 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={saveYaml}
+            disabled={saving}
+            class="px-3 py-1.5 text-xs font-medium rounded border border-flux-blue bg-flux-blue text-white hover:bg-blue-600 disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save YAML'}
+          </button>
+        </div>
+      </div>
+      {error && (
+        <div class="p-2 rounded border border-red-200 bg-red-50 text-xs text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-200">
+          {error}
+        </div>
+      )}
+      <textarea
+        aria-label="YAML object editor"
+        value={value}
+        onInput={(event) => setValue(event.currentTarget.value)}
+        spellcheck={false}
+        class="w-full min-h-[24rem] p-3 rounded-md border border-gray-300 bg-gray-50 font-mono text-xs leading-5 text-gray-900 focus:outline-none focus:ring-2 focus:ring-flux-blue dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+      />
+    </div>
   )
 }

--- a/web/src/components/dashboards/common/yaml.test.jsx
+++ b/web/src/components/dashboards/common/yaml.test.jsx
@@ -1,9 +1,14 @@
 // Copyright 2025 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { renderHook, cleanup } from '@testing-library/preact'
-import { usePrismTheme } from './yaml'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, renderHook, screen, fireEvent, waitFor, cleanup } from '@testing-library/preact'
+import { EditableYamlBlock, usePrismTheme } from './yaml'
+import { fetchWithMock } from '../../../utils/fetch'
+
+vi.mock('../../../utils/fetch', () => ({
+  fetchWithMock: vi.fn()
+}))
 import { appliedTheme } from '../../../utils/theme'
 
 describe('usePrismTheme', () => {
@@ -17,6 +22,7 @@ describe('usePrismTheme', () => {
     }
     // Reset theme to light
     appliedTheme.value = 'light'
+    fetchWithMock.mockReset()
   })
 
   afterEach(() => {
@@ -108,5 +114,69 @@ describe('usePrismTheme', () => {
     expect(updatedLink).not.toBeNull()
     // In test env we can't check actual CSS files, but link should be recreated
     expect(document.querySelectorAll(`#${LINK_ID}`).length).toBe(1)
+  })
+})
+
+describe('EditableYamlBlock', () => {
+  beforeEach(() => {
+    fetchWithMock.mockReset()
+    fetchWithMock.mockResolvedValue({ success: true, message: 'Updated ConfigMap default/app-config' })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('edits YAML and saves it through the object edit API', async () => {
+    const onSaved = vi.fn()
+    const data = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'app-config', namespace: 'default' },
+      data: { key: 'old-value' }
+    }
+
+    render(<EditableYamlBlock data={data} onSaved={onSaved} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit YAML' }))
+
+    const editor = screen.getByLabelText('YAML object editor')
+    expect(editor.value).toContain('old-value')
+
+    fireEvent.input(editor, {
+      target: { value: editor.value.replace('old-value', 'new-value') }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save YAML' }))
+
+    await waitFor(() => {
+      expect(fetchWithMock).toHaveBeenCalledWith({
+        endpoint: '/api/v1/object',
+        mockPath: '../mock/action',
+        mockExport: 'mockObjectEdit',
+        method: 'PUT',
+        body: expect.objectContaining({
+          yaml: expect.stringContaining('new-value'),
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          namespace: 'default',
+          name: 'app-config'
+        })
+      })
+      expect(onSaved).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('shows save errors without leaving edit mode', async () => {
+    fetchWithMock.mockRejectedValue(new Error('forbidden'))
+
+    render(<EditableYamlBlock data={{ apiVersion: 'v1', kind: 'ConfigMap', metadata: { name: 'app-config' } }} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit YAML' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save YAML' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('forbidden')).toBeInTheDocument()
+      expect(screen.getByLabelText('YAML object editor')).toBeInTheDocument()
+    })
   })
 })

--- a/web/src/components/dashboards/object/ObjectPage.jsx
+++ b/web/src/components/dashboards/object/ObjectPage.jsx
@@ -1,0 +1,103 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { fetchWithMock } from '../../../utils/fetch'
+import { usePrismTheme, EditableYamlBlock, YamlBlock } from '../common/yaml'
+import { DashboardPanel, TabButton } from '../common/panel'
+
+/**
+ * ObjectPage displays and edits an arbitrary Kubernetes object by apiVersion, kind, namespace and name.
+ */
+export function ObjectPage({ apiVersion, kind, namespace, name }) {
+  const resolvedNamespace = namespace === '_' ? '' : namespace
+  const decodedApiVersion = decodeURIComponent(apiVersion)
+  const decodedKind = decodeURIComponent(kind)
+  const decodedNamespace = decodeURIComponent(resolvedNamespace)
+  const decodedName = decodeURIComponent(name)
+  const [objectData, setObjectData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [tab, setTab] = useState('spec')
+
+  usePrismTheme()
+
+  const loadObject = async () => {
+    setLoading(true)
+    setError(null)
+    const params = new URLSearchParams({
+      apiVersion: decodedApiVersion,
+      kind: decodedKind,
+      name: decodedName
+    })
+    if (decodedNamespace) {
+      params.set('namespace', decodedNamespace)
+    }
+    try {
+      const data = await fetchWithMock({
+        endpoint: `/api/v1/object?${params.toString()}`,
+        mockPath: '../mock/resource',
+        mockExport: 'getMockResource'
+      })
+      setObjectData(data)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadObject()
+  }, [decodedApiVersion, decodedKind, decodedNamespace, decodedName])
+
+  const editableYaml = useMemo(() => {
+    if (!objectData) return null
+    const editable = { ...objectData }
+    delete editable.status
+    return editable
+  }, [objectData])
+
+  const statusYaml = useMemo(() => {
+    if (!objectData?.status) return null
+    return {
+      apiVersion: objectData.apiVersion,
+      kind: objectData.kind,
+      metadata: {
+        name: objectData.metadata?.name,
+        namespace: objectData.metadata?.namespace
+      },
+      status: objectData.status
+    }
+  }, [objectData])
+
+  return (
+    <main class="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6">
+      <DashboardPanel
+        title={`${decodedKind}/${decodedName}`}
+        subtitle={decodedNamespace ? `${decodedApiVersion} · ${decodedNamespace}` : decodedApiVersion}
+      >
+        {loading && (
+          <p class="text-sm text-gray-600 dark:text-gray-400">Loading object...</p>
+        )}
+        {error && (
+          <div class="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+            <p class="text-sm text-red-800 dark:text-red-200">Failed to load object: {error}</p>
+          </div>
+        )}
+        {!loading && !error && objectData && (
+          <>
+            <div class="border-b border-gray-200 dark:border-gray-700 mb-4">
+              <nav class="flex space-x-4" aria-label="Tabs">
+                <TabButton active={tab === 'spec'} onClick={() => setTab('spec')}>Specification</TabButton>
+                {statusYaml && <TabButton active={tab === 'status'} onClick={() => setTab('status')}>Status</TabButton>}
+              </nav>
+            </div>
+            {tab === 'spec' && <EditableYamlBlock data={editableYaml} onSaved={loadObject} />}
+            {tab === 'status' && <YamlBlock data={statusYaml} />}
+          </>
+        )}
+      </DashboardPanel>
+    </main>
+  )
+}

--- a/web/src/components/dashboards/resource/InventoryPanel.jsx
+++ b/web/src/components/dashboards/resource/InventoryPanel.jsx
@@ -170,8 +170,12 @@ export function InventoryPanel({ resourceData, onNavigate }) {
 
   // Build the dashboard URL for an inventory item, routing workloads to the
   // workload dashboard and Flux resources to the resource dashboard.
-  const getItemUrl = (item) =>
-    getDashboardUrl(item.kind, item.namespace || resourceData.metadata.namespace, item.name)
+  const getItemUrl = (item) => {
+    const isFluxResource = isFluxInventoryItem(item)
+    const isWorkload = !isFluxResource && isWorkloadInventoryItem(item)
+    const apiVersion = isFluxResource || isWorkload ? '' : item.apiVersion
+    return getDashboardUrl(item.kind, item.namespace || resourceData.metadata.namespace, item.name, apiVersion)
+  }
 
   return (
     <DashboardPanel title="Managed Objects" id="inventory-panel">
@@ -308,7 +312,7 @@ export function InventoryPanel({ resourceData, onNavigate }) {
                 return (
                   <tr key={idx} class="hover:bg-gray-50 dark:hover:bg-gray-800">
                     <td class="px-3 py-2 text-sm">
-                      {(isFluxResource || isWorkload) ? (
+                      {(isFluxResource || isWorkload || item.apiVersion) ? (
                         <a
                           href={getItemUrl(item)}
                           class="text-flux-blue dark:text-blue-400 hover:underline"

--- a/web/src/components/dashboards/resource/InventoryPanel.test.jsx
+++ b/web/src/components/dashboards/resource/InventoryPanel.test.jsx
@@ -448,7 +448,7 @@ describe('InventoryPanel component', () => {
     expect(kustomizationLink).toHaveAttribute('href', '/resource/Kustomization/production/backend')
   })
 
-  it('should not make non-Flux resources clickable in inventory', async () => {
+  it('should make API-versioned non-Flux resources clickable in inventory', async () => {
     const user = userEvent.setup()
 
     render(
@@ -462,10 +462,10 @@ describe('InventoryPanel component', () => {
     const inventoryTab = screen.getByText('Inventory')
     await user.click(inventoryTab)
 
-    // ConfigMap should not be in a link
-    const configMapElement = screen.getByText('app-config')
-    expect(configMapElement.tagName).toBe('SPAN')
-    expect(configMapElement.closest('a')).toBeNull()
+    // ConfigMap should link to the arbitrary object dashboard
+    const configMapLink = screen.getByText('app-config').closest('a')
+    expect(configMapLink).toBeInTheDocument()
+    expect(configMapLink).toHaveAttribute('href', '/object/v1/ConfigMap/production/app-config')
   })
 
   it('should toggle collapse/expand state', async () => {
@@ -570,7 +570,7 @@ describe('InventoryPanel component', () => {
     expect(textContent).toContain('Disabled')
   })
 
-  it('should not call onNavigate when clicking non-Flux resources', async () => {
+  it('should link non-Flux resources without calling onNavigate', async () => {
     const user = userEvent.setup()
 
     render(
@@ -584,13 +584,13 @@ describe('InventoryPanel component', () => {
     const inventoryTab = screen.getByText('Inventory')
     await user.click(inventoryTab)
 
-    // Check that there are no buttons in the table (all are non-Flux resources)
+    // Check that there are no buttons in the table
     const buttons = document.querySelectorAll('tbody button')
     expect(buttons.length).toBe(0)
 
-    // Check that spans are used instead
-    const spans = document.querySelectorAll('tbody td span')
-    expect(spans.length).toBeGreaterThan(0)
+    // Check that links are used for API-versioned objects
+    const links = document.querySelectorAll('tbody td a')
+    expect(links.length).toBeGreaterThan(0)
 
     // Verify onNavigate was not called
     expect(mockOnNavigate).not.toHaveBeenCalled()

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
@@ -7,7 +7,7 @@ import { formatTimestamp } from '../../../utils/time'
 import { getWorkloadStatusBadgeClass, formatWorkloadStatus, getEventBadgeClass, getContainerStateBadgeClass } from '../../../utils/status'
 import { formatScheduleMessage } from '../../../utils/cron'
 import { DashboardPanel, TabButton } from '../common/panel'
-import { YamlBlock } from '../common/yaml'
+import { EditableYamlBlock, YamlBlock } from '../common/yaml'
 import { WorkloadDeleteAction } from '../resource/WorkloadDeleteAction'
 import { WorkloadLogsViewer } from './WorkloadLogsViewer'
 import { LOGS_QUERY_PARAM, ALL_PODS_VALUE } from './WorkloadLogsAction'
@@ -607,7 +607,9 @@ export function WorkloadDetailPanel({
       )}
 
       {/* Workload Specification Tab */}
-      {workloadTab === 'spec' && <YamlBlock data={workloadSpecYaml} />}
+      {workloadTab === 'spec' && (
+        <EditableYamlBlock data={workloadSpecYaml} onSaved={onActionComplete} />
+      )}
 
       {/* Workload Status Tab */}
       {workloadTab === 'status' && <YamlBlock data={workloadStatusYaml} />}

--- a/web/src/components/search/ResourceDetailsView.jsx
+++ b/web/src/components/search/ResourceDetailsView.jsx
@@ -3,7 +3,7 @@
 
 import { useState, useMemo, useEffect, useRef } from 'preact/hooks'
 import { fetchWithMock } from '../../utils/fetch'
-import { usePrismTheme, YamlBlock } from '../dashboards/common/yaml'
+import { usePrismTheme, YamlBlock, EditableYamlBlock } from '../dashboards/common/yaml'
 import { isKindWithInventory, getKindAlias, isFluxInventoryItem, isWorkloadInventoryItem } from '../../utils/constants'
 import { getDashboardUrl } from '../../utils/routing'
 import { getStatusBadgeClass, cleanStatus } from '../../utils/status'
@@ -59,9 +59,9 @@ function InventoryItem({ item }) {
 
   // Build the dashboard URL, routing workloads and Flux resources accordingly
   const ns = item.namespace || ''
-  const dashboardUrl = getDashboardUrl(item.kind, ns, item.name)
+  const dashboardUrl = getDashboardUrl(item.kind, ns, item.name, isFluxResource || isWorkload ? '' : item.apiVersion)
 
-  if (isFluxResource || isWorkload) {
+  if (isFluxResource || isWorkload || item.apiVersion) {
     return (
       <div class="py-1 px-2 text-xs break-all">
         <a
@@ -404,7 +404,13 @@ export function ResourceDetailsView({ kind, name, namespace, isExpanded }) {
 
           {/* Specification Tab */}
           {activeTab === 'specification' && (
-            <YamlBlock data={definitionData} />
+            <EditableYamlBlock
+              data={definitionData}
+              onSaved={() => {
+                fetchingRef.current = false
+                setResourceData(null)
+              }}
+            />
           )}
 
           {/* Status Tab */}

--- a/web/src/mock/action.js
+++ b/web/src/mock/action.js
@@ -21,3 +21,11 @@ export const mockWorkloadAction = (body) => {
     message: `${message} for ${body.namespace}/${body.name}`
   }
 }
+
+// Mock object edit response for PUT /api/v1/object
+export const mockObjectEdit = () => {
+  return {
+    success: true,
+    message: 'Object updated'
+  }
+}

--- a/web/src/utils/routing.js
+++ b/web/src/utils/routing.js
@@ -15,9 +15,28 @@ import { workloadKinds } from './constants'
  * @param {string} name - Object name
  * @returns {string} Dashboard path
  */
-export function getDashboardUrl(kind, namespace, name) {
-  const base = workloadKinds.includes(kind) ? 'workload' : 'resource'
-  return `/${base}/${encodeURIComponent(kind)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`
+export function getDashboardUrl(kind, namespace, name, apiVersion = '') {
+  const isNativeWorkload = workloadKinds.includes(kind) && (!apiVersion || apiVersion === 'apps/v1' || apiVersion === 'batch/v1')
+  if (isNativeWorkload) {
+    return `/workload/${encodeURIComponent(kind)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`
+  }
+  if (apiVersion) {
+    return getObjectDashboardUrl(apiVersion, kind, namespace, name)
+  }
+  return `/resource/${encodeURIComponent(kind)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`
+}
+
+/**
+ * Builds the dashboard URL for an arbitrary Kubernetes object.
+ *
+ * @param {string} apiVersion - Object API version
+ * @param {string} kind - Object kind
+ * @param {string} namespace - Object namespace
+ * @param {string} name - Object name
+ * @returns {string} Dashboard path
+ */
+export function getObjectDashboardUrl(apiVersion, kind, namespace, name) {
+  return `/object/${encodeURIComponent(apiVersion)}/${encodeURIComponent(kind)}/${encodeURIComponent(namespace || '_')}/${encodeURIComponent(name)}`
 }
 
 /**

--- a/web/src/utils/routing.test.js
+++ b/web/src/utils/routing.test.js
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/preact'
 import { signal } from '@preact/signals'
-import { serializeFilters, urlWithParam } from './routing'
+import { serializeFilters, urlWithParam, getDashboardUrl, getObjectDashboardUrl } from './routing'
 
 describe('serializeFilters', () => {
   it('should serialize simple filter object to query string', () => {
@@ -59,6 +59,21 @@ describe('serializeFilters', () => {
   it('should handle numeric string values', () => {
     const filters = { limit: '10', offset: '0' }
     expect(serializeFilters(filters)).toBe('limit=10&offset=0')
+  })
+})
+
+describe('dashboard object routing', () => {
+  it('routes native workloads to workload dashboards', () => {
+    expect(getDashboardUrl('Deployment', 'apps', 'podinfo', 'apps/v1')).toBe('/workload/Deployment/apps/podinfo')
+    expect(getDashboardUrl('CronJob', 'apps', 'podinfo', 'batch/v1')).toBe('/workload/CronJob/apps/podinfo')
+  })
+
+  it('routes non-native workload-shaped objects to arbitrary object dashboards', () => {
+    expect(getDashboardUrl('Deployment', 'apps', 'podinfo', 'custom.example.io/v1')).toBe('/object/custom.example.io%2Fv1/Deployment/apps/podinfo')
+  })
+
+  it('encodes apiVersion and cluster-scoped namespace sentinel for arbitrary objects', () => {
+    expect(getObjectDashboardUrl('rbac.authorization.k8s.io/v1', 'ClusterRole', '', 'admin')).toBe('/object/rbac.authorization.k8s.io%2Fv1/ClusterRole/_/admin')
   })
 })
 


### PR DESCRIPTION
## Summary

Adds live YAML editing to the Flux Operator Web UI so operators can update Kubernetes objects without leaving the dashboard.

- adds `GET/PUT /api/v1/object` for arbitrary Kubernetes objects using the authenticated user's impersonated client
- adds an editable YAML block with save/cancel/error states and identity protection for `apiVersion`, `kind`, `namespace`, and `name`
- enables editing from Flux resource details, workload spec tabs, and a new arbitrary object detail page
- links inventory objects such as ConfigMaps and cluster-scoped objects to the new object page
- documents the non-elevated RBAC model for live editing

## Validation

- `KUBEBUILDER_ASSETS=/Users/aso/src/flux-operator/bin/k8s/1.36.0-darwin-arm64 go test ./internal/web -count=1`
- `make web-build`

## AI assistance disclosure

Implemented with assistance from Hermes Agent/gpt-5.5.
