### PR TITLE
mcp: introduce debug tool log

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -49,11 +49,12 @@ we adapt to new features and/or find better ways to facilitate what it does.`,
 }
 
 type rootFlags struct {
-	timeout     time.Duration
-	maskSecrets bool
-	readOnly    bool
-	transport   string
-	port        int
+	timeout         time.Duration
+	maskSecrets     bool
+	readOnly        bool
+	transport       string
+	port            int
+	toolCallLogFile string
 }
 
 var (
@@ -74,6 +75,8 @@ func init() {
 		"The transport protocol to use for the MCP server. Options: [stdio, http, sse].")
 	rootCmd.PersistentFlags().IntVar(&rootArgs.port, "port", 8080,
 		"The port to use for the MCP server. This is only used when the transport is not 'stdio'.")
+	rootCmd.PersistentFlags().StringVar(&rootArgs.toolCallLogFile, "tool-call-log-file", "",
+		"Path to a JSONL file for appending MCP tool call inputs and outputs.")
 	addKubeConfigFlags(rootCmd)
 	rootCmd.SetOut(os.Stdout)
 	rootCmd.AddCommand(serveCmd)
@@ -177,6 +180,9 @@ func serveCmdRun(cmd *cobra.Command, args []string) error {
 		HasTools:   true,
 		HasPrompts: true,
 	})
+	if rootArgs.toolCallLogFile != "" {
+		mcpServer.AddReceivingMiddleware(toolCallLogMiddleware(rootArgs.toolCallLogFile))
+	}
 
 	// Register tools and prompts
 	kubeClient := k8s.NewClientFactory(kubeconfigArgs)

--- a/cmd/mcp/tool_call_log.go
+++ b/cmd/mcp/tool_call_log.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// toolCallLogEntry is the JSON document appended for each MCP tool call.
+type toolCallLogEntry struct {
+	Timestamp string          `json:"timestamp"`
+	SessionID string          `json:"sessionID,omitempty"`
+	Tool      string          `json:"tool"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	Output    mcp.Result      `json:"output,omitempty"`
+	Error     string          `json:"error,omitempty"`
+}
+
+// toolCallLogMiddleware returns middleware that logs MCP tool calls after
+// the tool handler returns.
+func toolCallLogMiddleware(path string) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			result, err := next(ctx, method, req)
+
+			callReq, ok := req.(*mcp.CallToolRequest)
+			if !ok || method != "tools/call" {
+				return result, err
+			}
+
+			entry := toolCallLogEntry{
+				Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+				Tool:      callReq.Params.Name,
+				Input:     callReq.Params.Arguments,
+				Output:    result,
+			}
+			if session := req.GetSession(); session != nil {
+				entry.SessionID = session.ID()
+			}
+			if err != nil {
+				entry.Error = err.Error()
+			}
+			if logErr := appendToolCallLog(path, entry); logErr != nil {
+				fmt.Fprintf(os.Stderr, "failed to append MCP tool call log: %v\n", logErr)
+			}
+
+			return result, err
+		}
+	}
+}
+
+// appendToolCallLog appends one JSON document to path using a fresh file
+// descriptor for each call.
+func appendToolCallLog(path string, entry toolCallLogEntry) error {
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshal log entry: %w", err)
+	}
+	data = append(data, '\n')
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("open log file: %w", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write log file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close log file: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
`--tool-call-log-file` will log all tool calls to a JSONL file for debugging.