### PR TITLE
operator: fix electing versions beyond supported

### DIFF
--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -278,9 +278,11 @@ echo $ENTERPRISE_TOKEN | flux-operator create secret registry flux-enterprise-au
 The `.spec.distribution.artifact` field is optional and specifies the OCI artifact URL
 containing the Flux distribution manifests. When specified, the operator will pull the
 artifact on a regular interval to determine the latest Flux version available
-including CVE patches and hotfixes. When not specified, the operator will use
-the artifact embedded into its container image. This is the recommended setting
-for air-gapped environments.
+including CVE patches and hotfixes. Version selection is constrained to Flux versions
+embedded in the running operator image, but the operator still builds the selected
+version from the artifact contents so image digest updates from the artifact are used.
+When not specified, the operator will use the artifact embedded into its container image.
+This is the recommended setting for air-gapped environments.
 
 Example using the official distribution artifact:
 

--- a/docs/web/web-least-privilege-rbac.md
+++ b/docs/web/web-least-privilege-rbac.md
@@ -32,6 +32,8 @@ administrators can enforce a much stricter least-privilege posture.
 3. **RBAC Minimization.** Each usage of elevated system privileges exists because it enables a
    specific, high-value feature that significantly decreases the permissions
    that users would otherwise require, improving support for the principle of least privilege.
+4. **Web UI scope.** Operator reconciliation paths outside the Web UI backend
+   are documented here only when they change Web UI RBAC requirements.
 
 ---
 

