### PR TITLE
Add flag to scope RS/RSIP to given namespaces

### DIFF
--- a/cmd/operator/cache.go
+++ b/cmd/operator/cache.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// resolveWatchNamespaces converts the raw --watch-namespaces flag values into a
+// sorted, de-duplicated namespace set used to scope ResourceSet /
+// ResourceSetInputProvider reconciliation. Each value may be repeated and/or
+// comma-separated. The operator's runtime namespace is always included.
+//
+// It returns (nil, nil) when no scoping is requested (empty input). It returns
+// an error if any token is not a valid DNS-1123 label, or if values were given
+// but none resolved to a non-empty namespace (so a typo like
+// "--watch-namespaces=," fails loudly instead of silently scoping to just the
+// runtime namespace).
+func resolveWatchNamespaces(runtimeNamespace string, watchNamespaces []string) ([]string, error) {
+	if len(watchNamespaces) == 0 {
+		return nil, nil
+	}
+	set := map[string]struct{}{runtimeNamespace: {}}
+	valid := 0
+	for _, entry := range watchNamespaces {
+		// Accept both repeated flags and comma-separated values.
+		for _, ns := range strings.Split(entry, ",") {
+			ns = strings.TrimSpace(ns)
+			if ns == "" {
+				continue
+			}
+			if errs := validation.IsDNS1123Label(ns); len(errs) > 0 {
+				return nil, fmt.Errorf("invalid namespace %q: %s", ns, strings.Join(errs, "; "))
+			}
+			set[ns] = struct{}{}
+			valid++
+		}
+	}
+	if valid == 0 {
+		return nil, fmt.Errorf("--watch-namespaces was set but contained no valid namespaces")
+	}
+	out := make([]string, 0, len(set))
+	for ns := range set {
+		out = append(out, ns)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/cmd/operator/cache_test.go
+++ b/cmd/operator/cache_test.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestResolveWatchNamespaces(t *testing.T) {
+	const rt = "flux-system"
+	tests := []struct {
+		name    string
+		in      []string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty input is no-op", in: nil, want: nil},
+		{name: "single namespace adds runtime", in: []string{"app-a"}, want: []string{"app-a", "flux-system"}},
+		{name: "comma separated", in: []string{"app-a,app-b"}, want: []string{"app-a", "app-b", "flux-system"}},
+		{name: "repeated flags", in: []string{"app-a", "app-b"}, want: []string{"app-a", "app-b", "flux-system"}},
+		{name: "dedup including runtime", in: []string{"app-a", "app-a", "flux-system"}, want: []string{"app-a", "flux-system"}},
+		{name: "whitespace trimmed", in: []string{" app-a , app-b "}, want: []string{"app-a", "app-b", "flux-system"}},
+		{name: "all-empty tokens error", in: []string{" , "}, wantErr: true},
+		{name: "invalid dns label error", in: []string{"Bad_NS"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveWatchNamespaces(rt, tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveWatchNamespaces() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("resolveWatchNamespaces() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -93,6 +93,7 @@ func main() {
 		defaultWorkloadIdentityServiceAccount string
 		overrideFieldManagers                 []string
 		watchOptions                          runtimeCtrl.WatchOptions
+		watchNamespaces                       []string
 		webServerPort                         int
 		webServerOnly                         bool
 		webConfigFile                         string
@@ -119,6 +120,11 @@ func main() {
 		"Field manager disallowed to perform changes on managed resources.")
 	flag.CommandLine.StringVar(&watchOptions.ConfigsLabelSelector, "watch-configs-label-selector", meta.LabelKeyWatch+"="+meta.LabelValueWatchEnabled,
 		"Watch for ConfigMaps and Secrets with matching labels.")
+	flag.StringArrayVar(&watchNamespaces, "watch-namespaces", nil,
+		"Restrict ResourceSet and ResourceSetInputProvider reconciliation to these namespaces. "+
+			"May be set multiple times and/or comma-separated (e.g. --watch-namespaces=a,b). "+
+			"The operator's own runtime namespace is always included. "+
+			"Empty (default) preserves the upstream cluster-wide behaviour.")
 	flag.IntVar(&webServerPort, "web-server-port", 9080,
 		"The port for the web server to listen on. If set to 0, the web server is disabled.")
 	flag.BoolVar(&webServerOnly, "web-server-only", false,
@@ -207,6 +213,58 @@ func main() {
 		reporter.MustRegisterMetrics()
 	}
 
+	// Build the cache options. By default only FluxInstance/FluxReport are
+	// narrowed (to the singleton named 'flux' in the runtime namespace) while
+	// ResourceSet/ResourceSetInputProvider are cached cluster-wide.
+	cacheOptions := ctrlcache.Options{
+		ByObject: map[ctrlclient.Object]ctrlcache.ByObject{
+			&fluxcdv1.FluxInstance{}: {
+				// Only the FluxInstance with the name 'flux' can be reconciled.
+				Field: fields.SelectorFromSet(fields.Set{
+					"metadata.name":      fluxcdv1.DefaultInstanceName,
+					"metadata.namespace": runtimeNamespace,
+				}),
+			},
+			&fluxcdv1.FluxReport{}: {
+				// Only the FluxReport with the name 'flux' can be reconciled.
+				Field: fields.SelectorFromSet(fields.Set{
+					"metadata.name":      fluxcdv1.DefaultInstanceName,
+					"metadata.namespace": runtimeNamespace,
+				}),
+			},
+		},
+	}
+
+	// When --watch-namespaces is set, scope the ResourceSet and
+	// ResourceSetInputProvider caches to the given namespaces so a per-tenant
+	// operator only sees and reconciles its own objects instead of the whole
+	// cluster. The operator's own runtime namespace is always included so that
+	// RS/RSIP co-located with the operator are still reconciled. Other kinds are
+	// left untouched. Empty preserves the upstream cluster-wide behaviour.
+	//
+	// NOTE: only the RS/RSIP *caches* are scoped. The ConfigMap/Secret metadata
+	// watches set up by the ResourceSet controller stay cluster-wide (a
+	// ResourceSet may reference config inputs in any namespace), and the
+	// controller's RS/RSIP RBAC (+kubebuilder:rbac markers) is also cluster-wide.
+	// So a scoped operator still needs cluster-wide list/watch on RS, RSIP and
+	// ConfigMap/Secret metadata; revisit both axes if the operator's RBAC is ever
+	// tightened to the watched namespace set.
+	scopedNamespaces, err := resolveWatchNamespaces(runtimeNamespace, watchNamespaces)
+	if err != nil {
+		setupLog.Error(err, "invalid --watch-namespaces value")
+		os.Exit(1)
+	}
+	if len(scopedNamespaces) > 0 {
+		nsConfigs := make(map[string]ctrlcache.Config, len(scopedNamespaces))
+		for _, ns := range scopedNamespaces {
+			nsConfigs[ns] = ctrlcache.Config{}
+		}
+		cacheOptions.ByObject[&fluxcdv1.ResourceSet{}] = ctrlcache.ByObject{Namespaces: nsConfigs}
+		cacheOptions.ByObject[&fluxcdv1.ResourceSetInputProvider{}] = ctrlcache.ByObject{Namespaces: nsConfigs}
+		setupLog.Info("ResourceSet/ResourceSetInputProvider reconciliation scoped to namespaces",
+			"namespaces", scopedNamespaces)
+	}
+
 	ctx := ctrl.SetupSignalHandler()
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
@@ -230,24 +288,7 @@ func main() {
 				DisableFor: []ctrlclient.Object{&corev1.Secret{}, &corev1.ConfigMap{}},
 			},
 		},
-		Cache: ctrlcache.Options{
-			ByObject: map[ctrlclient.Object]ctrlcache.ByObject{
-				&fluxcdv1.FluxInstance{}: {
-					// Only the FluxInstance with the name 'flux' can be reconciled.
-					Field: fields.SelectorFromSet(fields.Set{
-						"metadata.name":      fluxcdv1.DefaultInstanceName,
-						"metadata.namespace": runtimeNamespace,
-					}),
-				},
-				&fluxcdv1.FluxReport{}: {
-					// Only the FluxReport with the name 'flux' can be reconciled.
-					Field: fields.SelectorFromSet(fields.Set{
-						"metadata.name":      fluxcdv1.DefaultInstanceName,
-						"metadata.namespace": runtimeNamespace,
-					}),
-				},
-			},
-		},
+		Cache: cacheOptions,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Closes #944.

### What
Adds an optional `--watch-namespaces` flag to the operator. When set, the
ResourceSet and ResourceSetInputProvider informer caches are scoped to the
given namespaces (repeatable and/or comma-separated; the operator's runtime
namespace is always included). When unset, behaviour is unchanged
(cluster-wide), so this is backward compatible.

### Why
Enables running one operator per tenant without each operator watching and
reconciling every other tenant's RS/RSIP. See #944 for the full discussion.

### Scope / non-goals
Only the RS/RSIP **caches** are narrowed. FluxInstance/FluxReport scoping,
the ConfigMap/Secret metadata watches, and the controller RBAC remain
cluster-wide (a ResourceSet may reference inputs in any namespace). Tightening
RBAC to the watched set would be a natural follow-up.

### Testing
- `resolveWatchNamespaces` is unit-tested: empty/no-op, single, comma-separated,
  repeated, dedup including the runtime namespace, whitespace trimming,
  all-empty-token error, and invalid DNS-1123 label error.
- `make test` passes locally.
- Validated on a live multi-tenant cluster: a scoped operator reconciles only
  its own namespace's RS/RSIP and leaves other tenants' objects untouched.

### AI disclosure
Implementation was AI-assisted (Claude, an Anthropic LLM) and reviewed by me.