### PR TITLE
operator: fix skipping flux patch versions in the artifact

### DIFF
--- a/docs/api/v1/fluxinstance.md
+++ b/docs/api/v1/fluxinstance.md
@@ -278,7 +278,7 @@ echo $ENTERPRISE_TOKEN | flux-operator create secret registry flux-enterprise-au
 The `.spec.distribution.artifact` field is optional and specifies the OCI artifact URL
 containing the Flux distribution manifests. When specified, the operator will pull the
 artifact on a regular interval to determine the latest Flux version available
-including CVE patches and hotfixes. Version selection is constrained to Flux versions
+including CVE patches and hotfixes. Version selection is constrained to Flux minor versions
 embedded in the running operator image, but the operator still builds the selected
 version from the artifact contents so image digest updates from the artifact are used.
 When not specified, the operator will use the artifact embedded into its container image.

--- a/internal/builder/semver.go
+++ b/internal/builder/semver.go
@@ -85,21 +85,21 @@ func MatchVersion(dataDir, semverRange string) (string, error) {
 }
 
 // MatchVersionWithEmbedded returns the latest version dir that matches the
-// given semver range and is also present in the embedded version directory
-// bundled with the running operator image.
+// given semver range and belongs to a Flux minor version present in the
+// embedded version directory bundled with the running operator image.
 func MatchVersionWithEmbedded(dataDir, embeddedDataDir, semverRange string) (string, error) {
-	embeddedVersions, err := getVersionSet(embeddedDataDir)
+	embeddedMinorVersions, err := getMinorVersionSet(embeddedDataDir)
 	if err != nil {
 		return "", err
 	}
 
-	matchingVersions, err := matchVersions(dataDir, semverRange, embeddedVersions)
+	matchingVersions, err := matchVersions(dataDir, semverRange, embeddedMinorVersions)
 	if err != nil {
 		return "", err
 	}
 
 	if len(matchingVersions) == 0 {
-		return "", fmt.Errorf("no match found for semver: %s in %s matching embedded versions in %s",
+		return "", fmt.Errorf("no match found for semver: %s in %s matching embedded minor versions in %s",
 			semverRange, dataDir, embeddedDataDir)
 	}
 
@@ -107,8 +107,8 @@ func MatchVersionWithEmbedded(dataDir, embeddedDataDir, semverRange string) (str
 	return matchingVersions[0].Original(), nil
 }
 
-// matchVersions returns all version directories matching the semver range and optional allowed version set.
-func matchVersions(dataDir, semverRange string, allowedVersions map[string]struct{}) ([]*semver.Version, error) {
+// matchVersions returns all version directories matching the semver range and optional allowed minor version set.
+func matchVersions(dataDir, semverRange string, allowedMinorVersions map[string]struct{}) ([]*semver.Version, error) {
 	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
 		return nil, fmt.Errorf("%s directory not found", dataDir)
 	}
@@ -139,8 +139,8 @@ func matchVersions(dataDir, semverRange string, allowedVersions map[string]struc
 		}
 
 		if constraint.Check(v) {
-			if allowedVersions != nil {
-				if _, ok := allowedVersions[v.String()]; !ok {
+			if allowedMinorVersions != nil {
+				if _, ok := allowedMinorVersions[majorMinor(v)]; !ok {
 					continue
 				}
 			}
@@ -151,8 +151,8 @@ func matchVersions(dataDir, semverRange string, allowedVersions map[string]struc
 	return matchingVersions, nil
 }
 
-// getVersionSet returns the normalized semver versions present in a directory.
-func getVersionSet(dataDir string) (map[string]struct{}, error) {
+// getMinorVersionSet returns the normalized semver major.minor versions present in a directory.
+func getMinorVersionSet(dataDir string) (map[string]struct{}, error) {
 	versions, err := matchVersions(dataDir, "*", nil)
 	if err != nil {
 		return nil, err
@@ -160,10 +160,15 @@ func getVersionSet(dataDir string) (map[string]struct{}, error) {
 
 	result := make(map[string]struct{}, len(versions))
 	for _, v := range versions {
-		result[v.String()] = struct{}{}
+		result[majorMinor(v)] = struct{}{}
 	}
 
 	return result, nil
+}
+
+// majorMinor returns the major.minor segment of a semver version.
+func majorMinor(v *semver.Version) string {
+	return fmt.Sprintf("%d.%d", v.Major(), v.Minor())
 }
 
 // getSourceAPIVersion determines the API version of the source based on the provided Flux version.

--- a/internal/builder/semver_test.go
+++ b/internal/builder/semver_test.go
@@ -49,6 +49,7 @@ func TestMatchVersionWithEmbedded(t *testing.T) {
 		filepath.Join(candidateDir, "v2.2.0"),
 		filepath.Join(candidateDir, "v2.2.1"),
 		filepath.Join(candidateDir, "v2.3.0"),
+		filepath.Join(candidateDir, "v2.3.1"),
 		filepath.Join(candidateDir, "v2.4.0"),
 		filepath.Join(embeddedDir, "v2.2.1"),
 		filepath.Join(embeddedDir, "v2.3.0"),
@@ -63,9 +64,11 @@ func TestMatchVersionWithEmbedded(t *testing.T) {
 	}{
 		{name: "exact embedded", exp: "v2.3.0", expected: "v2.3.0"},
 		{name: "patch embedded", exp: "2.2.x", expected: "v2.2.1"},
-		{name: "minor ignores non-embedded newer candidate", exp: "2.x", expected: "v2.3.0"},
-		{name: "latest ignores non-embedded newer candidate", exp: "*", expected: "v2.3.0"},
-		{name: "exact not embedded", exp: "v2.4.0", expected: ""},
+		{name: "exact embedded minor", exp: "v2.3.1", expected: "v2.3.1"},
+		{name: "patch embedded minor", exp: "2.3.x", expected: "v2.3.1"},
+		{name: "minor ignores non-embedded newer minor", exp: "2.x", expected: "v2.3.1"},
+		{name: "latest ignores non-embedded newer minor", exp: "*", expected: "v2.3.1"},
+		{name: "exact unsupported minor", exp: "v2.4.0", expected: ""},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/fluxinstance_controller_test.go
+++ b/internal/controller/fluxinstance_controller_test.go
@@ -636,17 +636,17 @@ func TestFluxInstanceReconciler_BuildFail(t *testing.T) {
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 }
 
-func TestFluxInstanceReconciler_BuildUsesArtifactForEmbeddedVersion(t *testing.T) {
+func TestFluxInstanceReconciler_BuildUsesArtifactPatchForEmbeddedMinor(t *testing.T) {
 	g := NewWithT(t)
 	const fakeDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 	baseDir := t.TempDir()
 	artifactDir := filepath.Join(baseDir, "artifact")
 	storageDir := filepath.Join(baseDir, "storage")
-	copyDir(t, filepath.Join("..", "..", "config", "data", "flux", "v2.3.0"), filepath.Join(artifactDir, "flux", "v2.3.0"))
+	copyDir(t, filepath.Join("..", "..", "config", "data", "flux", "v2.3.0"), filepath.Join(artifactDir, "flux", "v2.3.1"))
 	copyDir(t, filepath.Join("..", "..", "config", "data", "flux", "v2.9.0"), filepath.Join(artifactDir, "flux", "v2.9.0"))
 	copyDir(t, filepath.Join("..", "..", "config", "data", "flux", "v2.3.0"), filepath.Join(storageDir, "flux", "v2.3.0"))
-	writeSourceControllerImagePatch(t, filepath.Join(artifactDir, "flux-images", "v2.3.0", "upstream-alpine.yaml"), fakeDigest)
+	writeSourceControllerImagePatch(t, filepath.Join(artifactDir, "flux-images", "v2.3.1", "upstream-alpine.yaml"), fakeDigest)
 
 	reconciler := getFluxInstanceReconciler(t)
 	reconciler.StoragePath = storageDir
@@ -664,7 +664,7 @@ func TestFluxInstanceReconciler_BuildUsesArtifactForEmbeddedVersion(t *testing.T
 
 	result, err := reconciler.build(context.Background(), obj, artifactDir)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(result.Version).To(Equal("v2.3.0"))
+	g.Expect(result.Version).To(Equal("v2.3.1"))
 	var sourceControllerDigest string
 	for _, img := range result.ComponentImages {
 		if img.Name == "source-controller" {


### PR DESCRIPTION
#937 was too strict, the operator should still upgrade Flux to patch releases automatically if the minor is in the storage but the patch is only in the artifact.