### PR TITLE
web: compact list for resources, workloads and events

### DIFF
--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -19,8 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
 
 // EventsHandler handles GET /api/v1/events requests and returns Kubernetes events for Flux resources.
@@ -76,20 +74,10 @@ func (h *Handler) GetEvents(ctx context.Context, kind, name, namespace, excludeR
 	if kind != "" {
 		kinds = []string{kind}
 	} else {
-		// Default kinds
-		kinds = []string{
-			// Appliers
-			fluxcdv1.ResourceSetKind,
-			fluxcdv1.FluxKustomizationKind,
-			fluxcdv1.FluxHelmReleaseKind,
-			// Sources
-			fluxcdv1.FluxGitRepositoryKind,
-			fluxcdv1.FluxOCIRepositoryKind,
-			fluxcdv1.FluxHelmChartKind,
-			fluxcdv1.FluxHelmRepositoryKind,
-			fluxcdv1.FluxBucketKind,
-			fluxcdv1.FluxArtifactGeneratorKind,
-			fluxcdv1.ResourceSetInputProviderKind,
+		// Default to all Flux kinds present in the search index
+		kinds = h.searchIndex.Kinds()
+		if len(kinds) == 0 {
+			kinds = defaultFluxKinds()
 		}
 	}
 
@@ -107,11 +95,6 @@ func (h *Handler) GetEvents(ctx context.Context, kind, name, namespace, excludeR
 		// If the user has no access to any namespaces, return empty result
 		if len(userNamespaces) == 0 {
 			return []Event{}, nil
-		}
-
-		// If the user has cluster-wide access, we can add FluxInstance to kinds
-		if all && kind == "" {
-			kinds = append(kinds, fluxcdv1.FluxInstanceKind)
 		}
 
 		// If the user does not have access to all namespaces, limit search to their namespaces

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -145,9 +145,9 @@ func (h *Handler) GetEvents(ctx context.Context, kind, name, namespace, excludeR
 				fields.OneTermEqualSelector("involvedObject.kind", kind),
 			}
 
-			// Add name filter if provided and doesn't contain wildcards
-			// For exact match, use field selector (faster)
-			if name != "" && !hasWildcard(name) {
+			// Add an exact-match field selector for a plain name (faster); wildcard
+			// and negated ("!") patterns are matched in memory below.
+			if name != "" && !isNamePattern(name) {
 				selectors = append(selectors, fields.OneTermEqualSelector("involvedObject.name", name))
 			}
 
@@ -186,9 +186,9 @@ func (h *Handler) GetEvents(ctx context.Context, kind, name, namespace, excludeR
 					continue
 				}
 
-				// Filter by name using wildcard matching if needed
+				// Filter by name using wildcard/negation matching if needed
 				filteredEvents := el.Items
-				if hasWildcard(name) {
+				if isNamePattern(name) {
 					filteredEvents = []corev1.Event{}
 					for _, event := range el.Items {
 						if matchesWildcard(event.InvolvedObject.Name, name) {

--- a/internal/web/events_test.go
+++ b/internal/web/events_test.go
@@ -74,6 +74,51 @@ func TestGetEvents_Privileged(t *testing.T) {
 	g.Expect(found).To(BeTrue(), "should find the test event")
 }
 
+func TestGetEvents_Negation(t *testing.T) {
+	g := NewWithT(t)
+
+	// Two events for differently-named involved objects; the negated query must
+	// drop one and keep the other. Exercises the live events.go path where a "!"
+	// name skips the exact-match field selector (isNamePattern) and is excluded
+	// by in-memory matchesWildcard.
+	for _, n := range []string{"neg-evt-keep", "neg-evt-exclude"} {
+		event := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      n + "-event",
+				Namespace: "default",
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Kind:      fluxcdv1.ResourceSetKind,
+				Name:      n,
+				Namespace: "default",
+			},
+			Type:          "Normal",
+			Reason:        "TestReason",
+			Message:       "Test event message",
+			LastTimestamp: metav1.Now(),
+		}
+		g.Expect(testClient.Create(ctx, event)).To(Succeed())
+		defer testClient.Delete(ctx, event)
+	}
+
+	handler := &Handler{
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	events, err := handler.GetEvents(ctx, "ResourceSet", "!neg-evt-exclude", "default", "", "")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	involved := make(map[string]bool, len(events))
+	for _, e := range events {
+		involved[e.InvolvedObject] = true
+	}
+	g.Expect(involved).To(HaveKey("ResourceSet/neg-evt-keep"), "non-matching event should be kept")
+	g.Expect(involved).NotTo(HaveKey("ResourceSet/neg-evt-exclude"), "negated event should be excluded")
+}
+
 func TestGetEvents_UnprivilegedUser_EmptyResult(t *testing.T) {
 	g := NewWithT(t)
 

--- a/internal/web/resources.go
+++ b/internal/web/resources.go
@@ -172,8 +172,9 @@ func (h *Handler) GetLiveResources(ctx context.Context, kind, name, namespace, s
 					listOpts = append(listOpts, client.InNamespace(ns))
 				}
 
-				// Add name filter if provided and doesn't contain wildcards
-				if name != "" && !hasWildcard(name) {
+				// Add an exact-match field selector for a plain name; wildcard and
+				// negated ("!") patterns are matched in memory below.
+				if name != "" && !isNamePattern(name) {
 					listOpts = append(listOpts, client.MatchingFields{"metadata.name": name})
 				}
 
@@ -187,8 +188,8 @@ func (h *Handler) GetLiveResources(ctx context.Context, kind, name, namespace, s
 				}
 
 				for _, obj := range list.Items {
-					// Filter by name using wildcard matching if needed
-					if hasWildcard(name) {
+					// Filter by name using wildcard/negation matching if needed
+					if isNamePattern(name) {
 						objName, _, _ := unstructured.NestedString(obj.Object, "metadata", "name")
 						if !matchesWildcard(objName, name) {
 							continue

--- a/internal/web/resources.go
+++ b/internal/web/resources.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -64,6 +65,25 @@ func (h *Handler) ResourcesHandler(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+// defaultFluxKinds returns the set of Flux kinds queried by default when no
+// kind filter is provided and the search index has not been populated yet.
+// It is derived from the canonical operator and Flux kind lists so it stays in
+// sync as kinds are added, excluding FluxReport which is the report object
+// itself rather than a reconciled resource shown on the Status Page. Kinds
+// whose CRDs are not installed are skipped at query time, so listing them here
+// is harmless.
+func defaultFluxKinds() []string {
+	infos := slices.Concat(fluxcdv1.FluxOperatorKinds, fluxcdv1.FluxKinds)
+	kinds := make([]string, 0, len(infos))
+	for _, info := range infos {
+		if info.Name == fluxcdv1.FluxReportKind {
+			continue
+		}
+		kinds = append(kinds, info.Name)
+	}
+	return kinds
+}
+
 // GetLiveResources returns a list of ResourceStatus for the specified filters by querying the cluster directly.
 // If name and namespace filters are empty, it will return resources across all namespaces (subject to RBAC).
 func (h *Handler) GetLiveResources(ctx context.Context, kind, name, namespace, status string,
@@ -74,20 +94,10 @@ func (h *Handler) GetLiveResources(ctx context.Context, kind, name, namespace, s
 	if kind != "" {
 		kinds = []string{kind}
 	} else {
-		// Default kinds
-		kinds = []string{
-			// Appliers
-			fluxcdv1.ResourceSetKind,
-			fluxcdv1.FluxKustomizationKind,
-			fluxcdv1.FluxHelmReleaseKind,
-			// Sources
-			fluxcdv1.FluxGitRepositoryKind,
-			fluxcdv1.FluxOCIRepositoryKind,
-			fluxcdv1.FluxHelmChartKind,
-			fluxcdv1.FluxHelmRepositoryKind,
-			fluxcdv1.FluxBucketKind,
-			fluxcdv1.FluxArtifactGeneratorKind,
-			fluxcdv1.ResourceSetInputProviderKind,
+		// Default to all Flux kinds present in the search index
+		kinds = h.searchIndex.Kinds()
+		if len(kinds) == 0 {
+			kinds = defaultFluxKinds()
 		}
 	}
 
@@ -105,11 +115,6 @@ func (h *Handler) GetLiveResources(ctx context.Context, kind, name, namespace, s
 		// If the user has no access to any namespaces, return empty result
 		if len(userNamespaces) == 0 {
 			return []reporter.ResourceStatus{}, nil
-		}
-
-		// If the user has cluster-wide access, we can add FluxInstance to kinds
-		if all && kind == "" {
-			kinds = append(kinds, fluxcdv1.FluxInstanceKind)
 		}
 
 		// If the user does not have access to all namespaces, limit search to their namespaces

--- a/internal/web/resources_test.go
+++ b/internal/web/resources_test.go
@@ -54,6 +54,47 @@ func TestGetResourcesStatus_Privileged(t *testing.T) {
 	g.Expect(found).To(BeTrue(), "should find the test resource")
 }
 
+func TestGetLiveResources_Negation(t *testing.T) {
+	g := NewWithT(t)
+
+	// Two ResourceSets; the negated query must drop one and keep the other. This
+	// exercises the live resources.go path where a "!" name skips the exact-match
+	// field selector (isNamePattern) and is excluded by in-memory matchesWildcard.
+	keep := &fluxcdv1.ResourceSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "neg-keep", Namespace: "default"},
+		Spec: fluxcdv1.ResourceSetSpec{
+			ResourcesTemplate: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm-keep\n  namespace: default\n",
+		},
+	}
+	exclude := &fluxcdv1.ResourceSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "neg-exclude", Namespace: "default"},
+		Spec: fluxcdv1.ResourceSetSpec{
+			ResourcesTemplate: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm-exclude\n  namespace: default\n",
+		},
+	}
+	g.Expect(testClient.Create(ctx, keep)).To(Succeed())
+	defer testClient.Delete(ctx, keep)
+	g.Expect(testClient.Create(ctx, exclude)).To(Succeed())
+	defer testClient.Delete(ctx, exclude)
+
+	handler := &Handler{
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+	}
+
+	resources, err := handler.GetLiveResources(ctx, "ResourceSet", "!neg-exclude", "", "", 100)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	names := make(map[string]bool, len(resources))
+	for _, r := range resources {
+		names[r.Name] = true
+	}
+	g.Expect(names).To(HaveKey("neg-keep"), "non-matching resource should be kept")
+	g.Expect(names).NotTo(HaveKey("neg-exclude"), "negated resource should be excluded")
+}
+
 func TestGetResourcesStatus_UnprivilegedUser_EmptyResult(t *testing.T) {
 	g := NewWithT(t)
 

--- a/internal/web/search.go
+++ b/internal/web/search.go
@@ -29,9 +29,9 @@ func (h *Handler) SearchHandler(w http.ResponseWriter, req *http.Request) {
 	namespace := queryParams.Get("namespace")
 	kind := queryParams.Get("kind")
 
-	// if name does not contain wildcard, append * to perform partial match
-	if name != "" && !hasWildcard(name) {
-		name = "*" + name + "*"
+	// Wrap a plain term so it matches as a substring (preserving "!" negation).
+	if name != "" {
+		name = wrapPartialMatch(name)
 	}
 
 	// Query the cached search index with RBAC filtering.
@@ -83,10 +83,40 @@ func hasWildcard(pattern string) bool {
 	return pattern != "" && strings.Contains(pattern, "*")
 }
 
+// isNamePattern reports whether name is a match pattern that must be evaluated
+// in memory — a "*" wildcard or a leading "!" negation — as opposed to a plain
+// name that can use an indexed exact-match field selector. A negated name cannot
+// use a positive field selector, so it has to go through matchesWildcard.
+func isNamePattern(name string) bool {
+	return strings.HasPrefix(name, "!") || hasWildcard(name)
+}
+
+// wrapPartialMatch turns a plain search term into a substring pattern
+// ("foo" -> "*foo*") so it matches anywhere in the name, preserving a leading
+// "!" negation ("!foo" -> "!*foo*"). Terms that already contain a "*" wildcard
+// (after the optional "!") are returned unchanged.
+func wrapPartialMatch(name string) string {
+	neg := ""
+	if strings.HasPrefix(name, "!") {
+		neg, name = "!", name[1:]
+	}
+	if name == "" || strings.Contains(name, "*") {
+		return neg + name
+	}
+	return neg + "*" + name + "*"
+}
+
 // matchesWildcard checks if a name matches a pattern with wildcard support.
-// Supports * (matches any characters). If no wildcards present, does exact match.
-// Matching is case-insensitive.
+// Supports * (matches any characters) and a leading "!" that negates the match
+// (e.g. "!foo" matches everything except "foo", "!*foo*" everything that does
+// not contain "foo"). If no wildcards present, does exact match. Matching is
+// case-insensitive.
 func matchesWildcard(name, pattern string) bool {
+	// A leading "!" negates the result of matching the rest of the pattern.
+	if strings.HasPrefix(pattern, "!") {
+		return !matchesWildcard(name, pattern[1:])
+	}
+
 	name = strings.ToLower(name)
 	pattern = strings.ToLower(pattern)
 

--- a/internal/web/search_index.go
+++ b/internal/web/search_index.go
@@ -102,6 +102,31 @@ func (idx *SearchIndex) SearchResources(allowedNamespaces []string, kind, name, 
 	return result
 }
 
+// Kinds returns the distinct resource kinds present in the index,
+// sorted alphabetically.
+func (idx *SearchIndex) Kinds() []string {
+	if idx == nil {
+		return nil
+	}
+
+	idx.mu.RLock()
+	resources := idx.resources
+	idx.mu.RUnlock()
+
+	seen := make(map[string]struct{}, len(resources))
+	kinds := make([]string, 0)
+	for _, rs := range resources {
+		if _, ok := seen[rs.Kind]; ok {
+			continue
+		}
+		seen[rs.Kind] = struct{}{}
+		kinds = append(kinds, rs.Kind)
+	}
+
+	sort.Strings(kinds)
+	return kinds
+}
+
 // buildSearchIndex normalises resource names for case-insensitive matching
 // and returns a stable-sorted copy suitable for the SearchIndex.
 func buildSearchIndex(resources []reporter.ResourceStatus) []reporter.ResourceStatus {

--- a/internal/web/search_index_test.go
+++ b/internal/web/search_index_test.go
@@ -70,6 +70,28 @@ func TestSearchIndex_Update(t *testing.T) {
 	g.Expect(idx.resources).To(HaveLen(1))
 }
 
+func TestSearchIndex_Kinds(t *testing.T) {
+	g := NewWithT(t)
+
+	// A nil index returns no kinds instead of panicking.
+	var nilIdx *SearchIndex
+	g.Expect(nilIdx.Kinds()).To(BeNil())
+
+	// An empty index returns no kinds.
+	idx := &SearchIndex{}
+	g.Expect(idx.Kinds()).To(BeEmpty())
+
+	// Distinct kinds are returned sorted alphabetically, with duplicates removed.
+	idx.Update([]reporter.ResourceStatus{
+		{Name: "app-1", Kind: "Kustomization", Namespace: "default", Status: reporter.StatusReady},
+		{Name: "app-2", Kind: "HelmRelease", Namespace: "default", Status: reporter.StatusReady},
+		{Name: "app-3", Kind: "Kustomization", Namespace: "team-a", Status: reporter.StatusFailed},
+		{Name: "repo-1", Kind: "ImageRepository", Namespace: "default", Status: reporter.StatusReady},
+	})
+
+	g.Expect(idx.Kinds()).To(Equal([]string{"HelmRelease", "ImageRepository", "Kustomization"}))
+}
+
 func TestSearchIndex_SearchResources_NameFilter(t *testing.T) {
 	g := NewWithT(t)
 

--- a/internal/web/search_test.go
+++ b/internal/web/search_test.go
@@ -296,11 +296,94 @@ func TestMatchesWildcard(t *testing.T) {
 			pattern:  "*kustomize*",
 			expected: true,
 		},
+
+		// Negation (leading "!")
+		{
+			name:     "negation excludes exact match",
+			input:    "flux-system",
+			pattern:  "!flux-system",
+			expected: false,
+		},
+		{
+			name:     "negation keeps non-match",
+			input:    "other-app",
+			pattern:  "!flux-system",
+			expected: true,
+		},
+		{
+			name:     "negation with contains excludes match",
+			input:    "my-flux-app",
+			pattern:  "!*flux*",
+			expected: false,
+		},
+		{
+			name:     "negation with contains keeps non-match",
+			input:    "other-app",
+			pattern:  "!*flux*",
+			expected: true,
+		},
+		{
+			name:     "negation with prefix excludes match",
+			input:    "test-service",
+			pattern:  "!test*",
+			expected: false,
+		},
+		{
+			name:     "negation case insensitive",
+			input:    "Flux-System",
+			pattern:  "!flux-system",
+			expected: false,
+		},
+		{
+			name:     "bang only excludes nothing",
+			input:    "anything",
+			pattern:  "!",
+			expected: true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			result := matchesWildcard(tt.input, tt.pattern)
 			g.Expect(result).To(Equal(tt.expected), "matchesWildcard(%q, %q)", tt.input, tt.pattern)
+		})
+	}
+}
+
+func TestIsNamePattern(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		pattern  string
+		expected bool
+	}{
+		{name: "empty", pattern: "", expected: false},
+		{name: "plain name", pattern: "test", expected: false},
+		{name: "wildcard", pattern: "*test*", expected: true},
+		{name: "negation", pattern: "!test", expected: true},
+		{name: "negation with wildcard", pattern: "!*test*", expected: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isNamePattern(tt.pattern)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestWrapPartialMatch(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty stays empty", input: "", expected: ""},
+		{name: "plain name wrapped", input: "flux", expected: "*flux*"},
+		{name: "existing wildcard unchanged", input: "*flux", expected: "*flux"},
+		{name: "negated plain name wrapped inside", input: "!flux", expected: "!*flux*"},
+		{name: "negated wildcard unchanged", input: "!*flux*", expected: "!*flux*"},
+		{name: "bang only stays", input: "!", expected: "!"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(wrapPartialMatch(tt.input)).To(Equal(tt.expected))
 		})
 	}
 }
@@ -501,6 +584,39 @@ func TestSearchHandler_WildcardExpansion(t *testing.T) {
 	resources, ok := response["resources"].([]any)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(resources).To(HaveLen(2), "should match both flux-system and my-flux-app")
+}
+
+func TestSearchHandler_Negation(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := &Handler{
+		kubeClient:    kubeClient,
+		version:       "v1.0.0",
+		statusManager: "test-status-manager",
+		namespace:     "flux-system",
+		searchIndex:   &SearchIndex{},
+	}
+
+	handler.searchIndex.Update([]reporter.ResourceStatus{
+		{Name: "flux-system", Kind: "Kustomization", Namespace: "default", Status: reporter.StatusReady, LastReconciled: metav1.Now()},
+		{Name: "my-flux-app", Kind: "HelmRelease", Namespace: "default", Status: reporter.StatusReady, LastReconciled: metav1.Now()},
+		{Name: "other-app", Kind: "Kustomization", Namespace: "default", Status: reporter.StatusReady, LastReconciled: metav1.Now()},
+	})
+
+	// "!flux" wraps to "!*flux*" and should exclude anything containing "flux".
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?name=%21flux", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	handler.SearchHandler(rec, req)
+
+	g.Expect(rec.Code).To(Equal(http.StatusOK))
+
+	var response map[string]any
+	g.Expect(json.Unmarshal(rec.Body.Bytes(), &response)).To(Succeed())
+
+	resources, ok := response["resources"].([]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(resources).To(HaveLen(1), "should exclude flux-system and my-flux-app, keeping other-app")
+	g.Expect(resources[0].(map[string]any)["name"]).To(Equal("other-app"))
 }
 
 func TestSearchHandler_MessageStripped(t *testing.T) {

--- a/internal/web/workloads.go
+++ b/internal/web/workloads.go
@@ -164,9 +164,9 @@ func (h *Handler) WorkloadsSearchHandler(w http.ResponseWriter, req *http.Reques
 	namespace := queryParams.Get("namespace")
 	kind := queryParams.Get("kind")
 
-	// If name does not contain a wildcard, wrap it to perform a partial match.
-	if name != "" && !hasWildcard(name) {
-		name = "*" + name + "*"
+	// Wrap a plain term so it matches as a substring (preserving "!" negation).
+	if name != "" {
+		name = wrapPartialMatch(name)
 	}
 
 	// Query the cached workload index with RBAC filtering.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -113,13 +113,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -138,21 +138,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -169,14 +169,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -199,14 +199,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -216,9 +216,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -226,29 +226,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -268,9 +268,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -288,9 +288,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -298,27 +298,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -390,33 +390,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -424,14 +424,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1934,30 +1934,29 @@
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.16.tgz",
-      "integrity": "sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.16",
-        "ast-v8-to-istanbul": "^0.3.8",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.16",
-        "vitest": "4.0.16"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1966,31 +1965,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
-      "integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.16",
-        "@vitest/utils": "4.0.16",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
-      "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.16",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1999,7 +1998,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -2021,26 +2020,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
-      "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.16.tgz",
-      "integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.16",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2048,13 +2047,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
-      "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.16",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2063,9 +2063,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
-      "integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2073,14 +2073,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
-      "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.16",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2120,9 +2121,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2234,15 +2235,15 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
-      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
-        "js-tokens": "^9.0.1"
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
@@ -2256,9 +2257,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2373,9 +2374,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3030,9 +3031,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4110,21 +4111,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.23",
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
@@ -4370,14 +4356,14 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
-      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
     },
@@ -5498,9 +5484,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5727,9 +5713,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5864,13 +5850,13 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -5988,31 +5974,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
-      "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.16",
-        "@vitest/mocker": "4.0.16",
-        "@vitest/pretty-format": "4.0.16",
-        "@vitest/runner": "4.0.16",
-        "@vitest/snapshot": "4.0.16",
-        "@vitest/spy": "4.0.16",
-        "@vitest/utils": "4.0.16",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -6028,12 +6014,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.16",
-        "@vitest/browser-preview": "4.0.16",
-        "@vitest/browser-webdriverio": "4.0.16",
-        "@vitest/ui": "4.0.16",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -6054,6 +6043,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -6062,6 +6057,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -6230,9 +6228,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -101,34 +101,27 @@ export async function fetchFluxReport() {
  * TabNavigation - Tab navigation for switching between Favorites, Resources, and Events views
  */
 // Section tabs rendered as classic underline tabs: the active tab gets a
-// flux-blue bottom border and label.
-const NAV_TABS = [
-  { href: '/favorites', label: 'Favorites' },
-  { href: '/resources', label: 'Resources' },
-  { href: '/workloads', label: 'Workloads' },
-  { href: '/events', label: 'Events' },
+// flux-blue bottom border and label. Each entry also carries the result-count
+// `data` signal (and `loading` signal, where the list fetches) folded into the
+// active tab's count on the right. Favorites are read straight from local storage,
+// so there is no loading signal — just the favorite count.
+const SECTION_TABS = [
+  { href: '/favorites', label: 'Favorites', countLabel: 'favorites', data: favorites },
+  { href: '/resources', label: 'Resources', countLabel: 'resources', data: resourcesData, loading: resourcesLoading },
+  { href: '/workloads', label: 'Workloads', countLabel: 'workloads', data: workloadsData, loading: workloadsLoading },
+  { href: '/events', label: 'Events', countLabel: 'events', data: eventsData, loading: eventsLoading },
 ]
-
-// Result count + loading signals per section, folded into the active tab.
-// Keyed by path so the nav reflects the active list. Favorites are read straight
-// from local storage, so there is no loading signal — just the favorite count.
-const TAB_META = {
-  '/favorites': { data: favorites, label: 'favorites' },
-  '/resources': { data: resourcesData, loading: resourcesLoading, label: 'resources' },
-  '/workloads': { data: workloadsData, loading: workloadsLoading, label: 'workloads' },
-  '/events': { data: eventsData, loading: eventsLoading, label: 'events' },
-}
 
 function TabNavigation() {
   const location = useLocation()
   const currentPath = location.path
-  const meta = TAB_META[currentPath]
+  const meta = SECTION_TABS.find(tab => tab.href === currentPath)
 
   return (
     <div class="max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8">
       <div class="flex items-end justify-between gap-3 border-b border-gray-200 dark:border-gray-700">
         <nav class="flex gap-6 sm:gap-8">
-          {NAV_TABS.map(tab => (
+          {SECTION_TABS.map(tab => (
             <a
               key={tab.href}
               href={tab.href}
@@ -153,7 +146,7 @@ function TabNavigation() {
                 <span>Loading…</span>
               </>
             ) : (
-              meta.data?.value?.length > 0 && <span>{meta.data.value.length} {meta.label}</span>
+              meta.data?.value?.length > 0 && <span>{meta.data.value.length} {meta.countLabel}</span>
             )}
           </div>
         )}

--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -13,15 +13,17 @@ import { ConnectionStatus } from './components/layout/ConnectionStatus'
 import { Header } from './components/layout/Header'
 import { LoginPage } from './components/auth/LoginPage'
 import { ClusterPage } from './components/dashboards/cluster/ClusterPage'
-import { EventList } from './components/search/EventList'
-import { ResourceList } from './components/search/ResourceList'
-import { WorkloadList } from './components/search/WorkloadList'
+import { EventList, eventsData, eventsLoading } from './components/search/EventList'
+import { ResourceList, resourcesData, resourcesLoading } from './components/search/ResourceList'
+import { WorkloadList, workloadsData, workloadsLoading } from './components/search/WorkloadList'
 import { ResourcePage } from './components/dashboards/resource/ResourcePage'
 import { WorkloadPage } from './components/dashboards/workload/WorkloadPage'
 import { FavoritesPage } from './components/favorites/FavoritesPage'
+import { favorites } from './utils/favorites'
 import { ProfilePage } from './components/user/ProfilePage'
 import { NotFoundPage } from './components/layout/NotFoundPage'
 import { FluxOperatorIcon } from './components/layout/Icons'
+import { Spinner } from './components/search/compactRow'
 
 // Global signals for FluxReport data and application state
 // These signals are exported and used by child components throughout the app
@@ -98,55 +100,63 @@ export async function fetchFluxReport() {
 /**
  * TabNavigation - Tab navigation for switching between Favorites, Resources, and Events views
  */
+// Section tabs rendered as classic underline tabs: the active tab gets a
+// flux-blue bottom border and label.
+const NAV_TABS = [
+  { href: '/favorites', label: 'Favorites' },
+  { href: '/resources', label: 'Resources' },
+  { href: '/workloads', label: 'Workloads' },
+  { href: '/events', label: 'Events' },
+]
+
+// Result count + loading signals per section, folded into the active tab.
+// Keyed by path so the nav reflects the active list. Favorites are read straight
+// from local storage, so there is no loading signal — just the favorite count.
+const TAB_META = {
+  '/favorites': { data: favorites, label: 'favorites' },
+  '/resources': { data: resourcesData, loading: resourcesLoading, label: 'resources' },
+  '/workloads': { data: workloadsData, loading: workloadsLoading, label: 'workloads' },
+  '/events': { data: eventsData, loading: eventsLoading, label: 'events' },
+}
+
 function TabNavigation() {
   const location = useLocation()
   const currentPath = location.path
+  const meta = TAB_META[currentPath]
 
   return (
-    <div class="border-b border-gray-200 dark:border-gray-700 transition-colors">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <nav class="-mb-px flex space-x-8">
-          <a
-            href="/favorites"
-            class={`${
-              currentPath === '/favorites'
-                ? 'border-flux-blue text-flux-blue dark:text-blue-400'
-                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
-            } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm focus:outline-none transition-colors`}
-          >
-            Favorites
-          </a>
-          <a
-            href="/resources"
-            class={`${
-              currentPath === '/resources'
-                ? 'border-flux-blue text-flux-blue dark:text-blue-400'
-                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
-            } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm focus:outline-none transition-colors`}
-          >
-            Resources
-          </a>
-          <a
-            href="/workloads"
-            class={`${
-              currentPath === '/workloads'
-                ? 'border-flux-blue text-flux-blue dark:text-blue-400'
-                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
-            } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm focus:outline-none transition-colors`}
-          >
-            Workloads
-          </a>
-          <a
-            href="/events"
-            class={`${
-              currentPath === '/events'
-                ? 'border-flux-blue text-flux-blue dark:text-blue-400'
-                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
-            } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm focus:outline-none transition-colors`}
-          >
-            Events
-          </a>
+    <div class="max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8">
+      <div class="flex items-end justify-between gap-3 border-b border-gray-200 dark:border-gray-700">
+        <nav class="flex gap-6 sm:gap-8">
+          {NAV_TABS.map(tab => (
+            <a
+              key={tab.href}
+              href={tab.href}
+              class={`${
+                currentPath === tab.href
+                  ? 'border-flux-blue text-flux-blue dark:text-blue-400'
+                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
+              } -mb-px whitespace-nowrap py-3 px-1 border-b-2 font-medium text-sm focus:outline-none transition-colors`}
+            >
+              {tab.label}
+            </a>
+          ))}
         </nav>
+
+        {/* Active section count / loader on the right (desktop; on mobile the
+            toolbar shows it). */}
+        {meta && (
+          <div class="hidden sm:flex items-center gap-2 pb-3 text-sm text-gray-600 dark:text-gray-400">
+            {meta.loading?.value ? (
+              <>
+                <Spinner cls="w-4 h-4" />
+                <span>Loading…</span>
+              </>
+            ) : (
+              meta.data?.value?.length > 0 && <span>{meta.data.value.length} {meta.label}</span>
+            )}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -309,15 +309,26 @@ function AppContent({ spec, namespace }) {
   const isTabView = currentPath === '/favorites' || currentPath === '/events' || currentPath === '/resources' || currentPath === '/workloads'
 
   return (
-    <div class="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors flex flex-col">
+    <div
+      class="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors flex flex-col"
+      // --chrome-h is the combined height of the sticky header (57px) + tab nav
+      // (46px). The filter bars stick just below it (sm:top-[var(--chrome-h)]),
+      // so there is a single source of truth for the offset.
+      style={{ '--chrome-h': '103px' }}
+    >
       {/* Connection status banner (only visible when disconnected) */}
       <ConnectionStatus />
 
-      {/* Header with navigation and refresh button */}
-      <Header />
+      {/* Sticky top chrome on desktop: the header and tab nav pin to the top so
+          the list scrolls behind them. On mobile they stay in normal flow. The
+          page background keeps the nav region opaque so rows don't show through. */}
+      <div class="sm:sticky sm:top-0 sm:z-30 bg-gray-50 dark:bg-gray-900">
+        {/* Header with navigation and refresh button */}
+        <Header />
 
-      {/* Tab Navigation - Show only in tab views */}
-      {isTabView && <TabNavigation />}
+        {/* Tab Navigation - Show only in tab views */}
+        {isTabView && <TabNavigation />}
+      </div>
 
       {/* Main content area: route-based navigation */}
       <Router>

--- a/web/src/app.test.jsx
+++ b/web/src/app.test.jsx
@@ -13,6 +13,7 @@ import {
   connectionStatus
 } from './app'
 import { POLL_INTERVAL_MS } from './utils/constants'
+import { favorites } from './utils/favorites'
 
 // Mock location state that can be modified in tests
 let mockLocationPath = '/'
@@ -44,15 +45,21 @@ vi.mock('./components/dashboards/cluster/ClusterPage', () => ({
 }))
 
 vi.mock('./components/search/EventList', () => ({
-  EventList: () => <div data-testid="event-list">EventList</div>
+  EventList: () => <div data-testid="event-list">EventList</div>,
+  eventsData: { value: [] },
+  eventsLoading: { value: false }
 }))
 
 vi.mock('./components/search/ResourceList', () => ({
-  ResourceList: () => <div data-testid="resource-list">ResourceList</div>
+  ResourceList: () => <div data-testid="resource-list">ResourceList</div>,
+  resourcesData: { value: [] },
+  resourcesLoading: { value: false }
 }))
 
 vi.mock('./components/search/WorkloadList', () => ({
-  WorkloadList: () => <div data-testid="workload-list">WorkloadList</div>
+  WorkloadList: () => <div data-testid="workload-list">WorkloadList</div>,
+  workloadsData: { value: [] },
+  workloadsLoading: { value: false }
 }))
 
 vi.mock('./components/dashboards/resource/ResourcePage', () => ({
@@ -63,7 +70,7 @@ vi.mock('./components/dashboards/workload/WorkloadPage', () => ({
   WorkloadPage: () => <div data-testid="workload-page">WorkloadPage</div>
 }))
 
-vi.mock('./components/common/NotFoundPage', () => ({
+vi.mock('./components/layout/NotFoundPage', () => ({
   NotFoundPage: () => <div data-testid="not-found-page">NotFoundPage</div>
 }))
 
@@ -598,9 +605,10 @@ describe('app.jsx', () => {
       const resourcesTab = screen.getByRole('link', { name: 'Resources' })
       const eventsTab = screen.getByRole('link', { name: 'Events' })
 
+      // Active tab gets a flux-blue underline + label; inactive tabs are muted.
       expect(resourcesTab.className).toContain('border-flux-blue')
       expect(resourcesTab.className).toContain('text-flux-blue')
-      expect(eventsTab.className).toContain('border-transparent')
+      expect(eventsTab.className).not.toContain('border-flux-blue')
     })
 
     it('should highlight Events tab when on /events path', () => {
@@ -613,9 +621,10 @@ describe('app.jsx', () => {
       const resourcesTab = screen.getByRole('link', { name: 'Resources' })
       const eventsTab = screen.getByRole('link', { name: 'Events' })
 
+      // Active tab gets a flux-blue underline + label; inactive tabs are muted.
       expect(eventsTab.className).toContain('border-flux-blue')
       expect(eventsTab.className).toContain('text-flux-blue')
-      expect(resourcesTab.className).toContain('border-transparent')
+      expect(resourcesTab.className).not.toContain('border-flux-blue')
     })
 
     it('should have correct href on Resources tab', async () => {
@@ -638,6 +647,23 @@ describe('app.jsx', () => {
 
       const eventsTab = screen.getByRole('link', { name: 'Events' })
       expect(eventsTab).toHaveAttribute('href', '/events')
+    })
+
+    it('should show the favorites count in the tab nav on /favorites path', () => {
+      mockLocationPath = '/favorites'
+      reportLoading.value = false
+      reportData.value = mockReport
+      favorites.value = [
+        { kind: 'Kustomization', namespace: 'flux-system', name: 'apps' },
+        { kind: 'HelmRelease', namespace: 'default', name: 'podinfo' }
+      ]
+
+      render(<App />)
+
+      // The count moved out of the page body into the section tab bar.
+      expect(screen.getByText('2 favorites')).toBeInTheDocument()
+
+      favorites.value = []
     })
   })
 
@@ -671,8 +697,8 @@ describe('app.jsx', () => {
       render(<App />)
 
       // Tab navigation should not be visible for unknown routes
-      expect(screen.queryByRole('button', { name: 'Resources' })).not.toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: 'Events' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Resources' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Events' })).not.toBeInTheDocument()
     })
   })
 

--- a/web/src/components/dashboards/cluster/ReconcilersPanel.jsx
+++ b/web/src/components/dashboards/cluster/ReconcilersPanel.jsx
@@ -22,7 +22,9 @@ import { fluxCRDs } from '../../../utils/constants'
  * - Docs icon link opens documentation in new tab
  */
 function ReconcilerCard({ crd, stats, isInstalled }) {
-  const total = (stats.failing || 0) + (stats.running || 0) + (stats.suspended || 0)
+  // Running already includes failing resources (failing is a subset of running),
+  // so the total is running + suspended to avoid double-counting failures.
+  const total = (stats.running || 0) + (stats.suspended || 0)
 
   // Determine status color - gray for not installed CRDs
   const getStatusColor = () => {
@@ -201,8 +203,10 @@ export function ReconcilersPanel({ reconcilers }) {
   // Track which CRDs are installed (have data from the API)
   const installedKinds = new Set(reconcilers.map(r => r.kind))
 
+  // Running already includes failing resources (failing is a subset of running),
+  // so the total is running + suspended to avoid double-counting failures.
   const totalResources = reconcilers.reduce((sum, r) => {
-    return sum + (r.stats.failing || 0) + (r.stats.running || 0) + (r.stats.suspended || 0)
+    return sum + (r.stats.running || 0) + (r.stats.suspended || 0)
   }, 0)
 
   const totalFailing = reconcilers.reduce((sum, r) => sum + (r.stats.failing || 0), 0)

--- a/web/src/components/dashboards/cluster/ReconcilersPanel.test.jsx
+++ b/web/src/components/dashboards/cluster/ReconcilersPanel.test.jsx
@@ -61,8 +61,9 @@ describe('ReconcilersPanel', () => {
     it('should show total resource count', () => {
       render(<ReconcilersPanel reconcilers={mockReconcilers} />)
 
-      // Total: 5+2+1 + 3 + 4+1 + 2 + 1 + 1+1 = 21
-      expect(screen.getByText(/21 resources/)).toBeInTheDocument()
+      // Running already includes failing, so total = running + suspended per card:
+      // (5+1) + 3 + 4 + 2 + 1 + 1 = 17
+      expect(screen.getByText(/17 resources/)).toBeInTheDocument()
     })
 
     it('should show failing count when there are failures', () => {
@@ -145,9 +146,10 @@ describe('ReconcilersPanel', () => {
     it('should display total resource count for each reconciler', () => {
       render(<ReconcilersPanel reconcilers={mockReconcilers} />)
 
-      // Find the Kustomization card and check its total (5+2+1 = 8)
+      // Find the Kustomization card and check its total (running 5 + suspended 1 = 6;
+      // failing 2 is a subset of running and not added again)
       const kustomizationCard = screen.getByText('Kustomization').closest('a')
-      expect(kustomizationCard).toHaveTextContent('8')
+      expect(kustomizationCard).toHaveTextContent('6')
     })
 
     it('should show running badge when stats.running > 0', () => {

--- a/web/src/components/dashboards/common/yaml.jsx
+++ b/web/src/components/dashboards/common/yaml.jsx
@@ -81,18 +81,38 @@ export function usePrismTheme() {
 }
 
 /**
- * YAML code block with syntax highlighting
+ * YAML code block with syntax highlighting.
+ *
+ * @param {Object} props
+ * @param {*} props.data - The object to render as YAML
+ * @param {boolean} [props.nested] - When true, drops the block's own padding,
+ *   background and rounding so it flows inside an already-padded container (e.g.
+ *   the compact list detail panel) instead of nesting a second padded box.
  */
-export function YamlBlock({ data }) {
+export function YamlBlock({ data, nested = false }) {
   const highlighted = useMemo(() => {
     if (!data) return ''
     const yamlStr = yaml.dump(data, { indent: 2, lineWidth: -1 })
     return Prism.highlight(yamlStr, Prism.languages.yaml, 'yaml')
   }, [data])
 
+  // Inline styles win over the Prism theme stylesheet, whose
+  // `pre[class*="language-"]` rule sets its own background, padding, margin and
+  // radius. In nested mode we strip all of that so the YAML flows inside the
+  // already-padded detail panel instead of nesting a second padded box. The
+  // monospace YAML also reads visually larger than the surrounding 12px sans
+  // text, so nested mode shrinks it to 11px to match the compact detail panel.
+  const fontSize = nested ? '11px' : '12px'
+  const preStyle = nested
+    ? `font-size: ${fontSize}; line-height: 1.5; background: transparent; padding: 0; margin: 0;`
+    : `font-size: ${fontSize}; line-height: 1.5;`
+
   return (
-    <pre class="p-3 bg-gray-50 dark:bg-gray-900 rounded-md overflow-x-auto language-yaml" style="font-size: 12px; line-height: 1.5;">
-      <code class="language-yaml" style="font-size: 12px;" dangerouslySetInnerHTML={{ __html: highlighted }} />
+    <pre
+      class={`overflow-x-auto language-yaml${nested ? '' : ' p-3 bg-gray-50 dark:bg-gray-900 rounded-md'}`}
+      style={preStyle}
+    >
+      <code class="language-yaml" style={`font-size: ${fontSize}; background: transparent;`} dangerouslySetInnerHTML={{ __html: highlighted }} />
     </pre>
   )
 }

--- a/web/src/components/dashboards/resource/ReconcilerPanel.jsx
+++ b/web/src/components/dashboards/resource/ReconcilerPanel.jsx
@@ -6,6 +6,7 @@ import { fetchWithMock } from '../../../utils/fetch'
 import { formatTimestamp } from '../../../utils/time'
 import { getControllerName, getKindAlias } from '../../../utils/constants'
 import { getDashboardUrl } from '../../../utils/routing'
+import { getReconcileInterval, getReconcileTimeout } from '../../../utils/reconciler'
 import { DashboardPanel, TabButton } from '../common/panel'
 import { YamlBlock } from '../common/yaml'
 import { getStatusBadgeClass, getEventBadgeClass, cleanStatus } from '../../../utils/status'
@@ -40,66 +41,8 @@ export function ReconcilerPanel({ kind, name, namespace, resourceData }) {
   const message = reconcilerRef?.message || resourceData?.status?.conditions?.[0]?.message || ''
   const lastReconciled = reconcilerRef?.lastReconciled || resourceData?.status?.conditions?.[0]?.lastTransitionTime
 
-  const reconcileInterval = useMemo(() => {
-    if (!resourceData) return null
-
-    // Check spec.interval first
-    if (resourceData.spec?.interval) {
-      return resourceData.spec.interval
-    }
-
-    // Check annotation
-    const annotation = resourceData.metadata?.annotations?.['fluxcd.controlplane.io/reconcileEvery']
-    if (annotation) {
-      return annotation
-    }
-
-    // Apply defaults based on kind
-    const k = resourceData.kind
-    if (k === 'FluxInstance' || k === 'ResourceSet') {
-      return '60m'
-    }
-    if (k === 'ResourceSetInputProvider') {
-      return '10m'
-    }
-
-    return null
-  }, [resourceData])
-
-  const reconcileTimeout = useMemo(() => {
-    if (!resourceData) return null
-
-    const k = resourceData.kind
-    const spec = resourceData.spec || {}
-    const annotations = resourceData.metadata?.annotations || {}
-
-    // Any resource with spec.timeout field, use that value if set
-    if (spec.timeout) {
-      return spec.timeout
-    }
-
-    // Source types
-    if (resourceData.apiVersion && resourceData.apiVersion.startsWith('source.toolkit.fluxcd.io')) {
-      return '1m'
-    }
-
-    // Kustomization
-    if (k === 'Kustomization') {
-      return spec.interval || null
-    }
-
-    // HelmRelease
-    if (k === 'HelmRelease') {
-      return '5m'
-    }
-
-    // FluxInstance, ResourceSet, ResourceSetInputProvider
-    if (k === 'FluxInstance' || k === 'ResourceSet' || k === 'ResourceSetInputProvider') {
-      return annotations['fluxcd.controlplane.io/reconcileTimeout'] || '5m'
-    }
-
-    return null
-  }, [resourceData])
+  const reconcileInterval = useMemo(() => getReconcileInterval(resourceData), [resourceData])
+  const reconcileTimeout = useMemo(() => getReconcileTimeout(resourceData), [resourceData])
 
   // Memoized YAML data
   const specYaml = useMemo(() => {

--- a/web/src/components/dashboards/resource/ReconcilerPanel.jsx
+++ b/web/src/components/dashboards/resource/ReconcilerPanel.jsx
@@ -6,7 +6,7 @@ import { fetchWithMock } from '../../../utils/fetch'
 import { formatTimestamp } from '../../../utils/time'
 import { getControllerName, getKindAlias } from '../../../utils/constants'
 import { getDashboardUrl } from '../../../utils/routing'
-import { getReconcileInterval, getReconcileTimeout } from '../../../utils/reconciler'
+import { getReconcileInterval, getReconcileTimeout, getReconcilerSummary } from '../../../utils/reconciler'
 import { DashboardPanel, TabButton } from '../common/panel'
 import { YamlBlock } from '../common/yaml'
 import { getStatusBadgeClass, getEventBadgeClass, cleanStatus } from '../../../utils/status'
@@ -36,10 +36,7 @@ export function ReconcilerPanel({ kind, name, namespace, resourceData }) {
   }, [kind, namespace, name])
 
   // Derived data
-  const reconcilerRef = resourceData?.status?.reconcilerRef
-  const status = reconcilerRef?.status || 'Unknown'
-  const message = reconcilerRef?.message || resourceData?.status?.conditions?.[0]?.message || ''
-  const lastReconciled = reconcilerRef?.lastReconciled || resourceData?.status?.conditions?.[0]?.lastTransitionTime
+  const { ref: reconcilerRef, status, message, lastReconciled } = getReconcilerSummary(resourceData)
 
   const reconcileInterval = useMemo(() => getReconcileInterval(resourceData), [resourceData])
   const reconcileTimeout = useMemo(() => getReconcileTimeout(resourceData), [resourceData])

--- a/web/src/components/favorites/FavoriteCard.jsx
+++ b/web/src/components/favorites/FavoriteCard.jsx
@@ -13,9 +13,17 @@ import { getDashboardUrl } from '../../utils/routing'
  * @param {Object} props
  * @param {Object} props.favorite - Favorite object with kind, namespace, name
  * @param {Object} props.resourceData - Resource data with status, lastReconciled (may be null if not found)
+ * @param {boolean} [props.loading] - True while the initial status fetch is in flight.
+ *   The favorite itself comes from local storage and renders instantly; this only
+ *   gates the per-card status placeholders.
  */
-export function FavoriteCard({ favorite, resourceData }) {
+export function FavoriteCard({ favorite, resourceData, loading = false }) {
   const { kind, namespace, name } = favorite
+
+  // Until the first status fetch settles, resourceData is null. Show skeleton
+  // placeholders (instead of an "Unknown" badge and a shorter card) so the card
+  // keeps its final height and the live status fills in without a layout jump.
+  const isLoading = loading && !resourceData
 
   // Handle unfavorite - need both preventDefault and stopPropagation
   // preventDefault: prevents the anchor's default navigation
@@ -41,7 +49,7 @@ export function FavoriteCard({ favorite, resourceData }) {
   return (
     <a
       href={getDashboardUrl(kind, namespace, name)}
-      class={`card border-l-4 p-4 hover:shadow-md transition-shadow dark:shadow-none cursor-pointer text-left w-full block ${getStatusBorderClass(status)} ${notFound ? 'opacity-60' : ''}`}
+      class={`card border-l-4 p-4 hover:shadow-md transition-shadow dark:shadow-none cursor-pointer text-left w-full block ${isLoading ? 'border-gray-200 dark:border-gray-700' : getStatusBorderClass(status)} ${notFound ? 'opacity-60' : ''}`}
     >
       {/* Header row: star + kind + status badge */}
       <div class="flex items-center justify-between mb-2">
@@ -59,9 +67,13 @@ export function FavoriteCard({ favorite, resourceData }) {
           <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
             {kind}
           </span>
-          <span class={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${notFound ? 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400' : badgeClass}`}>
-            {displayStatus}
-          </span>
+          {isLoading ? (
+            <span class="inline-block h-5 w-16 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse" />
+          ) : (
+            <span class={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${notFound ? 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400' : badgeClass}`}>
+              {displayStatus}
+            </span>
+          )}
         </div>
       </div>
 
@@ -102,8 +114,25 @@ export function FavoriteCard({ favorite, resourceData }) {
             <span class="truncate">{namespace}</span>
           </div>
 
+          {/* While the initial status fetch is in flight, hold the card's height
+              with skeleton rows that stand in for the timestamp and message. */}
+          {isLoading && (
+            <>
+              {/* h-5 matches the text-sm line height of the real rows below, so the
+                  card height is identical loading vs loaded (no jump on settle). */}
+              <div class="flex items-center gap-1.5 h-5">
+                <div class="w-4 h-4 rounded bg-gray-200 dark:bg-gray-700 animate-pulse flex-shrink-0" />
+                <div class="h-3.5 w-24 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+              </div>
+              <div class="flex items-center gap-1.5 h-5">
+                <div class="w-4 h-4 rounded bg-gray-200 dark:bg-gray-700 animate-pulse flex-shrink-0" />
+                <div class="h-3.5 w-32 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+              </div>
+            </>
+          )}
+
           {/* Last reconciled timestamp */}
-          {lastReconciled && (
+          {!isLoading && lastReconciled && (
             <div class="flex items-center gap-1.5 text-sm text-gray-700 dark:text-gray-300">
               <svg class="w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />

--- a/web/src/components/favorites/FavoritesHeader.jsx
+++ b/web/src/components/favorites/FavoritesHeader.jsx
@@ -127,13 +127,15 @@ export function FavoritesHeader({
     )
   }
 
-  // Normal mode: show status bar with edit and search buttons on the same line
+  // Normal mode: show status bar with edit and search buttons on the same line.
+  // On mobile the card is compacted to the same collapsed height as the Resources
+  // filter bar (px-3 py-2.5 + a 28px row); on desktop it keeps the roomier layout.
   return (
-    <div class="card p-4">
+    <div class="card px-3 py-2.5 sm:p-4">
       {/* Status bar with buttons on the right */}
       <div class="flex items-center gap-3">
-        {/* Status bar - takes remaining space */}
-        <div class="relative flex gap-0 flex-1" style={{ height: '32px' }}>
+        {/* Status bar - takes remaining space (28px on mobile, 32px on desktop) */}
+        <div class="relative flex gap-0 flex-1 h-7 sm:h-8">
           {loading ? (
             <div class="w-full h-full bg-gray-200 dark:bg-gray-700 animate-pulse" />
           ) : statusBars.length === 0 ? (
@@ -180,9 +182,8 @@ export function FavoritesHeader({
           {/* Edit order button */}
           <button
             onClick={onEditModeToggle}
-            class="inline-flex items-center justify-center p-2 text-gray-600 dark:text-gray-400 hover:text-flux-blue dark:hover:text-blue-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
+            class="inline-flex items-center justify-center p-1 sm:p-2 text-gray-600 dark:text-gray-400 hover:text-flux-blue dark:hover:text-blue-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
             title="Edit order"
-            disabled={!resources || resources.length === 0}
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4.5h14.25M3 9h9.75M3 13.5h9.75m4.5-4.5v12m0 0-3.75-3.75M17.25 21 21 17.25" />
@@ -192,7 +193,7 @@ export function FavoritesHeader({
           {/* Search button */}
           <button
             onClick={handleSearchOpen}
-            class="inline-flex items-center justify-center p-2 text-gray-600 dark:text-gray-400 hover:text-flux-blue dark:hover:text-blue-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
+            class="inline-flex items-center justify-center p-1 sm:p-2 text-gray-600 dark:text-gray-400 hover:text-flux-blue dark:hover:text-blue-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
             title="Search favorites"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/web/src/components/favorites/FavoritesHeader.jsx
+++ b/web/src/components/favorites/FavoritesHeader.jsx
@@ -81,7 +81,7 @@ export function FavoritesHeader({
   // Edit mode: show Save and Cancel icon buttons
   if (editMode) {
     return (
-      <div class="card px-3 py-2.5">
+      <div class="card px-3 py-2.5 sm:sticky sm:top-[var(--chrome-h)] sm:z-10">
         <div class="flex items-center justify-between">
           <div class="text-sm text-gray-600 dark:text-gray-400">
             Drag to reorder favorites
@@ -116,7 +116,7 @@ export function FavoritesHeader({
   // Search mode: show search input
   if (searchMode) {
     return (
-      <div class="card px-3 py-2.5">
+      <div class="card px-3 py-2.5 sm:sticky sm:top-[var(--chrome-h)] sm:z-10">
         <FavoritesSearch
           onFilter={onFilter}
           onClose={handleSearchClose}
@@ -131,7 +131,7 @@ export function FavoritesHeader({
   // Sized to match the shared compact FilterBar (px-3 py-2.5 + a 28px row) at every
   // breakpoint, so the favorites toolbar is no taller than the other search pages.
   return (
-    <div class="card px-3 py-2.5">
+    <div class="card px-3 py-2.5 sm:sticky sm:top-[var(--chrome-h)] sm:z-10">
       {/* Status bar with buttons on the right */}
       <div class="flex items-center gap-3">
         {/* Status bar - takes remaining space (28px, matching the FilterBar row) */}
@@ -161,16 +161,17 @@ export function FavoritesHeader({
                 >
                   <div class={`h-full ${colorClass} ${roundCls} cursor-pointer transition-opacity ${isFaded ? 'opacity-30' : 'hover:opacity-80'}`} />
 
-                  {/* Tooltip - hidden on mobile */}
+                  {/* Tooltip - hidden on mobile. Pops downward (top-full) so the
+                      sticky header/nav above the pinned filter bar can't clip it. */}
                   {hoveredBar === index && (
-                    <div class="hidden md:block absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-10 pointer-events-none">
+                    <div class="hidden md:block absolute top-full left-1/2 -translate-x-1/2 mt-2 z-10 pointer-events-none">
                       <div class="bg-gray-900 dark:bg-gray-800 text-white text-xs rounded-lg py-2 px-3 shadow-lg whitespace-nowrap">
                         <div class="font-semibold">{bar.status}</div>
                         <div class="text-gray-300 mt-1">Count: {bar.count}</div>
                         <div class="text-gray-300">Percentage: {bar.percentage.toFixed(1)}%</div>
                         {isActive && <div class="text-blue-300 mt-1">Click to clear filter</div>}
-                        <div class="absolute top-full left-1/2 -translate-x-1/2 -mt-px">
-                          <div class="border-4 border-transparent border-t-gray-900 dark:border-t-gray-800"></div>
+                        <div class="absolute bottom-full left-1/2 -translate-x-1/2 -mb-px">
+                          <div class="border-4 border-transparent border-b-gray-900 dark:border-b-gray-800"></div>
                         </div>
                       </div>
                     </div>

--- a/web/src/components/favorites/FavoritesHeader.jsx
+++ b/web/src/components/favorites/FavoritesHeader.jsx
@@ -81,7 +81,7 @@ export function FavoritesHeader({
   // Edit mode: show Save and Cancel icon buttons
   if (editMode) {
     return (
-      <div class="card p-4">
+      <div class="card px-3 py-2.5">
         <div class="flex items-center justify-between">
           <div class="text-sm text-gray-600 dark:text-gray-400">
             Drag to reorder favorites
@@ -90,7 +90,7 @@ export function FavoritesHeader({
             {/* Cancel button */}
             <button
               onClick={onCancelEdit}
-              class="inline-flex items-center justify-center p-2 text-gray-600 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
+              class="inline-flex items-center justify-center p-1 text-gray-600 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
               title="Cancel"
             >
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -100,7 +100,7 @@ export function FavoritesHeader({
             {/* Save button */}
             <button
               onClick={onSaveOrder}
-              class="inline-flex items-center justify-center p-2 text-gray-600 dark:text-gray-400 hover:text-green-500 dark:hover:text-green-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
+              class="inline-flex items-center justify-center p-1 text-gray-600 dark:text-gray-400 hover:text-green-500 dark:hover:text-green-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
               title="Save"
             >
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -116,7 +116,7 @@ export function FavoritesHeader({
   // Search mode: show search input
   if (searchMode) {
     return (
-      <div class="card p-4">
+      <div class="card px-3 py-2.5">
         <FavoritesSearch
           onFilter={onFilter}
           onClose={handleSearchClose}
@@ -128,23 +128,27 @@ export function FavoritesHeader({
   }
 
   // Normal mode: show status bar with edit and search buttons on the same line.
-  // On mobile the card is compacted to the same collapsed height as the Resources
-  // filter bar (px-3 py-2.5 + a 28px row); on desktop it keeps the roomier layout.
+  // Sized to match the shared compact FilterBar (px-3 py-2.5 + a 28px row) at every
+  // breakpoint, so the favorites toolbar is no taller than the other search pages.
   return (
-    <div class="card px-3 py-2.5 sm:p-4">
+    <div class="card px-3 py-2.5">
       {/* Status bar with buttons on the right */}
       <div class="flex items-center gap-3">
-        {/* Status bar - takes remaining space (28px on mobile, 32px on desktop) */}
-        <div class="relative flex gap-0 flex-1 h-7 sm:h-8">
+        {/* Status bar - takes remaining space (28px, matching the FilterBar row) */}
+        <div class="relative flex gap-0 flex-1 h-7">
           {loading ? (
-            <div class="w-full h-full bg-gray-200 dark:bg-gray-700 animate-pulse" />
+            <div class="w-full h-full bg-gray-200 dark:bg-gray-700 rounded-full animate-pulse" />
           ) : statusBars.length === 0 ? (
-            <div class="w-full h-full bg-gray-200 dark:bg-gray-700" />
+            <div class="w-full h-full bg-gray-200 dark:bg-gray-700 rounded-full" />
           ) : (
             statusBars.map((bar, index) => {
               const colorClass = getStatusBarColor(bar.status)
               const isActive = statusFilter === bar.status
               const isFaded = statusFilter && !isActive
+              // Round only the outer ends so the whole bar reads as a single pill
+              // (like the Resources status chart). Done per-segment instead of
+              // clipping the row with overflow-hidden, which would crop the tooltip.
+              const roundCls = `${index === 0 ? 'rounded-l-full' : ''} ${index === statusBars.length - 1 ? 'rounded-r-full' : ''}`
 
               return (
                 <div
@@ -155,7 +159,7 @@ export function FavoritesHeader({
                   onMouseLeave={() => setHoveredBar(null)}
                   onClick={() => onStatusFilter(statusFilter === bar.status ? null : bar.status)}
                 >
-                  <div class={`h-full ${colorClass} cursor-pointer transition-opacity ${isFaded ? 'opacity-30' : 'hover:opacity-80'}`} />
+                  <div class={`h-full ${colorClass} ${roundCls} cursor-pointer transition-opacity ${isFaded ? 'opacity-30' : 'hover:opacity-80'}`} />
 
                   {/* Tooltip - hidden on mobile */}
                   {hoveredBar === index && (
@@ -182,7 +186,7 @@ export function FavoritesHeader({
           {/* Edit order button */}
           <button
             onClick={onEditModeToggle}
-            class="inline-flex items-center justify-center p-1 sm:p-2 text-gray-600 dark:text-gray-400 hover:text-flux-blue dark:hover:text-blue-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
+            class="inline-flex items-center justify-center p-1 text-gray-600 dark:text-gray-400 hover:text-flux-blue dark:hover:text-blue-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
             title="Edit order"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -193,7 +197,7 @@ export function FavoritesHeader({
           {/* Search button */}
           <button
             onClick={handleSearchOpen}
-            class="inline-flex items-center justify-center p-1 sm:p-2 text-gray-600 dark:text-gray-400 hover:text-flux-blue dark:hover:text-blue-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
+            class="inline-flex items-center justify-center p-1 text-gray-600 dark:text-gray-400 hover:text-flux-blue dark:hover:text-blue-400 transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue rounded-md"
             title="Search favorites"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/web/src/components/favorites/FavoritesHeader.test.jsx
+++ b/web/src/components/favorites/FavoritesHeader.test.jsx
@@ -73,11 +73,14 @@ describe('FavoritesHeader component', () => {
       expect(mockOnEditModeToggle).toHaveBeenCalled()
     })
 
-    it('should disable edit button when no resources', () => {
+    it('should keep edit button enabled when the filtered set is empty', () => {
+      // The header only renders when favorites exist, and reordering operates on
+      // all favorites — so a search that filters the visible set down to nothing
+      // must not disable "Edit order".
       render(<FavoritesHeader {...defaultProps} resources={[]} />)
 
       const editButton = screen.getByTitle('Edit order')
-      expect(editButton).toBeDisabled()
+      expect(editButton).toBeEnabled()
     })
   })
 

--- a/web/src/components/favorites/FavoritesPage.jsx
+++ b/web/src/components/favorites/FavoritesPage.jsx
@@ -9,7 +9,6 @@ import { usePageMeta } from '../../utils/meta'
 import { normalizeToFluxStatus } from '../../utils/status'
 import { FavoritesHeader } from './FavoritesHeader'
 import { FavoriteCard } from './FavoriteCard'
-import { FluxOperatorIcon } from '../layout/Icons'
 
 /**
  * Normalize a favorite's status to the Flux vocabulary (Ready/Failed/Progressing/
@@ -37,7 +36,6 @@ export function FavoritesPage() {
   // State
   const [resourcesData, setResourcesData] = useState({}) // Map of key -> resource data
   const [loading, setLoading] = useState(true)
-  const [refreshing, setRefreshing] = useState(false) // Delayed refresh indicator
   const [error, setError] = useState(null)
   const [editMode, setEditMode] = useState(false)
   const [editOrder, setEditOrder] = useState([]) // Temporary order during edit
@@ -47,7 +45,6 @@ export function FavoritesPage() {
 
   // Track if initial load has completed (to avoid showing loading on refresh)
   const initialLoadDone = useRef(false)
-  const refreshTimeoutRef = useRef(null)
 
   // Get current favorites from signal
   const currentFavorites = favorites.value
@@ -75,14 +72,9 @@ export function FavoritesPage() {
         return
       }
 
-      // Only show loading on initial load, not on refresh
+      // Only show loading on initial load; refreshes update silently in place.
       if (!initialLoadDone.current) {
         if (!cancelled) setLoading(true)
-      } else {
-        // For refreshes, show spinner after 300ms delay
-        refreshTimeoutRef.current = window.setTimeout(() => {
-          if (!cancelled) setRefreshing(true)
-        }, 300)
       }
       if (!cancelled) setError(null)
 
@@ -118,13 +110,7 @@ export function FavoritesPage() {
         }
         // Don't clear existing data on error - keep showing stale data
       } finally {
-        // Always clear timeout (no cancelled guard)
-        if (refreshTimeoutRef.current) {
-          window.clearTimeout(refreshTimeoutRef.current)
-          refreshTimeoutRef.current = null
-        }
         if (!cancelled) {
-          setRefreshing(false)
           setLoading(false)
         }
         initialLoadDone.current = true
@@ -292,13 +278,12 @@ export function FavoritesPage() {
     setStatusFilter(status)
   }, [])
 
-  // Empty state
-  if (!loading && currentFavorites.length === 0) {
+  // Empty state — favorites come from local storage synchronously, so this is
+  // accurate on the very first render without waiting for the status fetch.
+  if (currentFavorites.length === 0) {
     return (
-      <main data-testid="favorites-page" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow w-full">
+      <main data-testid="favorites-page" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8 flex-grow w-full">
         <div class="space-y-6">
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Favorites</h2>
-
           <div class="card py-12">
             <div class="text-center">
               <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -327,22 +312,8 @@ export function FavoritesPage() {
   }
 
   return (
-    <main data-testid="favorites-page" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow w-full">
+    <main data-testid="favorites-page" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8 flex-grow w-full">
       <div class="space-y-6">
-        {/* Page Title */}
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Favorites</h2>
-          {/* Favorites count with refresh indicator */}
-          {!loading && filteredFavorites.length > 0 && (
-            <span class="text-sm text-gray-600 dark:text-gray-400 flex items-center gap-2">
-              {refreshing && (
-                <div class="animate-spin rounded-full h-3 w-3 border-b-2 border-gray-400"></div>
-              )}
-              {filteredFavorites.length} resources
-            </span>
-          )}
-        </div>
-
         {/* Header with status bar and controls */}
         <FavoritesHeader
           resources={resourcesForChart}
@@ -421,35 +392,30 @@ export function FavoritesPage() {
           </div>
         )}
 
-        {/* Normal Mode: Favorite cards grid */}
-        {!editMode && !loading && filteredFavorites.length > 0 && (
+        {/* Normal Mode: favorite cards grid. Rendered straight from local storage
+            so the cards appear instantly; each card's live status fills in once
+            the status fetch settles (until then the badge reads "Unknown"). */}
+        {!editMode && filteredFavorites.length > 0 && (
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {filteredFavorites.map((fav) => (
               <FavoriteCard
                 key={getFavoriteKey(fav.kind, fav.namespace, fav.name)}
                 favorite={fav}
                 resourceData={fav.resourceData}
+                loading={loading}
               />
             ))}
           </div>
         )}
 
         {/* No results after filtering */}
-        {!editMode && !loading && filteredFavorites.length === 0 && currentFavorites.length > 0 && (
+        {!editMode && filteredFavorites.length === 0 && currentFavorites.length > 0 && (
           <div class="card py-8">
             <div class="text-center">
               <p class="text-sm text-gray-600 dark:text-gray-400">
                 No favorites match your search
               </p>
             </div>
-          </div>
-        )}
-
-        {/* Loading state */}
-        {loading && (
-          <div class="flex items-center justify-center p-8">
-            <FluxOperatorIcon className="animate-spin h-8 w-8 text-flux-blue" />
-            <span class="ml-3 text-gray-600 dark:text-gray-400">Loading favorites...</span>
           </div>
         )}
       </div>

--- a/web/src/components/favorites/FavoritesPage.jsx
+++ b/web/src/components/favorites/FavoritesPage.jsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { useState, useEffect, useMemo, useCallback, useRef } from 'preact/hooks'
+import { signal } from '@preact/signals'
 import { fetchWithMock } from '../../utils/fetch'
 import { favorites, reorderFavorites, getFavoriteKey, removeFavorite } from '../../utils/favorites'
 import { POLL_INTERVAL_MS } from '../../utils/constants'
@@ -9,6 +10,17 @@ import { usePageMeta } from '../../utils/meta'
 import { normalizeToFluxStatus } from '../../utils/status'
 import { FavoritesHeader } from './FavoritesHeader'
 import { FavoriteCard } from './FavoriteCard'
+
+// Cached favorite status map (favoriteKey -> { status, lastReconciled, message }),
+// held at module scope so leaving and returning to the page renders the last-known
+// status instantly from cache while a background refresh updates it. Mirrors the
+// module signals used by the Resources/Workloads lists.
+export const favoritesData = signal({})
+// True while a /api/v1/favorites request is in flight. Initialized true so the
+// very first (cold) page load paints the skeleton state immediately, rather than
+// flashing an "Unknown" badge for one frame before the mount effect starts the
+// fetch. On warm return visits hasCachedData suppresses the pulse regardless.
+export const favoritesFetching = signal(true)
 
 /**
  * Normalize a favorite's status to the Flux vocabulary (Ready/Failed/Progressing/
@@ -33,9 +45,13 @@ function getChartStatus(fav) {
 export function FavoritesPage() {
   usePageMeta('Favorites', 'Favorites dashboard')
 
+  // Cached status map + in-flight flag, read from the module signals so a return
+  // visit renders the warm cache immediately. Reading `.value` here subscribes the
+  // component, so it re-renders when a fetch updates either signal.
+  const resourcesData = favoritesData.value
+  const loading = favoritesFetching.value
+
   // State
-  const [resourcesData, setResourcesData] = useState({}) // Map of key -> resource data
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [editMode, setEditMode] = useState(false)
   const [editOrder, setEditOrder] = useState([]) // Temporary order during edit
@@ -43,8 +59,9 @@ export function FavoritesPage() {
   const [filter, setFilter] = useState({ namespace: null, kind: null, name: '' })
   const [statusFilter, setStatusFilter] = useState(null)
 
-  // Track if initial load has completed (to avoid showing loading on refresh)
-  const initialLoadDone = useRef(false)
+  // True once we have any cached status. Drives whether a fetch counts as a
+  // first-load (skeletons + chart pulse) or a silent background refresh.
+  const hasCachedData = Object.keys(resourcesData).length > 0
 
   // Get current favorites from signal
   const currentFavorites = favorites.value
@@ -64,18 +81,14 @@ export function FavoritesPage() {
 
     const fetchData = async () => {
       if (currentFavorites.length === 0) {
-        if (!cancelled) {
-          setResourcesData({})
-          setLoading(false)
-        }
-        initialLoadDone.current = true
+        // Reset the cache so deleting every favorite doesn't resurrect stale
+        // statuses on the next add.
+        favoritesData.value = {}
+        favoritesFetching.value = false
         return
       }
 
-      // Only show loading on initial load; refreshes update silently in place.
-      if (!initialLoadDone.current) {
-        if (!cancelled) setLoading(true)
-      }
+      favoritesFetching.value = true
       if (!cancelled) setError(null)
 
       try {
@@ -102,18 +115,16 @@ export function FavoritesPage() {
           }
         })
 
-        if (!cancelled) setResourcesData(results)
+        if (!cancelled) favoritesData.value = results
       } catch (err) {
-        // Only show error panel on initial load, not on refresh
-        if (!initialLoadDone.current && !cancelled) {
+        // Surface the error panel only when there is no cached status to fall
+        // back on; background refreshes (and any visit with a warm cache) fail
+        // silently and keep showing the last-known status.
+        if (!cancelled && Object.keys(favoritesData.value).length === 0) {
           setError(err.message)
         }
-        // Don't clear existing data on error - keep showing stale data
       } finally {
-        if (!cancelled) {
-          setLoading(false)
-        }
-        initialLoadDone.current = true
+        if (!cancelled) favoritesFetching.value = false
       }
     }
 
@@ -313,11 +324,11 @@ export function FavoritesPage() {
 
   return (
     <main data-testid="favorites-page" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8 flex-grow w-full">
-      <div class="space-y-6">
+      <div class="space-y-3">
         {/* Header with status bar and controls */}
         <FavoritesHeader
           resources={resourcesForChart}
-          loading={loading}
+          loading={loading && !hasCachedData}
           editMode={editMode}
           onEditModeToggle={handleEditModeToggle}
           onSaveOrder={handleSaveOrder}
@@ -402,6 +413,10 @@ export function FavoritesPage() {
                 key={getFavoriteKey(fav.kind, fav.namespace, fav.name)}
                 favorite={fav}
                 resourceData={fav.resourceData}
+                /* Pass raw `loading` (not gated by hasCachedData like the header):
+                   the card skeletons only when loading AND it has no cached status
+                   of its own, so on a warm return visit cached cards never skeleton
+                   while a brand-new favorite still does. */
                 loading={loading}
               />
             ))}

--- a/web/src/components/favorites/FavoritesPage.test.jsx
+++ b/web/src/components/favorites/FavoritesPage.test.jsx
@@ -3,7 +3,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/preact'
-import { FavoritesPage } from './FavoritesPage'
+import { FavoritesPage, favoritesData, favoritesFetching } from './FavoritesPage'
 import { favorites, reorderFavorites, removeFavorite } from '../../utils/favorites'
 import { fetchWithMock } from '../../utils/fetch'
 import { POLL_INTERVAL_MS } from '../../utils/constants'
@@ -90,6 +90,12 @@ describe('FavoritesPage component', () => {
     vi.clearAllMocks()
     // Clear favorites
     favorites.value = []
+    // Reset the module-level status cache so warm state from one test doesn't
+    // leak into the next (a cached map would skip the first-load skeleton path).
+    // favoritesFetching mirrors a cold page load (true until the first fetch
+    // settles), matching the module default.
+    favoritesData.value = {}
+    favoritesFetching.value = true
 
     // Setup default mock response for POST /api/v1/favorites
     // Returns only the resources that match the requested favorites
@@ -167,6 +173,26 @@ describe('FavoritesPage component', () => {
       await waitFor(() => {
         expect(screen.getByTestId('header-loading')).toHaveTextContent('loaded')
       })
+    })
+
+    it('renders cached status instantly on a return visit without a loading pass', async () => {
+      favorites.value = mockFavorites
+
+      // First visit warms the module-level cache.
+      const { unmount } = render(<FavoritesPage />)
+      await waitFor(() => {
+        expect(screen.getByTestId('header-loading')).toHaveTextContent('loaded')
+      })
+      unmount()
+
+      // Navigate away and back: the second mount reads the warm cache, so cards
+      // render their status immediately and the header never enters the loading
+      // (pulse) state even though a background refresh is in flight.
+      render(<FavoritesPage />)
+
+      expect(screen.getByTestId('header-loading')).toHaveTextContent('loaded')
+      const fluxCard = screen.getByTestId('favorite-card-flux')
+      expect(fluxCard.querySelector('[data-testid="card-status"]')).toHaveTextContent('Ready')
     })
   })
 

--- a/web/src/components/favorites/FavoritesPage.test.jsx
+++ b/web/src/components/favorites/FavoritesPage.test.jsx
@@ -197,15 +197,8 @@ describe('FavoritesPage component', () => {
       })
     })
 
-    it('should show favorites count in title section', async () => {
-      favorites.value = mockFavorites
-
-      render(<FavoritesPage />)
-
-      await waitFor(() => {
-        expect(screen.getByText('3 resources')).toBeInTheDocument()
-      })
-    })
+    // The favorites count now lives in the section tab bar (see app.test.jsx),
+    // not in the page body, so it is asserted there rather than here.
   })
 
   describe('filtering', () => {
@@ -412,16 +405,6 @@ describe('FavoritesPage component', () => {
         const card = screen.getByTestId('favorite-card-deleted-resource')
         expect(card.querySelector('[data-testid="card-status"]')).toHaveTextContent('null')
       })
-    })
-  })
-
-  describe('page title', () => {
-    it('should display "Favorites" title', () => {
-      favorites.value = mockFavorites
-
-      render(<FavoritesPage />)
-
-      expect(screen.getByText('Favorites')).toBeInTheDocument()
     })
   })
 

--- a/web/src/components/layout/UserMenu.test.jsx
+++ b/web/src/components/layout/UserMenu.test.jsx
@@ -9,9 +9,10 @@ import { clearFavorites } from '../../utils/favorites'
 import { logSettings, DEFAULT_LOG_SETTINGS } from '../../utils/logSettings'
 import { reportData } from '../../app'
 
-// Mock the favorites module
+// Mock the favorites module (app.jsx reads the favorites signal for the tab count)
 vi.mock('../../utils/favorites', () => ({
-  clearFavorites: vi.fn()
+  clearFavorites: vi.fn(),
+  favorites: { value: [] }
 }))
 
 describe('UserMenu', () => {

--- a/web/src/components/search/EventList.jsx
+++ b/web/src/components/search/EventList.jsx
@@ -80,12 +80,14 @@ function EventRow({ event }) {
 
   // One-word severity label for the chip tooltip and the mobile second line.
   const severity = event.type === 'Warning' ? 'Warning' : 'Info'
+  const chipColor = getEventBadgeClass(event.type)
+  const chipTitle = `${kind} · ${severity}`
 
   return (
     <div class="border-b border-gray-100 dark:border-gray-700/60 last:border-0">
       <div class="px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700/30">
         <div class="flex items-center gap-2.5">
-          <KindChip kind={kind} colorClass={getEventBadgeClass(event.type)} title={`${kind} · ${severity}`} cls="hidden sm:inline-block" />
+          <KindChip kind={kind} colorClass={chipColor} title={chipTitle} cls="hidden sm:inline-block" />
           <NameLink href={resourceUrl} namespace={event.namespace} name={name} cls="rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue" />
           <span class="hidden sm:block flex-1 min-w-0 truncate text-xs text-gray-500 dark:text-gray-400">{event.message}</span>
           <span class="hidden sm:block shrink-0 text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap tabular-nums">{formatTimestamp(event.lastTimestamp)}</span>
@@ -93,7 +95,7 @@ function EventRow({ event }) {
         </div>
         {/* Mobile-only second line: colored kind pill + severity word + timestamp. */}
         <div class="sm:hidden mt-1 flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
-          <KindChip kind={kind} colorClass={getEventBadgeClass(event.type)} title={`${kind} · ${severity}`} />
+          <KindChip kind={kind} colorClass={chipColor} title={chipTitle} />
           <span class="whitespace-nowrap"><span class="capitalize">{severity}</span> {formatTimestamp(event.lastTimestamp)}</span>
         </div>
       </div>

--- a/web/src/components/search/EventList.jsx
+++ b/web/src/components/search/EventList.jsx
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { signal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { fetchWithMock } from '../../utils/fetch'
 import { formatTimestamp } from '../../utils/time'
 import { getEventBadgeClass } from '../../utils/status'
 import { usePageMeta } from '../../utils/meta'
 import { reportData } from '../../app'
 import { FilterForm } from './FilterForm'
+import { FilterBar } from './FilterBar'
+import { Chevron, KindChip, NameLink, Reveal } from './compactRow'
 import { getDashboardUrl, useRestoreFiltersFromUrl, useSyncFiltersToUrl } from '../../utils/routing'
 import { StatusChart } from './StatusChart'
 import { useInfiniteScroll } from '../../utils/scroll'
@@ -54,94 +55,59 @@ export async function fetchEvents() {
 
 
 /**
- * EventCard - Individual card displaying a Kubernetes event
+ * EventRow - compact list row for a single Kubernetes event.
  *
  * @param {Object} props
- * @param {Object} props.event - Event object with type, message, involvedObject, timestamp
+ * @param {Object} props.event - Event with type, involvedObject, namespace, message, lastTimestamp
  *
- * Features:
- * - Shows resource kind and name from involvedObject
- * - Displays event severity badge (Info for Normal, Warning for Warning)
- * - Shows event message with expand/collapse for long messages
- * - Displays namespace and timestamp
- * - Clickable resource name that navigates to resources page with filters
+ * The kind chip is colored by event severity (Normal -> Info, Warning). On
+ * desktop the row shows the namespace/name link, the truncated message and the
+ * timestamp on one line; on mobile the link sits on the top row and a second
+ * line repeats the colored chip beside the severity word and timestamp. The
+ * namespace/name link routes to the involved object's dashboard. Events already
+ * carry their full message in the list, so expanding reveals it inline (a dark
+ * rounded block, newlines preserved) instantly with a plain chevron and no
+ * spinner — there is nothing to fetch.
  */
-function EventCard({ event }) {
-  const [isExpanded, setIsExpanded] = useState(false)
+function EventRow({ event }) {
+  const [open, setOpen] = useState(false)
 
-  // Parse involvedObject to get kind and name
+  // Parse involvedObject "Kind/name" into kind and name.
   const [kind, name] = event.involvedObject.split('/')
 
-  // Build the dashboard URL, routing workload-kind events to the workload dashboard
+  // Build the dashboard URL, routing workload-kind events to the workload dashboard.
   const resourceUrl = getDashboardUrl(kind, event.namespace, name)
 
-  // Map event type to display status
-  const displayStatus = event.type === 'Normal' ? 'Info' : 'Warning'
-
-  // Check if message is long or contains newlines
-  const isLongMessage = event.message.length > 150 || event.message.includes('\n')
-  const shouldTruncate = isLongMessage && !isExpanded
-
-  // Truncate to first line or 150 chars
-  const getTruncatedMessage = () => {
-    const firstLine = event.message.split('\n')[0]
-    if (firstLine.length > 150) {
-      return firstLine.substring(0, 150) + '...'
-    }
-    return firstLine
-  }
-
-  const displayMessage = shouldTruncate ? getTruncatedMessage() : event.message
+  // One-word severity label for the chip tooltip and the mobile second line.
+  const severity = event.type === 'Warning' ? 'Warning' : 'Info'
 
   return (
-    <div class="card p-4 hover:shadow-md transition-shadow">
-      {/* Header row: kind + status badge + timestamp */}
-      <div class="flex items-center justify-between mb-3">
-        <div class="flex items-center gap-3">
-          <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
-            {kind}
-          </span>
-          <span class={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getEventBadgeClass(event.type)}`}>
-            {displayStatus}
-          </span>
+    <div class="border-b border-gray-100 dark:border-gray-700/60 last:border-0">
+      <div class="px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700/30">
+        <div class="flex items-center gap-2.5">
+          <KindChip kind={kind} colorClass={getEventBadgeClass(event.type)} title={`${kind} · ${severity}`} cls="hidden sm:inline-block" />
+          <NameLink href={resourceUrl} namespace={event.namespace} name={name} cls="rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue" />
+          <span class="hidden sm:block flex-1 min-w-0 truncate text-xs text-gray-500 dark:text-gray-400">{event.message}</span>
+          <span class="hidden sm:block shrink-0 text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap tabular-nums">{formatTimestamp(event.lastTimestamp)}</span>
+          <button onClick={() => setOpen(!open)} class="shrink-0 rounded p-0.5 text-gray-400 hover:text-flux-blue" title="Details" aria-label="Toggle event details"><Chevron open={open} /></button>
         </div>
-        <span class="hidden sm:inline text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap ml-4">
-          {formatTimestamp(event.lastTimestamp)}
-        </span>
+        {/* Mobile-only second line: colored kind pill + severity word + timestamp. */}
+        <div class="sm:hidden mt-1 flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
+          <KindChip kind={kind} colorClass={getEventBadgeClass(event.type)} title={`${kind} · ${severity}`} />
+          <span class="whitespace-nowrap"><span class="capitalize">{severity}</span> {formatTimestamp(event.lastTimestamp)}</span>
+        </div>
       </div>
-
-      {/* Resource namespace/name - clickable link */}
-      <div class="mb-1 sm:mb-2">
-        <a
-          href={resourceUrl}
-          class="text-sm text-left hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue rounded inline-block group"
-        >
-          <span class="text-gray-500 dark:text-gray-400">{event.namespace}/</span><span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-flux-blue dark:group-hover:text-blue-400">{name}</span><svg class="w-3.5 h-3.5 text-gray-400 group-hover:text-flux-blue dark:group-hover:text-blue-400 transition-colors ml-1 inline-block align-middle" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
-        </a>
-      </div>
-
-      {/* Mobile timestamp - below namespace/name */}
-      <div class="flex sm:hidden items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 mb-2">
-        <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-        </svg>
-        {formatTimestamp(event.lastTimestamp)}
-      </div>
-
-      {/* Message */}
-      <div class="text-sm text-gray-700 dark:text-gray-300">
-        <pre class="whitespace-pre-wrap break-words font-sans">
-          {displayMessage}
-        </pre>
-        {isLongMessage && (
-          <button
-            onClick={() => setIsExpanded(!isExpanded)}
-            class="text-flux-blue dark:text-blue-400 text-xs mt-1 hover:underline focus:outline-none"
-          >
-            {isExpanded ? 'Show less' : 'Show more'}
-          </button>
-        )}
-      </div>
+      {/* Events carry the full message in the list, so there is nothing to fetch:
+          the panel reveals instantly (no spinner) with the same animation. */}
+      <Reveal open={open}>
+        <div class="px-3 pt-1 pb-4">
+          {/* A long event message is capped at 60vh and scrolls inside, matching
+              the resource/workload detail panels. */}
+          <div class="bg-gray-100 dark:bg-gray-900/70 rounded-md px-3 py-2 text-xs text-gray-700 dark:text-gray-300 max-h-[60vh] overflow-y-auto">
+            <pre class="whitespace-pre-wrap break-words font-sans leading-relaxed">{event.message}</pre>
+          </div>
+        </div>
+      </Reveal>
     </div>
   )
 }
@@ -152,7 +118,7 @@ function EventCard({ event }) {
  * Features:
  * - Fetches events from the API with optional filters (kind, name, namespace, severity)
  * - Auto-refetches when filter signals change
- * - Displays events in card format with expandable messages
+ * - Displays events as compact, expandable rows with the full message inline
  * - Shows loading, error, and empty states
  */
 export function EventList() {
@@ -197,21 +163,25 @@ export function EventList() {
   }
 
   return (
-    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow w-full">
-      <div class="space-y-6">
-        {/* Page Title */}
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Flux Events</h2>
-          {/* Event count */}
-          {!eventsLoading.value && eventsData.value.length > 0 && (
-            <span class="text-sm text-gray-600 dark:text-gray-400">
-              {eventsData.value.length} events
-            </span>
-          )}
-        </div>
-
-        {/* Filters */}
-        <div class="card p-4">
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8 flex-grow w-full">
+      <div class="space-y-3">
+        {/* Filters + status chart toolbar */}
+        <FilterBar
+          count={eventsData.value.length}
+          label="events"
+          loading={eventsLoading.value}
+          statusChart={
+            <StatusChart
+              items={eventsData.value}
+              loading={eventsLoading.value}
+              mode="events"
+              compact
+              onBarClick={(status) => {
+                selectedEventSeverity.value = selectedEventSeverity.value === status ? '' : status
+              }}
+            />
+          }
+        >
           <FilterForm
             kindSignal={selectedEventKind}
             nameSignal={selectedEventName}
@@ -219,18 +189,9 @@ export function EventList() {
             severitySignal={selectedEventSeverity}
             namespaces={reportData.value?.spec?.namespaces || []}
             onClear={handleClearFilters}
+            onRefresh={fetchEvents}
           />
-        </div>
-
-        {/* Status Chart */}
-        <StatusChart
-          items={eventsData.value}
-          loading={eventsLoading.value}
-          mode="events"
-          onBarClick={(status) => {
-            selectedEventSeverity.value = selectedEventSeverity.value === status ? '' : status
-          }}
-        />
+        </FilterBar>
 
         {/* Error State */}
         {eventsError.value && (
@@ -248,7 +209,6 @@ export function EventList() {
           </div>
         )}
 
-        {/* Events List */}
         {/* Empty State */}
         {!eventsLoading.value && eventsData.value.length === 0 && (
           <div class="card py-12">
@@ -263,11 +223,12 @@ export function EventList() {
           </div>
         )}
 
-        {/* Events Cards */}
+        {/* Events List — rows provide their own padding, so drop the card's
+            heavy padding on mobile (keep it on desktop). */}
         {!eventsLoading.value && eventsData.value.length > 0 && (
-          <div class="space-y-4">
+          <div class="card overflow-hidden p-0 sm:p-2">
             {visibleEvents.map((event, index) => (
-              <EventCard key={`${event.involvedObject}-${event.lastTimestamp}-${index}`} event={event} />
+              <EventRow key={`${event.involvedObject}-${event.lastTimestamp}-${index}`} event={event} />
             ))}
 
             {/* Sentinel element for infinite scroll */}

--- a/web/src/components/search/EventList.test.jsx
+++ b/web/src/components/search/EventList.test.jsx
@@ -224,17 +224,20 @@ describe('EventList', () => {
       })
     })
 
-    it('should display event cards when data loads', async () => {
+    it('should display event rows when data loads', async () => {
       fetchWithMock.mockResolvedValue({ events: mockEvents })
 
       render(<EventList />)
 
+      // Each row renders the involved-object link twice (mobile + desktop layouts),
+      // so the name appears in two links.
       await waitFor(() => {
-        expect(screen.getAllByText(/flux-system/)).toHaveLength(3) // namespace + name in both cards
+        expect(screen.getAllByRole('link', { name: 'flux-system/flux-system' })).toHaveLength(2)
       })
-      expect(screen.getByText(/Fetched revision/)).toBeInTheDocument()
-      expect(screen.getByText('apps')).toBeInTheDocument()
-      expect(screen.getByText('Health check failed')).toBeInTheDocument()
+      expect(screen.getAllByText('apps')).toHaveLength(2)
+      // The message shows in the desktop one-line summary and again in the inline reveal.
+      expect(screen.getAllByText(/Fetched revision/).length).toBeGreaterThan(0)
+      expect(screen.getAllByText('Health check failed').length).toBeGreaterThan(0)
     })
 
     it('should show empty state when no events match filters', async () => {
@@ -262,18 +265,22 @@ describe('EventList', () => {
 
       render(<EventList />)
 
+      // The count renders once, in the FilterBar toolbar. (The desktop section
+      // count lives in the App tab nav, not this component.)
       await waitFor(() => {
-        expect(screen.getByText('2 events')).toBeInTheDocument()
+        expect(screen.getAllByText('2 events')).toHaveLength(1)
       })
     })
 
-    it('should not display event count when loading', async () => {
-      eventsData.value = []
+    it('should show a loading indicator instead of the count while loading', async () => {
+      eventsData.value = mockEvents
       eventsLoading.value = true
 
       render(<EventList />)
 
-      expect(screen.queryByText(/events$/)).not.toBeInTheDocument()
+      // While loading the FilterBar shows "Loading…" rather than a (stale) count.
+      expect(screen.getByText('Loading…')).toBeInTheDocument()
+      expect(screen.queryByText('2 events')).not.toBeInTheDocument()
     })
   })
 
@@ -361,8 +368,37 @@ describe('EventList', () => {
     })
   })
 
-  describe('EventCard rendering', () => {
-    it('should display event type badge as "Info" for Normal events', async () => {
+  describe('EventRow rendering', () => {
+    it('should render a severity-colored kind chip for Normal events', async () => {
+      fetchWithMock.mockResolvedValue({ events: [mockEvents[0]] })
+
+      render(<EventList />)
+
+      // GitRepository shortens to "gitrepo"; the chip is rendered for both the
+      // desktop top row and the mobile second line.
+      await waitFor(() => {
+        expect(screen.getAllByText('gitrepo').length).toBeGreaterThan(0)
+      })
+      screen.getAllByText('gitrepo').forEach((chip) => {
+        expect(chip.className).toContain('bg-green-100')
+      })
+    })
+
+    it('should render a severity-colored kind chip for Warning events', async () => {
+      fetchWithMock.mockResolvedValue({ events: [mockEvents[1]] })
+
+      render(<EventList />)
+
+      // Kustomization shortens to "ks"; Warning events get the red chip palette.
+      await waitFor(() => {
+        expect(screen.getAllByText('ks').length).toBeGreaterThan(0)
+      })
+      screen.getAllByText('ks').forEach((chip) => {
+        expect(chip.className).toContain('bg-red-100')
+      })
+    })
+
+    it('should display the severity word "Info" for Normal events', async () => {
       fetchWithMock.mockResolvedValue({ events: [mockEvents[0]] })
 
       render(<EventList />)
@@ -372,7 +408,7 @@ describe('EventList', () => {
       })
     })
 
-    it('should display event type badge as "Warning" for Warning events', async () => {
+    it('should display the severity word "Warning" for Warning events', async () => {
       fetchWithMock.mockResolvedValue({ events: [mockEvents[1]] })
 
       render(<EventList />)
@@ -381,46 +417,81 @@ describe('EventList', () => {
         expect(screen.getByText('Warning')).toBeInTheDocument()
       })
     })
+  })
 
-    it('should show expand button for long messages', async () => {
-      const longMessage = 'a'.repeat(200)
-      fetchWithMock.mockResolvedValue({ events: [{
-        ...mockEvents[0],
-        message: longMessage
-      }] })
+  describe('Inline message reveal', () => {
+    it('should render a details toggle for each event', async () => {
+      fetchWithMock.mockResolvedValue({ events: mockEvents })
 
       render(<EventList />)
 
       await waitFor(() => {
-        expect(screen.getByText('Show more')).toBeInTheDocument()
+        expect(screen.getAllByLabelText('Toggle event details')).toHaveLength(2)
       })
     })
 
-    it('should expand message when show more is clicked', async () => {
-      const longMessage = 'a'.repeat(200)
-      fetchWithMock.mockResolvedValue({ events: [{
-        ...mockEvents[0],
-        message: longMessage
-      }] })
+    it('should reveal the full message inline when expanded, with no spinner or fetch', async () => {
+      const fullMessage = 'Line one of the event\nLine two with more detail'
+      fetchWithMock.mockResolvedValue({ events: [{ ...mockEvents[0], message: fullMessage }] })
 
-      render(<EventList />)
+      const { container } = render(<EventList />)
 
-      const showMoreButton = await screen.findByText('Show more')
-      fireEvent.click(showMoreButton)
+      const toggle = await screen.findByLabelText('Toggle event details')
 
-      expect(screen.getByText('Show less')).toBeInTheDocument()
+      // Collapsed before expanding, and only the mount fetch has run.
+      const reveal = container.querySelector('[class*="grid-rows-"]')
+      expect(reveal.className).toContain('grid-rows-[0fr]')
+      expect(fetchWithMock).toHaveBeenCalledTimes(1)
+
+      fireEvent.click(toggle)
+
+      // Expanded: the animated reveal opens and shows the full message verbatim.
+      await waitFor(() => {
+        expect(container.querySelector('[class*="grid-rows-"]').className).toContain('grid-rows-[1fr]')
+      })
+      const pre = container.querySelector('pre')
+      expect(pre).toBeInTheDocument()
+      expect(pre.textContent).toBe(fullMessage)
+
+      // Events carry their message in the list, so expanding triggers no extra
+      // fetch and shows no loading spinner.
+      expect(fetchWithMock).toHaveBeenCalledTimes(1)
+      expect(container.querySelector('.animate-spin')).not.toBeInTheDocument()
+    })
+
+    it('should collapse the reveal again when the toggle is clicked twice', async () => {
+      fetchWithMock.mockResolvedValue({ events: [mockEvents[0]] })
+
+      const { container } = render(<EventList />)
+
+      const toggle = await screen.findByLabelText('Toggle event details')
+
+      fireEvent.click(toggle)
+      await waitFor(() => {
+        expect(container.querySelector('[class*="grid-rows-"]').className).toContain('grid-rows-[1fr]')
+      })
+
+      fireEvent.click(toggle)
+      await waitFor(() => {
+        expect(container.querySelector('[class*="grid-rows-"]').className).toContain('grid-rows-[0fr]')
+      })
     })
   })
 
   describe('Navigation to resource dashboard', () => {
-    it('should have correct href on resource name link', async () => {
+    it('should link the involved object to its dashboard', async () => {
       fetchWithMock.mockResolvedValue({ events: [mockEvents[0]] })
 
       render(<EventList />)
 
-      // Wait for events to load and find the resource name link
-      const resourceLink = await screen.findByRole('link', { name: /flux-system\/flux-system/ })
-      expect(resourceLink).toHaveAttribute('href', '/resource/GitRepository/flux-system/flux-system')
+      // The name link is rendered twice (mobile + desktop); both point at the
+      // involved object's dashboard.
+      await waitFor(() => {
+        expect(screen.getAllByRole('link', { name: 'flux-system/flux-system' })).toHaveLength(2)
+      })
+      screen.getAllByRole('link', { name: 'flux-system/flux-system' }).forEach((link) => {
+        expect(link).toHaveAttribute('href', '/resource/GitRepository/flux-system/flux-system')
+      })
     })
 
     it('should have correct href for different resource', async () => {
@@ -428,20 +499,12 @@ describe('EventList', () => {
 
       render(<EventList />)
 
-      const resourceLink = await screen.findByRole('link', { name: /flux-system\/apps/ })
-      expect(resourceLink).toHaveAttribute('href', '/resource/Kustomization/flux-system/apps')
-    })
-
-    it('should display navigation icon in resource link', async () => {
-      fetchWithMock.mockResolvedValue({ events: [mockEvents[0]] })
-
-      render(<EventList />)
-
-      const resourceLink = await screen.findByRole('link', { name: /flux-system\/flux-system/ })
-      const svg = resourceLink.querySelector('svg')
-
-      expect(svg).toBeInTheDocument()
-      expect(svg).toHaveAttribute('viewBox', '0 0 24 24')
+      await waitFor(() => {
+        expect(screen.getAllByRole('link', { name: 'flux-system/apps' })).toHaveLength(2)
+      })
+      screen.getAllByRole('link', { name: 'flux-system/apps' }).forEach((link) => {
+        expect(link).toHaveAttribute('href', '/resource/Kustomization/flux-system/apps')
+      })
     })
   })
 })

--- a/web/src/components/search/FilterBar.jsx
+++ b/web/src/components/search/FilterBar.jsx
@@ -28,7 +28,10 @@ export function FilterBar({ count, label, loading, children, statusChart }) {
   const [showFilters, setShowFilters] = useState(false)
 
   return (
-    <div class="card px-3 py-2.5">
+    // Sticky below the header+nav on desktop so the filters stay in view while
+    // the list scrolls behind (the card background keeps it opaque). Normal flow
+    // on mobile.
+    <div class="card px-3 py-2.5 sm:sticky sm:top-[var(--chrome-h)] sm:z-10">
       {/* Mobile: a single row with the count (or loader) + a filter toggle. The
           full filter form (and status chart) opens on demand. */}
       <div class="sm:hidden flex items-center justify-between">

--- a/web/src/components/search/FilterBar.jsx
+++ b/web/src/components/search/FilterBar.jsx
@@ -1,0 +1,67 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+//
+// Toolbar wrapper for the compact list view: a result count, a mobile-only
+// "Filters" toggle that collapses the form, the FilterForm in a collapsible
+// container, and an optional status chart shown only on desktop.
+
+import { useState } from 'preact/hooks'
+import { Spinner } from './compactRow'
+
+/**
+ * FilterBar - presentational toolbar that wraps a FilterForm. On mobile it
+ * shows the result count beside a funnel toggle and hides the form until the
+ * toggle is pressed; on desktop the form (and the status chart) is always
+ * visible. The filter signals stay in the FilterForm passed as `children`.
+ *
+ * @param {Object} props
+ * @param {number} props.count - Number of results, shown before `label`
+ * @param {string} props.label - Plural noun for the count (e.g. "resources")
+ * @param {boolean} [props.loading] - When true, shows a spinner + "Loading…"
+ *   instead of the (still-zero) result count
+ * @param {*} props.children - The FilterForm element
+ * @param {*} [props.statusChart] - Status chart node; FilterBar hides it on
+ *   mobile (it stays in the desktop toolbar only)
+ */
+export function FilterBar({ count, label, loading, children, statusChart }) {
+  // Mobile: the filter form is collapsed behind a toggle to save vertical space.
+  const [showFilters, setShowFilters] = useState(false)
+
+  return (
+    <div class="card px-3 py-2.5">
+      {/* Mobile: a single row with the count (or loader) + a filter toggle. The
+          full filter form (and status chart) opens on demand. */}
+      <div class="sm:hidden flex items-center justify-between">
+        <span class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          {loading ? (
+            <>
+              <Spinner cls="w-4 h-4" />
+              Loading…
+            </>
+          ) : (
+            <>{count} {label}</>
+          )}
+        </span>
+        <button
+          onClick={() => setShowFilters(v => !v)}
+          aria-label="Toggle filters"
+          aria-expanded={showFilters}
+          aria-controls="filter-panel"
+          class={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm hover:text-flux-blue ${showFilters ? 'text-flux-blue' : 'text-gray-500 dark:text-gray-400'}`}
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h18M6 9h12M10 14h4M12 19h0" /></svg>
+          Filters
+        </button>
+      </div>
+      {/* Filters + status chart: always shown on desktop, toggled on mobile. The
+          top margin only spaces this below the mobile bar; on desktop the bar is
+          hidden, so the margin collapses and the card padding stays symmetric. */}
+      <div id="filter-panel" class={`${showFilters ? 'block' : 'hidden'} sm:block mt-2.5 sm:mt-0 space-y-2.5`}>
+        {children}
+        {/* Status chart is desktop-only — kept out of the mobile filter panel even
+            when it is expanded. */}
+        {statusChart && <div class="hidden sm:block">{statusChart}</div>}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/search/FilterBar.test.jsx
+++ b/web/src/components/search/FilterBar.test.jsx
@@ -1,0 +1,61 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { FilterBar } from './FilterBar'
+
+describe('FilterBar', () => {
+  it('renders the result count and label', () => {
+    render(
+      <FilterBar count={5} label="resources">
+        <div data-testid="form">form</div>
+      </FilterBar>
+    )
+    expect(screen.getByText('5 resources')).toBeInTheDocument()
+  })
+
+  it('shows a loader instead of the count while loading', () => {
+    const { container } = render(
+      <FilterBar count={0} label="events" loading>
+        <div data-testid="form">form</div>
+      </FilterBar>
+    )
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+    expect(screen.queryByText('0 events')).not.toBeInTheDocument()
+    expect(container.querySelector('.animate-spin')).toBeTruthy()
+  })
+
+  it('collapses the form on mobile until the Filters toggle is pressed', () => {
+    render(
+      <FilterBar count={3} label="events">
+        <div data-testid="form">form</div>
+      </FilterBar>
+    )
+
+    // The form container is hidden on mobile (still sm:block for desktop).
+    const formContainer = screen.getByTestId('form').parentElement
+    expect(formContainer).toHaveClass('hidden')
+    expect(formContainer).toHaveClass('sm:block')
+    expect(formContainer).not.toHaveClass('block')
+
+    // Pressing the toggle expands the form.
+    fireEvent.click(screen.getByRole('button', { name: /toggle filters/i }))
+    expect(formContainer).toHaveClass('block')
+    expect(formContainer).not.toHaveClass('hidden')
+
+    // Pressing again collapses it back.
+    fireEvent.click(screen.getByRole('button', { name: /toggle filters/i }))
+    expect(formContainer).toHaveClass('hidden')
+    expect(formContainer).not.toHaveClass('block')
+  })
+
+  it('renders the status chart node alongside the form', () => {
+    render(
+      <FilterBar count={1} label="resource" statusChart={<div data-testid="chart">chart</div>}>
+        <div data-testid="form">form</div>
+      </FilterBar>
+    )
+    expect(screen.getByTestId('chart')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/search/FilterForm.jsx
+++ b/web/src/components/search/FilterForm.jsx
@@ -1,10 +1,18 @@
 // Copyright 2025 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
+import { useState } from 'preact/hooks'
 import { fluxCRDs, eventSeverities, resourceStatuses } from '../../utils/constants'
 
 // Derive unique groups from fluxCRDs array (preserving order of first occurrence)
 const crdGroups = [...new Set(fluxCRDs.map(crd => crd.group))]
+
+// Compact field styling shared by the name input and the dropdowns. Selects get
+// their chevron + right padding from the global `select` rule in index.css.
+const FIELD = 'w-full px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-flux-blue'
+
+// Compact icon button styling for the clear/refresh actions.
+const ICON_BTN = 'inline-flex items-center p-1 rounded-md text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white focus:outline-none transition-colors'
 
 /**
  * FilterForm component - Reusable filter form for Events and Resources
@@ -19,111 +27,154 @@ const crdGroups = [...new Set(fluxCRDs.map(crd => crd.group))]
  * @param {Array<string>} [props.kinds] - Optional flat list of kinds. When provided, the kind
  *   dropdown renders a flat list instead of the Flux group-based optgroup layout.
  * @param {Function} props.onClear - Callback function to clear filters
+ * @param {Function} [props.onRefresh] - Optional async callback to re-fetch the list. When provided,
+ *   a refresh button is rendered after clear and spins while the refresh is in flight.
  */
-export function FilterForm({ kindSignal, nameSignal, namespaceSignal, namespaces, severitySignal, statusSignal, kinds, onClear }) {
+export function FilterForm({ kindSignal, nameSignal, namespaceSignal, namespaces, severitySignal, statusSignal, kinds, onClear, onRefresh }) {
+  const [refreshing, setRefreshing] = useState(false)
+
+  const handleRefresh = async () => {
+    if (!onRefresh || refreshing) return
+    setRefreshing(true)
+    try {
+      await onRefresh()
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
   return (
-    <div class="flex flex-wrap gap-4 items-center">
-      {/* Name Filter */}
-      <div class="flex-1 min-w-[200px]">
-        <input
-          id="filter-name"
-          name="name"
-          type="text"
-          value={nameSignal.value}
-          onChange={(e) => nameSignal.value = e.target.value}
-          placeholder="Resource name (* for wildcard)"
-          class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-flux-blue"
-        />
-      </div>
+    // Mobile: a two-row stack (name + status/severity + clear, then namespace +
+    // kind + refresh). Each row wrapper collapses on desktop via `sm:contents`,
+    // so the field divs become direct children of the wrapping flex line again
+    // and `sm:order` restores the original single-line layout.
+    <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-2">
+      {/* Mobile row 1: name + status/severity + clear */}
+      <div class="flex items-center gap-2 sm:contents">
+        {/* Name Filter — each field is wrapped in a flex-1 div (the control fills
+            it via w-full), so all fields distribute equally on both mobile rows;
+            the name keeps a slightly larger desktop min-width. */}
+        <div class="flex-1 min-w-0 sm:min-w-[200px] sm:order-1">
+          <input
+            id="filter-name"
+            name="name"
+            type="text"
+            value={nameSignal.value}
+            onChange={(e) => nameSignal.value = e.target.value}
+            placeholder="Resource name (* for wildcard)"
+            class={FIELD}
+          />
+        </div>
 
-      {/* Namespace Filter */}
-      <div class="flex-1 min-w-[200px]">
-        <select
-          id="filter-namespace"
-          name="namespace"
-          value={namespaceSignal.value}
-          onChange={(e) => namespaceSignal.value = e.target.value}
-          class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-flux-blue"
-        >
-          <option value="">All namespaces</option>
-          {(namespaces || []).map(ns => (
-            <option key={ns} value={ns}>{ns}</option>
-          ))}
-        </select>
-      </div>
+        {/* Severity Filter (Events only) */}
+        {severitySignal && (
+          <div class="flex-1 min-w-0 sm:min-w-[170px] sm:order-4">
+            <select
+              id="filter-severity"
+              name="severity"
+              value={severitySignal.value}
+              onChange={(e) => severitySignal.value = e.target.value}
+              class={FIELD}
+            >
+              <option value="">All severities</option>
+              {eventSeverities.map(severity => (
+                <option key={severity} value={severity}>{severity}</option>
+              ))}
+            </select>
+          </div>
+        )}
 
-      {/* Kind Filter */}
-      <div class="flex-1 min-w-[200px]">
-        <select
-          id="filter-kind"
-          name="kind"
-          value={kindSignal.value}
-          onChange={(e) => kindSignal.value = e.target.value}
-          class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-flux-blue"
-        >
-          <option value="">All kinds</option>
-          {kinds
-            ? kinds.map(kind => (
-              <option key={kind} value={kind}>{kind}</option>
-            ))
-            : crdGroups.map(group => (
-              <optgroup key={group} label={group}>
-                {fluxCRDs.filter(crd => crd.group === group).map(crd => (
-                  <option key={crd.kind} value={crd.kind}>{crd.kind}</option>
-                ))}
-              </optgroup>
-            ))}
-        </select>
-      </div>
+        {/* Status Filter (Resources only) */}
+        {statusSignal && (
+          <div class="flex-1 min-w-0 sm:min-w-[170px] sm:order-4">
+            <select
+              id="filter-status"
+              name="status"
+              value={statusSignal.value}
+              onChange={(e) => statusSignal.value = e.target.value}
+              class={FIELD}
+            >
+              <option value="">All statuses</option>
+              {resourceStatuses.map(status => (
+                <option key={status} value={status}>{status}</option>
+              ))}
+            </select>
+          </div>
+        )}
 
-      {/* Severity Filter (Events only) */}
-      {severitySignal && (
-        <div class="flex-1 min-w-[200px]">
-          <select
-            id="filter-severity"
-            name="severity"
-            value={severitySignal.value}
-            onChange={(e) => severitySignal.value = e.target.value}
-            class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-flux-blue"
+        {/* Clear Filters Button */}
+        <div class="sm:order-5">
+          <button
+            onClick={onClear}
+            title="Clear"
+            aria-label="Clear filters"
+            class={ICON_BTN}
           >
-            <option value="">All severities</option>
-            {eventSeverities.map(severity => (
-              <option key={severity} value={severity}>{severity}</option>
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile row 2: namespace + kind + refresh */}
+      <div class="flex items-center gap-2 sm:contents">
+        {/* Namespace Filter */}
+        <div class="flex-1 min-w-0 sm:min-w-[170px] sm:order-2">
+          <select
+            id="filter-namespace"
+            name="namespace"
+            value={namespaceSignal.value}
+            onChange={(e) => namespaceSignal.value = e.target.value}
+            class={FIELD}
+          >
+            <option value="">All namespaces</option>
+            {(namespaces || []).map(ns => (
+              <option key={ns} value={ns}>{ns}</option>
             ))}
           </select>
         </div>
-      )}
 
-      {/* Status Filter (Resources only) */}
-      {statusSignal && (
-        <div class="flex-1 min-w-[200px]">
+        {/* Kind Filter */}
+        <div class="flex-1 min-w-0 sm:min-w-[170px] sm:order-3">
           <select
-            id="filter-status"
-            name="status"
-            value={statusSignal.value}
-            onChange={(e) => statusSignal.value = e.target.value}
-            class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-flux-blue"
+            id="filter-kind"
+            name="kind"
+            value={kindSignal.value}
+            onChange={(e) => kindSignal.value = e.target.value}
+            class={FIELD}
           >
-            <option value="">All statuses</option>
-            {resourceStatuses.map(status => (
-              <option key={status} value={status}>{status}</option>
-            ))}
+            <option value="">All kinds</option>
+            {kinds
+              ? kinds.map(kind => (
+                <option key={kind} value={kind}>{kind}</option>
+              ))
+              : crdGroups.map(group => (
+                <optgroup key={group} label={group}>
+                  {fluxCRDs.filter(crd => crd.group === group).map(crd => (
+                    <option key={crd.kind} value={crd.kind}>{crd.kind}</option>
+                  ))}
+                </optgroup>
+              ))}
           </select>
         </div>
-      )}
 
-      {/* Clear Filters Button */}
-      <div>
-        <button
-          onClick={onClear}
-          title="Clear"
-          aria-label="Clear filters"
-          class="p-2 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white focus:outline-none transition-colors"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
+        {/* Refresh Button (re-fetches the list) */}
+        {onRefresh && (
+          <div class="sm:order-6">
+            <button
+              onClick={handleRefresh}
+              disabled={refreshing}
+              title="Refresh"
+              aria-label="Refresh"
+              class={`${ICON_BTN} disabled:opacity-60`}
+            >
+              <svg class={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/web/src/components/search/FilterForm.jsx
+++ b/web/src/components/search/FilterForm.jsx
@@ -61,7 +61,7 @@ export function FilterForm({ kindSignal, nameSignal, namespaceSignal, namespaces
             type="text"
             value={nameSignal.value}
             onChange={(e) => nameSignal.value = e.target.value}
-            placeholder="Resource name (* for wildcard)"
+            placeholder="Resource name (* wildcard, ! exclude)"
             class={FIELD}
           />
         </div>

--- a/web/src/components/search/FilterForm.test.jsx
+++ b/web/src/components/search/FilterForm.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/preact'
+import { render, screen, fireEvent, waitFor } from '@testing-library/preact'
 import { signal } from '@preact/signals'
 import { FilterForm } from './FilterForm'
 import { fluxKinds, eventSeverities, resourceStatuses, workloadKinds } from '../../utils/constants'
@@ -381,6 +381,82 @@ describe('FilterForm', () => {
       expect(screen.getByPlaceholderText(/Resource name/)).toHaveValue('apps')
       expect(document.querySelector('#filter-kind')).toHaveValue('Kustomization')
       expect(document.querySelector('#filter-namespace')).toHaveValue('default')
+    })
+  })
+
+  describe('Refresh button', () => {
+    it('should not render a refresh button when onRefresh is not provided', () => {
+      render(
+        <FilterForm
+          kindSignal={kindSignal}
+          nameSignal={nameSignal}
+          namespaceSignal={namespaceSignal}
+          namespaces={mockNamespaces}
+          onClear={onClear}
+        />
+      )
+
+      expect(screen.queryByRole('button', { name: /refresh/i })).not.toBeInTheDocument()
+    })
+
+    it('should render a refresh button when onRefresh is provided', () => {
+      render(
+        <FilterForm
+          kindSignal={kindSignal}
+          nameSignal={nameSignal}
+          namespaceSignal={namespaceSignal}
+          namespaces={mockNamespaces}
+          onClear={onClear}
+          onRefresh={vi.fn()}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument()
+    })
+
+    it('should call onRefresh when the refresh button is clicked', () => {
+      const onRefresh = vi.fn().mockResolvedValue(undefined)
+      render(
+        <FilterForm
+          kindSignal={kindSignal}
+          nameSignal={nameSignal}
+          namespaceSignal={namespaceSignal}
+          namespaces={mockNamespaces}
+          onClear={onClear}
+          onRefresh={onRefresh}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /refresh/i }))
+
+      expect(onRefresh).toHaveBeenCalledTimes(1)
+    })
+
+    it('should disable and spin the refresh button while refreshing, then restore', async () => {
+      let resolveRefresh
+      const onRefresh = vi.fn(() => new Promise(resolve => { resolveRefresh = resolve }))
+      render(
+        <FilterForm
+          kindSignal={kindSignal}
+          nameSignal={nameSignal}
+          namespaceSignal={namespaceSignal}
+          namespaces={mockNamespaces}
+          onClear={onClear}
+          onRefresh={onRefresh}
+        />
+      )
+
+      const refreshButton = screen.getByRole('button', { name: /refresh/i })
+      fireEvent.click(refreshButton)
+
+      // While the refresh promise is pending the button is disabled and spins.
+      await waitFor(() => expect(refreshButton).toBeDisabled())
+      expect(refreshButton.querySelector('svg').getAttribute('class')).toMatch(/animate-spin/)
+
+      // Once it settles the button is re-enabled and stops spinning.
+      resolveRefresh()
+      await waitFor(() => expect(refreshButton).not.toBeDisabled())
+      expect(refreshButton.querySelector('svg').getAttribute('class')).not.toMatch(/animate-spin/)
     })
   })
 })

--- a/web/src/components/search/ResourceDetailsView.jsx
+++ b/web/src/components/search/ResourceDetailsView.jsx
@@ -3,11 +3,14 @@
 
 import { useState, useMemo, useEffect, useRef } from 'preact/hooks'
 import { fetchWithMock } from '../../utils/fetch'
+import { formatTimestamp } from '../../utils/time'
 import { usePrismTheme, YamlBlock } from '../dashboards/common/yaml'
-import { isKindWithInventory, getKindAlias, isFluxInventoryItem, isWorkloadInventoryItem } from '../../utils/constants'
+import { isKindWithInventory, getControllerName, isFluxInventoryItem, isWorkloadInventoryItem } from '../../utils/constants'
 import { getDashboardUrl } from '../../utils/routing'
-import { getStatusBadgeClass, cleanStatus } from '../../utils/status'
+import { cleanStatus } from '../../utils/status'
+import { getReconcileInterval, getReconcileTimeout } from '../../utils/reconciler'
 import { FluxOperatorIcon } from '../layout/Icons'
+import { TabbedPanel, Field, ResourceLink, StatusBadge } from './detailPanel'
 
 /**
  * Helper to group inventory items by apiVersion
@@ -119,23 +122,33 @@ function InventoryGroupByApiVersion({ apiVersion, items }) {
  * @param {string} props.name - Resource name
  * @param {string} props.namespace - Resource namespace
  * @param {boolean} props.isExpanded - Whether the view is expanded
+ * @param {string} [props.status] - Display status for the Overview badge, used as a
+ *   fallback when the resource has no reconcilerRef status yet
+ * @param {Function} [props.onReady] - Called once the data fetch settles (success or
+ *   error), so the parent row can swap its spinner for the revealed panel
+ * @param {Function} [props.onData] - Called with the fetched resource on success, so
+ *   the parent row can refresh its collapsed summary (status/message/lastReconciled)
+ *   from the server-computed reconcilerRef and not contradict the open panel
  *
  * Features:
  * - Lazy loads complete resource data on expand
- * - Tabbed interface with up to four sections (in order):
- *   1. Inventory: Grouped list of managed resources (if present, shown first)
- *   2. Source: Details about the resource's source (if present)
- *   3. Specification: Complete resource definition as syntax-highlighted YAML
- *   4. Status: YAML display of apiVersion, kind, metadata, and status (without inventory)
+ * - Tabbed interface with up to five sections (in order):
+ *   1. Overview: Reconciler status, controller, interval, owner and last action (default)
+ *   2. Inventory: Grouped list of managed resources (if present)
+ *   3. Source: Details about the resource's source (if present)
+ *   4. Specification: Complete resource definition as syntax-highlighted YAML
+ *   5. Status: YAML display of apiVersion, kind, metadata, and status (without inventory)
+ * - Renders the tab chrome through the shared compact TabbedPanel (mobile segmented
+ *   control, desktop vertical right-rail merging into a cohesive panel)
  * - Dynamically switches Prism theme (light/dark) based on app theme
  * - Caches data to avoid redundant fetches
  * - Handles loading and error states
  */
-export function ResourceDetailsView({ kind, name, namespace, isExpanded }) {
+export function ResourceDetailsView({ kind, name, namespace, isExpanded, status, onReady, onData }) {
   const [resourceData, setResourceData] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
-  const [activeTab, setActiveTab] = useState('inventory')
+  const [activeTab, setActiveTab] = useState('overview')
   const fetchingRef = useRef(false)
 
   // Load Prism theme based on current app theme
@@ -145,7 +158,7 @@ export function ResourceDetailsView({ kind, name, namespace, isExpanded }) {
   useEffect(() => {
     setResourceData(null)
     setError(null)
-    setActiveTab('inventory')
+    setActiveTab('overview')
   }, [kind, name, namespace])
 
   // Fetch resource details when expanded
@@ -169,25 +182,25 @@ export function ResourceDetailsView({ kind, name, namespace, isExpanded }) {
           mockPath: '../mock/resource',
           mockExport: 'getMockResource'
         })
+        // Overview is the default tab and is always available (set on mount and on
+        // identity change), so the active tab needs no adjustment once data lands.
         if (!cancelled) {
           setResourceData(data)
-
-          // Set default active tab: inventory > source > specification
-          const hasInventory = data.status?.inventory && data.status.inventory.length > 0
-          if (isKindWithInventory(data.kind) || hasInventory) {
-            setActiveTab('inventory')
-          } else if (data.status?.sourceRef) {
-            setActiveTab('source')
-          } else {
-            setActiveTab('specification')
-          }
+          // Hand the fresh, server-computed summary back to the row so the collapsed
+          // list entry can't contradict the panel that just opened.
+          onData && onData(data)
         }
       } catch (err) {
         console.error('Failed to fetch resource details:', err)
         if (!cancelled) setError(err.message)
       } finally {
         fetchingRef.current = false
-        if (!cancelled) setLoading(false)
+        if (!cancelled) {
+          setLoading(false)
+          // Signal the parent row that the fetch settled (success or error) so it
+          // can swap its spinner for the revealed panel.
+          onReady && onReady()
+        }
       }
     }
 
@@ -249,6 +262,26 @@ export function ResourceDetailsView({ kind, name, namespace, isExpanded }) {
   // Get inventory count
   const inventoryCount = resourceData?.status?.inventory?.length || 0
 
+  // Overview derivations (mirror the Resource dashboard Reconciler panel). All use
+  // optional chaining so they are safe before the data lands.
+  const reconcilerRef = resourceData?.status?.reconcilerRef
+  const rStatus = reconcilerRef?.status || status || 'Unknown'
+  const rMessage = reconcilerRef?.message || resourceData?.status?.conditions?.[0]?.message || ''
+  const rLast = reconcilerRef?.lastReconciled || resourceData?.status?.conditions?.[0]?.lastTransitionTime
+  const interval = getReconcileInterval(resourceData)
+  const timeout = getReconcileTimeout(resourceData)
+  const managedBy = reconcilerRef?.managedBy
+
+  // Build the ordered tab list, including Inventory/Source only when they apply.
+  const tabs = useMemo(() => {
+    const list = [{ id: 'overview', label: 'Overview' }]
+    if (shouldShowInventoryTab) list.push({ id: 'inventory', label: 'Inventory' })
+    if (resourceData?.status?.sourceRef) list.push({ id: 'source', label: 'Source' })
+    list.push({ id: 'specification', label: 'Spec' })
+    list.push({ id: 'status', label: 'Status' })
+    return list
+  }, [shouldShowInventoryTab, resourceData])
+
   if (!isExpanded) return null
 
   return (
@@ -274,57 +307,35 @@ export function ResourceDetailsView({ kind, name, namespace, isExpanded }) {
 
       {/* Tabs + Content */}
       {!loading && !error && resourceData && (
-        <>
-          {/* Tab Navigation */}
-          <div class="border-b border-gray-200 dark:border-gray-700 mb-4">
-            <nav class="flex space-x-4 overflow-x-auto" aria-label="Tabs">
-              {shouldShowInventoryTab && (
-                <button
-                  onClick={() => setActiveTab('inventory')}
-                  class={`py-2 px-1 text-sm font-medium border-b-2 transition-colors ${
-                    activeTab === 'inventory'
-                      ? 'border-flux-blue text-flux-blue dark:text-blue-400'
-                      : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
-                  }`}
-                >
-                  Inventory ({inventoryCount})
-                </button>
+        <TabbedPanel tabs={tabs} active={activeTab} onSelect={setActiveTab}>
+          {/* Overview Tab — metadata fields left, last action + message right */}
+          {activeTab === 'overview' && (
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4 text-xs">
+              {/* Left: reconciler metadata, evenly stacked */}
+              <div class="space-y-2.5 self-start">
+                <Field label="Resource"><ResourceLink kind={kind} namespace={namespace} name={name} /></Field>
+                <Field label={kind}><StatusBadge status={rStatus} /></Field>
+                <Field label="Reconciled by">{getControllerName(kind)}</Field>
+                <Field label="Reconcile every">{interval ? (timeout ? `${interval} (timeout ${timeout})` : interval) : null}</Field>
+                <Field label="Managed by">
+                  {managedBy ? (() => {
+                    const [rk, rn, rnm] = managedBy.split('/')
+                    return <ResourceLink kind={rk} namespace={rn} name={rnm} />
+                  })() : null}
+                </Field>
+              </div>
+
+              {/* Right: last action + reconciler message */}
+              {rMessage && (
+                <div class="space-y-1.5 self-start md:border-l md:border-gray-200 md:dark:border-gray-700 md:pl-8">
+                  {rLast && (
+                    <div class="text-gray-500 dark:text-gray-400">Last action <span class="text-gray-900 dark:text-gray-100">{formatTimestamp(rLast)}</span></div>
+                  )}
+                  <pre class="whitespace-pre-wrap break-words font-sans leading-relaxed text-gray-700 dark:text-gray-300">{rMessage}</pre>
+                </div>
               )}
-              {resourceData.status?.sourceRef && (
-                <button
-                  onClick={() => setActiveTab('source')}
-                  class={`py-2 px-1 text-sm font-medium border-b-2 transition-colors ${
-                    activeTab === 'source'
-                      ? 'border-flux-blue text-flux-blue dark:text-blue-400'
-                      : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
-                  }`}
-                >
-                  Source
-                </button>
-              )}
-              <button
-                onClick={() => setActiveTab('specification')}
-                class={`py-2 px-1 text-sm font-medium border-b-2 transition-colors ${
-                  activeTab === 'specification'
-                    ? 'border-flux-blue text-flux-blue dark:text-blue-400'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
-                }`}
-              >
-                <span class="inline sm:hidden">Spec</span>
-                <span class="hidden sm:inline">Specification</span>
-              </button>
-              <button
-                onClick={() => setActiveTab('status')}
-                class={`py-2 px-1 text-sm font-medium border-b-2 transition-colors ${
-                  activeTab === 'status'
-                    ? 'border-flux-blue text-flux-blue dark:text-blue-400'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
-                }`}
-              >
-                Status
-              </button>
-            </nav>
-          </div>
+            </div>
+          )}
 
           {/* Inventory Tab */}
           {activeTab === 'inventory' && shouldShowInventoryTab && (
@@ -345,73 +356,35 @@ export function ResourceDetailsView({ kind, name, namespace, isExpanded }) {
             </div>
           )}
 
-          {/* Source Tab */}
+          {/* Source Tab — same "Resource: ns/name link" + "<kind>: status"
+              layout and link style as the Overview tab. */}
           {activeTab === 'source' && resourceData.status?.sourceRef && (
-            <div class="space-y-4">
-              {/* Resource Link */}
-              <a
-                href={getDashboardUrl(resourceData.status.sourceRef.kind, resourceData.status.sourceRef.namespace, resourceData.status.sourceRef.name)}
-                class="flex items-center gap-2 text-sm text-flux-blue dark:text-blue-400 hover:underline"
-              >
-                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                </svg>
-                <span class="hidden md:inline break-all">{resourceData.status.sourceRef.kind}/{resourceData.status.sourceRef.namespace}/{resourceData.status.sourceRef.name}</span>
-                <span class="md:hidden break-all">{getKindAlias(resourceData.status.sourceRef.kind)}/{resourceData.status.sourceRef.name}</span>
-              </a>
-
-              {/* Status Badge */}
-              {resourceData.status.sourceRef.status && (
-                <div class="text-sm">
-                  <span class="text-gray-500 dark:text-gray-400">Status</span>
-                  <span class={`ml-1 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusBadgeClass(resourceData.status.sourceRef.status)}`}>
-                    {resourceData.status.sourceRef.status}
-                  </span>
-                </div>
-              )}
-
-              {/* URL */}
-              <div class="text-sm">
-                <span class="text-gray-500 dark:text-gray-400">URL</span>
-                <span class="ml-1 text-gray-900 dark:text-white break-words">{resourceData.status.sourceRef.url}</span>
-              </div>
-
-              {/* Origin URL (if present) */}
-              {resourceData.status.sourceRef.originURL && (
-                <div class="text-sm">
-                  <span class="text-gray-500 dark:text-gray-400">Origin URL</span>
-                  <span class="ml-1 text-gray-900 dark:text-white break-words">{resourceData.status.sourceRef.originURL}</span>
-                </div>
-              )}
-
-              {/* Origin Revision (if present) */}
-              {resourceData.status.sourceRef.originRevision && (
-                <div class="text-sm">
-                  <span class="text-gray-500 dark:text-gray-400">Origin Revision</span>
-                  <span class="ml-1 text-gray-900 dark:text-white break-words">{resourceData.status.sourceRef.originRevision}</span>
-                </div>
-              )}
-
-              {/* Fetch result */}
-              {resourceData.status.sourceRef.message && (
-                <div class="text-sm">
-                  <span class="text-gray-500 dark:text-gray-400">Fetch result</span>
-                  <span class="ml-1 text-gray-900 dark:text-white break-words">{resourceData.status.sourceRef.message}</span>
-                </div>
-              )}
+            <div class="space-y-2.5 text-xs">
+              <Field label="Resource">
+                <ResourceLink
+                  kind={resourceData.status.sourceRef.kind}
+                  namespace={resourceData.status.sourceRef.namespace}
+                  name={resourceData.status.sourceRef.name}
+                />
+              </Field>
+              <Field label={resourceData.status.sourceRef.kind}><StatusBadge status={resourceData.status.sourceRef.status} /></Field>
+              <Field label="URL">{resourceData.status.sourceRef.url}</Field>
+              <Field label="Origin URL">{resourceData.status.sourceRef.originURL}</Field>
+              <Field label="Origin Revision">{resourceData.status.sourceRef.originRevision}</Field>
+              <Field label="Fetch result">{resourceData.status.sourceRef.message}</Field>
             </div>
           )}
 
           {/* Specification Tab */}
           {activeTab === 'specification' && (
-            <YamlBlock data={definitionData} />
+            <YamlBlock data={definitionData} nested />
           )}
 
           {/* Status Tab */}
           {activeTab === 'status' && (
-            <YamlBlock data={statusData} />
+            <YamlBlock data={statusData} nested />
           )}
-        </>
+        </TabbedPanel>
       )}
     </div>
   )

--- a/web/src/components/search/ResourceDetailsView.jsx
+++ b/web/src/components/search/ResourceDetailsView.jsx
@@ -8,7 +8,7 @@ import { usePrismTheme, YamlBlock } from '../dashboards/common/yaml'
 import { isKindWithInventory, getControllerName, isFluxInventoryItem, isWorkloadInventoryItem } from '../../utils/constants'
 import { getDashboardUrl } from '../../utils/routing'
 import { cleanStatus } from '../../utils/status'
-import { getReconcileInterval, getReconcileTimeout } from '../../utils/reconciler'
+import { getReconcileInterval, getReconcileTimeout, getReconcilerSummary } from '../../utils/reconciler'
 import { FluxOperatorIcon } from '../layout/Icons'
 import { TabbedPanel, Field, ResourceLink, StatusBadge } from './detailPanel'
 
@@ -262,12 +262,11 @@ export function ResourceDetailsView({ kind, name, namespace, isExpanded, status,
   // Get inventory count
   const inventoryCount = resourceData?.status?.inventory?.length || 0
 
-  // Overview derivations (mirror the Resource dashboard Reconciler panel). All use
-  // optional chaining so they are safe before the data lands.
-  const reconcilerRef = resourceData?.status?.reconcilerRef
+  // Overview derivations (mirror the Resource dashboard Reconciler panel). The
+  // shared summary falls back to the first status condition; rStatus additionally
+  // folds in the row's listed `status` prop before the detail data lands.
+  const { ref: reconcilerRef, message: rMessage, lastReconciled: rLast } = getReconcilerSummary(resourceData)
   const rStatus = reconcilerRef?.status || status || 'Unknown'
-  const rMessage = reconcilerRef?.message || resourceData?.status?.conditions?.[0]?.message || ''
-  const rLast = reconcilerRef?.lastReconciled || resourceData?.status?.conditions?.[0]?.lastTransitionTime
   const interval = getReconcileInterval(resourceData)
   const timeout = getReconcileTimeout(resourceData)
   const managedBy = reconcilerRef?.managedBy

--- a/web/src/components/search/ResourceDetailsView.test.jsx
+++ b/web/src/components/search/ResourceDetailsView.test.jsx
@@ -131,6 +131,192 @@ describe('ResourceDetailsView component', () => {
     })
   })
 
+  it('should call onReady once the fetch settles successfully', async () => {
+    fetchWithMock.mockResolvedValue(mockResourceData)
+    const onReady = vi.fn()
+
+    render(
+      <ResourceDetailsView
+        kind="Kustomization"
+        name="apps"
+        namespace="flux-system"
+        isExpanded={true}
+        onReady={onReady}
+      />
+    )
+
+    await waitFor(() => {
+      expect(onReady).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should call onReady even when the fetch fails', async () => {
+    fetchWithMock.mockRejectedValue(new Error('boom'))
+    const onReady = vi.fn()
+
+    render(
+      <ResourceDetailsView
+        kind="Kustomization"
+        name="apps"
+        namespace="flux-system"
+        isExpanded={true}
+        onReady={onReady}
+      />
+    )
+
+    await waitFor(() => {
+      expect(onReady).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Overview tab', () => {
+    const mockResourceWithReconciler = {
+      apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+      kind: 'Kustomization',
+      metadata: {
+        name: 'apps',
+        namespace: 'flux-system'
+      },
+      spec: {
+        interval: '10m'
+      },
+      status: {
+        reconcilerRef: {
+          status: 'Ready',
+          message: 'Applied revision: main@sha1:abc123def456',
+          lastReconciled: '2025-01-15T10:00:00Z',
+          managedBy: 'Kustomization/flux-system/flux-system'
+        },
+        inventory: [
+          { apiVersion: 'v1', kind: 'Namespace', name: 'production' }
+        ]
+      }
+    }
+
+    it('should default to the Overview tab and mark it active', async () => {
+      fetchWithMock.mockResolvedValue(mockResourceWithReconciler)
+
+      render(
+        <ResourceDetailsView
+          kind="Kustomization"
+          name="apps"
+          namespace="flux-system"
+          isExpanded={true}
+        />
+      )
+
+      // The Overview tab is rendered and selected by default, even though the
+      // resource also has an Inventory tab available.
+      const overviewTab = await screen.findByText('Overview')
+      expect(overviewTab).toBeInTheDocument()
+      // Active tab merges into the content panel by sharing its background.
+      expect(overviewTab).toHaveClass('bg-gray-100')
+
+      // Inventory tab is present but not active.
+      const inventoryTab = screen.getByText('Inventory')
+      expect(inventoryTab).not.toHaveClass('bg-gray-100')
+    })
+
+    it('should show the reconciler status badge', async () => {
+      fetchWithMock.mockResolvedValue(mockResourceWithReconciler)
+
+      render(
+        <ResourceDetailsView
+          kind="Kustomization"
+          name="apps"
+          namespace="flux-system"
+          isExpanded={true}
+        />
+      )
+
+      // The Overview badge is labelled with the resource kind and shows the
+      // reconciler status with the corresponding badge styling.
+      await waitFor(() => {
+        expect(screen.getByText('Kustomization')).toBeInTheDocument()
+      })
+      const badge = screen.getByText('Ready')
+      expect(badge).toBeInTheDocument()
+      expect(badge).toHaveClass('bg-green-100')
+    })
+
+    it('should show the controller, interval and managed-by link', async () => {
+      fetchWithMock.mockResolvedValue(mockResourceWithReconciler)
+
+      render(
+        <ResourceDetailsView
+          kind="Kustomization"
+          name="apps"
+          namespace="flux-system"
+          isExpanded={true}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Reconciled by')).toBeInTheDocument()
+      })
+
+      // Controller name derived from the kind.
+      expect(screen.getByText('kustomize-controller')).toBeInTheDocument()
+
+      // Reconcile interval field with the spec interval.
+      expect(screen.getByText('Reconcile every')).toBeInTheDocument()
+      expect(document.body.textContent).toContain('10m')
+
+      // Managed-by renders a namespace/name link to the owning resource dashboard.
+      expect(screen.getByText('Managed by')).toBeInTheDocument()
+      const managedByLink = screen.getByRole('link', { name: 'flux-system/flux-system' })
+      expect(managedByLink).toHaveAttribute('href', '/resource/Kustomization/flux-system/flux-system')
+    })
+
+    it('should show the last action timestamp and reconciler message', async () => {
+      fetchWithMock.mockResolvedValue(mockResourceWithReconciler)
+
+      render(
+        <ResourceDetailsView
+          kind="Kustomization"
+          name="apps"
+          namespace="flux-system"
+          isExpanded={true}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(/Last action/)).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('Applied revision: main@sha1:abc123def456')).toBeInTheDocument()
+    })
+
+    it('should fall back to the status prop for the Overview badge', async () => {
+      const resourceWithoutReconciler = {
+        apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+        kind: 'Kustomization',
+        metadata: { name: 'apps', namespace: 'flux-system' },
+        spec: { interval: '10m' },
+        status: {}
+      }
+
+      fetchWithMock.mockResolvedValue(resourceWithoutReconciler)
+
+      render(
+        <ResourceDetailsView
+          kind="Kustomization"
+          name="apps"
+          namespace="flux-system"
+          isExpanded={true}
+          status="Suspended"
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Overview')).toBeInTheDocument()
+      })
+
+      // With no reconcilerRef status, the Overview badge uses the status prop.
+      expect(screen.getByText('Suspended')).toBeInTheDocument()
+    })
+  })
+
   it('should display specification tab as highlighted YAML after loading', async () => {
     fetchWithMock.mockResolvedValue(mockResourceData)
     const user = userEvent.setup()
@@ -145,11 +331,11 @@ describe('ResourceDetailsView component', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Specification')).toBeInTheDocument()
+      expect(screen.getByText('Spec')).toBeInTheDocument()
     })
 
-    // Click on Specification tab (Inventory is default when present)
-    const specTab = screen.getByText('Specification')
+    // Overview is the default tab, switch to the Spec tab to see the YAML.
+    const specTab = screen.getByText('Spec')
     await user.click(specTab)
 
     // Check that specification content is present
@@ -221,7 +407,7 @@ describe('ResourceDetailsView component', () => {
     )
 
     // Wait for inventory tab to appear
-    const inventoryTab = await screen.findByText(/Inventory \(3\)/)
+    const inventoryTab = await screen.findByText('Inventory')
     expect(inventoryTab).toBeInTheDocument()
 
     // Click on Inventory tab
@@ -253,14 +439,15 @@ describe('ResourceDetailsView component', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Specification')).toBeInTheDocument()
+      expect(screen.getByText('Spec')).toBeInTheDocument()
     })
 
     // Inventory tab should not be present
-    expect(screen.queryByText(/Inventory/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Inventory')).not.toBeInTheDocument()
 
-    // Only Specification and Status tabs should be visible
-    expect(screen.getByText('Specification')).toBeInTheDocument()
+    // Overview, Specification and Status tabs should be visible
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+    expect(screen.getByText('Spec')).toBeInTheDocument()
     expect(screen.getByText('Status')).toBeInTheDocument()
   })
 
@@ -306,7 +493,7 @@ describe('ResourceDetailsView component', () => {
 
     // Data should still be displayed with tabs
     await waitFor(() => {
-      expect(screen.getByText('Specification')).toBeInTheDocument()
+      expect(screen.getByText('Spec')).toBeInTheDocument()
       expect(screen.getByText('Status')).toBeInTheDocument()
     })
   })
@@ -346,6 +533,7 @@ describe('ResourceDetailsView component', () => {
     }
 
     fetchWithMock.mockResolvedValue(resourceWithEmptySpec)
+    const user = userEvent.setup()
 
     render(
       <ResourceDetailsView
@@ -357,12 +545,16 @@ describe('ResourceDetailsView component', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Specification')).toBeInTheDocument()
+      expect(screen.getByText('Spec')).toBeInTheDocument()
     })
 
-    // Should show specification with empty spec in YAML
-    const codeElement = document.querySelector('.language-yaml')
-    expect(codeElement).toBeInTheDocument()
+    // Switch to the Spec tab and confirm the empty spec renders as YAML.
+    await user.click(screen.getByText('Spec'))
+
+    await waitFor(() => {
+      const codeElement = document.querySelector('.language-yaml')
+      expect(codeElement).toBeInTheDocument()
+    })
   })
 
   it('should sort inventory by apiVersion with priorities', async () => {
@@ -398,7 +590,7 @@ describe('ResourceDetailsView component', () => {
     )
 
     // Wait for inventory tab to appear
-    const inventoryTab = await screen.findByText(/Inventory \(5\)/)
+    const inventoryTab = await screen.findByText('Inventory')
     expect(inventoryTab).toBeInTheDocument()
 
     // Click on Inventory tab
@@ -445,7 +637,7 @@ describe('ResourceDetailsView component', () => {
     )
 
     // Wait for inventory tab to appear
-    const inventoryTab = await screen.findByText(/Inventory \(2\)/)
+    const inventoryTab = await screen.findByText('Inventory')
     expect(inventoryTab).toBeInTheDocument()
 
     // Click on Inventory tab
@@ -529,13 +721,13 @@ describe('ResourceDetailsView component', () => {
       expect(screen.getByText('Source')).toBeInTheDocument()
     })
 
-    // Source tab should be visible along with Specification and Status
+    // Source tab should be visible along with Spec and Status
     expect(screen.getByText('Source')).toBeInTheDocument()
-    expect(screen.getByText('Specification')).toBeInTheDocument()
+    expect(screen.getByText('Spec')).toBeInTheDocument()
     expect(screen.getByText('Status')).toBeInTheDocument()
   })
 
-  it('should show Inventory tab as default for Kustomization even when empty', async () => {
+  it('should show an Inventory tab for Kustomization even when empty', async () => {
     const resourceWithSourceRef = {
       apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
       kind: 'Kustomization',
@@ -565,6 +757,7 @@ describe('ResourceDetailsView component', () => {
     }
 
     fetchWithMock.mockResolvedValue(resourceWithSourceRef)
+    const user = userEvent.setup()
 
     render(
       <ResourceDetailsView
@@ -575,21 +768,20 @@ describe('ResourceDetailsView component', () => {
       />
     )
 
-    // Wait for Inventory tab to appear and be active (even though empty)
-    await waitFor(() => {
-      const inventoryTab = screen.getByText('Inventory (0)')
-      expect(inventoryTab).toBeInTheDocument()
-      expect(inventoryTab).toHaveClass('border-flux-blue')
-    })
+    // Inventory tab is present (kinds with inventory always expose it), even
+    // though the inventory is empty. Overview remains the default tab.
+    const inventoryTab = await screen.findByText('Inventory')
+    expect(inventoryTab).toBeInTheDocument()
 
-    // Should show empty inventory message
+    // Switching to it shows the empty inventory message.
+    await user.click(inventoryTab)
     expect(screen.getByText('Empty inventory, no managed objects')).toBeInTheDocument()
 
     // Source tab should also be visible
     expect(screen.getByText('Source')).toBeInTheDocument()
   })
 
-  it('should show Inventory tab as default for ResourceSet even when empty', async () => {
+  it('should show an Inventory tab for ResourceSet even when empty', async () => {
     const resourceSet = {
       apiVersion: 'fluxcd.controlplane.io/v1',
       kind: 'ResourceSet',
@@ -614,6 +806,7 @@ describe('ResourceDetailsView component', () => {
     }
 
     fetchWithMock.mockResolvedValue(resourceSet)
+    const user = userEvent.setup()
 
     render(
       <ResourceDetailsView
@@ -624,14 +817,12 @@ describe('ResourceDetailsView component', () => {
       />
     )
 
-    // Wait for Inventory tab to appear and be active (even though empty)
-    await waitFor(() => {
-      const inventoryTab = screen.getByText('Inventory (0)')
-      expect(inventoryTab).toBeInTheDocument()
-      expect(inventoryTab).toHaveClass('border-flux-blue')
-    })
+    // Inventory tab is present even though the inventory is empty.
+    const inventoryTab = await screen.findByText('Inventory')
+    expect(inventoryTab).toBeInTheDocument()
 
-    // Should show empty inventory message
+    // Switching to it shows the empty inventory message.
+    await user.click(inventoryTab)
     expect(screen.getByText('Empty inventory, no managed objects')).toBeInTheDocument()
   })
 
@@ -684,8 +875,9 @@ describe('ResourceDetailsView component', () => {
     await waitFor(() => {
       const textContent = document.body.textContent
 
-      // Check resource link: kind/namespace/name (now as clickable link without ID: prefix)
-      expect(textContent).toContain('OCIRepository/cert-manager/cert-manager')
+      // Resource link shows namespace/name; the kind labels the status field.
+      expect(textContent).toContain('cert-manager/cert-manager')
+      expect(textContent).toContain('OCIRepository')
 
       // Check URL
       expect(textContent).toContain('URL')
@@ -749,9 +941,10 @@ describe('ResourceDetailsView component', () => {
     // Check that Origin URL is not displayed when empty
     await waitFor(() => {
       const textContent = document.body.textContent
-      expect(textContent).toContain('GitRepository/flux-system/flux-system')
+      // Resource link shows namespace/name; the kind labels the status field.
+      expect(textContent).toContain('flux-system/flux-system')
+      expect(textContent).toContain('GitRepository')
       expect(textContent).toContain('URL')
-      expect(textContent).toContain('Status')
       expect(textContent).toContain('Fetch result')
 
       // Origin URL should not appear when empty
@@ -773,7 +966,7 @@ describe('ResourceDetailsView component', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Specification')).toBeInTheDocument()
+      expect(screen.getByText('Spec')).toBeInTheDocument()
     })
 
     // Source tab should not be present when sourceRef is missing
@@ -811,7 +1004,7 @@ describe('ResourceDetailsView component', () => {
       )
 
       // Wait for inventory tab to appear and click it
-      const inventoryTab = await screen.findByText(/Inventory \(2\)/)
+      const inventoryTab = await screen.findByText('Inventory')
       await user.click(inventoryTab)
 
       // Find the GitRepository link
@@ -852,7 +1045,7 @@ describe('ResourceDetailsView component', () => {
       )
 
       // Wait for inventory tab and click it
-      const inventoryTab = await screen.findByText(/Inventory \(2\)/)
+      const inventoryTab = await screen.findByText('Inventory')
       await user.click(inventoryTab)
 
       // ConfigMap and Deployment should not be buttons
@@ -898,7 +1091,7 @@ describe('ResourceDetailsView component', () => {
       )
 
       // Wait for inventory tab and click it
-      const inventoryTab = await screen.findByText(/Inventory \(1\)/)
+      const inventoryTab = await screen.findByText('Inventory')
       await user.click(inventoryTab)
 
       // Find the FluxInstance link
@@ -937,7 +1130,7 @@ describe('ResourceDetailsView component', () => {
       )
 
       // Wait for inventory tab and click it
-      const inventoryTab = await screen.findByText(/Inventory \(1\)/)
+      const inventoryTab = await screen.findByText('Inventory')
       await user.click(inventoryTab)
 
       // Find the link and check for icon

--- a/web/src/components/search/ResourceList.jsx
+++ b/web/src/components/search/ResourceList.jsx
@@ -2,18 +2,20 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { signal } from '@preact/signals'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect } from 'preact/hooks'
 import { fetchWithMock } from '../../utils/fetch'
 import { formatTimestamp } from '../../utils/time'
 import { getStatusBadgeClass } from '../../utils/status'
 import { usePageMeta } from '../../utils/meta'
 import { reportData } from '../../app'
 import { FilterForm } from './FilterForm'
+import { FilterBar } from './FilterBar'
 import { ResourceDetailsView } from './ResourceDetailsView'
 import { getDashboardUrl, useRestoreFiltersFromUrl, useSyncFiltersToUrl } from '../../utils/routing'
 import { StatusChart } from './StatusChart'
 import { useInfiniteScroll } from '../../utils/scroll'
 import { isFavorite, toggleFavorite, favorites } from '../../utils/favorites'
+import { Star, KindChip, NameLink, Chevron, Spinner, useDisclosure, Reveal } from './compactRow'
 
 // Resources data signals
 export const resourcesData = signal([])
@@ -55,136 +57,83 @@ export async function fetchResourcesStatus() {
 
 
 /**
- * ResourceCard - Individual card displaying a Flux resource with status and details
+ * ResourceRow - Compact two-line responsive row for a Flux resource.
  *
  * @param {Object} props
- * @param {Object} props.resource - Resource object with kind, name, status, message
+ * @param {Object} props.resource - Resource object with kind, namespace, name,
+ *   status, message and lastReconciled
  *
- * Features:
- * - Shows resource kind, namespace, and name
- * - Displays status badge (Ready, Failed, Progressing, Suspended, Unknown)
- * - Shows status message with expand/collapse for long messages
- * - Displays last reconciled timestamp
- * - Expandable details section showing spec and inventory (lazy-loaded via ResourceDetailsView)
+ * Layout:
+ * - Line 1: favorite star, desktop colored kind chip, namespace/name dashboard
+ *   link (full-width on mobile, fixed-width NameLink on desktop), desktop status
+ *   message, desktop timestamp, and the expand button.
+ * - Line 2 (mobile only): colored kind chip, status word and timestamp.
+ *
+ * Expanding the row lazily mounts {@link ResourceDetailsView}: the expand button
+ * spins while the panel fetches, then the panel animates open once `onReady`
+ * fires. The panel stays mounted after the first load so re-opening is instant.
  */
-function ResourceCard({ resource }) {
-  const [isExpanded, setIsExpanded] = useState(false)
-  const [isDetailsExpanded, setIsDetailsExpanded] = useState(false)
+function ResourceRow({ resource }) {
+  const d = useDisclosure()
 
-  // Check if resource is a favorite (reactive via favorites signal)
-  // Access favorites.value to subscribe to changes and trigger re-renders
+  // Check if resource is a favorite (reactive via favorites signal).
+  // Access favorites.value to subscribe to changes and trigger re-renders.
   const isFavorited = favorites.value && isFavorite(resource.kind, resource.namespace, resource.name)
 
-  // Handle favorite toggle
+  // Toggle favorite without expanding the row.
   const handleFavoriteClick = (e) => {
     e.stopPropagation()
     toggleFavorite(resource.kind, resource.namespace, resource.name)
   }
 
-  // Check if message is long or contains newlines
-  const isLongMessage = resource.message.length > 150 || resource.message.includes('\n')
-  const shouldTruncate = isLongMessage && !isExpanded
+  const dashboardUrl = getDashboardUrl(resource.kind, resource.namespace, resource.name)
 
-  // Truncate to first line or 150 chars
-  const getTruncatedMessage = () => {
-    const firstLine = resource.message.split('\n')[0]
-    if (firstLine.length > 150) {
-      return firstLine.substring(0, 150) + '...'
-    }
-    return firstLine
+  // When the detail panel finishes loading, refresh this row's summary from the
+  // detail's reconcilerRef (computed by the same server NewResourceStatus the list
+  // uses), so a row that listed as e.g. Failed updates if the resource is now Ready
+  // by the time it is expanded. No-op when the summary is unchanged.
+  const handleData = (data) => {
+    const ref = data?.status?.reconcilerRef
+    if (!ref) return
+    const cur = resourcesData.value.find(r =>
+      r.kind === resource.kind && r.namespace === resource.namespace && r.name === resource.name)
+    if (!cur || (cur.status === ref.status && cur.message === ref.message && cur.lastReconciled === ref.lastReconciled)) return
+    resourcesData.value = resourcesData.value.map(r =>
+      r === cur ? { ...r, status: ref.status, message: ref.message, lastReconciled: ref.lastReconciled } : r)
   }
 
-  const displayMessage = shouldTruncate ? getTruncatedMessage() : resource.message
-
   return (
-    <div class="card p-4 hover:shadow-md transition-shadow">
-      {/* Header row: star + kind + status badge + timestamp */}
-      <div class="flex items-center justify-between mb-3">
-        <div class="flex items-center gap-3">
-          {/* Favorite star button */}
-          <button
-            onClick={handleFavoriteClick}
-            class={`p-0.5 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue focus:ring-offset-1 ${
-              isFavorited
-                ? 'text-yellow-500 hover:text-yellow-600'
-                : 'text-gray-400 hover:text-flux-blue dark:hover:text-blue-400'
-            }`}
-            title={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
-          >
-            <svg class="w-4 h-4" fill={isFavorited ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          </button>
-          <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
-            {resource.kind}
-          </span>
-          <span class={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusBadgeClass(resource.status)}`}>
-            {resource.status}
-          </span>
+    <div class="border-b border-gray-100 dark:border-gray-700/60 last:border-0">
+      <div class="px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700/30">
+        <div class="flex items-center gap-2.5">
+          <Star active={isFavorited} onClick={handleFavoriteClick} />
+          <KindChip kind={resource.kind} colorClass={getStatusBadgeClass(resource.status)} title={`${resource.kind} · ${resource.status}`} cls="hidden sm:inline-block" />
+          <NameLink href={dashboardUrl} namespace={resource.namespace} name={resource.name} />
+          <span class="hidden sm:block flex-1 min-w-0 truncate text-xs text-gray-500 dark:text-gray-400">{resource.message}</span>
+          <span class="hidden sm:block shrink-0 text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap tabular-nums">{formatTimestamp(resource.lastReconciled)}</span>
+          <button onClick={d.toggle} class="shrink-0 rounded p-0.5 text-gray-400 hover:text-flux-blue" title="Details" aria-label="Toggle details">{d.loading ? <Spinner /> : <Chevron open={d.open} />}</button>
         </div>
-        <span class="hidden sm:inline text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap ml-4">
-          {formatTimestamp(resource.lastReconciled)}
-        </span>
+        {/* Mobile-only second line: colored kind pill + status word + timestamp. */}
+        <div class="sm:hidden mt-1 pl-[30px] flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
+          <KindChip kind={resource.kind} colorClass={getStatusBadgeClass(resource.status)} title={`${resource.kind} · ${resource.status}`} />
+          <span class="whitespace-nowrap"><span class="capitalize">{resource.status}</span> {formatTimestamp(resource.lastReconciled)}</span>
+        </div>
       </div>
-
-      {/* Resource namespace/name - clickable link to dashboard */}
-      <div class="mb-1 sm:mb-2">
-        <a
-          href={getDashboardUrl(resource.kind, resource.namespace, resource.name)}
-          class="text-sm text-left hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue rounded inline-block group"
-        >
-          <span class="text-gray-500 dark:text-gray-400">{resource.namespace}/</span><span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-flux-blue dark:group-hover:text-blue-400">{resource.name}</span><svg class="w-3.5 h-3.5 text-gray-400 group-hover:text-flux-blue dark:group-hover:text-blue-400 transition-colors ml-1 inline-block align-middle" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
-        </a>
-      </div>
-
-      {/* Mobile timestamp - below namespace/name */}
-      <div class="flex sm:hidden items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 mb-2">
-        <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-        </svg>
-        {formatTimestamp(resource.lastReconciled)}
-      </div>
-
-      {/* Message */}
-      <div class="text-sm text-gray-700 dark:text-gray-300">
-        <pre class="whitespace-pre-wrap break-words font-sans">
-          {displayMessage}
-        </pre>
-        {isLongMessage && (
-          <button
-            onClick={() => setIsExpanded(!isExpanded)}
-            class="text-flux-blue dark:text-blue-400 text-xs mt-1 hover:underline focus:outline-none"
-          >
-            {isExpanded ? 'Show less' : 'Show more'}
-          </button>
-        )}
-      </div>
-
-      {/* Details Panel - Spec + Inventory (Lazy Loaded) */}
-      <div class="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
-        <button
-          onClick={() => setIsDetailsExpanded(!isDetailsExpanded)}
-          class="flex items-center space-x-2 text-sm text-gray-700 dark:text-gray-300 hover:text-flux-blue dark:hover:text-blue-400 focus:outline-none transition-colors"
-        >
-          <svg
-            class={`w-4 h-4 transition-transform ${isDetailsExpanded ? 'rotate-90' : ''}`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
-          </svg>
-          <span class="font-medium">Details</span>
-        </button>
-      </div>
-
-      {/* ResourceDetailsView Component */}
-      <ResourceDetailsView
-        kind={resource.kind}
-        name={resource.name}
-        namespace={resource.namespace}
-        isExpanded={isDetailsExpanded}
-      />
+      <Reveal open={d.open}>
+        <div class="pl-3 sm:pl-[42px] pr-3 pt-1 pb-4">
+          {d.mounted && (
+            <ResourceDetailsView
+              kind={resource.kind}
+              name={resource.name}
+              namespace={resource.namespace}
+              status={resource.status}
+              isExpanded
+              onReady={d.onReady}
+              onData={handleData}
+            />
+          )}
+        </div>
+      </Reveal>
     </div>
   )
 }
@@ -195,7 +144,8 @@ function ResourceCard({ resource }) {
  * Features:
  * - Fetches resource statuses from the API with optional filters (kind, name, namespace, status)
  * - Auto-refetches when filter signals change
- * - Displays resources in card format with status badges and expandable inventory
+ * - Displays resources as compact two-line responsive rows with a colored kind
+ *   chip and an expandable, lazily loaded detail panel
  * - Sorts resources by last reconciled timestamp (newest first)
  * - Shows loading, error, and empty states
  */
@@ -241,21 +191,25 @@ export function ResourceList() {
   }
 
   return (
-    <main data-testid="resource-list" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow w-full">
+    <main data-testid="resource-list" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8 flex-grow w-full">
       <div class="space-y-6">
-        {/* Page Title */}
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Flux Resources</h2>
-          {/* Resource count */}
-          {!resourcesLoading.value && resourcesData.value.length > 0 && (
-            <span class="text-sm text-gray-600 dark:text-gray-400">
-              {resourcesData.value.length} resources
-            </span>
-          )}
-        </div>
-
-        {/* Filters */}
-        <div class="card p-4">
+        {/* Toolbar: count + mobile Filters toggle, FilterForm, desktop StatusChart */}
+        <FilterBar
+          count={resourcesData.value.length}
+          label="resources"
+          loading={resourcesLoading.value}
+          statusChart={
+            <StatusChart
+              items={resourcesData.value}
+              loading={resourcesLoading.value}
+              mode="resources"
+              compact
+              onBarClick={(status) => {
+                selectedResourceStatus.value = selectedResourceStatus.value === status ? '' : status
+              }}
+            />
+          }
+        >
           <FilterForm
             kindSignal={selectedResourceKind}
             nameSignal={selectedResourceName}
@@ -263,18 +217,9 @@ export function ResourceList() {
             statusSignal={selectedResourceStatus}
             namespaces={reportData.value?.spec?.namespaces || []}
             onClear={handleClearFilters}
+            onRefresh={fetchResourcesStatus}
           />
-        </div>
-
-        {/* Status Chart */}
-        <StatusChart
-          items={resourcesData.value}
-          loading={resourcesLoading.value}
-          mode="resources"
-          onBarClick={(status) => {
-            selectedResourceStatus.value = selectedResourceStatus.value === status ? '' : status
-          }}
-        />
+        </FilterBar>
 
         {/* Error State */}
         {resourcesError.value && (
@@ -307,11 +252,12 @@ export function ResourceList() {
           </div>
         )}
 
-        {/* Resource Cards */}
+        {/* Resource Rows — dense list; rows provide their own padding, so drop the
+            card's heavy padding on mobile and keep a light inset on desktop. */}
         {!resourcesLoading.value && resourcesData.value.length > 0 && (
-          <div class="space-y-4">
+          <div class="card overflow-hidden p-0 sm:p-2">
             {visibleResources.map((resource, index) => (
-              <ResourceCard key={`${resource.namespace}-${resource.kind}-${resource.name}-${index}`} resource={resource} />
+              <ResourceRow key={`${resource.namespace}-${resource.kind}-${resource.name}-${index}`} resource={resource} />
             ))}
 
             {/* Sentinel element for infinite scroll */}

--- a/web/src/components/search/ResourceList.jsx
+++ b/web/src/components/search/ResourceList.jsx
@@ -15,7 +15,7 @@ import { getDashboardUrl, useRestoreFiltersFromUrl, useSyncFiltersToUrl } from '
 import { StatusChart } from './StatusChart'
 import { useInfiniteScroll } from '../../utils/scroll'
 import { isFavorite, toggleFavorite, favorites } from '../../utils/favorites'
-import { Star, KindChip, NameLink, Chevron, Spinner, useDisclosure, Reveal } from './compactRow'
+import { Star, KindChip, NameLink, Chevron, Spinner, useDisclosure, Reveal, patchRowInSignal } from './compactRow'
 
 // Resources data signals
 export const resourcesData = signal([])
@@ -71,7 +71,7 @@ export async function fetchResourcesStatus() {
  *
  * Expanding the row lazily mounts {@link ResourceDetailsView}: the expand button
  * spins while the panel fetches, then the panel animates open once `onReady`
- * fires. The panel stays mounted after the first load so re-opening is instant.
+ * fires. Collapsing unmounts the panel, so each expand re-fetches fresh data.
  */
 function ResourceRow({ resource }) {
   const d = useDisclosure()
@@ -87,6 +87,8 @@ function ResourceRow({ resource }) {
   }
 
   const dashboardUrl = getDashboardUrl(resource.kind, resource.namespace, resource.name)
+  const chipColor = getStatusBadgeClass(resource.status)
+  const chipTitle = `${resource.kind} · ${resource.status}`
 
   // When the detail panel finishes loading, refresh this row's summary from the
   // detail's reconcilerRef (computed by the same server NewResourceStatus the list
@@ -95,11 +97,7 @@ function ResourceRow({ resource }) {
   const handleData = (data) => {
     const ref = data?.status?.reconcilerRef
     if (!ref) return
-    const cur = resourcesData.value.find(r =>
-      r.kind === resource.kind && r.namespace === resource.namespace && r.name === resource.name)
-    if (!cur || (cur.status === ref.status && cur.message === ref.message && cur.lastReconciled === ref.lastReconciled)) return
-    resourcesData.value = resourcesData.value.map(r =>
-      r === cur ? { ...r, status: ref.status, message: ref.message, lastReconciled: ref.lastReconciled } : r)
+    patchRowInSignal(resourcesData, resource, { status: ref.status, message: ref.message, lastReconciled: ref.lastReconciled })
   }
 
   return (
@@ -107,7 +105,7 @@ function ResourceRow({ resource }) {
       <div class="px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700/30">
         <div class="flex items-center gap-2.5">
           <Star active={isFavorited} onClick={handleFavoriteClick} />
-          <KindChip kind={resource.kind} colorClass={getStatusBadgeClass(resource.status)} title={`${resource.kind} · ${resource.status}`} cls="hidden sm:inline-block" />
+          <KindChip kind={resource.kind} colorClass={chipColor} title={chipTitle} cls="hidden sm:inline-block" />
           <NameLink href={dashboardUrl} namespace={resource.namespace} name={resource.name} />
           <span class="hidden sm:block flex-1 min-w-0 truncate text-xs text-gray-500 dark:text-gray-400">{resource.message}</span>
           <span class="hidden sm:block shrink-0 text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap tabular-nums">{formatTimestamp(resource.lastReconciled)}</span>
@@ -115,7 +113,7 @@ function ResourceRow({ resource }) {
         </div>
         {/* Mobile-only second line: colored kind pill + status word + timestamp. */}
         <div class="sm:hidden mt-1 pl-[30px] flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
-          <KindChip kind={resource.kind} colorClass={getStatusBadgeClass(resource.status)} title={`${resource.kind} · ${resource.status}`} />
+          <KindChip kind={resource.kind} colorClass={chipColor} title={chipTitle} />
           <span class="whitespace-nowrap"><span class="capitalize">{resource.status}</span> {formatTimestamp(resource.lastReconciled)}</span>
         </div>
       </div>
@@ -192,7 +190,7 @@ export function ResourceList() {
 
   return (
     <main data-testid="resource-list" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8 flex-grow w-full">
-      <div class="space-y-6">
+      <div class="space-y-3">
         {/* Toolbar: count + mobile Filters toggle, FilterForm, desktop StatusChart */}
         <FilterBar
           count={resourcesData.value.length}

--- a/web/src/components/search/ResourceList.test.jsx
+++ b/web/src/components/search/ResourceList.test.jsx
@@ -16,6 +16,7 @@ import {
 } from './ResourceList'
 import { reportData } from '../../app'
 import { fetchWithMock } from '../../utils/fetch'
+import { favorites } from '../../utils/favorites'
 
 // Mock the fetch utility
 vi.mock('../../utils/fetch', () => ({
@@ -51,14 +52,24 @@ vi.mock('./FilterForm', () => ({
   )
 }))
 
-// Mock ResourceDetailsView component to simplify testing
+// Mock ResourceDetailsView component to simplify testing.
+// Exposes a "details-ready" button so tests can drive the disclosure's `onReady`
+// callback (which the real panel fires once its data has loaded), letting us
+// assert the spinner -> reveal transition deterministically.
 vi.mock('./ResourceDetailsView', () => ({
-  ResourceDetailsView: ({ kind, name, namespace, isExpanded }) => (
+  ResourceDetailsView: ({ kind, name, namespace, isExpanded, onReady, onData }) => (
     isExpanded ? (
       <div data-testid="resource-details-view">
         <span data-testid="resource-details-view-kind">{kind}</span>
         <span data-testid="resource-details-view-name">{name}</span>
         <span data-testid="resource-details-view-namespace">{namespace}</span>
+        <button data-testid="details-ready" onClick={onReady}>ready</button>
+        {/* Simulates the detail fetch landing with a fresher server-computed
+            reconcilerRef summary, used to test the row write-back. */}
+        <button
+          data-testid="details-emit-data"
+          onClick={() => onData && onData({ status: { reconcilerRef: { status: 'Ready', message: 'now reconciled', lastReconciled: '2025-11-18T11:10:59Z' } } })}
+        >emit</button>
       </div>
     ) : null
   )
@@ -105,6 +116,9 @@ describe('ResourceList', () => {
         namespaces: ['flux-system', 'default']
       }
     }
+
+    // Reset favorites (persisted in localStorage across tests in this file)
+    favorites.value = []
 
     // Reset mocks
     vi.clearAllMocks()
@@ -242,17 +256,20 @@ describe('ResourceList', () => {
       })
     })
 
-    it('should display resource cards when data loads', async () => {
+    it('should display resource rows when data loads', async () => {
       fetchWithMock.mockResolvedValue({ resources: mockResources })
 
       render(<ResourceList />)
 
+      // Each row renders the namespace/name link twice (mobile + desktop variants).
       await waitFor(() => {
-        expect(screen.getAllByText(/flux-system/)).toHaveLength(3) // namespace + name in both cards
+        expect(screen.getAllByText(/flux-system/).length).toBeGreaterThan(0)
       })
+      // The status message is desktop-only, so it appears exactly once per row.
       expect(screen.getByText(/Stored artifact/)).toBeInTheDocument()
-      expect(screen.getByText('apps')).toBeInTheDocument()
       expect(screen.getByText('Health check failed')).toBeInTheDocument()
+      // The Kustomization name is rendered in both the mobile and desktop links.
+      expect(screen.getAllByText('apps').length).toBeGreaterThan(0)
     })
 
     it('should show empty state when no resources match filters', async () => {
@@ -280,18 +297,22 @@ describe('ResourceList', () => {
 
       render(<ResourceList />)
 
+      // The count renders once, in the FilterBar toolbar. (The desktop section
+      // count lives in the App tab nav, not this component.)
       await waitFor(() => {
-        expect(screen.getByText('2 resources')).toBeInTheDocument()
+        expect(screen.getAllByText('2 resources')).toHaveLength(1)
       })
     })
 
-    it('should not display resource count when loading', async () => {
-      resourcesData.value = []
+    it('should show a loading indicator instead of the count while loading', async () => {
+      resourcesData.value = mockResources
       resourcesLoading.value = true
 
       render(<ResourceList />)
 
-      expect(screen.queryByText(/resources$/)).not.toBeInTheDocument()
+      // While loading the FilterBar shows "Loading…" rather than a (stale) count.
+      expect(screen.getByText('Loading…')).toBeInTheDocument()
+      expect(screen.queryByText('2 resources')).not.toBeInTheDocument()
     })
 
     it('should sort resources by lastReconciled (newest first)', async () => {
@@ -299,11 +320,14 @@ describe('ResourceList', () => {
 
       render(<ResourceList />)
 
+      // Rows render their dashboard links in list order; the GitRepository
+      // (10:00:00) must come before the Kustomization (09:00:00).
       await waitFor(() => {
-        const cards = screen.getAllByText(/GitRepository|Kustomization/i)
-        // First card should be GitRepository (10:00:00), second should be Kustomization (09:00:00)
-        expect(cards[0].textContent).toBe('GitRepository')
-        expect(cards[1].textContent).toBe('Kustomization')
+        const hrefs = screen.getAllByRole('link').map((a) => a.getAttribute('href'))
+        const gitIdx = hrefs.findIndex((h) => h.includes('GitRepository'))
+        const ksIdx = hrefs.findIndex((h) => h.includes('Kustomization'))
+        expect(gitIdx).toBeGreaterThanOrEqual(0)
+        expect(gitIdx).toBeLessThan(ksIdx)
       })
     })
   })
@@ -391,7 +415,7 @@ describe('ResourceList', () => {
     })
   })
 
-  describe('ResourceCard rendering', () => {
+  describe('Compact row rendering', () => {
     it('should display status badges correctly', async () => {
       fetchWithMock.mockResolvedValue({ resources: mockResources })
 
@@ -426,55 +450,71 @@ describe('ResourceList', () => {
       })
     })
 
-    it('should show expand button for long messages', async () => {
-      const longMessage = 'a'.repeat(200)
-      fetchWithMock.mockResolvedValue({ resources: [{
-        ...mockResources[0],
-        message: longMessage
-      }] })
-
-      render(<ResourceList />)
-
-      await waitFor(() => {
-        expect(screen.getByText('Show more')).toBeInTheDocument()
-      })
-    })
-
-    it('should expand message when show more is clicked', async () => {
-      const longMessage = 'a'.repeat(200)
-      fetchWithMock.mockResolvedValue({ resources: [{
-        ...mockResources[0],
-        message: longMessage
-      }] })
-
-      render(<ResourceList />)
-
-      const showMoreButton = await screen.findByText('Show more')
-      fireEvent.click(showMoreButton)
-
-      expect(screen.getByText('Show less')).toBeInTheDocument()
-    })
-
-    it('should display details toggle for all resources', async () => {
+    it('should display a details toggle for every resource', async () => {
       fetchWithMock.mockResolvedValue({ resources: mockResources })
 
       render(<ResourceList />)
 
+      // The expand affordance is now an icon button labelled "Toggle details".
       await waitFor(() => {
-        const detailsButtons = screen.getAllByText('Details')
-        expect(detailsButtons).toHaveLength(2) // One for each resource
+        expect(screen.getAllByLabelText('Toggle details')).toHaveLength(2)
       })
     })
 
-    it('should expand ResourceDetailsView when details toggle is clicked', async () => {
+    it('should expose the namespace/name dashboard link and favorite star', async () => {
       fetchWithMock.mockResolvedValue({ resources: [mockResources[0]] })
 
       render(<ResourceList />)
 
-      const detailsToggle = await screen.findByText('Details')
-      fireEvent.click(detailsToggle)
+      // The row links the namespace/name to the resource dashboard (mobile +
+      // desktop variants share the same href).
+      await waitFor(() => {
+        const hrefs = screen.getAllByRole('link').map((a) => a.getAttribute('href'))
+        expect(hrefs).toContain('/resource/GitRepository/flux-system/flux-system')
+      })
 
-      // Check that ResourceDetailsView is rendered with correct props
+      // The favorite star toggles the resource in/out of favorites.
+      const star = screen.getByTitle('Add to favorites')
+      fireEvent.click(star)
+      expect(screen.getByTitle('Remove from favorites')).toBeInTheDocument()
+    })
+  })
+
+  describe('Row disclosure', () => {
+    it('should spin, mount ResourceDetailsView, then reveal it on expand', async () => {
+      fetchWithMock.mockResolvedValue({ resources: [mockResources[0]] })
+
+      render(<ResourceList />)
+
+      const toggle = await screen.findByLabelText('Toggle details')
+
+      // Collapsed: the panel is not mounted and the button shows no spinner.
+      expect(screen.queryByTestId('resource-details-view')).not.toBeInTheDocument()
+      expect(toggle.querySelector('.animate-spin')).not.toBeInTheDocument()
+
+      // Expand: the panel mounts (still collapsed) and the button spins while it
+      // "loads".
+      fireEvent.click(toggle)
+      expect(screen.getByTestId('resource-details-view')).toBeInTheDocument()
+      expect(toggle.querySelector('.animate-spin')).toBeInTheDocument()
+
+      // The panel signals readiness via onReady -> the spinner is replaced by the
+      // open chevron and the row is revealed.
+      fireEvent.click(screen.getByTestId('details-ready'))
+      await waitFor(() => {
+        expect(toggle.querySelector('.animate-spin')).not.toBeInTheDocument()
+      })
+      expect(toggle.querySelector('.rotate-90')).toBeInTheDocument()
+    })
+
+    it('should mount ResourceDetailsView with the resource identity', async () => {
+      fetchWithMock.mockResolvedValue({ resources: [mockResources[0]] })
+
+      render(<ResourceList />)
+
+      const toggle = await screen.findByLabelText('Toggle details')
+      fireEvent.click(toggle)
+
       await waitFor(() => {
         expect(screen.getByTestId('resource-details-view')).toBeInTheDocument()
       })
@@ -482,79 +522,56 @@ describe('ResourceList', () => {
       expect(screen.getByTestId('resource-details-view-name')).toHaveTextContent('flux-system')
       expect(screen.getByTestId('resource-details-view-namespace')).toHaveTextContent('flux-system')
     })
+
+    it('refreshes the row summary from the detail data (stale Failed -> Ready)', async () => {
+      const stale = {
+        kind: 'Kustomization', namespace: 'flux-system', name: 'apps',
+        status: 'Failed', message: 'reconciliation failed', lastReconciled: '2025-11-01T00:00:00Z'
+      }
+      fetchWithMock.mockResolvedValue({ resources: [stale] })
+
+      render(<ResourceList />)
+
+      const toggle = await screen.findByLabelText('Toggle details')
+      // The row first shows the stale list summary.
+      expect(screen.getByText('reconciliation failed')).toBeInTheDocument()
+
+      fireEvent.click(toggle)
+      // The panel lands with a fresher reconcilerRef summary -> the row updates.
+      fireEvent.click(screen.getByTestId('details-emit-data'))
+
+      await waitFor(() => {
+        expect(screen.getByText('now reconciled')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('reconciliation failed')).not.toBeInTheDocument()
+    })
   })
 
-  describe('Message truncation', () => {
-    it('should not truncate short single-line messages', async () => {
-      const resourceWithShortMessage = {
-        kind: 'GitRepository',
-        name: 'repo',
-        namespace: 'default',
-        status: 'Ready',
-        message: 'Short message under 150 characters',
-        lastReconciled: new Date('2025-01-15T10:00:00Z'),
-        inventory: []
-      }
-
-      fetchWithMock.mockResolvedValue({ resources: [resourceWithShortMessage] })
+  describe('FilterBar', () => {
+    it('should show the result count header', async () => {
+      fetchWithMock.mockResolvedValue({ resources: mockResources })
 
       render(<ResourceList />)
 
+      // The FilterBar always renders the count, even on mobile where the desktop
+      // page header is hidden.
       await waitFor(() => {
-        expect(screen.getByText('Short message under 150 characters')).toBeInTheDocument()
+        expect(screen.getAllByText('2 resources').length).toBeGreaterThan(0)
       })
-
-      // Should not show "Show more" button for short messages
-      expect(screen.queryByText(/Show more/)).not.toBeInTheDocument()
     })
 
-    it('should show first line without truncation when it is short but message has multiple lines', async () => {
-      const resourceWithMultilineMessage = {
-        kind: 'GitRepository',
-        name: 'repo',
-        namespace: 'default',
-        status: 'Failed',
-        message: 'First line is short\nSecond line contains more details\nThird line with even more information',
-        lastReconciled: new Date('2025-01-15T10:00:00Z'),
-        inventory: []
-      }
-
-      fetchWithMock.mockResolvedValue({ resources: [resourceWithMultilineMessage] })
+    it('should toggle the mobile filters form', async () => {
+      fetchWithMock.mockResolvedValue({ resources: mockResources })
 
       render(<ResourceList />)
 
-      // Should show truncated to first line
-      await waitFor(() => {
-        expect(screen.getByText(/First line is short/)).toBeInTheDocument()
-      })
+      const filtersToggle = await screen.findByLabelText('Toggle filters')
+      expect(filtersToggle).toBeInTheDocument()
 
-      // Should show "Show more" button for multiline messages
-      expect(screen.getByText(/Show more/)).toBeInTheDocument()
-    })
-
-    it('should truncate first line when it exceeds 150 characters', async () => {
-      const longFirstLine = 'This is a very long message that exceeds one hundred and fifty characters and should be truncated at exactly that length with ellipsis added to indicate continuation'
-
-      const resourceWithLongFirstLine = {
-        kind: 'Kustomization',
-        name: 'apps',
-        namespace: 'default',
-        status: 'Failed',
-        message: longFirstLine,
-        lastReconciled: new Date('2025-01-15T10:00:00Z'),
-        inventory: []
-      }
-
-      fetchWithMock.mockResolvedValue({ resources: [resourceWithLongFirstLine] })
-
-      render(<ResourceList />)
-
-      // Should show truncated message with ellipsis
-      await waitFor(() => {
-        const messageElement = screen.getByText(/This is a very long message/)
-        expect(messageElement.textContent).toContain('...')
-        expect(messageElement.textContent.length).toBeLessThan(longFirstLine.length)
-      })
+      // The FilterForm is always present in the DOM (CSS controls mobile
+      // visibility); pressing the toggle is a no-throw interaction.
+      fireEvent.click(filtersToggle)
+      expect(screen.getByTestId('filter-form')).toBeInTheDocument()
     })
   })
 })

--- a/web/src/components/search/StatusChart.jsx
+++ b/web/src/components/search/StatusChart.jsx
@@ -265,7 +265,10 @@ export function StatusChart({ items, loading, mode = 'events', onBarClick, compa
             positioned over the centre of the hovered segment. */}
         {hoveredBar !== null && statusBars[hoveredBar] && (
           <div
-            class="absolute bottom-full mb-2 z-10 -translate-x-1/2 pointer-events-none"
+            // In compact mode the chart lives in the sticky filter bar; popping the
+            // tooltip downward keeps it clear of the opaque sticky header/nav above,
+            // which would otherwise clip an upward tooltip. Non-compact keeps it above.
+            class={`absolute z-10 -translate-x-1/2 pointer-events-none ${compact ? 'top-full mt-2' : 'bottom-full mb-2'}`}
             style={{ left: `${statusBars.slice(0, hoveredBar).reduce((sum, b) => sum + b.percentage, 0) + statusBars[hoveredBar].percentage / 2}%` }}
           >
             <div class="bg-gray-900 dark:bg-gray-800 text-white text-xs rounded-lg py-2 px-3 shadow-lg whitespace-nowrap">
@@ -278,9 +281,10 @@ export function StatusChart({ items, loading, mode = 'events', onBarClick, compa
               <div class="text-gray-300">
                 Percentage: {statusBars[hoveredBar].percentage.toFixed(1)}%
               </div>
-              {/* Tooltip arrow */}
-              <div class="absolute top-full left-1/2 -translate-x-1/2 -mt-px">
-                <div class="border-4 border-transparent border-t-gray-900 dark:border-t-gray-800"></div>
+              {/* Tooltip arrow: points down toward the bar when the tooltip is
+                  above it, up toward the bar when below it (compact). */}
+              <div class={`absolute left-1/2 -translate-x-1/2 ${compact ? 'bottom-full -mb-px' : 'top-full -mt-px'}`}>
+                <div class={`border-4 border-transparent ${compact ? 'border-b-gray-900 dark:border-b-gray-800' : 'border-t-gray-900 dark:border-t-gray-800'}`}></div>
               </div>
             </div>
           </div>

--- a/web/src/components/search/StatusChart.jsx
+++ b/web/src/components/search/StatusChart.jsx
@@ -63,6 +63,9 @@ function getBarColor(status, mode) {
  * @param {Array} props.items - Array of event or resource objects
  * @param {boolean} props.loading - Whether data is currently loading
  * @param {string} props.mode - 'events' or 'resources'
+ * @param {boolean} [props.compact] - When true, renders a thin rounded bar with no
+ *   card wrapper and no count/stats header (the count lives in the toolbar). The
+ *   hover tooltip and click-to-filter behavior are preserved.
  *
  * Features:
  * - Displays one bar per status type (Ready, Failed, Progressing, etc.)
@@ -72,7 +75,7 @@ function getBarColor(status, mode) {
  * - Shows placeholder bar during loading
  * - Tooltip on hover with count and percentage
  */
-export function StatusChart({ items, loading, mode = 'events', onBarClick }) {
+export function StatusChart({ items, loading, mode = 'events', onBarClick, compact = false }) {
   const [hoveredBar, setHoveredBar] = useState(null)
   const [animationComplete, setAnimationComplete] = useState(false)
 
@@ -104,7 +107,7 @@ export function StatusChart({ items, loading, mode = 'events', onBarClick }) {
   }, [loading, items, mode, itemsKey])
 
   return (
-    <div class="card p-4" data-testid="status-chart">
+    <div class={compact ? '' : 'card p-4'} data-testid="status-chart">
       <style>{`
         @keyframes fillRight {
           from {
@@ -151,121 +154,136 @@ export function StatusChart({ items, loading, mode = 'events', onBarClick }) {
         }
       `}</style>
 
-      {/* Header with total count and stats */}
-      <div class="flex items-center justify-between mb-2">
-        {/* Left: Total count */}
-        <div class="text-sm text-gray-600 dark:text-gray-400">
-          {loading ? (
-            <span>Loading...</span>
-          ) : (
-            <span>
-              {mode === 'events' ? 'Reconcile events: ' : 'Resources: '}
-              <span class="font-semibold text-gray-900 dark:text-gray-100">
-                {items && items.length > 0 ? items.length : 0}
+      {/* Header with total count and stats (omitted in compact mode, where the
+          count is shown by the toolbar instead) */}
+      {!compact && (
+        <div class="flex items-center justify-between mb-2">
+          {/* Left: Total count */}
+          <div class="text-sm text-gray-600 dark:text-gray-400">
+            {loading ? (
+              <span>Loading...</span>
+            ) : (
+              <span>
+                {mode === 'events' ? 'Reconcile events: ' : 'Resources: '}
+                <span class="font-semibold text-gray-900 dark:text-gray-100">
+                  {items && items.length > 0 ? items.length : 0}
+                </span>
               </span>
-            </span>
-          )}
-        </div>
+            )}
+          </div>
 
-        {/* Right: Status/Severity stats (hidden on mobile, only shown when multiple statuses) */}
-        <div class="hidden md:block text-sm text-gray-600 dark:text-gray-400">
-          {!loading && items && items.length > 0 && statusBars.length > 1 && (
-            <span class="space-x-3">
-              {statusBars.map((bar) => {
+          {/* Right: Status/Severity stats (hidden on mobile, only shown when multiple statuses) */}
+          <div class="hidden md:block text-sm text-gray-600 dark:text-gray-400">
+            {!loading && items && items.length > 0 && statusBars.length > 1 && (
+              <span class="space-x-3">
+                {statusBars.map((bar) => {
                 // Get text color class based on status type
-                let textColorClass
-                if (mode === 'events') {
-                  textColorClass = bar.status === 'Normal'
-                    ? 'text-green-600 dark:text-green-400'
-                    : 'text-red-600 dark:text-red-400'
-                } else {
+                  let textColorClass
+                  if (mode === 'events') {
+                    textColorClass = bar.status === 'Normal'
+                      ? 'text-green-600 dark:text-green-400'
+                      : 'text-red-600 dark:text-red-400'
+                  } else {
                   // resources mode
-                  if (bar.status === 'Ready') {
-                    textColorClass = 'text-green-600 dark:text-green-400'
-                  } else if (bar.status === 'Failed') {
-                    textColorClass = 'text-red-600 dark:text-red-400'
-                  } else if (bar.status === 'Progressing') {
-                    textColorClass = 'text-blue-600 dark:text-blue-400'
-                  } else if (bar.status === 'Suspended') {
-                    textColorClass = 'text-yellow-600 dark:text-yellow-400'
-                  } else if (bar.status === 'Unknown') {
-                    textColorClass = 'text-gray-600 dark:text-gray-400'
+                    if (bar.status === 'Ready') {
+                      textColorClass = 'text-green-600 dark:text-green-400'
+                    } else if (bar.status === 'Failed') {
+                      textColorClass = 'text-red-600 dark:text-red-400'
+                    } else if (bar.status === 'Progressing') {
+                      textColorClass = 'text-blue-600 dark:text-blue-400'
+                    } else if (bar.status === 'Suspended') {
+                      textColorClass = 'text-yellow-600 dark:text-yellow-400'
+                    } else if (bar.status === 'Unknown') {
+                      textColorClass = 'text-gray-600 dark:text-gray-400'
+                    }
                   }
-                }
 
-                // Map Normal to Info for display
-                const displayName = mode === 'events' && bar.status === 'Normal' ? 'Info' : bar.status
+                  // Map Normal to Info for display
+                  const displayName = mode === 'events' && bar.status === 'Normal' ? 'Info' : bar.status
 
-                return (
-                  <span key={bar.status}>
-                    {displayName}: <span class={textColorClass}>{bar.count}</span>
-                  </span>
-                )
-              })}
-            </span>
+                  return (
+                    <span key={bar.status}>
+                      {displayName}: <span class={textColorClass}>{bar.count}</span>
+                    </span>
+                  )
+                })}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Horizontal bar chart - status distribution. The bar lives in a
+          non-clipped relative wrapper so the hover tooltip can overflow above
+          it even in compact mode, where the bar itself uses overflow-hidden to
+          get its rounded ends. */}
+      <div class="relative">
+        <div
+          class={`relative flex gap-0 ${compact ? 'h-2.5 rounded-full overflow-hidden' : ''}`}
+          style={compact ? undefined : { height: '32px' }}
+        >
+          {loading ? (
+            /* Single loading bar with shimmer */
+            <div class="w-full h-full bg-gray-200 dark:bg-gray-700 loading-shimmer" />
+          ) : statusBars.length === 0 ? (
+            /* No data - gray bar */
+            <div class="w-full h-full bg-gray-200 dark:bg-gray-700" />
+          ) : (
+            statusBars.map((bar, index) => {
+              const colorClass = getBarColor(bar.status, mode)
+              const grayClass = 'bg-gray-200 dark:bg-gray-700'
+
+              return (
+                <div
+                  key={bar.status}
+                  class="relative group"
+                  style={{ flex: `0 0 ${bar.percentage}%` }}
+                  onMouseEnter={() => setHoveredBar(index)}
+                  onMouseLeave={() => setHoveredBar(null)}
+                  onClick={() => onBarClick?.(bar.status)}
+                  role={onBarClick ? 'button' : undefined}
+                >
+                  {/* Gray background */}
+                  <div class={`h-full ${grayClass}`}>
+                    {/* Colored fill overlay - animates from left to right on initial load */}
+                    <div
+                      class={`h-full transition-opacity duration-200 ${colorClass}${onBarClick ? ' hover:opacity-80 cursor-pointer' : ''}`}
+                      style={{
+                        width: '100%',
+                        animation: !animationComplete ? 'fillRight 0.8s ease-out both' : 'none',
+                        clipPath: animationComplete ? 'none' : undefined
+                      }}
+                    />
+                  </div>
+                </div>
+              )
+            })
           )}
         </div>
-      </div>
 
-      {/* Horizontal bar chart - status distribution */}
-      <div class="relative flex gap-0" style={{ height: '32px' }}>
-        {loading ? (
-          /* Single loading bar with shimmer */
-          <div class="w-full h-full bg-gray-200 dark:bg-gray-700 loading-shimmer" />
-        ) : statusBars.length === 0 ? (
-          /* No data - gray bar */
-          <div class="w-full h-full bg-gray-200 dark:bg-gray-700" />
-        ) : (
-          statusBars.map((bar, index) => {
-            const colorClass = getBarColor(bar.status, mode)
-            const grayClass = 'bg-gray-200 dark:bg-gray-700'
-
-            return (
-              <div
-                key={bar.status}
-                class="relative group"
-                style={{ flex: `0 0 ${bar.percentage}%` }}
-                onMouseEnter={() => setHoveredBar(index)}
-                onMouseLeave={() => setHoveredBar(null)}
-                onClick={() => onBarClick?.(bar.status)}
-                role={onBarClick ? 'button' : undefined}
-              >
-                {/* Gray background */}
-                <div class={`h-full ${grayClass}`}>
-                  {/* Colored fill overlay - animates from left to right on initial load */}
-                  <div
-                    class={`h-full transition-opacity duration-200 ${colorClass}${onBarClick ? ' hover:opacity-80 cursor-pointer' : ''}`}
-                    style={{
-                      width: '100%',
-                      animation: !animationComplete ? 'fillRight 0.8s ease-out both' : 'none',
-                      clipPath: animationComplete ? 'none' : undefined
-                    }}
-                  />
-                </div>
-
-                {/* Tooltip */}
-                {hoveredBar === index && (
-                  <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-10 pointer-events-none">
-                    <div class="bg-gray-900 dark:bg-gray-800 text-white text-xs rounded-lg py-2 px-3 shadow-lg whitespace-nowrap">
-                      <div class="font-semibold">
-                        {bar.status}
-                      </div>
-                      <div class="text-gray-300 mt-1">
-                        Count: {bar.count}
-                      </div>
-                      <div class="text-gray-300">
-                        Percentage: {bar.percentage.toFixed(1)}%
-                      </div>
-                      {/* Tooltip arrow */}
-                      <div class="absolute top-full left-1/2 -translate-x-1/2 -mt-px">
-                        <div class="border-4 border-transparent border-t-gray-900 dark:border-t-gray-800"></div>
-                      </div>
-                    </div>
-                  </div>
-                )}
+        {/* Tooltip overlay - rendered outside the (possibly clipped) bar and
+            positioned over the centre of the hovered segment. */}
+        {hoveredBar !== null && statusBars[hoveredBar] && (
+          <div
+            class="absolute bottom-full mb-2 z-10 -translate-x-1/2 pointer-events-none"
+            style={{ left: `${statusBars.slice(0, hoveredBar).reduce((sum, b) => sum + b.percentage, 0) + statusBars[hoveredBar].percentage / 2}%` }}
+          >
+            <div class="bg-gray-900 dark:bg-gray-800 text-white text-xs rounded-lg py-2 px-3 shadow-lg whitespace-nowrap">
+              <div class="font-semibold">
+                {statusBars[hoveredBar].status}
               </div>
-            )
-          })
+              <div class="text-gray-300 mt-1">
+                Count: {statusBars[hoveredBar].count}
+              </div>
+              <div class="text-gray-300">
+                Percentage: {statusBars[hoveredBar].percentage.toFixed(1)}%
+              </div>
+              {/* Tooltip arrow */}
+              <div class="absolute top-full left-1/2 -translate-x-1/2 -mt-px">
+                <div class="border-4 border-transparent border-t-gray-900 dark:border-t-gray-800"></div>
+              </div>
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/web/src/components/search/StatusChart.test.jsx
+++ b/web/src/components/search/StatusChart.test.jsx
@@ -615,4 +615,44 @@ describe('StatusChart', () => {
       expect(container.textContent).toContain('0')
     })
   })
+
+  describe('Compact mode', () => {
+    it('renders a thin rounded bar without a card wrapper', () => {
+      const { getByTestId } = render(
+        <StatusChart items={createMockResources(4, 'Ready')} loading={false} mode="resources" compact />
+      )
+
+      const root = getByTestId('status-chart')
+      // No card box in compact mode.
+      expect(root.className).not.toContain('card')
+      // The bar itself is the thin rounded variant.
+      expect(root.querySelector('.h-2\\.5.rounded-full')).toBeTruthy()
+    })
+
+    it('omits the count/stats header in compact mode', () => {
+      const resources = [
+        ...createMockResources(3, 'Ready'),
+        ...createMockResources(1, 'Failed')
+      ]
+      const { container } = render(
+        <StatusChart items={resources} loading={false} mode="resources" compact />
+      )
+
+      // The header (count + per-status stats) lives in the toolbar instead.
+      expect(container.textContent).not.toContain('Resources:')
+      expect(container.textContent).not.toContain('Ready:')
+    })
+
+    it('still calls onBarClick when a bar is clicked in compact mode', () => {
+      const onBarClick = vi.fn()
+      const { container } = render(
+        <StatusChart items={createMockResources(4, 'Ready')} loading={false} mode="resources" compact onBarClick={onBarClick} />
+      )
+
+      const bar = container.querySelector('[role="button"]')
+      expect(bar).toBeTruthy()
+      fireEvent.click(bar)
+      expect(onBarClick).toHaveBeenCalledWith('Ready')
+    })
+  })
 })

--- a/web/src/components/search/WorkloadDetailsView.jsx
+++ b/web/src/components/search/WorkloadDetailsView.jsx
@@ -3,11 +3,12 @@
 
 import { useState, useMemo, useEffect, useRef } from 'preact/hooks'
 import { fetchWithMock } from '../../utils/fetch'
+import { formatTimestamp } from '../../utils/time'
 import { getWorkloadStatusBadgeClass, formatWorkloadStatus } from '../../utils/status'
 import { summarizePods } from '../../utils/pods'
 import { formatScheduleMessage } from '../../utils/cron'
 import { usePrismTheme, YamlBlock } from '../dashboards/common/yaml'
-import { FluxOperatorIcon } from '../layout/Icons'
+import { TabbedPanel, Field, ResourceLink, StatusBadge } from './detailPanel'
 
 /**
  * WorkloadDetailsView - Read-only inline detail panel for a Kubernetes workload
@@ -17,16 +18,20 @@ import { FluxOperatorIcon } from '../layout/Icons'
  * @param {string} props.name - Workload name
  * @param {string} props.namespace - Workload namespace
  * @param {boolean} props.isExpanded - Whether the view is expanded
+ * @param {Function} [props.onReady] - Called once the fetch settles (success or
+ *   error), so the parent row can swap its spinner for the revealed panel
  *
  * Features:
  * - Lazy loads workload data from the RBAC-enforced /api/v1/workload endpoint on
  *   first expand and caches it to avoid redundant fetches.
  * - Tabbed interface with three read-only sections: Overview, Specification, Status.
+ *   Tabs render through the shared TabbedPanel (mobile segmented control / desktop
+ *   vertical rail merging into a cohesive dark content panel).
  * - Mirrors the Resources list detail panel (ResourceDetailsView). Pod listing,
  *   events, and actions live on the full workload dashboard, not here.
  * - Handles loading, error, and not-found states (e.g. forbidden namespaces).
  */
-export function WorkloadDetailsView({ kind, name, namespace, isExpanded }) {
+export function WorkloadDetailsView({ kind, name, namespace, reconcilerKind, reconcilerNamespace, reconcilerName, isExpanded, onReady }) {
   const [workloadData, setWorkloadData] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
@@ -70,7 +75,14 @@ export function WorkloadDetailsView({ kind, name, namespace, isExpanded }) {
         if (!cancelled) setError(err.message)
       } finally {
         fetchingRef.current = false
-        if (!cancelled) setLoading(false)
+        if (!cancelled) {
+          setLoading(false)
+          // Signal the parent row once the fetch settles (success or error) so it
+          // can swap its spinner for the revealed panel. Skipped when cancelled
+          // (the row was collapsed mid-fetch and unmounted us), otherwise the
+          // disclosure would be marked loaded+open with no panel mounted.
+          if (onReady) onReady()
+        }
       }
     }
 
@@ -98,19 +110,6 @@ export function WorkloadDetailsView({ kind, name, namespace, isExpanded }) {
       ? workloadData.spec.jobTemplate?.spec?.template?.spec
       : workloadData.spec.template?.spec
   }, [workloadData, kind])
-
-  // Extract and sort unique container ports from the spec
-  const containerPorts = useMemo(() => {
-    if (!podSpec) return []
-    const containers = [...(podSpec.containers || []), ...(podSpec.initContainers || [])]
-    const ports = new Set()
-    for (const c of containers) {
-      for (const p of c.ports || []) {
-        if (p.containerPort) ports.add(p.containerPort)
-      }
-    }
-    return [...ports].sort((a, b) => a - b)
-  }, [podSpec])
 
   // Last action timestamp: conditions for apps/v1, lastScheduleTime for CronJob
   const lastActionTime = useMemo(() => {
@@ -149,150 +148,86 @@ export function WorkloadDetailsView({ kind, name, namespace, isExpanded }) {
 
   if (!isExpanded) return null
 
+  // Tab definitions for the shared TabbedPanel (short labels for the compact rail).
+  const tabs = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'specification', label: 'Spec' },
+    { id: 'status', label: 'Status' }
+  ]
+
   return (
     <div class="mt-3 space-y-4">
       {/* Loading State */}
       {loading && (
-        <div class="flex items-center justify-center p-4">
-          <FluxOperatorIcon className="animate-spin h-6 w-6 text-flux-blue" />
-          <span class="ml-2 text-sm text-gray-600 dark:text-gray-400">
-            Loading details...
-          </span>
+        <div class="py-3 text-xs text-gray-500 dark:text-gray-400">
+          Loading details…
         </div>
       )}
 
       {/* Error State */}
       {error && (
-        <div class="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
-          <p class="text-sm text-red-800 dark:text-red-200">
-            Failed to load details: {error}
-          </p>
+        <div class="py-3 text-xs text-red-600 dark:text-red-400">
+          Failed to load details: {error}
         </div>
       )}
 
       {/* Not Found State (deleted or not visible to the user) */}
       {!loading && !error && isNotFound && (
-        <div class="p-3 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-md">
-          <p class="text-sm text-gray-600 dark:text-gray-400">
-            Workload not found in the cluster.
-          </p>
+        <div class="py-3 text-xs text-gray-500 dark:text-gray-400">
+          Workload not found in the cluster.
         </div>
       )}
 
       {/* Tabs + Content */}
       {!loading && !error && workloadData && !isNotFound && (
-        <>
-          {/* Tab Navigation */}
-          <div class="border-b border-gray-200 dark:border-gray-700 mb-4">
-            <nav class="flex space-x-4 overflow-x-auto" aria-label="Tabs">
-              <button
-                onClick={() => setActiveTab('overview')}
-                class={`py-2 px-1 text-sm font-medium border-b-2 transition-colors ${
-                  activeTab === 'overview'
-                    ? 'border-flux-blue text-flux-blue dark:text-blue-400'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
-                }`}
-              >
-                <span class="inline sm:hidden">Info</span>
-                <span class="hidden sm:inline">Overview</span>
-              </button>
-              <button
-                onClick={() => setActiveTab('specification')}
-                class={`py-2 px-1 text-sm font-medium border-b-2 transition-colors ${
-                  activeTab === 'specification'
-                    ? 'border-flux-blue text-flux-blue dark:text-blue-400'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
-                }`}
-              >
-                <span class="inline sm:hidden">Spec</span>
-                <span class="hidden sm:inline">Specification</span>
-              </button>
-              <button
-                onClick={() => setActiveTab('status')}
-                class={`py-2 px-1 text-sm font-medium border-b-2 transition-colors ${
-                  activeTab === 'status'
-                    ? 'border-flux-blue text-flux-blue dark:text-blue-400'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
-                }`}
-              >
-                Status
-              </button>
-            </nav>
-          </div>
-
-          {/* Overview Tab */}
+        <TabbedPanel tabs={tabs} active={activeTab} onSelect={setActiveTab}>
+          {/* Overview — two columns: metadata fields left, last action + message right */}
           {activeTab === 'overview' && (
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-              {/* Left column: status and metadata */}
-              <div class="space-y-4">
-                {/* Status Badge */}
-                <div class="text-sm">
-                  <span class="text-gray-500 dark:text-gray-400">{kind}</span>
-                  <span class={`ml-1 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getWorkloadStatusBadgeClass(workloadStatus)}`}>
-                    {formatWorkloadStatus(workloadStatus)}
-                  </span>
-                </div>
-
-                {/* Created At */}
-                {workloadInfo?.createdAt && (
-                  <div class="text-sm">
-                    <span class="text-gray-500 dark:text-gray-400">Created</span>
-                    <span class="ml-1 text-gray-900 dark:text-white">{new Date(workloadInfo.createdAt).toLocaleString().replace(',', '')}</span>
-                  </div>
-                )}
-
-                {/* Pods readiness / phase summary */}
-                <div class="text-sm">
-                  <span class="text-gray-500 dark:text-gray-400">Pods</span>
-                  <span class="ml-1 text-gray-900 dark:text-white">{podSummary.primary}</span>
-                  {podSummary.detail && podSummary.total > 0 && (
-                    <span class="text-gray-500 dark:text-gray-400"> ({podSummary.detail})</span>
-                  )}
-                </div>
-
-                {/* Service Account */}
-                {podSpec?.serviceAccountName && (
-                  <div class="text-sm">
-                    <span class="text-gray-500 dark:text-gray-400">Service account</span>
-                    <span class="ml-1 text-gray-900 dark:text-white">{podSpec.serviceAccountName}</span>
-                  </div>
-                )}
-
-                {/* Container Ports */}
-                {containerPorts.length > 0 && (
-                  <div class="text-sm">
-                    <span class="text-gray-500 dark:text-gray-400">Ports</span>
-                    <span class="ml-1 text-gray-900 dark:text-white">{containerPorts.join(', ')}</span>
-                  </div>
-                )}
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4 text-xs">
+              {/* Left: metadata fields, evenly stacked. Leads with the same
+                  "Resource: ns/name link" + "<kind>: status" pair as the
+                  resource Overview/Source tabs. */}
+              <div class="space-y-2.5 self-start">
+                <Field label="Workload"><ResourceLink kind={kind} namespace={namespace} name={name} /></Field>
+                <Field label={kind}>
+                  <StatusBadge status={formatWorkloadStatus(workloadStatus)} colorClass={getWorkloadStatusBadgeClass(workloadStatus)} />
+                </Field>
+                <Field label="Pods">
+                  {podSummary
+                    ? `${podSummary.primary}${podSummary.detail && podSummary.total > 0 ? ` (${podSummary.detail})` : ''}`
+                    : null}
+                </Field>
+                <Field label="Service account">{podSpec?.serviceAccountName || 'default'}</Field>
+                {reconcilerName ? (
+                  <Field label="Managed by">
+                    <ResourceLink kind={reconcilerKind} namespace={reconcilerNamespace} name={reconcilerName} />
+                  </Field>
+                ) : null}
               </div>
 
-              {/* Right column: last action and status message */}
-              {workloadInfo?.statusMessage && (
-                <div class="space-y-2 border-gray-200 dark:border-gray-700 border-t pt-4 md:border-t-0 md:border-l md:pt-0 md:pl-6">
-                  {lastActionTime && (
-                    <div class="text-sm text-gray-500 dark:text-gray-400">
-                      Last action <span class="text-gray-900 dark:text-white">{new Date(lastActionTime).toLocaleString().replace(',', '')}</span>
-                    </div>
+              {/* Right: created + last action + message */}
+              {(workloadInfo?.createdAt || lastActionTime || workloadInfo?.statusMessage) && (
+                <div class="space-y-2.5 self-start md:border-l md:border-gray-200 md:dark:border-gray-700 md:pl-8">
+                  <Field label="Created">{workloadInfo?.createdAt ? formatTimestamp(workloadInfo.createdAt) : null}</Field>
+                  <Field label="Last action">{lastActionTime ? formatTimestamp(lastActionTime) : null}</Field>
+                  {workloadInfo?.statusMessage && (
+                    <pre class="whitespace-pre-wrap break-words font-sans leading-relaxed text-gray-700 dark:text-gray-300">{formatScheduleMessage(workloadInfo.statusMessage)}</pre>
                   )}
-                  <div class="text-sm text-gray-700 dark:text-gray-300">
-                    <pre class="whitespace-pre-wrap break-all font-sans">{formatScheduleMessage(workloadInfo.statusMessage)}</pre>
-                  </div>
                 </div>
               )}
             </div>
           )}
 
-          {/* Specification Tab */}
-          {activeTab === 'specification' && (
-            <YamlBlock data={workloadSpecYaml} />
+          {/* Specification Tab — height is capped/scrolled by the TabbedPanel. */}
+          {activeTab === 'specification' && workloadSpecYaml && (
+            <YamlBlock data={workloadSpecYaml} nested />
           )}
 
-          {/* Status Tab */}
-          {activeTab === 'status' && (
-            <YamlBlock data={workloadStatusYaml} />
+          {/* Status Tab — height is capped/scrolled by the TabbedPanel. */}
+          {activeTab === 'status' && workloadStatusYaml && (
+            <YamlBlock data={workloadStatusYaml} nested />
           )}
-        </>
+        </TabbedPanel>
       )}
     </div>
   )

--- a/web/src/components/search/WorkloadDetailsView.jsx
+++ b/web/src/components/search/WorkloadDetailsView.jsx
@@ -20,6 +20,9 @@ import { TabbedPanel, Field, ResourceLink, StatusBadge } from './detailPanel'
  * @param {boolean} props.isExpanded - Whether the view is expanded
  * @param {Function} [props.onReady] - Called once the fetch settles (success or
  *   error), so the parent row can swap its spinner for the revealed panel
+ * @param {Function} [props.onData] - Called with the fetched workload on success, so
+ *   the parent row can refresh its owning-reconciler summary (status + last
+ *   reconciled) from the detail's reconciler reference
  *
  * Features:
  * - Lazy loads workload data from the RBAC-enforced /api/v1/workload endpoint on
@@ -31,7 +34,7 @@ import { TabbedPanel, Field, ResourceLink, StatusBadge } from './detailPanel'
  *   events, and actions live on the full workload dashboard, not here.
  * - Handles loading, error, and not-found states (e.g. forbidden namespaces).
  */
-export function WorkloadDetailsView({ kind, name, namespace, reconcilerKind, reconcilerNamespace, reconcilerName, isExpanded, onReady }) {
+export function WorkloadDetailsView({ kind, name, namespace, reconcilerKind, reconcilerNamespace, reconcilerName, isExpanded, onReady, onData }) {
   const [workloadData, setWorkloadData] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
@@ -69,7 +72,12 @@ export function WorkloadDetailsView({ kind, name, namespace, reconcilerKind, rec
           mockPath: '../mock/workload',
           mockExport: 'getMockWorkload'
         })
-        if (!cancelled) setWorkloadData(data)
+        if (!cancelled) {
+          setWorkloadData(data)
+          // Hand the fresh payload back so the row can refresh its reconciler
+          // summary from the detail's enriched reconciler reference.
+          onData && onData(data)
+        }
       } catch (err) {
         console.error('Failed to fetch workload details:', err)
         if (!cancelled) setError(err.message)

--- a/web/src/components/search/WorkloadDetailsView.test.jsx
+++ b/web/src/components/search/WorkloadDetailsView.test.jsx
@@ -96,13 +96,14 @@ describe('WorkloadDetailsView component', () => {
       <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />
     )
 
-    expect(screen.getByText('Loading details...')).toBeInTheDocument()
-    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
+    // The inline panel renders a plain loading line; the spinner lives on the
+    // parent row and is swapped out via the onReady callback once the fetch settles.
+    expect(screen.getByText('Loading details…')).toBeInTheDocument()
 
     resolvePromise(mockWorkloadData)
 
     await waitFor(() => {
-      expect(screen.queryByText('Loading details...')).not.toBeInTheDocument()
+      expect(screen.queryByText('Loading details…')).not.toBeInTheDocument()
     })
   })
 
@@ -110,19 +111,32 @@ describe('WorkloadDetailsView component', () => {
     fetchWithMock.mockResolvedValue(mockWorkloadData)
 
     render(
-      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />
+      <WorkloadDetailsView
+        kind="Deployment"
+        name="podinfo"
+        namespace="apps"
+        reconcilerKind="Kustomization"
+        reconcilerNamespace="flux-system"
+        reconcilerName="apps"
+        isExpanded={true}
+      />
     )
 
     await waitFor(() => {
       expect(screen.getByText('Service account')).toBeInTheDocument()
     })
 
+    // Overview is the default tab in the TabbedPanel: kind badge + metadata fields.
+    expect(screen.getByRole('button', { name: 'Overview' })).toBeInTheDocument()
     expect(screen.getByText('Service account')).toBeInTheDocument()
     expect(screen.getByText('podinfo')).toBeInTheDocument()
-    expect(screen.getByText('Ports')).toBeInTheDocument()
-    expect(screen.getByText('9797, 9898')).toBeInTheDocument()
+    // Managed-by renders a namespace/name link to the parent reconciler.
+    expect(screen.getByText('Managed by')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'flux-system/apps' })).toHaveAttribute('href', '/resource/Kustomization/flux-system/apps')
     expect(screen.getByText('Pods')).toBeInTheDocument()
-    expect(screen.getByText('2/2 ready')).toBeInTheDocument()
+    // Primary readiness plus the phase breakdown in parentheses.
+    expect(screen.getByText('2/2 ready (2 running)')).toBeInTheDocument()
+    // YAML-only fields are not surfaced on the Overview tab.
     expect(screen.queryByText('Strategy')).not.toBeInTheDocument()
   })
 
@@ -134,11 +148,12 @@ describe('WorkloadDetailsView component', () => {
       <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} />
     )
 
+    // The compact rail uses a short "Spec" label for the specification tab.
     await waitFor(() => {
-      expect(screen.getByText('Specification')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Spec' })).toBeInTheDocument()
     })
 
-    await user.click(screen.getByText('Specification'))
+    await user.click(screen.getByRole('button', { name: 'Spec' }))
 
     await waitFor(() => {
       const codeElement = document.querySelector('.language-yaml')
@@ -159,10 +174,10 @@ describe('WorkloadDetailsView component', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Specification')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Spec' })).toBeInTheDocument()
     })
 
-    // The Status tab button is disambiguated from the Overview "Status" label by role.
+    // Select the Status tab from the rail (a button, not the Overview field label).
     await user.click(screen.getByRole('button', { name: 'Status' }))
 
     await waitFor(() => {
@@ -212,6 +227,32 @@ describe('WorkloadDetailsView component', () => {
     expect(screen.queryByRole('button', { name: 'Events' })).not.toBeInTheDocument()
     expect(screen.queryByTestId('logs-pod-button')).not.toBeInTheDocument()
     expect(screen.queryByTestId('workload-delete-action')).not.toBeInTheDocument()
+  })
+
+  it('should call onReady once the fetch settles successfully', async () => {
+    fetchWithMock.mockResolvedValue(mockWorkloadData)
+    const onReady = vi.fn()
+
+    render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} onReady={onReady} />
+    )
+
+    await waitFor(() => {
+      expect(onReady).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should call onReady even when the fetch fails', async () => {
+    fetchWithMock.mockRejectedValue(new Error('forbidden'))
+    const onReady = vi.fn()
+
+    render(
+      <WorkloadDetailsView kind="Deployment" name="podinfo" namespace="apps" isExpanded={true} onReady={onReady} />
+    )
+
+    await waitFor(() => {
+      expect(onReady).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('should fetch only once across collapse and re-expand', async () => {

--- a/web/src/components/search/WorkloadList.jsx
+++ b/web/src/components/search/WorkloadList.jsx
@@ -12,7 +12,7 @@ import { reportData } from '../../app'
 import { FilterForm } from './FilterForm'
 import { FilterBar } from './FilterBar'
 import { WorkloadDetailsView } from './WorkloadDetailsView'
-import { Star, KindChip, NEUTRAL_CHIP, NameLink, Chevron, Spinner, useDisclosure, Reveal } from './compactRow'
+import { Star, KindChip, NEUTRAL_CHIP, NameLink, Chevron, Spinner, useDisclosure, Reveal, patchRowInSignal } from './compactRow'
 import { useRestoreFiltersFromUrl, useSyncFiltersToUrl, getDashboardUrl } from '../../utils/routing'
 import { useInfiniteScroll } from '../../utils/scroll'
 import { isFavorite, toggleFavorite, favorites } from '../../utils/favorites'
@@ -92,6 +92,7 @@ function WorkloadRow({ workload }) {
 
   const dashboardUrl = getDashboardUrl(workload.kind, workload.namespace, workload.name)
   const reconcilerTitle = `Managed by ${workload.reconcilerKind} ${workload.reconcilerNamespace}/${workload.reconcilerName} (${workload.reconcilerStatus})`
+  const chipTitle = `${workload.kind} · reconciler ${workload.reconcilerStatus}`
 
   // Color the kind chip by the workload's own status only while the panel is open
   // (and once its status is known); collapsed rows keep the neutral chip.
@@ -106,11 +107,7 @@ function WorkloadRow({ workload }) {
     setLiveStatus(data?.workloadInfo?.status || null)
     const ref = data?.workloadInfo?.reconciler?.status?.reconcilerRef
     if (!ref) return
-    const cur = workloadsData.value.find(w =>
-      w.kind === workload.kind && w.namespace === workload.namespace && w.name === workload.name)
-    if (!cur || (cur.reconcilerStatus === ref.status && cur.lastReconciled === ref.lastReconciled)) return
-    workloadsData.value = workloadsData.value.map(w =>
-      w === cur ? { ...w, reconcilerStatus: ref.status, lastReconciled: ref.lastReconciled } : w)
+    patchRowInSignal(workloadsData, workload, { reconcilerStatus: ref.status, lastReconciled: ref.lastReconciled })
   }
 
   return (
@@ -120,7 +117,7 @@ function WorkloadRow({ workload }) {
           <Star active={isFavorited} onClick={handleFavoriteClick} />
           {/* Neutral chip in the list; colored by the workload's own status once
               expanded (see chipColor). */}
-          <KindChip kind={workload.kind} colorClass={chipColor} title={`${workload.kind} · reconciler ${workload.reconcilerStatus}`} cls="hidden sm:inline-block" />
+          <KindChip kind={workload.kind} colorClass={chipColor} title={chipTitle} cls="hidden sm:inline-block" />
           <NameLink href={dashboardUrl} namespace={workload.namespace} name={workload.name} />
           {/* Desktop: parent reconciler reference with a status dot. The status
               belongs to the reconciler, never the workload itself. */}
@@ -136,14 +133,14 @@ function WorkloadRow({ workload }) {
             has no status of its own in the list, so we state the reconcile time
             instead of a (reconciler) status word. */}
         <div class="sm:hidden mt-1 pl-[30px] flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
-          <KindChip kind={workload.kind} colorClass={chipColor} title={`${workload.kind} · reconciler ${workload.reconcilerStatus}`} />
+          <KindChip kind={workload.kind} colorClass={chipColor} title={chipTitle} />
           <span class="whitespace-nowrap">Reconciled {formatTimestamp(workload.lastReconciled)}</span>
         </div>
       </div>
       <Reveal open={d.open}>
         <div class="pl-3 sm:pl-[42px] pr-3 pt-1 pb-4">
-          {/* Lazily mounted on first expand; stays mounted afterwards so re-opening
-              is instant. onReady flips the disclosure once the fetch settles. */}
+          {/* Lazily mounted on expand; unmounted on collapse so each expand
+              re-fetches. onReady flips the disclosure once the fetch settles. */}
           {d.mounted && (
             <WorkloadDetailsView
               kind={workload.kind}

--- a/web/src/components/search/WorkloadList.jsx
+++ b/web/src/components/search/WorkloadList.jsx
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { signal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { fetchWithMock } from '../../utils/fetch'
 import { formatTimestamp } from '../../utils/time'
-import { getStatusDotClass } from '../../utils/status'
+import { getStatusDotClass, getWorkloadStatusBadgeClass } from '../../utils/status'
 import { usePageMeta } from '../../utils/meta'
 import { workloadKinds } from '../../utils/constants'
 import { reportData } from '../../app'
@@ -75,6 +75,12 @@ function WorkloadRow({ workload }) {
   // fetches, then the panel animates open via Reveal.
   const d = useDisclosure()
 
+  // The workload's own status (Current/Idle/InProgress/…) is only known once the
+  // detail panel has fetched it; the list index carries no workload status. We
+  // capture it on expand to color the kind chip, and fall back to the neutral
+  // chip while collapsed.
+  const [liveStatus, setLiveStatus] = useState(null)
+
   // Check if workload is a favorite (reactive via favorites signal)
   const isFavorited = favorites.value && isFavorite(workload.kind, workload.namespace, workload.name)
 
@@ -87,13 +93,34 @@ function WorkloadRow({ workload }) {
   const dashboardUrl = getDashboardUrl(workload.kind, workload.namespace, workload.name)
   const reconcilerTitle = `Managed by ${workload.reconcilerKind} ${workload.reconcilerNamespace}/${workload.reconcilerName} (${workload.reconcilerStatus})`
 
+  // Color the kind chip by the workload's own status only while the panel is open
+  // (and once its status is known); collapsed rows keep the neutral chip.
+  const chipColor = d.open && liveStatus ? getWorkloadStatusBadgeClass(liveStatus) : NEUTRAL_CHIP
+
+  // When the detail panel finishes loading, refresh this row's owning-reconciler
+  // summary from the detail's enriched reconciler (its status.reconcilerRef is the
+  // same NewResourceStatus the workloads index uses), so a row that listed a stale
+  // reconciler status/time updates on expand. No-op when unchanged.
+  const handleData = (data) => {
+    // Capture the workload's own status to color the kind chip while expanded.
+    setLiveStatus(data?.workloadInfo?.status || null)
+    const ref = data?.workloadInfo?.reconciler?.status?.reconcilerRef
+    if (!ref) return
+    const cur = workloadsData.value.find(w =>
+      w.kind === workload.kind && w.namespace === workload.namespace && w.name === workload.name)
+    if (!cur || (cur.reconcilerStatus === ref.status && cur.lastReconciled === ref.lastReconciled)) return
+    workloadsData.value = workloadsData.value.map(w =>
+      w === cur ? { ...w, reconcilerStatus: ref.status, lastReconciled: ref.lastReconciled } : w)
+  }
+
   return (
     <div class="border-b border-gray-100 dark:border-gray-700/60 last:border-0">
       <div class="px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700/30">
         <div class="flex items-center gap-2.5">
           <Star active={isFavorited} onClick={handleFavoriteClick} />
-          {/* Neutral chip: workloads have no status of their own in the list. */}
-          <KindChip kind={workload.kind} colorClass={NEUTRAL_CHIP} title={`${workload.kind} · reconciler ${workload.reconcilerStatus}`} cls="hidden sm:inline-block" />
+          {/* Neutral chip in the list; colored by the workload's own status once
+              expanded (see chipColor). */}
+          <KindChip kind={workload.kind} colorClass={chipColor} title={`${workload.kind} · reconciler ${workload.reconcilerStatus}`} cls="hidden sm:inline-block" />
           <NameLink href={dashboardUrl} namespace={workload.namespace} name={workload.name} />
           {/* Desktop: parent reconciler reference with a status dot. The status
               belongs to the reconciler, never the workload itself. */}
@@ -109,7 +136,7 @@ function WorkloadRow({ workload }) {
             has no status of its own in the list, so we state the reconcile time
             instead of a (reconciler) status word. */}
         <div class="sm:hidden mt-1 pl-[30px] flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
-          <KindChip kind={workload.kind} colorClass={NEUTRAL_CHIP} title={`${workload.kind} · reconciler ${workload.reconcilerStatus}`} />
+          <KindChip kind={workload.kind} colorClass={chipColor} title={`${workload.kind} · reconciler ${workload.reconcilerStatus}`} />
           <span class="whitespace-nowrap">Reconciled {formatTimestamp(workload.lastReconciled)}</span>
         </div>
       </div>
@@ -127,6 +154,7 @@ function WorkloadRow({ workload }) {
               reconcilerName={workload.reconcilerName}
               isExpanded
               onReady={d.onReady}
+              onData={handleData}
             />
           )}
         </div>

--- a/web/src/components/search/WorkloadList.jsx
+++ b/web/src/components/search/WorkloadList.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { signal } from '@preact/signals'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect } from 'preact/hooks'
 import { fetchWithMock } from '../../utils/fetch'
 import { formatTimestamp } from '../../utils/time'
 import { getStatusDotClass } from '../../utils/status'
@@ -10,7 +10,9 @@ import { usePageMeta } from '../../utils/meta'
 import { workloadKinds } from '../../utils/constants'
 import { reportData } from '../../app'
 import { FilterForm } from './FilterForm'
+import { FilterBar } from './FilterBar'
 import { WorkloadDetailsView } from './WorkloadDetailsView'
+import { Star, KindChip, NEUTRAL_CHIP, NameLink, Chevron, Spinner, useDisclosure, Reveal } from './compactRow'
 import { useRestoreFiltersFromUrl, useSyncFiltersToUrl, getDashboardUrl } from '../../utils/routing'
 import { useInfiniteScroll } from '../../utils/scroll'
 import { isFavorite, toggleFavorite, favorites } from '../../utils/favorites'
@@ -52,112 +54,83 @@ export async function fetchWorkloadsStatus() {
 }
 
 /**
- * WorkloadCard - Individual card displaying a Kubernetes workload and its parent reconciler
+ * WorkloadRow - Compact list row for a Kubernetes workload and its parent reconciler
  *
  * @param {Object} props
  * @param {Object} props.workload - WorkloadRef object with kind, name, namespace, reconciler ref
  *   fields (reconcilerKind, reconcilerNamespace, reconcilerName, reconcilerStatus) and lastReconciled
  *
  * Features:
- * - Shows workload kind, namespace, and name (links to the workload dashboard)
- * - Displays the parent reconciler reference with a small status badge reflecting the
- *   reconciler's status (never the reconciler message)
- * - Favorite star button (writes via the kind-agnostic favorites store)
+ * - A neutral kind chip: a workload carries no status of its own in the list (the
+ *   index only knows the reconciler's status), so the chip is never colored by status.
+ * - Desktop: a "managed by" line referencing the parent reconciler, with a small
+ *   status dot that reflects the reconciler's status (never the reconciler message).
+ * - Mobile: a second line with the neutral chip and the reconcile time (a workload
+ *   has no status word of its own to show).
+ * - Favorite star (kind-agnostic favorites store) and an expand chevron that lazily
+ *   mounts {@link WorkloadDetailsView}, spinning until the detail fetch settles.
  */
-function WorkloadCard({ workload }) {
-  // Lazy-loaded inline details panel (collapsed by default)
-  const [isDetailsExpanded, setIsDetailsExpanded] = useState(false)
+function WorkloadRow({ workload }) {
+  // Disclosure state: the chevron spins while the lazily mounted detail panel
+  // fetches, then the panel animates open via Reveal.
+  const d = useDisclosure()
 
   // Check if workload is a favorite (reactive via favorites signal)
   const isFavorited = favorites.value && isFavorite(workload.kind, workload.namespace, workload.name)
 
-  // Handle favorite toggle
+  // Handle favorite toggle (stop propagation so the row click is unaffected)
   const handleFavoriteClick = (e) => {
     e.stopPropagation()
     toggleFavorite(workload.kind, workload.namespace, workload.name)
   }
 
+  const dashboardUrl = getDashboardUrl(workload.kind, workload.namespace, workload.name)
+  const reconcilerTitle = `Managed by ${workload.reconcilerKind} ${workload.reconcilerNamespace}/${workload.reconcilerName} (${workload.reconcilerStatus})`
+
   return (
-    <div class="card p-4 hover:shadow-md transition-shadow">
-      {/* Header row: star + kind + timestamp */}
-      <div class="flex items-center justify-between mb-3">
-        <div class="flex items-center gap-3">
-          {/* Favorite star button */}
-          <button
-            onClick={handleFavoriteClick}
-            class={`p-0.5 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-flux-blue focus:ring-offset-1 ${
-              isFavorited
-                ? 'text-yellow-500 hover:text-yellow-600'
-                : 'text-gray-400 hover:text-flux-blue dark:hover:text-blue-400'
-            }`}
-            title={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
-          >
-            <svg class="w-4 h-4" fill={isFavorited ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          </button>
-          <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
-            {workload.kind}
+    <div class="border-b border-gray-100 dark:border-gray-700/60 last:border-0">
+      <div class="px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700/30">
+        <div class="flex items-center gap-2.5">
+          <Star active={isFavorited} onClick={handleFavoriteClick} />
+          {/* Neutral chip: workloads have no status of their own in the list. */}
+          <KindChip kind={workload.kind} colorClass={NEUTRAL_CHIP} title={`${workload.kind} · reconciler ${workload.reconcilerStatus}`} cls="hidden sm:inline-block" />
+          <NameLink href={dashboardUrl} namespace={workload.namespace} name={workload.name} />
+          {/* Desktop: parent reconciler reference with a status dot. The status
+              belongs to the reconciler, never the workload itself. */}
+          <span class="hidden sm:flex flex-1 min-w-0 items-center gap-1.5 truncate text-xs text-gray-500 dark:text-gray-400" title={reconcilerTitle}>
+            <span class="text-gray-400 dark:text-gray-500 flex-shrink-0">managed by</span>
+            <span class={`w-2 h-2 rounded-full flex-shrink-0 ${getStatusDotClass(workload.reconcilerStatus)}`} />
+            <span class="truncate min-w-0">{workload.reconcilerKind}/{workload.reconcilerNamespace}/{workload.reconcilerName}</span>
           </span>
+          <span class="hidden sm:block shrink-0 text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap tabular-nums">{formatTimestamp(workload.lastReconciled)}</span>
+          <button onClick={d.toggle} class="shrink-0 rounded p-0.5 text-gray-400 hover:text-flux-blue" title="Details" aria-label="Toggle details">{d.loading ? <Spinner /> : <Chevron open={d.open} />}</button>
         </div>
-        <span class="hidden sm:inline text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap ml-4">
-          {formatTimestamp(workload.lastReconciled)}
-        </span>
+        {/* Mobile-only second line: neutral kind pill + reconciled time. A workload
+            has no status of its own in the list, so we state the reconcile time
+            instead of a (reconciler) status word. */}
+        <div class="sm:hidden mt-1 pl-[30px] flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
+          <KindChip kind={workload.kind} colorClass={NEUTRAL_CHIP} title={`${workload.kind} · reconciler ${workload.reconcilerStatus}`} />
+          <span class="whitespace-nowrap">Reconciled {formatTimestamp(workload.lastReconciled)}</span>
+        </div>
       </div>
-
-      {/* Workload namespace/name - clickable link to dashboard */}
-      <div class="mb-1 sm:mb-2">
-        <a
-          href={getDashboardUrl(workload.kind, workload.namespace, workload.name)}
-          class="text-sm text-left hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-flux-blue rounded inline-block group"
-        >
-          <span class="text-gray-500 dark:text-gray-400">{workload.namespace}/</span><span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-flux-blue dark:group-hover:text-blue-400">{workload.name}</span><svg class="w-3.5 h-3.5 text-gray-400 group-hover:text-flux-blue dark:group-hover:text-blue-400 transition-colors ml-1 inline-block align-middle" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
-        </a>
-      </div>
-
-      {/* Mobile timestamp - below namespace/name */}
-      <div class="flex sm:hidden items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 mb-2">
-        <svg class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-        </svg>
-        {formatTimestamp(workload.lastReconciled)}
-      </div>
-
-      {/* Parent reconciler reference: a muted "Managed by" line with a small status
-          dot. The status belongs to the reconciler, never the workload itself. */}
-      <div
-        class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400"
-        title={`Managed by ${workload.reconcilerKind} ${workload.reconcilerNamespace}/${workload.reconcilerName} (${workload.reconcilerStatus})`}
-      >
-        <span class="flex-shrink-0">Managed by</span>
-        <span class={`w-2 h-2 rounded-full flex-shrink-0 ${getStatusDotClass(workload.reconcilerStatus)}`} />
-        <span class="truncate min-w-0">{workload.reconcilerKind}/{workload.reconcilerNamespace}/{workload.reconcilerName}</span>
-      </div>
-
-      {/* Details Panel - Overview/Spec/Status (lazy loaded on expand) */}
-      <div class="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
-        <button
-          onClick={() => setIsDetailsExpanded(!isDetailsExpanded)}
-          class="flex items-center space-x-2 text-sm text-gray-700 dark:text-gray-300 hover:text-flux-blue dark:hover:text-blue-400 focus:outline-none transition-colors"
-        >
-          <svg
-            class={`w-4 h-4 transition-transform ${isDetailsExpanded ? 'rotate-90' : ''}`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
-          </svg>
-          <span class="font-medium">Details</span>
-        </button>
-      </div>
-
-      <WorkloadDetailsView
-        kind={workload.kind}
-        name={workload.name}
-        namespace={workload.namespace}
-        isExpanded={isDetailsExpanded}
-      />
+      <Reveal open={d.open}>
+        <div class="pl-3 sm:pl-[42px] pr-3 pt-1 pb-4">
+          {/* Lazily mounted on first expand; stays mounted afterwards so re-opening
+              is instant. onReady flips the disclosure once the fetch settles. */}
+          {d.mounted && (
+            <WorkloadDetailsView
+              kind={workload.kind}
+              name={workload.name}
+              namespace={workload.namespace}
+              reconcilerKind={workload.reconcilerKind}
+              reconcilerNamespace={workload.reconcilerNamespace}
+              reconcilerName={workload.reconcilerName}
+              isExpanded
+              onReady={d.onReady}
+            />
+          )}
+        </div>
+      </Reveal>
     </div>
   )
 }
@@ -168,7 +141,7 @@ function WorkloadCard({ workload }) {
  * Features:
  * - Fetches workloads from the API with optional filters (kind, name, namespace)
  * - Auto-refetches when filter signals change
- * - Displays workloads in card format with the parent reconciler status badge
+ * - Renders workloads as compact rows that expand into an inline detail panel
  * - Shows loading, error, and empty states
  * - No status filter and no status chart (workloads have no status of their own)
  */
@@ -211,21 +184,10 @@ export function WorkloadList() {
   }
 
   return (
-    <main data-testid="workload-list" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-grow w-full">
-      <div class="space-y-6">
-        {/* Page Title */}
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Flux Workloads</h2>
-          {/* Workload count */}
-          {!workloadsLoading.value && workloadsData.value.length > 0 && (
-            <span class="text-sm text-gray-600 dark:text-gray-400">
-              {workloadsData.value.length} workloads
-            </span>
-          )}
-        </div>
-
-        {/* Filters */}
-        <div class="card p-4">
+    <main data-testid="workload-list" class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-8 flex-grow w-full">
+      <div class="space-y-3">
+        {/* Filters - mobile-collapsing toolbar; no status chart for workloads */}
+        <FilterBar count={workloadsData.value.length} label="workloads" loading={workloadsLoading.value}>
           <FilterForm
             kindSignal={selectedWorkloadKind}
             nameSignal={selectedWorkloadName}
@@ -233,8 +195,9 @@ export function WorkloadList() {
             namespaces={reportData.value?.spec?.namespaces || []}
             kinds={workloadKinds}
             onClear={handleClearFilters}
+            onRefresh={fetchWorkloadsStatus}
           />
-        </div>
+        </FilterBar>
 
         {/* Error State */}
         {workloadsError.value && (
@@ -266,11 +229,12 @@ export function WorkloadList() {
           </div>
         )}
 
-        {/* Workload Cards */}
+        {/* Workload Rows - dense list; rows provide their own padding, so drop the
+            card's heavy padding on mobile (keep a little on desktop). */}
         {!workloadsLoading.value && workloadsData.value.length > 0 && (
-          <div class="space-y-4">
+          <div class="card overflow-hidden p-0 sm:p-2">
             {visibleWorkloads.map((workload, index) => (
-              <WorkloadCard key={`${workload.namespace}-${workload.kind}-${workload.name}-${index}`} workload={workload} />
+              <WorkloadRow key={`${workload.namespace}-${workload.kind}-${workload.name}-${index}`} workload={workload} />
             ))}
 
             {/* Sentinel element for infinite scroll */}

--- a/web/src/components/search/WorkloadList.test.jsx
+++ b/web/src/components/search/WorkloadList.test.jsx
@@ -43,13 +43,19 @@ vi.mock('preact-iso', () => ({
 // onReady automatically; instead the mock exposes a button the test clicks to
 // simulate the detail fetch settling.
 vi.mock('./WorkloadDetailsView', () => ({
-  WorkloadDetailsView: ({ kind, name, namespace, isExpanded, onReady }) => (
+  WorkloadDetailsView: ({ kind, name, namespace, isExpanded, onReady, onData }) => (
     isExpanded ? (
       <div data-testid="workload-details-view">
         <span data-testid="workload-details-view-kind">{kind}</span>
         <span data-testid="workload-details-view-name">{name}</span>
         <span data-testid="workload-details-view-namespace">{namespace}</span>
         <button data-testid="settle-details" onClick={onReady}>settle</button>
+        {/* Simulates the detail fetch landing with a fresher parent reconciler
+            summary, used to test the row write-back. */}
+        <button
+          data-testid="emit-details-data"
+          onClick={() => onData && onData({ workloadInfo: { status: 'Current', reconciler: { status: { reconcilerRef: { status: 'Ready', lastReconciled: '2025-11-18T11:10:59Z' } } } } })}
+        >emit</button>
       </div>
     ) : null
   )
@@ -343,6 +349,57 @@ describe('WorkloadList', () => {
       expect(screen.getByTestId('workload-details-view-kind')).toHaveTextContent('Deployment')
       expect(screen.getByTestId('workload-details-view-name')).toHaveTextContent('podinfo')
       expect(screen.getByTestId('workload-details-view-namespace')).toHaveTextContent('apps')
+    })
+
+    it('refreshes the row reconciler summary from the detail data (stale Failed -> Ready)', async () => {
+      const stale = {
+        kind: 'Deployment', namespace: 'apps', name: 'podinfo',
+        reconcilerKind: 'Kustomization', reconcilerNamespace: 'flux-system', reconcilerName: 'apps',
+        reconcilerStatus: 'Failed', lastReconciled: '2025-11-01T00:00:00Z'
+      }
+      fetchWithMock.mockResolvedValue({ workloads: [stale] })
+
+      render(<WorkloadList />)
+
+      const toggle = await screen.findByLabelText('Toggle details')
+      // The "managed by" label first reflects the stale Failed reconciler status.
+      expect(screen.getByTitle(/\(Failed\)$/)).toBeInTheDocument()
+
+      fireEvent.click(toggle)
+      // The panel lands with a fresher parent reconciler summary -> the row updates.
+      fireEvent.click(screen.getByTestId('emit-details-data'))
+
+      await waitFor(() => {
+        expect(screen.getByTitle(/\(Ready\)$/)).toBeInTheDocument()
+      })
+      expect(screen.queryByTitle(/\(Failed\)$/)).not.toBeInTheDocument()
+    })
+
+    it('colors the kind chip by the workload status while expanded, neutral when collapsed', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: [mockWorkloads[0]] })
+      const { container } = render(<WorkloadList />)
+
+      const toggle = await screen.findByLabelText('Toggle details')
+      const chip = () => container.querySelector('span[class*="w-[74px]"]')
+
+      // Collapsed: the kind chip is neutral (gray).
+      expect(chip().className).toContain('bg-gray-100')
+
+      fireEvent.click(toggle)
+      fireEvent.click(screen.getByTestId('settle-details'))   // onReady -> open
+      fireEvent.click(screen.getByTestId('emit-details-data')) // onData -> workload status known
+
+      // Expanded: the chip takes the workload's own status color (Current -> green).
+      await waitFor(() => {
+        expect(chip().className).toContain('bg-green-100')
+      })
+      expect(chip().className).not.toContain('bg-gray-100')
+
+      // Collapse: the chip reverts to neutral.
+      fireEvent.click(toggle)
+      await waitFor(() => {
+        expect(chip().className).toContain('bg-gray-100')
+      })
     })
 
     it('should spin the toggle while the detail fetch is in flight', async () => {

--- a/web/src/components/search/WorkloadList.test.jsx
+++ b/web/src/components/search/WorkloadList.test.jsx
@@ -37,14 +37,19 @@ vi.mock('preact-iso', () => ({
   })
 }))
 
-// Mock WorkloadDetailsView component to simplify testing
+// Mock WorkloadDetailsView. The compact row mounts it lazily on expand and waits
+// for it to call `onReady` before it reveals the panel (and swaps the toggle
+// spinner back to a chevron). To keep the disclosure controllable we do NOT call
+// onReady automatically; instead the mock exposes a button the test clicks to
+// simulate the detail fetch settling.
 vi.mock('./WorkloadDetailsView', () => ({
-  WorkloadDetailsView: ({ kind, name, namespace, isExpanded }) => (
+  WorkloadDetailsView: ({ kind, name, namespace, isExpanded, onReady }) => (
     isExpanded ? (
       <div data-testid="workload-details-view">
         <span data-testid="workload-details-view-kind">{kind}</span>
         <span data-testid="workload-details-view-name">{name}</span>
         <span data-testid="workload-details-view-namespace">{namespace}</span>
+        <button data-testid="settle-details" onClick={onReady}>settle</button>
       </div>
     ) : null
   )
@@ -160,15 +165,16 @@ describe('WorkloadList', () => {
       })
     })
 
-    it('should display workload cards when data loads', async () => {
+    it('should display workload rows when data loads', async () => {
       fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
 
       render(<WorkloadList />)
 
+      // The name renders twice per row (a mobile link and a desktop link).
       await waitFor(() => {
-        expect(screen.getByText('podinfo')).toBeInTheDocument()
+        expect(screen.getAllByText('podinfo').length).toBeGreaterThan(0)
       })
-      expect(screen.getByText('node-exporter')).toBeInTheDocument()
+      expect(screen.getAllByText('node-exporter').length).toBeGreaterThan(0)
     })
 
     it('should show empty state when no workloads match filters', async () => {
@@ -196,37 +202,78 @@ describe('WorkloadList', () => {
 
       render(<WorkloadList />)
 
+      // The count renders both in the desktop page title and the FilterBar toolbar.
       await waitFor(() => {
-        expect(screen.getByText('2 workloads')).toBeInTheDocument()
+        expect(screen.getAllByText('2 workloads').length).toBeGreaterThan(0)
       })
     })
   })
 
-  describe('Reconciler status', () => {
-    it('should render the parent reconciler ref as a "Managed by" line with a status dot', async () => {
+  describe('Compact row', () => {
+    it('should render a neutral kind pill regardless of the reconciler status', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      render(<WorkloadList />)
+
+      // Chips show the kubectl-style short name: Deployment -> deploy, DaemonSet -> ds.
+      await waitFor(() => {
+        expect(screen.getAllByText('deploy').length).toBeGreaterThan(0)
+      })
+
+      // Both the Ready (podinfo/deploy) and Failed (node-exporter/ds) rows carry a
+      // neutral gray chip: a workload has no status of its own in the list, so the
+      // chip is never tinted by the reconciler's status.
+      const chips = [...screen.getAllByText('deploy'), ...screen.getAllByText('ds')]
+      expect(chips.length).toBe(4) // two chips (mobile + desktop) per row
+      chips.forEach((chip) => {
+        expect(chip.className).toContain('bg-gray-100')
+        expect(chip.className).not.toMatch(/bg-(red|green|blue|yellow)-/)
+      })
+    })
+
+    it('should show a "Reconciled <time>" mobile line with no status word', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      render(<WorkloadList />)
+
+      // The mobile second line states the reconcile time instead of a status word,
+      // because the workload itself has no status in the list index.
+      await waitFor(() => {
+        expect(screen.getAllByText(/^Reconciled\b/).length).toBe(2)
+      })
+
+      // No bare status word is rendered for the workload (status lives only in the
+      // reconciler dot/tooltip, not as visible text).
+      expect(screen.queryByText('Ready')).not.toBeInTheDocument()
+      expect(screen.queryByText('Failed')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Reconciler reference', () => {
+    it('should render the parent reconciler as a "managed by" line with a status dot', async () => {
       fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
 
       render(<WorkloadList />)
 
       await waitFor(() => {
-        expect(screen.getByText('podinfo')).toBeInTheDocument()
+        expect(screen.getAllByText('podinfo').length).toBeGreaterThan(0)
       })
 
-      // Each card carries a muted "Managed by" label.
-      expect(screen.getAllByText('Managed by')).toHaveLength(2)
+      // Each row carries a muted desktop "managed by" label.
+      expect(screen.getAllByText('managed by')).toHaveLength(2)
 
       // Reconciler ref is shown as a single kind/namespace/name path.
       expect(screen.getByText('Kustomization/flux-system/apps')).toBeInTheDocument()
       expect(screen.getByText('HelmRelease/monitoring/metrics')).toBeInTheDocument()
 
       // Reconciler status is conveyed via a colored dot + tooltip, never a message.
-      const readyLine = screen.getByText('Kustomization/flux-system/apps').closest('div')
-      expect(readyLine.querySelector('span.bg-green-500')).toBeInTheDocument()
-      expect(readyLine.getAttribute('title')).toContain('(Ready)')
+      const readyRef = screen.getByText('Kustomization/flux-system/apps').closest('span[title]')
+      expect(readyRef.querySelector('span.bg-green-500')).toBeInTheDocument()
+      expect(readyRef.getAttribute('title')).toContain('(Ready)')
 
-      const failedLine = screen.getByText('HelmRelease/monitoring/metrics').closest('div')
-      expect(failedLine.querySelector('span.bg-red-500')).toBeInTheDocument()
-      expect(failedLine.getAttribute('title')).toContain('(Failed)')
+      const failedRef = screen.getByText('HelmRelease/monitoring/metrics').closest('span[title]')
+      expect(failedRef.querySelector('span.bg-red-500')).toBeInTheDocument()
+      expect(failedRef.getAttribute('title')).toContain('(Failed)')
     })
 
     it('should link the workload name to the workload dashboard', async () => {
@@ -235,11 +282,13 @@ describe('WorkloadList', () => {
       render(<WorkloadList />)
 
       await waitFor(() => {
-        expect(screen.getByText('podinfo')).toBeInTheDocument()
+        expect(screen.getAllByText('podinfo').length).toBeGreaterThan(0)
       })
 
-      const link = screen.getByText('podinfo').closest('a')
-      expect(link).toHaveAttribute('href', '/workload/Deployment/apps/podinfo')
+      // Both the mobile and desktop name links point at the dashboard.
+      screen.getAllByText('podinfo').forEach((nameSpan) => {
+        expect(nameSpan.closest('a')).toHaveAttribute('href', '/workload/Deployment/apps/podinfo')
+      })
     })
 
     it('should not render the workload reconciler message', async () => {
@@ -249,7 +298,7 @@ describe('WorkloadList', () => {
       render(<WorkloadList />)
 
       await waitFor(() => {
-        expect(screen.getByText('podinfo')).toBeInTheDocument()
+        expect(screen.getAllByText('podinfo').length).toBeGreaterThan(0)
       })
 
       expect(screen.queryByText('should not appear')).not.toBeInTheDocument()
@@ -263,7 +312,7 @@ describe('WorkloadList', () => {
       render(<WorkloadList />)
 
       await waitFor(() => {
-        expect(screen.getAllByText('Details')).toHaveLength(2)
+        expect(screen.getAllByLabelText('Toggle details')).toHaveLength(2)
       })
     })
 
@@ -273,19 +322,20 @@ describe('WorkloadList', () => {
       render(<WorkloadList />)
 
       await waitFor(() => {
-        expect(screen.getByText('podinfo')).toBeInTheDocument()
+        expect(screen.getAllByText('podinfo').length).toBeGreaterThan(0)
       })
 
+      // Lazily mounted: the panel is absent until the row is expanded.
       expect(screen.queryByTestId('workload-details-view')).not.toBeInTheDocument()
     })
 
-    it('should expand WorkloadDetailsView with the workload identity when toggled', async () => {
+    it('should mount WorkloadDetailsView with the workload identity when toggled', async () => {
       fetchWithMock.mockResolvedValue({ workloads: [mockWorkloads[0]] })
 
       render(<WorkloadList />)
 
-      const detailsToggle = await screen.findByText('Details')
-      fireEvent.click(detailsToggle)
+      const toggle = await screen.findByLabelText('Toggle details')
+      fireEvent.click(toggle)
 
       await waitFor(() => {
         expect(screen.getByTestId('workload-details-view')).toBeInTheDocument()
@@ -294,9 +344,66 @@ describe('WorkloadList', () => {
       expect(screen.getByTestId('workload-details-view-name')).toHaveTextContent('podinfo')
       expect(screen.getByTestId('workload-details-view-namespace')).toHaveTextContent('apps')
     })
+
+    it('should spin the toggle while the detail fetch is in flight', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: [mockWorkloads[0]] })
+
+      render(<WorkloadList />)
+
+      const toggle = await screen.findByLabelText('Toggle details')
+
+      // Collapsed: the toggle shows a static chevron, not a spinner.
+      expect(toggle.querySelector('svg.animate-spin')).not.toBeInTheDocument()
+
+      fireEvent.click(toggle)
+
+      // While the lazily mounted panel is fetching (onReady not yet called), the
+      // toggle shows a spinner and the panel is kept collapsed.
+      await waitFor(() => {
+        expect(toggle.querySelector('svg.animate-spin')).toBeInTheDocument()
+      })
+      const revealWrapper = screen.getByTestId('workload-details-view').closest('div.grid')
+      expect(revealWrapper.className).toContain('grid-rows-[0fr]')
+    })
+
+    it('should reveal the panel once the detail view reports ready', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: [mockWorkloads[0]] })
+
+      render(<WorkloadList />)
+
+      const toggle = await screen.findByLabelText('Toggle details')
+      fireEvent.click(toggle)
+
+      // Spinner first, while the fetch is pending.
+      await waitFor(() => {
+        expect(toggle.querySelector('svg.animate-spin')).toBeInTheDocument()
+      })
+
+      // Simulate the detail fetch settling: the mock calls onReady.
+      fireEvent.click(screen.getByTestId('settle-details'))
+
+      // The spinner is swapped back to a chevron and the Reveal opens.
+      await waitFor(() => {
+        expect(toggle.querySelector('svg.animate-spin')).not.toBeInTheDocument()
+      })
+      const revealWrapper = screen.getByTestId('workload-details-view').closest('div.grid')
+      expect(revealWrapper.className).toContain('grid-rows-[1fr]')
+    })
   })
 
-  describe('FilterForm wiring', () => {
+  describe('FilterBar wiring', () => {
+    it('should render the filter toolbar with the workload count', async () => {
+      fetchWithMock.mockResolvedValue({ workloads: mockWorkloads })
+
+      render(<WorkloadList />)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('filter-form')).toBeInTheDocument()
+      })
+      // FilterBar shows the count + label (mobile toolbar row).
+      expect(screen.getAllByText('2 workloads').length).toBeGreaterThan(0)
+    })
+
     it('should pass workload kinds and omit the status signal', async () => {
       fetchWithMock.mockResolvedValue({ workloads: [] })
 
@@ -312,7 +419,7 @@ describe('WorkloadList', () => {
       const { container } = render(<WorkloadList />)
 
       await waitFor(() => {
-        expect(screen.getByText('podinfo')).toBeInTheDocument()
+        expect(screen.getAllByText('podinfo').length).toBeGreaterThan(0)
       })
 
       // StatusChart renders a status timeline; none should be present

--- a/web/src/components/search/compactRow.jsx
+++ b/web/src/components/search/compactRow.jsx
@@ -1,0 +1,173 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+//
+// Shared row UI kit for the compact list view: the loading spinner, the
+// expand chevron, the favorite star, the colored kind chip, the namespace/name
+// link, the spinner-on-press disclosure hook, and the animated reveal.
+
+import { useState } from 'preact/hooks'
+import { getKindChipAlias } from '../../utils/constants'
+
+/**
+ * Chevron - expand caret that rotates 90° when its row is open.
+ *
+ * @param {Object} props
+ * @param {boolean} props.open - Whether the row is expanded
+ */
+export function Chevron({ open }) {
+  return (
+    <svg class={`w-3.5 h-3.5 transition-transform ${open ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+    </svg>
+  )
+}
+
+/**
+ * Spinner - circular loading spinner. Defaults to the chevron size (w-3.5 h-3.5)
+ * so swapping it for the row's expand caret causes no layout shift; pass `cls` to
+ * size it elsewhere (e.g. the toolbar/tab-nav count loaders use w-4 h-4).
+ *
+ * @param {Object} props
+ * @param {string} [props.cls] - Size classes for the SVG
+ */
+export function Spinner({ cls = 'w-3.5 h-3.5' }) {
+  return (
+    <svg class={`${cls} animate-spin`} viewBox="0 0 24 24" fill="none">
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+      <path class="opacity-90" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+    </svg>
+  )
+}
+
+// Inner two-tone "namespace/name" label shared by both NameLink variants: muted
+// namespace, emphasized name, both turning flux-blue on row hover (the row sets
+// the `group` class).
+function NameSpans({ namespace, name }) {
+  return (
+    <>
+      <span class="text-gray-500 dark:text-gray-400 group-hover:text-flux-blue dark:group-hover:text-blue-400">{namespace}/</span><span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-flux-blue dark:group-hover:text-blue-400">{name}</span>
+    </>
+  )
+}
+
+/**
+ * NameLink - the row's "namespace/name" dashboard link. Rendered twice so the
+ * label can be full-width on mobile (grows to fill the row) and fixed-width on
+ * desktop (capped so the message/timestamp columns get room); one of the pair is
+ * always hidden by the breakpoint.
+ *
+ * @param {Object} props
+ * @param {string} props.href - Dashboard URL
+ * @param {string} props.namespace - Resource namespace
+ * @param {string} props.name - Resource name
+ * @param {string} [props.cls] - Extra classes applied to both variants (e.g. a
+ *   focus ring)
+ */
+export function NameLink({ href, namespace, name, cls = '' }) {
+  return (
+    <>
+      {/* Mobile: full-width, grows to fill the row */}
+      <a href={href} class={`sm:hidden min-w-0 flex-1 truncate text-sm group ${cls}`}>
+        <NameSpans namespace={namespace} name={name} />
+      </a>
+      {/* Desktop: fixed-width, capped at 40% */}
+      <a href={href} class={`hidden sm:block sm:shrink-0 truncate text-sm sm:max-w-[40%] group ${cls}`}>
+        <NameSpans namespace={namespace} name={name} />
+      </a>
+    </>
+  )
+}
+
+/**
+ * Star - favorite toggle, yellow when active. The caller is responsible for
+ * stopping event propagation in `onClick` when the row itself is clickable.
+ *
+ * @param {Object} props
+ * @param {boolean} props.active - Whether the item is favorited
+ * @param {Function} props.onClick - Toggle handler
+ */
+export function Star({ active, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      class={`shrink-0 rounded p-0.5 transition-colors ${active ? 'text-yellow-500' : 'text-gray-300 hover:text-gray-400 dark:text-gray-600 dark:hover:text-gray-400'}`}
+      title={active ? 'Remove from favorites' : 'Add to favorites'}
+    >
+      <svg class="w-4 h-4" fill={active ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+      </svg>
+    </button>
+  )
+}
+
+// Shared chip geometry: fixed width so chips align into a column regardless of
+// the alias length.
+export const CHIP_BASE = 'shrink-0 w-[74px] text-center rounded px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide'
+
+// Neutral chip palette, used for workloads whose own status is unknown in the
+// list (the index only carries the reconciler's status, not the workload's).
+export const NEUTRAL_CHIP = 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+
+/**
+ * KindChip - kind pill colored by status. `cls` adds caller-controlled
+ * breakpoint visibility (e.g. the desktop top-row chip hides on mobile, where
+ * the chip is rendered again on the second row beside the status word and
+ * timestamp).
+ *
+ * @param {Object} props
+ * @param {string} props.kind - Kubernetes kind, shortened via {@link getKindChipAlias}
+ * @param {string} props.colorClass - Tailwind classes for the chip background/text
+ * @param {string} [props.title] - Tooltip; defaults to the full kind
+ * @param {string} [props.cls] - Extra classes (e.g. responsive visibility)
+ */
+export function KindChip({ kind, colorClass, title, cls = '' }) {
+  return <span title={title || kind} class={`${CHIP_BASE} ${colorClass} ${cls}`}>{getKindChipAlias(kind)}</span>
+}
+
+/**
+ * useDisclosure - disclosure state for a row whose panel fetches before it
+ * reveals: the expand button spins while the lazily mounted content loads, then
+ * the panel animates open. The content stays mounted after the first load so
+ * re-opening is instant. The fetching child must call the returned `onReady`
+ * when its data has loaded (success or error).
+ *
+ * @returns {{open: boolean, mounted: boolean, loading: boolean, toggle: Function, onReady: Function}}
+ */
+export function useDisclosure() {
+  const [open, setOpen] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+
+  const onReady = () => { setLoaded(true); setLoading(false); setOpen(true) }
+  const toggle = () => {
+    if (open) { setOpen(false); return }                          // collapse
+    if (loading) { setLoading(false); setMounted(false); return } // cancel in-flight fetch
+    if (loaded) { setOpen(true); return }                         // already fetched, reveal now
+    setMounted(true); setLoading(true)                            // mount + fetch, reveal on ready
+  }
+  return { open, mounted, loading, toggle, onReady }
+}
+
+/**
+ * Reveal - animated disclosure: collapses to zero height via an animatable grid
+ * row while fading and sliding the content in. Children stay in the DOM when
+ * collapsed so a lazily mounted detail panel can fetch before the panel opens.
+ * Honors prefers-reduced-motion.
+ *
+ * @param {Object} props
+ * @param {boolean} props.open - Whether the content is revealed
+ * @param {*} props.children - Content to reveal
+ */
+export function Reveal({ open, children }) {
+  return (
+    <div class={`grid transition-all duration-300 ease-out motion-reduce:transition-none ${open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'}`}>
+      {/* `inert` when collapsed: the content stays mounted (so a lazily mounted
+          detail panel can fetch before opening) but is removed from the tab order
+          and the a11y tree, so keyboard users can't focus the hidden tabs/links. */}
+      <div {...(open ? {} : { inert: true })} class={`overflow-hidden transition-transform duration-300 ease-out ${open ? 'translate-y-0' : '-translate-y-1'}`}>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/search/compactRow.jsx
+++ b/web/src/components/search/compactRow.jsx
@@ -154,6 +154,27 @@ export function useDisclosure() {
 }
 
 /**
+ * patchRowInSignal - refresh a single row inside a list signal in place. Finds the
+ * row matching `kind/namespace/name`, and if any field in `patch` differs, replaces
+ * just that row with a `{ ...row, ...patch }` copy (new array, same identity for the
+ * untouched rows). No-op when the row is gone or every patched field already matches,
+ * so an unchanged detail fetch triggers no re-render.
+ *
+ * Used by the list rows to write a row's summary back from its expanded detail
+ * panel (the detail's reconcilerRef is computed by the same server status the list
+ * uses), so a row that listed a stale status updates when expanded.
+ *
+ * @param {import('@preact/signals').Signal} sig - Signal holding the row array
+ * @param {{kind: string, namespace: string, name: string}} id - Row identity
+ * @param {Object} patch - Fields to overwrite on the matched row
+ */
+export function patchRowInSignal(sig, { kind, namespace, name }, patch) {
+  const cur = sig.value.find(r => r.kind === kind && r.namespace === namespace && r.name === name)
+  if (!cur || Object.keys(patch).every(k => cur[k] === patch[k])) return
+  sig.value = sig.value.map(r => r === cur ? { ...r, ...patch } : r)
+}
+
+/**
  * Reveal - animated disclosure: collapses to zero height via an animatable grid
  * row while fading and sliding the content in. Children stay in the DOM when
  * collapsed so a lazily mounted detail panel can fetch before the panel opens.

--- a/web/src/components/search/compactRow.jsx
+++ b/web/src/components/search/compactRow.jsx
@@ -127,9 +127,10 @@ export function KindChip({ kind, colorClass, title, cls = '' }) {
 /**
  * useDisclosure - disclosure state for a row whose panel fetches before it
  * reveals: the expand button spins while the lazily mounted content loads, then
- * the panel animates open. The content stays mounted after the first load so
- * re-opening is instant. The fetching child must call the returned `onReady`
- * when its data has loaded (success or error).
+ * the panel animates open. Collapsing unmounts the panel, so each expand
+ * re-mounts and re-fetches fresh data rather than replaying a cached snapshot.
+ * The fetching child must call the returned `onReady` when its data has loaded
+ * (success or error).
  *
  * @returns {{open: boolean, mounted: boolean, loading: boolean, toggle: Function, onReady: Function}}
  */
@@ -137,14 +138,17 @@ export function useDisclosure() {
   const [open, setOpen] = useState(false)
   const [mounted, setMounted] = useState(false)
   const [loading, setLoading] = useState(false)
-  const [loaded, setLoaded] = useState(false)
 
-  const onReady = () => { setLoaded(true); setLoading(false); setOpen(true) }
+  // Reveal the panel once its fetch settles (success or error).
+  const onReady = () => { setLoading(false); setOpen(true) }
+
+  // First click mounts the panel and starts its fetch (reveal happens via
+  // onReady). Any later click — while still loading, or while revealed —
+  // discards the panel, so the next expand re-mounts and re-fetches instead of
+  // showing stale data.
   const toggle = () => {
-    if (open) { setOpen(false); return }                          // collapse
-    if (loading) { setLoading(false); setMounted(false); return } // cancel in-flight fetch
-    if (loaded) { setOpen(true); return }                         // already fetched, reveal now
-    setMounted(true); setLoading(true)                            // mount + fetch, reveal on ready
+    if (mounted) { setOpen(false); setLoading(false); setMounted(false); return }
+    setMounted(true); setLoading(true)
   }
   return { open, mounted, loading, toggle, onReady }
 }

--- a/web/src/components/search/compactRow.test.jsx
+++ b/web/src/components/search/compactRow.test.jsx
@@ -108,24 +108,25 @@ describe('useDisclosure', () => {
     expect(result.current.mounted).toBe(true)
   })
 
-  it('collapses on toggle while keeping the content mounted', () => {
+  it('collapses and unmounts the content on toggle', () => {
     const { result } = renderHook(() => useDisclosure())
     act(() => result.current.toggle())
     act(() => result.current.onReady())
     act(() => result.current.toggle())
     expect(result.current.open).toBe(false)
-    expect(result.current.mounted).toBe(true)
+    expect(result.current.mounted).toBe(false)
     expect(result.current.loading).toBe(false)
   })
 
-  it('re-opens instantly without a second loading pass once loaded', () => {
+  it('re-mounts and re-fetches on each expand (no cached snapshot)', () => {
     const { result } = renderHook(() => useDisclosure())
-    act(() => result.current.toggle())
-    act(() => result.current.onReady())
-    act(() => result.current.toggle()) // collapse
-    act(() => result.current.toggle()) // re-open
-    expect(result.current.open).toBe(true)
-    expect(result.current.loading).toBe(false)
+    act(() => result.current.toggle())   // mount + load
+    act(() => result.current.onReady())  // reveal
+    act(() => result.current.toggle())   // collapse + unmount
+    act(() => result.current.toggle())   // re-expand
+    expect(result.current.mounted).toBe(true)
+    expect(result.current.loading).toBe(true)
+    expect(result.current.open).toBe(false)
   })
 
   it('cancels an in-flight fetch when toggled while still loading', () => {

--- a/web/src/components/search/compactRow.test.jsx
+++ b/web/src/components/search/compactRow.test.jsx
@@ -1,0 +1,139 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, renderHook, act } from '@testing-library/preact'
+import {
+  Spinner,
+  Star,
+  KindChip,
+  Reveal,
+  useDisclosure,
+  NEUTRAL_CHIP,
+} from './compactRow'
+
+describe('Spinner', () => {
+  it('renders an animated spinner svg', () => {
+    const { container } = render(<Spinner />)
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg).toHaveClass('animate-spin')
+  })
+})
+
+describe('Star', () => {
+  it('renders as inactive (neutral) when not active', () => {
+    render(<Star active={false} onClick={() => {}} />)
+    const button = screen.getByRole('button')
+    expect(button).toHaveAttribute('title', 'Add to favorites')
+    expect(button).not.toHaveClass('text-yellow-500')
+  })
+
+  it('renders the active (yellow) state when favorited', () => {
+    render(<Star active={true} onClick={() => {}} />)
+    const button = screen.getByRole('button')
+    expect(button).toHaveAttribute('title', 'Remove from favorites')
+    expect(button).toHaveClass('text-yellow-500')
+  })
+
+  it('calls onClick when pressed', () => {
+    const onClick = vi.fn()
+    render(<Star active={false} onClick={onClick} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('KindChip', () => {
+  it('renders the short kind as its label', () => {
+    render(<KindChip kind="Kustomization" colorClass={NEUTRAL_CHIP} />)
+    expect(screen.getByText('ks')).toBeInTheDocument()
+  })
+
+  it('defaults the tooltip to the full kind', () => {
+    render(<KindChip kind="Deployment" colorClass={NEUTRAL_CHIP} />)
+    const chip = screen.getByText('deploy')
+    expect(chip).toHaveAttribute('title', 'Deployment')
+  })
+
+  it('applies the color class and extra responsive classes', () => {
+    render(<KindChip kind="Deployment" colorClass={NEUTRAL_CHIP} cls="hidden sm:block" title="custom" />)
+    const chip = screen.getByText('deploy')
+    expect(chip).toHaveClass('hidden')
+    expect(chip).toHaveAttribute('title', 'custom')
+  })
+})
+
+describe('Reveal', () => {
+  it('applies the open classes when revealed', () => {
+    const { container } = render(<Reveal open={true}><span>content</span></Reveal>)
+    const grid = container.firstChild
+    expect(grid).toHaveClass('grid-rows-[1fr]')
+    expect(grid).toHaveClass('opacity-100')
+    expect(screen.getByText('content')).toBeInTheDocument()
+  })
+
+  it('applies the collapsed classes but keeps children mounted', () => {
+    const { container } = render(<Reveal open={false}><span>content</span></Reveal>)
+    const grid = container.firstChild
+    expect(grid).toHaveClass('grid-rows-[0fr]')
+    expect(grid).toHaveClass('opacity-0')
+    // Children stay in the DOM so a lazily mounted panel can fetch while collapsed.
+    expect(screen.getByText('content')).toBeInTheDocument()
+  })
+})
+
+describe('useDisclosure', () => {
+  it('starts closed, unmounted and not loading', () => {
+    const { result } = renderHook(() => useDisclosure())
+    expect(result.current.open).toBe(false)
+    expect(result.current.mounted).toBe(false)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('mounts and enters the loading state on first toggle without opening yet', () => {
+    const { result } = renderHook(() => useDisclosure())
+    act(() => result.current.toggle())
+    expect(result.current.mounted).toBe(true)
+    expect(result.current.loading).toBe(true)
+    expect(result.current.open).toBe(false)
+  })
+
+  it('opens and clears loading when the panel signals onReady', () => {
+    const { result } = renderHook(() => useDisclosure())
+    act(() => result.current.toggle())
+    act(() => result.current.onReady())
+    expect(result.current.open).toBe(true)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.mounted).toBe(true)
+  })
+
+  it('collapses on toggle while keeping the content mounted', () => {
+    const { result } = renderHook(() => useDisclosure())
+    act(() => result.current.toggle())
+    act(() => result.current.onReady())
+    act(() => result.current.toggle())
+    expect(result.current.open).toBe(false)
+    expect(result.current.mounted).toBe(true)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('re-opens instantly without a second loading pass once loaded', () => {
+    const { result } = renderHook(() => useDisclosure())
+    act(() => result.current.toggle())
+    act(() => result.current.onReady())
+    act(() => result.current.toggle()) // collapse
+    act(() => result.current.toggle()) // re-open
+    expect(result.current.open).toBe(true)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('cancels an in-flight fetch when toggled while still loading', () => {
+    const { result } = renderHook(() => useDisclosure())
+    act(() => result.current.toggle()) // mount + loading
+    act(() => result.current.toggle()) // cancel before onReady
+    expect(result.current.loading).toBe(false)
+    expect(result.current.mounted).toBe(false)
+    expect(result.current.open).toBe(false)
+  })
+})

--- a/web/src/components/search/detailPanel.jsx
+++ b/web/src/components/search/detailPanel.jsx
@@ -1,0 +1,163 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+//
+// Shared tabbed detail layout for the compact list view, with two dedicated
+// responsive layouts:
+//
+//   - Mobile (default): a horizontal row of tabs above a full-width content box.
+//     The active tab is a filled pill that shares the content background. A
+//     vertical rail would waste the narrow viewport, so it is not used here.
+//   - Desktop (sm+): a vertical "folder tab" rail on the left and a content panel
+//     on the right. The active tab becomes a nub that merges into the panel.
+//
+// Desktop folder-tab technique: the content panel is the only bordered, rounded
+// box. The active nub carries a 3-sided border (top/left/bottom) with its left
+// corners rounded, and overlaps the panel's left border by exactly one pixel
+// (sm:-mr-px). The nub paints above the panel (sm:z-10) and shares its
+// background, so the nub's background covers that 1px of the panel's border along
+// the nub's height: the seam disappears and tab + panel become one shape. The nub
+// and panel borders are the same width and color, so the combined outline is
+// continuous with equal rounded-md corners.
+
+import { getDashboardUrl } from '../../utils/routing'
+import { getStatusBadgeClass } from '../../utils/status'
+
+// Rail width (desktop only) that lines the content panel up under the row's name
+// column: the rail starts under the kind chip (see the wrapper's left padding in
+// the list rows) and spans the chip→name gap.
+const RAIL = 'sm:w-[84px]'
+
+// Static class fragments for the tab buttons (kept as literals so Tailwind's JIT
+// can see every utility at build time). `select-none` stops the label text from
+// being highlighted on click. There is no color transition so switching tabs is
+// instant with no highlight fade.
+//
+// Base: a rounded pill on mobile; on desktop the pill rounding is dropped and a
+// constant 1px border (transparent until active) keeps the rail layout stable.
+const TAB_BASE =
+  'text-left whitespace-nowrap select-none px-2.5 py-1.5 text-xs font-medium focus:outline-none rounded-md sm:rounded-none sm:border sm:border-transparent'
+// Active marker: shares the panel background (`bg-gray-100`, asserted by tests).
+// Mobile = filled pill; desktop adds the folder-nub border + overlap.
+const TAB_ACTIVE =
+  'bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white sm:relative sm:z-10 sm:-mr-px sm:rounded-l-md sm:border-r-0 sm:border-gray-200 sm:dark:border-gray-700'
+const TAB_INACTIVE =
+  'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+
+/**
+ * TabbedPanel - the compact detail layout, with dedicated mobile and desktop
+ * views.
+ *
+ * On mobile the tabs are a horizontal row above a full-width content box (the
+ * active tab is a filled pill sharing the content background). On desktop the
+ * tabs become a vertical folder-tab rail on the left: inactive tabs are plain
+ * muted text and the active tab is a nub that flows into the content panel,
+ * sharing one background and one continuous border with no seam.
+ *
+ * The content panel is the bordered, rounded box. On desktop its top-left corner
+ * is squared only when the first tab is active, so the active nub provides that
+ * corner instead of the panel's rounding peeking out from behind the
+ * 1px-overlapping nub. On mobile every corner stays rounded.
+ *
+ * @param {Object} props
+ * @param {Array<{id: string, label: string}>} props.tabs - Tab definitions
+ * @param {string} props.active - The id of the active tab
+ * @param {Function} props.onSelect - Called with a tab id when a tab is clicked
+ * @param {*} props.children - The active tab's content
+ */
+export function TabbedPanel({ tabs, active, onSelect, children }) {
+  // Square off the panel's top-left corner (desktop only) when the first tab is
+  // active, so the nub's rounded top-left becomes the shape's top-left corner.
+  const isFirstActive = tabs.length > 0 && tabs[0].id === active
+  const panelCorners = `rounded-md ${isFirstActive ? 'sm:rounded-tl-none' : ''}`
+
+  return (
+    <div class="flex flex-col sm:flex-row">
+      {/* Tab strip: a horizontal scrollable row on mobile, a vertical rail on
+          desktop. Inactive tabs are plain text; the active tab shares the panel
+          background and (on desktop) overhangs the panel's left border. */}
+      <nav class={`flex flex-row sm:flex-col shrink-0 gap-1 sm:gap-0 mb-2 sm:mb-0 overflow-x-auto sm:overflow-visible ${RAIL}`}>
+        {tabs.map(t => (
+          <button
+            key={t.id}
+            onClick={() => onSelect(t.id)}
+            class={`${TAB_BASE} ${t.id === active ? TAB_ACTIVE : TAB_INACTIVE}`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+
+      {/* Content panel: the bordered, rounded box. On desktop the active nub
+          overlaps its left border by 1px (hidden by the nub's matching
+          background), so the two merge into one silhouette. The top padding
+          matches the tab's (py-1.5) so the first desktop content line lines up
+          with the first tab label. Tall content (huge YAML, long inventory) is
+          capped at 60vh and scrolls inside the panel so one expanded row never
+          takes over the page. */}
+      <div
+        class={`flex-1 min-w-0 max-h-[60vh] overflow-y-auto border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-900 px-3 pt-1.5 pb-3 ${panelCorners}`}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Field - an inline label + value, stacked with even vertical rhythm (mirrors
+ * the Resource dashboard Reconciler panel). Skipped when the value is empty.
+ *
+ * @param {Object} props
+ * @param {string} props.label - Field label
+ * @param {*} props.children - Field value
+ */
+export function Field({ label, children }) {
+  if (children === null || children === undefined || children === '') return null
+  return (
+    <div>
+      <span class="text-gray-500 dark:text-gray-400">{label}</span>{' '}
+      <span class="text-gray-900 dark:text-gray-100 break-words">{children}</span>
+    </div>
+  )
+}
+
+/**
+ * ResourceLink - the shared style for an inline link to a resource: a plain
+ * flux-blue `namespace/name` link with no icon. Used by the resource and
+ * workload detail tabs so every resource link looks identical.
+ *
+ * @param {Object} props
+ * @param {string} props.kind - Resource kind (used to build the dashboard URL)
+ * @param {string} props.namespace - Resource namespace
+ * @param {string} props.name - Resource name
+ */
+export function ResourceLink({ kind, namespace, name }) {
+  return (
+    <a
+      href={getDashboardUrl(kind, namespace, name)}
+      class="text-flux-blue dark:text-blue-400 hover:underline break-all"
+    >
+      {namespace}/{name}
+    </a>
+  )
+}
+
+/**
+ * StatusBadge - a small rounded status pill, rendered identically wherever a
+ * resource or workload status appears in a detail tab. Renders nothing when the
+ * status is empty.
+ *
+ * @param {Object} props
+ * @param {string} props.status - Status text (e.g. "Ready", "Idle")
+ * @param {string} [props.colorClass] - Badge background/text classes; defaults to
+ *   the Flux resource palette via {@link getStatusBadgeClass} (workload tabs pass
+ *   the kstatus palette instead)
+ */
+export function StatusBadge({ status, colorClass }) {
+  if (!status) return null
+  return (
+    <span class={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium align-middle ${colorClass || getStatusBadgeClass(status)}`}>
+      {status}
+    </span>
+  )
+}

--- a/web/src/components/search/detailPanel.test.jsx
+++ b/web/src/components/search/detailPanel.test.jsx
@@ -1,0 +1,88 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
+import { useState } from 'preact/hooks'
+import { TabbedPanel, Field } from './detailPanel'
+
+const tabs = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'spec', label: 'Specification' },
+  { id: 'status', label: 'Status' },
+]
+
+describe('TabbedPanel', () => {
+  it('renders a button for every tab and the active content', () => {
+    render(
+      <TabbedPanel tabs={tabs} active="overview" onSelect={() => {}}>
+        <div>overview content</div>
+      </TabbedPanel>
+    )
+
+    tabs.forEach(t => {
+      expect(screen.getByRole('button', { name: t.label })).toBeInTheDocument()
+    })
+    expect(screen.getByText('overview content')).toBeInTheDocument()
+  })
+
+  it('calls onSelect with the tab id when a tab is clicked', () => {
+    const onSelect = vi.fn()
+    render(
+      <TabbedPanel tabs={tabs} active="overview" onSelect={onSelect}>
+        <div>content</div>
+      </TabbedPanel>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Specification' }))
+    expect(onSelect).toHaveBeenCalledWith('spec')
+  })
+
+  it('switches the active tab styling and content when a tab is selected', () => {
+    // A small controlled wrapper exercises the active/onSelect contract end to end.
+    function Harness() {
+      const [active, setActive] = useState('overview')
+      return (
+        <TabbedPanel tabs={tabs} active={active} onSelect={setActive}>
+          <div>{active} panel</div>
+        </TabbedPanel>
+      )
+    }
+
+    render(<Harness />)
+    expect(screen.getByText('overview panel')).toBeInTheDocument()
+
+    // The active tab merges into the panel by sharing its background.
+    expect(screen.getByRole('button', { name: 'Overview' })).toHaveClass('bg-gray-100')
+    expect(screen.getByRole('button', { name: 'Status' })).not.toHaveClass('bg-gray-100')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Status' }))
+
+    expect(screen.getByText('status panel')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Status' })).toHaveClass('bg-gray-100')
+    expect(screen.getByRole('button', { name: 'Overview' })).not.toHaveClass('bg-gray-100')
+  })
+})
+
+describe('Field', () => {
+  it('renders the label and value', () => {
+    render(<Field label="Namespace">flux-system</Field>)
+    expect(screen.getByText('Namespace')).toBeInTheDocument()
+    expect(screen.getByText('flux-system')).toBeInTheDocument()
+  })
+
+  it('renders nothing when the value is an empty string', () => {
+    const { container } = render(<Field label="Source">{''}</Field>)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when the value is null', () => {
+    const { container } = render(<Field label="Source">{null}</Field>)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when the value is undefined', () => {
+    const { container } = render(<Field label="Source">{undefined}</Field>)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/web/src/mock/events.js
+++ b/web/src/mock/events.js
@@ -21,8 +21,14 @@ const parseInvolvedObject = (involvedObject) => {
 }
 
 // Helper to match name with wildcard pattern
-// Supports * (matches any characters). If no wildcards, does exact match.
+// Supports * (matches any characters) and a leading ! that negates the match
+// (e.g. "!foo" excludes "foo"). If no wildcards, does exact match.
 const matchesWildcard = (name, pattern) => {
+  // A leading "!" negates the result of matching the rest of the pattern.
+  if (pattern.startsWith('!')) {
+    return !matchesWildcard(name, pattern.slice(1))
+  }
+
   name = name.toLowerCase()
   pattern = pattern.toLowerCase()
 

--- a/web/src/mock/resources.js
+++ b/web/src/mock/resources.js
@@ -7,8 +7,14 @@
 import { mockWorkloads } from './workloads'
 
 // Helper to match name with wildcard pattern
-// Supports * (matches any characters). If no wildcards, does exact match.
+// Supports * (matches any characters) and a leading ! that negates the match
+// (e.g. "!foo" excludes "foo"). If no wildcards, does exact match.
 const matchesWildcard = (name, pattern) => {
+  // A leading "!" negates the result of matching the rest of the pattern.
+  if (pattern.startsWith('!')) {
+    return !matchesWildcard(name, pattern.slice(1))
+  }
+
   name = name.toLowerCase()
   pattern = pattern.toLowerCase()
 
@@ -25,6 +31,21 @@ const matchesWildcard = (name, pattern) => {
 
   const regex = new RegExp(`^${regexPattern}$`, 'i')
   return regex.test(name)
+}
+
+// Wrap a plain search term as a substring pattern ("foo" -> "*foo*"), preserving
+// a leading ! negation ("!foo" -> "!*foo*"). Terms that already contain a *
+// wildcard are returned unchanged. Mirrors the backend's wrapPartialMatch.
+const wrapPartialMatch = (pattern) => {
+  let neg = ''
+  if (pattern.startsWith('!')) {
+    neg = '!'
+    pattern = pattern.slice(1)
+  }
+  if (pattern === '' || pattern.includes('*')) {
+    return neg + pattern
+  }
+  return `${neg}*${pattern}*`
 }
 
 // Generate timestamps relative to now (same pattern as events.js)
@@ -457,9 +478,11 @@ export const getMockSearchResults = (endpoint) => {
   // Applier kinds that the search endpoint returns (matches search.go)
   const defaultSearchKinds = ['FluxInstance', 'ResourceSet', 'Kustomization', 'HelmRelease']
 
-  const searchTerm = nameFilter.toLowerCase()
+  // Wrap the term for a substring match, supporting * wildcards and ! negation
+  // (** matches all). Mirrors the backend search handler's wrapPartialMatch.
+  const namePattern = wrapPartialMatch(nameFilter)
 
-  // Filter resources: match name (contains) and limit to applier kinds (or specific kind)
+  // Filter resources: match name and limit to applier kinds (or specific kind)
   const filteredResources = mockResources.resources.filter(resource => {
     // If kind filter specified, use it; otherwise limit to default search kinds
     if (kindFilter) {
@@ -475,8 +498,8 @@ export const getMockSearchResults = (endpoint) => {
       return false
     }
 
-    // Filter by name with case-insensitive contains (** matches all)
-    if (searchTerm !== '**' && !resource.name.toLowerCase().includes(searchTerm)) {
+    // Filter by name (substring + * wildcard + ! negation)
+    if (!matchesWildcard(resource.name, namePattern)) {
       return false
     }
 

--- a/web/src/mock/resources.test.js
+++ b/web/src/mock/resources.test.js
@@ -123,6 +123,21 @@ describe('getMockResources', () => {
     expect(result.resources.every(r => r.name.toLowerCase().startsWith('flux'))).toBe(true)
     expect(result.resources.length).toBeGreaterThan(0)
   })
+
+  it('should exclude resources whose name matches a negated wildcard', () => {
+    const matching = getMockResources('/api/v1/resources?name=*configs')
+    const excluded = getMockResources('/api/v1/resources?name=!*configs')
+    expect(matching.resources.length).toBeGreaterThan(0)
+    expect(excluded.resources.length).toBeGreaterThan(0)
+    // Nothing ending in "configs" survives the negation.
+    expect(excluded.resources.every(r => !r.name.toLowerCase().endsWith('configs'))).toBe(true)
+  })
+
+  it('should exclude an exact name with negation', () => {
+    const excluded = getMockResources('/api/v1/resources?name=!flux-system')
+    expect(excluded.resources.some(r => r.name === 'flux-system')).toBe(false)
+    expect(excluded.resources.length).toBeGreaterThan(0)
+  })
 })
 
 describe('getMockSearchResults', () => {
@@ -185,6 +200,15 @@ describe('getMockSearchResults', () => {
   it('should limit results to 40 (10 per kind)', () => {
     const result = getMockSearchResults('/api/v1/search?name=**')
     expect(result.resources.length).toBeLessThanOrEqual(40)
+  })
+
+  it('should exclude matches in quick-search with negation', () => {
+    const matching = getMockSearchResults('/api/v1/search?name=flux')
+    const excluded = getMockSearchResults('/api/v1/search?name=!flux')
+    expect(matching.resources.length).toBeGreaterThan(0)
+    expect(excluded.resources.length).toBeGreaterThan(0)
+    // Nothing containing "flux" survives the negation.
+    expect(excluded.resources.every(r => !r.name.toLowerCase().includes('flux'))).toBe(true)
   })
 
   it('should return empty array when no resources match search term', () => {

--- a/web/src/mock/workloads.js
+++ b/web/src/mock/workloads.js
@@ -10,8 +10,14 @@
 // reconciler message. Workloads have no status of their own in the index.
 
 // Helper to match name with wildcard pattern.
-// Supports * (matches any characters). If no wildcards, does exact match.
+// Supports * (matches any characters) and a leading ! that negates the match
+// (e.g. "!foo" excludes "foo"). If no wildcards, does exact match.
 const matchesWildcard = (name, pattern) => {
+  // A leading "!" negates the result of matching the rest of the pattern.
+  if (pattern.startsWith('!')) {
+    return !matchesWildcard(name, pattern.slice(1))
+  }
+
   name = name.toLowerCase()
   pattern = pattern.toLowerCase()
 
@@ -27,6 +33,20 @@ const matchesWildcard = (name, pattern) => {
 
   const regex = new RegExp(`^${regexPattern}$`, 'i')
   return regex.test(name)
+}
+
+// Wrap a plain search term as a substring pattern ("foo" -> "*foo*"), preserving
+// a leading ! negation ("!foo" -> "!*foo*"). Mirrors the backend's wrapPartialMatch.
+const wrapPartialMatch = (pattern) => {
+  let neg = ''
+  if (pattern.startsWith('!')) {
+    neg = '!'
+    pattern = pattern.slice(1)
+  }
+  if (pattern === '' || pattern.includes('*')) {
+    return neg + pattern
+  }
+  return `${neg}*${pattern}*`
 }
 
 // Generate timestamps relative to now (same pattern as resources.js)
@@ -122,9 +142,9 @@ const filterWorkloads = (params, { wildcard }) => {
     }
     if (nameFilter) {
       if (wildcard) {
-        // Quick-search wraps the term, matching by contains (** matches all)
-        const term = nameFilter.toLowerCase()
-        if (term !== '**' && !workload.name.toLowerCase().includes(term)) {
+        // Quick-search wraps a plain term to a substring pattern, supporting *
+        // wildcards and ! negation (** matches all).
+        if (!matchesWildcard(workload.name, wrapPartialMatch(nameFilter))) {
           return false
         }
       } else if (!matchesWildcard(workload.name, nameFilter)) {

--- a/web/src/utils/constants.js
+++ b/web/src/utils/constants.js
@@ -16,7 +16,7 @@ export const fluxCRDs = [
   {
     kind: 'FluxInstance',
     apiVersion: 'fluxcd.controlplane.io/v1',
-    alias: 'fluxinstance',
+    alias: 'instance',
     group: 'Appliers',
     docUrl: 'https://fluxoperator.dev/docs/crd/fluxinstance/',
   },
@@ -242,4 +242,19 @@ export function isKindWithInventory(kind) {
 export function getKindAlias(kind) {
   const crd = fluxCRDs.find(c => c.kind === kind)
   return crd?.alias || kind.toLowerCase()
+}
+
+// kubectl-style short names for Kubernetes workload kinds (Flux kinds carry their
+// own alias in fluxCRDs).
+const workloadKindAliases = { Deployment: 'deploy', StatefulSet: 'sts', DaemonSet: 'ds', CronJob: 'cj' }
+
+/**
+ * Get the short display name for a kind chip: the Flux CRD alias (rset, ks, hr,
+ * instance…), then the workload short name (deploy, sts…), falling back to the
+ * full kind when neither applies.
+ * @param {string} kind - The resource or workload kind
+ * @returns {string} - The chip alias or the original kind
+ */
+export function getKindChipAlias(kind) {
+  return fluxCRDs.find(c => c.kind === kind)?.alias || workloadKindAliases[kind] || kind
 }

--- a/web/src/utils/constants.test.js
+++ b/web/src/utils/constants.test.js
@@ -1,0 +1,38 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect } from 'vitest'
+import { getKindAlias, getKindChipAlias } from './constants'
+
+describe('getKindAlias', () => {
+  it('returns the Flux CRD alias for known kinds', () => {
+    expect(getKindAlias('FluxInstance')).toBe('instance')
+    expect(getKindAlias('GitRepository')).toBe('gitrepo')
+  })
+
+  it('falls back to the lowercased kind when no alias is known', () => {
+    expect(getKindAlias('Deployment')).toBe('deployment')
+    expect(getKindAlias('Pod')).toBe('pod')
+  })
+})
+
+describe('getKindChipAlias', () => {
+  it('uses the Flux CRD alias for known kinds', () => {
+    expect(getKindChipAlias('FluxInstance')).toBe('instance')
+    expect(getKindChipAlias('ResourceSet')).toBe('rset')
+    expect(getKindChipAlias('Kustomization')).toBe('ks')
+    expect(getKindChipAlias('HelmRelease')).toBe('hr')
+  })
+
+  it('uses the kubectl-style short name for workload kinds', () => {
+    expect(getKindChipAlias('Deployment')).toBe('deploy')
+    expect(getKindChipAlias('StatefulSet')).toBe('sts')
+    expect(getKindChipAlias('DaemonSet')).toBe('ds')
+    expect(getKindChipAlias('CronJob')).toBe('cj')
+  })
+
+  it('falls back to the full kind when no alias is known', () => {
+    expect(getKindChipAlias('Pod')).toBe('Pod')
+    expect(getKindChipAlias('Unknown')).toBe('Unknown')
+  })
+})

--- a/web/src/utils/reconciler.js
+++ b/web/src/utils/reconciler.js
@@ -7,6 +7,26 @@
 // panel, so the two never drift.
 
 /**
+ * getReconcilerSummary - the reconciler status/message/lastReconciled triple for a
+ * resource, preferring the server-computed status.reconcilerRef and falling back to
+ * the first status condition. Shared by the resource dashboard Reconciler panel and
+ * the compact resource detail panel so the two never drift.
+ *
+ * @param {Object} resourceData - The full resource object (status.reconcilerRef, status.conditions)
+ * @returns {{ref: Object|undefined, status: string, message: string, lastReconciled: string|undefined}}
+ */
+export function getReconcilerSummary(resourceData) {
+  const ref = resourceData?.status?.reconcilerRef
+  const firstCondition = resourceData?.status?.conditions?.[0]
+  return {
+    ref,
+    status: ref?.status || 'Unknown',
+    message: ref?.message || firstCondition?.message || '',
+    lastReconciled: ref?.lastReconciled || firstCondition?.lastTransitionTime
+  }
+}
+
+/**
  * getReconcileInterval - the effective reconcile interval for a resource:
  * spec.interval, else the reconcileEvery annotation, else the per-kind default
  * (60m for FluxInstance/ResourceSet, 10m for ResourceSetInputProvider), else null.

--- a/web/src/utils/reconciler.js
+++ b/web/src/utils/reconciler.js
@@ -1,0 +1,57 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+//
+// Shared derivation of a Flux resource's effective reconcile interval and
+// timeout, applying the same spec → annotation → per-kind default policy used by
+// both the resource dashboard Reconciler panel and the compact resource detail
+// panel, so the two never drift.
+
+/**
+ * getReconcileInterval - the effective reconcile interval for a resource:
+ * spec.interval, else the reconcileEvery annotation, else the per-kind default
+ * (60m for FluxInstance/ResourceSet, 10m for ResourceSetInputProvider), else null.
+ *
+ * @param {Object} resourceData - The full resource object (apiVersion, kind, spec, metadata)
+ * @returns {string|null}
+ */
+export function getReconcileInterval(resourceData) {
+  if (!resourceData) return null
+
+  if (resourceData.spec?.interval) return resourceData.spec.interval
+
+  const annotation = resourceData.metadata?.annotations?.['fluxcd.controlplane.io/reconcileEvery']
+  if (annotation) return annotation
+
+  const k = resourceData.kind
+  if (k === 'FluxInstance' || k === 'ResourceSet') return '60m'
+  if (k === 'ResourceSetInputProvider') return '10m'
+
+  return null
+}
+
+/**
+ * getReconcileTimeout - the effective reconcile timeout for a resource:
+ * spec.timeout, else a per-kind default (1m for source.toolkit kinds, the
+ * interval for Kustomization, 5m for HelmRelease, the reconcileTimeout annotation
+ * or 5m for FluxInstance/ResourceSet/ResourceSetInputProvider), else null.
+ *
+ * @param {Object} resourceData - The full resource object
+ * @returns {string|null}
+ */
+export function getReconcileTimeout(resourceData) {
+  if (!resourceData) return null
+
+  const k = resourceData.kind
+  const spec = resourceData.spec || {}
+  const annotations = resourceData.metadata?.annotations || {}
+
+  if (spec.timeout) return spec.timeout
+  if (resourceData.apiVersion && resourceData.apiVersion.startsWith('source.toolkit.fluxcd.io')) return '1m'
+  if (k === 'Kustomization') return spec.interval || null
+  if (k === 'HelmRelease') return '5m'
+  if (k === 'FluxInstance' || k === 'ResourceSet' || k === 'ResourceSetInputProvider') {
+    return annotations['fluxcd.controlplane.io/reconcileTimeout'] || '5m'
+  }
+
+  return null
+}

--- a/web/src/utils/scroll.js
+++ b/web/src/utils/scroll.js
@@ -1,7 +1,7 @@
 // Copyright 2025 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { useState, useEffect, useRef } from 'preact/hooks'
+import { useState, useEffect, useCallback } from 'preact/hooks'
 
 /**
  * useInfiniteScroll - Hook for implementing infinite scroll functionality
@@ -40,8 +40,15 @@ export function useInfiniteScroll({
   deps = []
 }) {
   const [visibleCount, setVisibleCount] = useState(pageSize)
-  const sentinelRef = useRef(null)
-  const observerRef = useRef(null)
+  // The sentinel DOM node, tracked as state (via a callback ref) rather than a
+  // ref object: the lists unmount their sentinel while a refetch is in flight
+  // and remount a *new* node afterwards. A callback ref makes that swap a state
+  // change, so the observer effect below re-binds to the live node. With a plain
+  // ref object the effect would not re-run (its other deps are unchanged) and
+  // would keep observing the detached node — leaving the list stuck at page one
+  // after navigating away and back.
+  const [sentinelNode, setSentinelNode] = useState(null)
+  const sentinelRef = useCallback((node) => setSentinelNode(node), [])
 
   // Reset visible count when dependencies change (filters, data refetch, etc.)
   useEffect(() => {
@@ -58,29 +65,18 @@ export function useInfiniteScroll({
     }
   }
 
-  // Set up IntersectionObserver to detect when sentinel enters viewport
+  // Set up IntersectionObserver to detect when the sentinel enters the viewport.
+  // Re-binds whenever the sentinel node changes (remount after a refetch) or when
+  // more items load, so re-observing a still-visible sentinel keeps paging.
   useEffect(() => {
-    // Check if IntersectionObserver is supported
-    if (!window.IntersectionObserver) {
+    if (!window.IntersectionObserver || !hasMore || !sentinelNode) {
       return
     }
 
-    // Don't observe if no more items to load
-    if (!hasMore) {
-      return
-    }
-
-    // Clean up previous observer
-    if (observerRef.current) {
-      observerRef.current.disconnect()
-    }
-
-    // Create new observer
     // eslint-disable-next-line no-undef
-    observerRef.current = new IntersectionObserver(
+    const observer = new IntersectionObserver(
       (entries) => {
-        const entry = entries[0]
-        if (entry.isIntersecting) {
+        if (entries[0].isIntersecting) {
           loadMore()
         }
       },
@@ -90,18 +86,10 @@ export function useInfiniteScroll({
       }
     )
 
-    // Start observing the sentinel element
-    if (sentinelRef.current) {
-      observerRef.current.observe(sentinelRef.current)
-    }
+    observer.observe(sentinelNode)
 
-    // Cleanup on unmount
-    return () => {
-      if (observerRef.current) {
-        observerRef.current.disconnect()
-      }
-    }
-  }, [hasMore, visibleCount, totalItems])
+    return () => observer.disconnect()
+  }, [hasMore, visibleCount, totalItems, sentinelNode, threshold])
 
   return {
     visibleCount,

--- a/web/src/utils/scroll.test.js
+++ b/web/src/utils/scroll.test.js
@@ -130,7 +130,7 @@ describe('useInfiniteScroll', () => {
     expect(result.current.visibleCount).toBe(100)
   })
 
-  it('should provide sentinelRef for IntersectionObserver', () => {
+  it('should provide a sentinelRef callback for the IntersectionObserver', () => {
     const { result } = renderHook(() =>
       useInfiniteScroll({
         totalItems: 500,
@@ -138,8 +138,9 @@ describe('useInfiniteScroll', () => {
       })
     )
 
-    expect(result.current.sentinelRef).toBeDefined()
-    expect(result.current.sentinelRef.current).toBeNull() // Ref is initially null until attached
+    // sentinelRef is a callback ref (a function), so the observer re-binds when
+    // the sentinel node mounts/remounts rather than holding a stale node.
+    expect(typeof result.current.sentinelRef).toBe('function')
   })
 
   it('should load more items when sentinel intersects viewport', () => {
@@ -152,14 +153,13 @@ describe('useInfiniteScroll', () => {
 
     expect(result.current.visibleCount).toBe(100)
 
-    // Create a mock sentinel element
+    // Attach the sentinel via the callback ref; the effect then observes it.
     const mockSentinel = document.createElement('div')
-    result.current.sentinelRef.current = mockSentinel
-
-    // Manually call observe to simulate the effect
     act(() => {
-      observeMock(mockSentinel)
+      result.current.sentinelRef(mockSentinel)
     })
+
+    expect(observeMock).toHaveBeenCalledWith(mockSentinel)
 
     // Simulate intersection
     act(() => {
@@ -174,6 +174,48 @@ describe('useInfiniteScroll', () => {
     expect(result.current.visibleCount).toBe(200)
   })
 
+  it('re-binds the observer when the sentinel node is replaced after a refetch', () => {
+    // Regression: navigating away and back unmounts the list (and its sentinel)
+    // while a refetch is in flight, then remounts a NEW sentinel node. The
+    // observer must re-bind to the live node, otherwise paging is stuck at one
+    // page. An object ref would leave the observer watching the detached node.
+    const { result } = renderHook(() =>
+      useInfiniteScroll({
+        totalItems: 500,
+        pageSize: 100
+      })
+    )
+
+    const first = document.createElement('div')
+    act(() => {
+      result.current.sentinelRef(first)
+    })
+    expect(observeMock).toHaveBeenCalledWith(first)
+
+    // Sentinel unmounts (list hidden during refetch), then a new node remounts.
+    act(() => {
+      result.current.sentinelRef(null)
+    })
+    expect(disconnectMock).toHaveBeenCalled()
+
+    const second = document.createElement('div')
+    act(() => {
+      result.current.sentinelRef(second)
+    })
+    expect(observeMock).toHaveBeenCalledWith(second)
+
+    // Intersecting the fresh node still pages.
+    act(() => {
+      intersectionObserverCallback([
+        {
+          isIntersecting: true,
+          target: second
+        }
+      ])
+    })
+    expect(result.current.visibleCount).toBe(200)
+  })
+
   it('should not observe when there are no more items', () => {
     const { result } = renderHook(() =>
       useInfiniteScroll({
@@ -184,6 +226,13 @@ describe('useInfiniteScroll', () => {
 
     // Already showing all items
     expect(result.current.hasMore).toBe(false)
+
+    // Attach a sentinel: the effect must still skip observing because the
+    // !hasMore guard short-circuits before creating the observer.
+    const mockSentinel = document.createElement('div')
+    act(() => {
+      result.current.sentinelRef(mockSentinel)
+    })
     expect(observeMock).not.toHaveBeenCalled()
   })
 
@@ -195,19 +244,22 @@ describe('useInfiniteScroll', () => {
       })
     )
 
-    // Create a mock sentinel element
+    // Attach a sentinel via the callback ref so an observer is created.
     const mockSentinel = document.createElement('div')
-    result.current.sentinelRef.current = mockSentinel
+    act(() => {
+      result.current.sentinelRef(mockSentinel)
+    })
 
     expect(result.current.hasMore).toBe(true)
 
-    // Load remaining items
+    // Load remaining items; hasMore flips false and the observer is torn down.
     act(() => {
       result.current.loadMore()
     })
 
     expect(result.current.visibleCount).toBe(150)
     expect(result.current.hasMore).toBe(false)
+    expect(disconnectMock).toHaveBeenCalled()
   })
 
   it('should not create IntersectionObserver if not supported', () => {
@@ -266,12 +318,19 @@ describe('useInfiniteScroll', () => {
   })
 
   it('should cleanup observer on unmount', () => {
-    const { unmount } = renderHook(() =>
+    const { result, unmount } = renderHook(() =>
       useInfiniteScroll({
         totalItems: 500,
         pageSize: 100
       })
     )
+
+    // Attach a sentinel so an observer is actually created.
+    const mockSentinel = document.createElement('div')
+    act(() => {
+      result.current.sentinelRef(mockSentinel)
+    })
+    expect(observeMock).toHaveBeenCalled()
 
     unmount()
 


### PR DESCRIPTION
Redesign the search pages:

- compact filters and list rows
- sticky filters on infinite scroll
- add support for wildcard negation in search (e.g. `!flux*`)
- add overview panel to Resources and Workloads details

--- 

<img width="1021" height="653" alt="Screenshot 2026-06-29 at 02 12 51" src="https://github.com/user-attachments/assets/b398fb13-dbc4-4521-8728-2a72e6fd97e0" />

---

<img width="962" height="698" alt="Screenshot 2026-06-29 at 02 19 00" src="https://github.com/user-attachments/assets/75621869-9f20-48b6-b941-10248a844fcd" />

---

Fixes: #534
Closes: #930