--- a/internal/builder/semver.go
+++ b/internal/builder/semver.go
@@ -71,13 +71,51 @@ func IsMinorUpgrade(fromVer, toVer string) (bool, error) {
 
 // MatchVersion returns the latest version dir path that matches the given semver range.
 func MatchVersion(dataDir, semverRange string) (string, error) {
+	matchingVersions, err := matchVersions(dataDir, semverRange, nil)
+	if err != nil {
+		return "", err
+	}
+
+	if len(matchingVersions) == 0 {
+		return "", fmt.Errorf("no match found for semver: %s", semverRange)
+	}
+
+	sort.Sort(sort.Reverse(semver.Collection(matchingVersions)))
+	return matchingVersions[0].Original(), nil
+}
+
+// MatchVersionWithEmbedded returns the latest version dir that matches the
+// given semver range and is also present in the embedded version directory
+// bundled with the running operator image.
+func MatchVersionWithEmbedded(dataDir, embeddedDataDir, semverRange string) (string, error) {
+	embeddedVersions, err := getVersionSet(embeddedDataDir)
+	if err != nil {
+		return "", err
+	}
+
+	matchingVersions, err := matchVersions(dataDir, semverRange, embeddedVersions)
+	if err != nil {
+		return "", err
+	}
+
+	if len(matchingVersions) == 0 {
+		return "", fmt.Errorf("no match found for semver: %s in %s matching embedded versions in %s",
+			semverRange, dataDir, embeddedDataDir)
+	}
+
+	sort.Sort(sort.Reverse(semver.Collection(matchingVersions)))
+	return matchingVersions[0].Original(), nil
+}
+
+// matchVersions returns all version directories matching the semver range and optional allowed version set.
+func matchVersions(dataDir, semverRange string, allowedVersions map[string]struct{}) ([]*semver.Version, error) {
 	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
-		return "", fmt.Errorf("%s directory not found", dataDir)
+		return nil, fmt.Errorf("%s directory not found", dataDir)
 	}
 
 	matches, err := filepath.Glob(dataDir + "/*")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var dirs []string
@@ -90,7 +128,7 @@ func MatchVersion(dataDir, semverRange string) (string, error) {
 
 	constraint, err := semver.NewConstraint(semverRange)
 	if err != nil {
-		return "", fmt.Errorf("semver '%s' parse error: %w", semverRange, err)
+		return nil, fmt.Errorf("semver '%s' parse error: %w", semverRange, err)
 	}
 
 	var matchingVersions []*semver.Version
@@ -101,16 +139,31 @@ func MatchVersion(dataDir, semverRange string) (string, error) {
 		}
 
 		if constraint.Check(v) {
+			if allowedVersions != nil {
+				if _, ok := allowedVersions[v.String()]; !ok {
+					continue
+				}
+			}
 			matchingVersions = append(matchingVersions, v)
 		}
 	}
 
-	if len(matchingVersions) == 0 {
-		return "", fmt.Errorf("no match found for semver: %s", semverRange)
+	return matchingVersions, nil
+}
+
+// getVersionSet returns the normalized semver versions present in a directory.
+func getVersionSet(dataDir string) (map[string]struct{}, error) {
+	versions, err := matchVersions(dataDir, "*", nil)
+	if err != nil {
+		return nil, err
 	}
 
-	sort.Sort(sort.Reverse(semver.Collection(matchingVersions)))
-	return matchingVersions[0].Original(), nil
+	result := make(map[string]struct{}, len(versions))
+	for _, v := range versions {
+		result[v.String()] = struct{}{}
+	}
+
+	return result, nil
 }
 
 // getSourceAPIVersion determines the API version of the source based on the provided Flux version.

--- a/internal/builder/semver_test.go
+++ b/internal/builder/semver_test.go
@@ -4,6 +4,7 @@
 package builder
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,6 +29,49 @@ func TestMatchVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			ver, err := MatchVersion(fluxDir, tt.exp)
+			if tt.expected != "" {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ver).To(Equal(tt.expected))
+			} else {
+				g.Expect(err).To(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestMatchVersionWithEmbedded(t *testing.T) {
+	g := NewWithT(t)
+	baseDir := t.TempDir()
+	candidateDir := filepath.Join(baseDir, "candidate")
+	embeddedDir := filepath.Join(baseDir, "embedded")
+
+	for _, dir := range []string{
+		filepath.Join(candidateDir, "v2.2.0"),
+		filepath.Join(candidateDir, "v2.2.1"),
+		filepath.Join(candidateDir, "v2.3.0"),
+		filepath.Join(candidateDir, "v2.4.0"),
+		filepath.Join(embeddedDir, "v2.2.1"),
+		filepath.Join(embeddedDir, "v2.3.0"),
+	} {
+		g.Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+	}
+
+	tests := []struct {
+		name     string
+		exp      string
+		expected string
+	}{
+		{name: "exact embedded", exp: "v2.3.0", expected: "v2.3.0"},
+		{name: "patch embedded", exp: "2.2.x", expected: "v2.2.1"},
+		{name: "minor ignores non-embedded newer candidate", exp: "2.x", expected: "v2.3.0"},
+		{name: "latest ignores non-embedded newer candidate", exp: "*", expected: "v2.3.0"},
+		{name: "exact not embedded", exp: "v2.4.0", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ver, err := MatchVersionWithEmbedded(candidateDir, embeddedDir, tt.exp)
 			if tt.expected != "" {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(ver).To(Equal(tt.expected))

--- a/internal/controller/fluxinstance_controller.go
+++ b/internal/controller/fluxinstance_controller.go
@@ -325,7 +325,10 @@ func (r *FluxInstanceReconciler) build(ctx context.Context,
 		}
 	}()
 
-	ver, err := builder.MatchVersion(fluxManifestsDir, obj.Spec.Distribution.Version)
+	// Resolve versions from the candidate manifests, constrained by the
+	// versions embedded in the running operator image.
+	embeddedFluxManifestsDir := filepath.Join(r.StoragePath, "flux")
+	ver, err := builder.MatchVersionWithEmbedded(fluxManifestsDir, embeddedFluxManifestsDir, obj.Spec.Distribution.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +339,7 @@ func (r *FluxInstanceReconciler) build(ctx context.Context,
 		}
 	}
 
-	latestVer, err := builder.MatchVersion(fluxManifestsDir, "2.x")
+	latestVer, err := builder.MatchVersionWithEmbedded(fluxManifestsDir, embeddedFluxManifestsDir, "2.x")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/fluxinstance_controller_test.go
+++ b/internal/controller/fluxinstance_controller_test.go
@@ -636,6 +636,58 @@ func TestFluxInstanceReconciler_BuildFail(t *testing.T) {
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 }
 
+func TestFluxInstanceReconciler_BuildUsesArtifactForEmbeddedVersion(t *testing.T) {
+	g := NewWithT(t)
+	const fakeDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	baseDir := t.TempDir()
+	artifactDir := filepath.Join(baseDir, "artifact")
+	storageDir := filepath.Join(baseDir, "storage")
+	copyDir(t, filepath.Join("..", "..", "config", "data", "flux", "v2.3.0"), filepath.Join(artifactDir, "flux", "v2.3.0"))
+	copyDir(t, filepath.Join("..", "..", "config", "data", "flux", "v2.9.0"), filepath.Join(artifactDir, "flux", "v2.9.0"))
+	copyDir(t, filepath.Join("..", "..", "config", "data", "flux", "v2.3.0"), filepath.Join(storageDir, "flux", "v2.3.0"))
+	writeSourceControllerImagePatch(t, filepath.Join(artifactDir, "flux-images", "v2.3.0", "upstream-alpine.yaml"), fakeDigest)
+
+	reconciler := getFluxInstanceReconciler(t)
+	reconciler.StoragePath = storageDir
+	spec := getDefaultFluxSpec(t)
+	spec.Distribution.Version = "2.x"
+	spec.Components = []fluxcdv1.Component{"source-controller"}
+	spec.Sync = nil
+	obj := &fluxcdv1.FluxInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flux",
+			Namespace: fluxcdv1.DefaultNamespace,
+		},
+		Spec: spec,
+	}
+
+	result, err := reconciler.build(context.Background(), obj, artifactDir)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Version).To(Equal("v2.3.0"))
+	var sourceControllerDigest string
+	for _, img := range result.ComponentImages {
+		if img.Name == "source-controller" {
+			sourceControllerDigest = img.Digest
+			break
+		}
+	}
+	g.Expect(sourceControllerDigest).To(Equal(fakeDigest))
+
+	var sourceControllerImage string
+	for _, obj := range result.Objects {
+		if obj.GetKind() != "Deployment" || obj.GetName() != "source-controller" {
+			continue
+		}
+		containers, ok, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(ok).To(BeTrue())
+		sourceControllerImage = containers[0].(map[string]any)["image"].(string)
+		break
+	}
+	g.Expect(sourceControllerImage).To(ContainSubstring("@" + fakeDigest))
+}
+
 func TestFluxInstanceReconciler_Downgrade(t *testing.T) {
 	g := NewWithT(t)
 	reconciler := getFluxInstanceReconciler(t)
@@ -1122,6 +1174,28 @@ $patch: delete
 
 	// Wait for CRDs to be fully deleted to prevent race conditions with subsequent tests.
 	waitForFluxCRDsDeletion(ctx, g)
+}
+
+func copyDir(t *testing.T, src, dst string) {
+	t.Helper()
+	if err := os.CopyFS(dst, os.DirFS(src)); err != nil {
+		t.Fatalf("failed to copy %s to %s: %v", src, dst, err)
+	}
+}
+
+func writeSourceControllerImagePatch(t *testing.T, filename, digest string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+		t.Fatalf("failed to create image patch dir: %v", err)
+	}
+	data := fmt.Sprintf(`images:
+  - name: ghcr.io/fluxcd/source-controller
+    newTag: v1.3.0
+    digest: %s
+`, digest)
+	if err := os.WriteFile(filename, []byte(data), 0644); err != nil {
+		t.Fatalf("failed to write image patch: %v", err)
+	}
 }
 
 func getDefaultFluxSpec(t *testing.T) fluxcdv1.FluxInstanceSpec {


### PR DESCRIPTION
xref: https://github.com/fluxcd/flux2/issues/5965 (Avoiding `Fixes` to keep the issue open until the fix is released)

The operator will no longer consider Flux versions that are not present in the operator's container image. This avoids trying to upgrade to a Flux version that requires changes in the operator source code i.e. that requires a new version of the operator.