### PR TITLE
operator: reject invalid FluxInstance sharding with persistent storage

### DIFF
--- a/api/v1/fluxinstance_types.go
+++ b/api/v1/fluxinstance_types.go
@@ -21,6 +21,7 @@ const (
 )
 
 // FluxInstanceSpec defines the desired state of FluxInstance
+// +kubebuilder:validation:XValidation:rule="!has(self.sharding) || !has(self.sharding.storage) || self.sharding.storage != 'persistent' || has(self.storage)",message=".spec.storage must be set when .spec.sharding.storage is 'persistent'"
 type FluxInstanceSpec struct {
 	// Distribution specifies the version and container registry to pull images from.
 	// +required
@@ -224,7 +225,7 @@ type Sharding struct {
 	// Storage defines if the source-controller shards
 	// should use an emptyDir or a persistent volume claim for storage.
 	// Accepted values are 'ephemeral' or 'persistent', defaults to 'ephemeral'.
-	// For 'persistent' to take effect, the '.spec.storage' field must be set.
+	// When set to 'persistent', the '.spec.storage' field must be set.
 	// +kubebuilder:validation:Enum:=ephemeral;persistent
 	// +optional
 	Storage string `json:"storage,omitempty"`

--- a/cmd/cli/build_instance.go
+++ b/cmd/cli/build_instance.go
@@ -282,6 +282,9 @@ func validateInstance(instance *fluxcdv1.FluxInstance) error {
 		if len(instance.Spec.Sharding.Shards) == 0 {
 			return fmt.Errorf(".spec.sharding.shards is required")
 		}
+		if instance.Spec.Sharding.Storage == "persistent" && instance.Spec.Storage == nil {
+			return fmt.Errorf(".spec.storage must be set when .spec.sharding.storage is 'persistent'")
+		}
 	}
 
 	if instance.Spec.Storage != nil {

--- a/cmd/cli/build_instance_validation_test.go
+++ b/cmd/cli/build_instance_validation_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+func TestValidateInstanceShardingStorage(t *testing.T) {
+	newInstance := func(storage *fluxcdv1.Storage, shardingStorage string) *fluxcdv1.FluxInstance {
+		return &fluxcdv1.FluxInstance{
+			Spec: fluxcdv1.FluxInstanceSpec{
+				Distribution: fluxcdv1.Distribution{
+					Version:  "2.x",
+					Registry: "ghcr.io/fluxcd",
+				},
+				Sharding: &fluxcdv1.Sharding{
+					Shards:  []string{"shard1"},
+					Storage: shardingStorage,
+				},
+				Storage: storage,
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		obj     *fluxcdv1.FluxInstance
+		wantErr string
+	}{
+		{
+			name: "allows ephemeral sharding storage without artifact storage",
+			obj:  newInstance(nil, "ephemeral"),
+		},
+		{
+			name: "allows persistent sharding storage with artifact storage",
+			obj: newInstance(&fluxcdv1.Storage{
+				Class: "standard",
+				Size:  "10Gi",
+			}, "persistent"),
+		},
+		{
+			name:    "rejects persistent sharding storage without artifact storage",
+			obj:     newInstance(nil, "persistent"),
+			wantErr: ".spec.storage must be set when .spec.sharding.storage is 'persistent'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := validateInstance(tt.obj)
+			if tt.wantErr != "" {
+				g.Expect(err).To(MatchError(tt.wantErr))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+}

--- a/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
@@ -311,7 +311,7 @@ spec:
                       Storage defines if the source-controller shards
                       should use an emptyDir or a persistent volume claim for storage.
                       Accepted values are 'ephemeral' or 'persistent', defaults to 'ephemeral'.
-                      For 'persistent' to take effect, the '.spec.storage' field must be set.
+                      When set to 'persistent', the '.spec.storage' field must be set.
                     enum:
                     - ephemeral
                     - persistent
@@ -423,6 +423,10 @@ spec:
             required:
             - distribution
             type: object
+            x-kubernetes-validations:
+            - message: .spec.storage must be set when .spec.sharding.storage is 'persistent'
+              rule: '!has(self.sharding) || !has(self.sharding.storage) || self.sharding.storage
+                != ''persistent'' || has(self.storage)'
           status:
             description: FluxInstanceStatus defines the observed state of FluxInstance
             properties:

--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -576,6 +576,7 @@ for the source-controller shards.
 The supported values are `ephemeral` (default) and `persistent`.
 When set to `persistent`, the operator will create a persistent volume claim for each shard using
 the storage class and size specified in the `.spec.storage` field.
+The API rejects `persistent` sharding storage when `.spec.storage` is not set.
 
 ### Common metadata
 

--- a/docs/guides/instance/instance-sharding.md
+++ b/docs/guides/instance/instance-sharding.md
@@ -74,7 +74,8 @@ reduce the network traffic after a restart, as the controller will not need to
 re-download all the artifacts from the source repositories.
 
 To enable persistent storage for the source-controller shards,
-you can add the following configuration to the `FluxInstance`:
+you must set `.spec.storage` together with `.spec.sharding.storage: persistent`; otherwise Kubernetes admission rejects the `FluxInstance`.
+You can add the following configuration to the `FluxInstance`:
 
 ```yaml
 apiVersion: fluxcd.controlplane.io/v1


### PR DESCRIPTION
Setting `FluxInstance.spec.sharding.storage` to `persistent` requires `FluxInstance.spec.storage` to be set. Allowing `persistent` without `.spec.storage` means allowing an invalid, confusing config.