### PR TITLE
cli: support airgapped bootstrap in install command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ The project is structured as a Go module with the following components:
 - Run individual tests when debugging, run the full test suite when done
 - Replace `interface{}` with `any` type alias
 - Use `go doc` to read func signatures in external packages
-- Always keep docs/web/web-least-privilege-rbac.md updated after every change you make
+- Only if needed, update docs/web/web-least-privilege-rbac.md when Web UI changes involve RBAC
 
 ## Development Commands for AI Agents
 

--- a/cmd/cli/Dockerfile
+++ b/cmd/cli/Dockerfile
@@ -3,6 +3,14 @@ FROM ghcr.io/fluxcd/flux-cli:v2.9.2@sha256:816466603e4b2e30b4fce6ecc0df49c255660
 FROM ghcr.io/fluxcd/flux-schema:v0.10.2@sha256:4283d470c8c1777722266f96e3c5bd5daad2751ea4102dfed7e99fcec21d554c AS flux-schema
 FROM ghcr.io/fluxcd/flux-mirror:v0.8.0@sha256:432117c67f83ae3c78d2fd63a4023876b51eaeafbde6e9efb0b42788d86e7695 AS flux-mirror
 FROM registry.k8s.io/kubectl:v1.36.2@sha256:b0d792e0d8dfb9bb1b922b78b23137e2a34bb6f9667640353a9d2aadd1fd7761 AS kubectl
+FROM --platform=${BUILDPLATFORM} registry.k8s.io/kubectl:v1.36.2@sha256:b0d792e0d8dfb9bb1b922b78b23137e2a34bb6f9667640353a9d2aadd1fd7761 AS kubectl-build
+
+# Generate the Flux Operator install manifest for offline bootstrap.
+FROM --platform=${BUILDPLATFORM} golang:1.26 AS manifests
+WORKDIR /workspace
+COPY --from=kubectl-build /bin/kubectl /usr/local/bin/kubectl
+COPY config/ config/
+RUN kubectl kustomize config/default > /install-file.yaml
 
 # Build the Flux Operator CLI binary using Docker's Debian image.
 FROM --platform=${BUILDPLATFORM} golang:1.26 AS builder
@@ -41,6 +49,9 @@ COPY LICENSE /licenses/LICENSE
 
 # Copy the catalog for offline schema validation.
 COPY --from=flux-schema --chown=nonroot:nonroot /catalog /catalog
+
+# Copy the Flux Operator install manifest for offline bootstrap.
+COPY --from=manifests --chown=nonroot:nonroot /install-file.yaml /install-file.yaml
 
 # Copy the binaries.
 COPY --from=builder --chown=nonroot:nonroot /usr/local/bin/flux-operator /usr/local/bin/flux-operator

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -420,17 +420,19 @@ The `flux-operator install` command provides a quick way to bootstrap a Kubernet
 
 This command performs the following steps:
 
-1. Downloads the Flux Operator distribution artifact from `oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests`.
+1. Downloads the Flux Operator distribution artifact from `oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests`, or reads the Flux Operator install manifest from a local file when `--install-file` is set.
 2. Installs the Flux Operator in the `flux-system` namespace and waits for it to become ready.
 3. Installs the Flux instance in the `flux-system` namespace according to the provided configuration.
 4. Configures the pull secret for the instance sync source if credentials are provided.
 5. Configures Flux to bootstrap the cluster from a Git repository or OCI repository if a sync URL is provided.
-6. Configures automatic updates of the Flux Operator from the distribution artifact.
+6. Configures automatic updates of the Flux Operator from the generated or supplied OCIRepository.
 
 This command is intended for development and testing purposes. On production environments,
 it is recommended to follow the [installation guide](https://fluxcd.control-plane.io/operator/install/).
 
 - `flux-operator install`: Installs the Flux Operator and a Flux instance in the cluster.
+    - `--install-file`: Path to a local Flux Operator install manifest. When set, the command skips pulling the distribution artifact for the operator install manifest. The CLI image includes this file at `/install-file.yaml`.
+    - `--auto-update-oci-repository-file`: Path to a local Flux OCIRepository manifest that replaces the generated auto-update OCIRepository.
     - `--instance-file, -f`: Path to FluxInstance YAML file (local file, OCI or HTTPS URL).
     - `--instance-distribution-version`: Flux distribution version.
     - `--instance-distribution-registry`: Container registry to pull Flux images from.
@@ -451,11 +453,36 @@ it is recommended to follow the [installation guide](https://fluxcd.control-plan
     - `--instance-sync-gha-installation-owner`: GitHub App Installation Owner (optional).
     - `--instance-sync-gha-private-key-file`: Path to GitHub App private key file.
     - `--instance-sync-gha-base-url`: GitHub base URL for GitHub Enterprise Server (optional).
-    - `--auto-update`: Enable automatic updates of the Flux Operator from the distribution artifact.
+    - `--auto-update`: Enable automatic updates of the Flux Operator.
     - `--verify`: Verify the cosign signature of the distribution artifact before installing.
     - `--certificate-identity-regexp`: Certificate identity regexp for signature verification.
     - `--certificate-oidc-issuer`: OIDC issuer for signature verification.
     - `--trusted-root`: Path to a `trusted_root.json` file for offline signature verification.
+
+For air-gapped bootstrap with the CLI container image, mount the FluxInstance YAML into the Job, use the embedded install manifest, omit `spec.distribution.artifact`, and provide a local OCIRepository manifest when the auto-update source needs custom fields such as `insecure` or `certSecretRef`:
+
+```shell
+flux-operator install \
+  --install-file=/install-file.yaml \
+  --auto-update-oci-repository-file=/etc/flux-config/auto-update-oci-repository.yaml \
+  -f /etc/flux-config/flux-instance.yaml
+```
+
+Example content for `auto-update-oci-repository.yaml`:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: oci://registry.internal/flux-operator-manifests
+  ref:
+    tag: latest
+  insecure: true
+```
 
 ### Uninstall Command
 

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -31,12 +31,13 @@ var installCmd = &cobra.Command{
 	Long: `The install command provides a quick way to bootstrap a Kubernetes cluster with the Flux Operator and a Flux instance.
 
 The install command performs the following steps:
-  1. Downloads the Flux Operator distribution artifact from 'oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests'.
+  1. Downloads the Flux Operator distribution artifact from 'oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests',
+     or reads the Flux Operator install manifest from a local file when --install-file is set.
   2. Installs the Flux Operator in the 'flux-system' namespace and waits for it to become ready.
   3. Installs the Flux instance in the 'flux-system' namespace according to the provided configuration.
   4. Configures the pull secret for the instance sync source if credentials are provided.
-  4. Configures Flux to bootstrap the cluster from a Git repository or OCI repository if a sync URL is provided.
-  5. Configures automatic updates of the Flux Operator from the distribution artifact.
+  5. Configures Flux to bootstrap the cluster from a Git repository or OCI repository if a sync URL is provided.
+  6. Configures automatic updates of the Flux Operator from the configured OCIRepository.
 
 This command is intended for development and testing purposes. For production installations,
 it is recommended to follow the installation guide at https://fluxcd.control-plane.io/operator/install/
@@ -73,6 +74,12 @@ it is recommended to follow the installation guide at https://fluxcd.control-pla
   # Install using a Flux instance YAML file
   flux-operator install -f flux-instance.yaml
 
+  # Install in air-gapped mode using the embedded install manifest and a custom auto-update OCIRepository
+  flux-operator install \
+    --install-file=/install-file.yaml \
+    --auto-update-oci-repository-file=/etc/flux-config/auto-update-oci-repository.yaml \
+    -f /etc/flux-config/flux-instance.yaml
+
   # Install using a Flux instance from a GitHub URL
   flux-operator install \
     --instance-sync-creds=git:${GITHUB_TOKEN} \
@@ -95,36 +102,40 @@ it is recommended to follow the installation guide at https://fluxcd.control-pla
 }
 
 type installFlags struct {
-	instanceFile             string
-	components               []string
-	componentsExtra          []string
-	distributionVersion      string
-	distributionRegistry     string
-	distributionArtifact     string
-	clusterType              string
-	clusterSize              string
-	clusterDomain            string
-	clusterMultitenant       bool
-	clusterNetworkPolicy     bool
-	syncURL                  string
-	syncRef                  string
-	syncPath                 string
-	syncCreds                string
-	syncGHAAppID             string
-	syncGHAInstallationID    string
-	syncGHAInstallationOwner string
-	syncGHAPrivateKeyFile    string
-	syncGHABaseURL           string
-	autoUpdate               bool
-	verify                   bool
-	certIdentityRegexp       string
-	certOIDCIssuer           string
-	trustedRoot              string
+	installFile                 string
+	instanceFile                string
+	components                  []string
+	componentsExtra             []string
+	distributionVersion         string
+	distributionRegistry        string
+	distributionArtifact        string
+	clusterType                 string
+	clusterSize                 string
+	clusterDomain               string
+	clusterMultitenant          bool
+	clusterNetworkPolicy        bool
+	syncURL                     string
+	syncRef                     string
+	syncPath                    string
+	syncCreds                   string
+	syncGHAAppID                string
+	syncGHAInstallationID       string
+	syncGHAInstallationOwner    string
+	syncGHAPrivateKeyFile       string
+	syncGHABaseURL              string
+	autoUpdate                  bool
+	verify                      bool
+	certIdentityRegexp          string
+	certOIDCIssuer              string
+	trustedRoot                 string
+	autoUpdateOCIRepositoryFile string
 }
 
 var installArgs installFlags
 
 func init() {
+	installCmd.Flags().StringVar(&installArgs.installFile, "install-file", "",
+		"path to a local Flux Operator install manifest; when set, skips pulling the artifact for the operator install manifest")
 	installCmd.Flags().StringVarP(&installArgs.instanceFile, "instance-file", "f", "",
 		"path to Flux instance YAML file (local file or HTTPS URL)")
 	installCmd.Flags().StringSliceVar(&installArgs.components, "instance-components",
@@ -167,7 +178,9 @@ func init() {
 	installCmd.Flags().StringVar(&installArgs.syncGHABaseURL, "instance-sync-gha-base-url", "",
 		"GitHub base URL for GitHub Enterprise Server (optional)")
 	installCmd.Flags().BoolVar(&installArgs.autoUpdate, "auto-update", true,
-		"enable automatic updates of the Flux Operator from the distribution artifact")
+		"enable automatic updates of the Flux Operator")
+	installCmd.Flags().StringVar(&installArgs.autoUpdateOCIRepositoryFile, "auto-update-oci-repository-file", "",
+		"path to a local Flux OCIRepository manifest that replaces the generated auto-update OCIRepository")
 	installCmd.Flags().BoolVar(&installArgs.verify, "verify", false,
 		"verify the cosign signature of the distribution artifact before installing")
 	installCmd.Flags().StringVar(&installArgs.certIdentityRegexp, "certificate-identity-regexp", cosign.DefaultCertIdentityRegexp,
@@ -186,6 +199,10 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 		rootArgs.timeout = 5 * time.Minute
 	}
 
+	if err := validateInstallFlags(); err != nil {
+		return err
+	}
+
 	now := time.Now()
 
 	timeout := rootArgs.timeout - time.Minute
@@ -194,7 +211,7 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 
 	// Step 1: Generate Flux instance from file, URL or flags
 
-	rootCmd.Println(`◎`, "Downloading artifacts...")
+	printManifestLoadStart()
 	instance, artifactURL, err := makeFluxInstance(ctx)
 	if err != nil {
 		return err
@@ -214,13 +231,13 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 		rootCmd.Println(`✔`, "Artifact signature verified successfully")
 	}
 
-	// Step 3: Download the distribution artifact and extract the manifests
+	// Step 3: Download or read the operator install manifest
 
-	objects, err := fetchOperatorManifests(artifactURL)
+	objects, err := loadOperatorManifests(artifactURL)
 	if err != nil {
 		return err
 	}
-	rootCmd.Println(`✔`, "Download completed in", time.Since(now).Round(time.Second).String())
+	printManifestLoadComplete(now)
 
 	// Step 4: Install or upgrade the Flux Operator
 
@@ -229,23 +246,9 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("loading kubeconfig failed: %w", err)
 	}
 
-	installerOpts := []install.Option{
-		install.WithArtifactURL(artifactURL),
-		install.WithCredentials(installArgs.syncCreds),
-	}
-
-	if installArgs.hasSyncGHA() {
-		privateKey, err := os.ReadFile(installArgs.syncGHAPrivateKeyFile)
-		if err != nil {
-			return fmt.Errorf("unable to read GitHub App private key file: %w", err)
-		}
-		installerOpts = append(installerOpts, install.WithGitHubAppCredentials(&install.GitHubAppCredentials{
-			AppID:             installArgs.syncGHAAppID,
-			InstallationID:    installArgs.syncGHAInstallationID,
-			InstallationOwner: installArgs.syncGHAInstallationOwner,
-			PrivateKey:        string(privateKey),
-			BaseURL:           installArgs.syncGHABaseURL,
-		}))
+	installerOpts, err := makeInstallerOptions(artifactURL)
+	if err != nil {
+		return err
 	}
 
 	installer, err := install.NewInstaller(ctx, cfg, installerOpts...)
@@ -366,6 +369,22 @@ func installCmdRun(cmd *cobra.Command, args []string) error {
 // makeFluxInstance creates a FluxInstance object from the provided file or command-line flags.
 // If a file is provided, it takes precedence over the flags.
 // It also returns the artifact URL to be used for downloading the Flux Operator manifests.
+func printManifestLoadStart() {
+	if installArgs.installFile != "" {
+		rootCmd.Println(`◎`, "Loading manifests...")
+		return
+	}
+	rootCmd.Println(`◎`, "Downloading artifacts...")
+}
+
+func printManifestLoadComplete(start time.Time) {
+	if installArgs.installFile != "" {
+		rootCmd.Println(`✔`, "Manifests loaded in", time.Since(start).Round(time.Second).String())
+		return
+	}
+	rootCmd.Println(`✔`, "Download completed in", time.Since(start).Round(time.Second).String())
+}
+
 func makeFluxInstance(ctx context.Context) (instance *fluxcdv1.FluxInstance, artifactURL string, err error) {
 	instance = &fluxcdv1.FluxInstance{}
 	artifactURL = installArgs.distributionArtifact
@@ -468,6 +487,117 @@ func makeFluxInstance(ctx context.Context) (instance *fluxcdv1.FluxInstance, art
 	}
 
 	return instance, artifactURL, nil
+}
+
+// validateInstallFlags validates flag combinations for the install command.
+func validateInstallFlags() error {
+	if installArgs.installFile != "" && installArgs.verify {
+		return fmt.Errorf("--verify cannot be used with --install-file")
+	}
+
+	if installArgs.autoUpdateOCIRepositoryFile != "" && !installArgs.autoUpdate {
+		return fmt.Errorf("--auto-update-oci-repository-file cannot be set when --auto-update=false")
+	}
+
+	return nil
+}
+
+// makeInstallerOptions returns installer options from the install command flags.
+func makeInstallerOptions(artifactURL string) ([]install.Option, error) {
+	autoUpdateOCIRepository, err := loadAutoUpdateOCIRepository()
+	if err != nil {
+		return nil, err
+	}
+
+	installerOpts := []install.Option{
+		install.WithArtifactURL(artifactURL),
+		install.WithCredentials(installArgs.syncCreds),
+	}
+	if autoUpdateOCIRepository != "" {
+		installerOpts = append(installerOpts, install.WithAutoUpdateOCIRepository(autoUpdateOCIRepository))
+	}
+
+	if installArgs.hasSyncGHA() {
+		privateKey, err := os.ReadFile(installArgs.syncGHAPrivateKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read GitHub App private key file: %w", err)
+		}
+		installerOpts = append(installerOpts, install.WithGitHubAppCredentials(&install.GitHubAppCredentials{
+			AppID:             installArgs.syncGHAAppID,
+			InstallationID:    installArgs.syncGHAInstallationID,
+			InstallationOwner: installArgs.syncGHAInstallationOwner,
+			PrivateKey:        string(privateKey),
+			BaseURL:           installArgs.syncGHABaseURL,
+		}))
+	}
+
+	return installerOpts, nil
+}
+
+// loadAutoUpdateOCIRepository returns the custom OCIRepository manifest for the auto-update ResourceSet.
+func loadAutoUpdateOCIRepository() (string, error) {
+	if installArgs.autoUpdateOCIRepositoryFile == "" {
+		return "", nil
+	}
+	return readAutoUpdateOCIRepository(installArgs.autoUpdateOCIRepositoryFile)
+}
+
+// readAutoUpdateOCIRepository reads and validates a Flux OCIRepository manifest from a local file.
+func readAutoUpdateOCIRepository(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read auto-update OCIRepository file: %w", err)
+	}
+
+	objects, err := ssautil.ReadObjects(bytes.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("unable to parse auto-update OCIRepository file %s: %w", path, err)
+	}
+
+	if len(objects) == 0 {
+		return "", fmt.Errorf("no Kubernetes objects found in auto-update OCIRepository file %s", path)
+	}
+	if len(objects) != 1 {
+		return "", fmt.Errorf("expected exactly one Kubernetes object in auto-update OCIRepository file %s, got %d", path, len(objects))
+	}
+	if objects[0].GetKind() != "OCIRepository" {
+		return "", fmt.Errorf("expected auto-update OCIRepository file %s to contain kind OCIRepository, got %s", path, objects[0].GetKind())
+	}
+
+	manifest, err := yaml.Marshal(objects[0].Object)
+	if err != nil {
+		return "", fmt.Errorf("unable to encode auto-update OCIRepository file %s: %w", path, err)
+	}
+
+	return strings.TrimSpace(string(manifest)), nil
+}
+
+// loadOperatorManifests returns the Flux Operator install manifest objects from
+// a local file when --install-file is set, otherwise from the distribution artifact.
+func loadOperatorManifests(artifactURL string) ([]*unstructured.Unstructured, error) {
+	if installArgs.installFile != "" {
+		return readOperatorManifests(installArgs.installFile)
+	}
+	return fetchOperatorManifests(artifactURL)
+}
+
+// readOperatorManifests reads the Flux Operator install manifest from a local file.
+func readOperatorManifests(path string) ([]*unstructured.Unstructured, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read install file: %w", err)
+	}
+
+	objects, err := ssautil.ReadObjects(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse install file %s: %w", path, err)
+	}
+
+	if len(objects) == 0 {
+		return nil, fmt.Errorf("no Kubernetes objects found in install file %s", path)
+	}
+
+	return objects, nil
 }
 
 // fetchOperatorManifests downloads the Flux Operator distribution artifact

--- a/cmd/cli/install_file_test.go
+++ b/cmd/cli/install_file_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestReadOperatorManifests(t *testing.T) {
+	g := NewWithT(t)
+
+	manifest := `apiVersion: v1
+kind: Namespace
+metadata:
+  name: flux-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-operator
+  namespace: flux-system
+`
+	path := filepath.Join(t.TempDir(), "install.yaml")
+	g.Expect(os.WriteFile(path, []byte(manifest), 0644)).To(Succeed())
+
+	objects, err := readOperatorManifests(path)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(objects).To(HaveLen(2))
+	g.Expect(objects[0].GetKind()).To(Equal("Namespace"))
+	g.Expect(objects[1].GetKind()).To(Equal("ServiceAccount"))
+}
+
+func TestReadOperatorManifestsEmpty(t *testing.T) {
+	g := NewWithT(t)
+
+	path := filepath.Join(t.TempDir(), "install.yaml")
+	g.Expect(os.WriteFile(path, nil, 0644)).To(Succeed())
+
+	_, err := readOperatorManifests(path)
+	g.Expect(err).To(MatchError(ContainSubstring("no Kubernetes objects found in install file")))
+}
+
+func TestValidateInstallFlagsInstallFileWithVerify(t *testing.T) {
+	g := NewWithT(t)
+
+	original := installArgs
+	t.Cleanup(func() {
+		installArgs = original
+	})
+
+	installArgs.installFile = "/install-file.yaml"
+	installArgs.verify = true
+
+	g.Expect(validateInstallFlags()).To(MatchError("--verify cannot be used with --install-file"))
+}
+
+func TestValidateInstallFlagsAutoUpdateOCIRepositoryFileWithAutoUpdateDisabled(t *testing.T) {
+	g := NewWithT(t)
+
+	original := installArgs
+	t.Cleanup(func() {
+		installArgs = original
+	})
+
+	installArgs.autoUpdate = false
+	installArgs.autoUpdateOCIRepositoryFile = "/etc/flux-config/auto-update-oci-repository.yaml"
+
+	g.Expect(validateInstallFlags()).To(MatchError("--auto-update-oci-repository-file cannot be set when --auto-update=false"))
+}
+
+func TestValidateInstallFlagsAutoUpdateOCIRepositoryFileWithAutoUpdateEnabled(t *testing.T) {
+	g := NewWithT(t)
+
+	original := installArgs
+	t.Cleanup(func() {
+		installArgs = original
+	})
+
+	installArgs.autoUpdate = true
+	installArgs.autoUpdateOCIRepositoryFile = "/etc/flux-config/auto-update-oci-repository.yaml"
+
+	g.Expect(validateInstallFlags()).To(Succeed())
+}
+
+func TestReadAutoUpdateOCIRepository(t *testing.T) {
+	g := NewWithT(t)
+
+	manifest := `apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: oci://registry.example.com/flux-operator-manifests
+  ref:
+    tag: latest
+  insecure: true
+`
+	path := filepath.Join(t.TempDir(), "auto-update-oci-repository.yaml")
+	g.Expect(os.WriteFile(path, []byte(manifest), 0644)).To(Succeed())
+
+	result, err := readAutoUpdateOCIRepository(path)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(ContainSubstring("kind: OCIRepository"))
+	g.Expect(result).To(ContainSubstring("insecure: true"))
+}
+
+func TestReadAutoUpdateOCIRepositoryRejectsMultipleObjects(t *testing.T) {
+	g := NewWithT(t)
+
+	manifest := `apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: flux-operator-auth
+`
+	path := filepath.Join(t.TempDir(), "auto-update-oci-repository.yaml")
+	g.Expect(os.WriteFile(path, []byte(manifest), 0644)).To(Succeed())
+
+	_, err := readAutoUpdateOCIRepository(path)
+	g.Expect(err).To(MatchError(ContainSubstring("expected exactly one Kubernetes object in auto-update OCIRepository file")))
+}
+
+func TestReadAutoUpdateOCIRepositoryRejectsOtherKind(t *testing.T) {
+	g := NewWithT(t)
+
+	manifest := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: not-an-oci-repository
+`
+	path := filepath.Join(t.TempDir(), "auto-update-oci-repository.yaml")
+	g.Expect(os.WriteFile(path, []byte(manifest), 0644)).To(Succeed())
+
+	_, err := readAutoUpdateOCIRepository(path)
+	g.Expect(err).To(MatchError(ContainSubstring("to contain kind OCIRepository, got ConfigMap")))
+}

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -26,6 +26,8 @@ import (
 	// +kubebuilder:scaffold:imports
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/cosign"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/install"
 )
 
 var (
@@ -131,6 +133,22 @@ func resetCmdArgs() {
 
 	// Version command
 	versionArgs = versionFlags{}
+
+	// Install command
+	installArgs = installFlags{
+		components:           []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"},
+		distributionVersion:  "2.x",
+		distributionRegistry: "ghcr.io/fluxcd",
+		distributionArtifact: install.DefaultArtifactURL,
+		clusterType:          "kubernetes",
+		clusterSize:          "medium",
+		clusterDomain:        "cluster.local",
+		clusterNetworkPolicy: true,
+		syncPath:             "./",
+		autoUpdate:           true,
+		certIdentityRegexp:   cosign.DefaultCertIdentityRegexp,
+		certOIDCIssuer:       cosign.DefaultCertOIDCIssuer,
+	}
 
 	// Build commands
 	buildInstanceArgs = buildInstanceFlags{}

--- a/docs/guides/operator/operator-install.md
+++ b/docs/guides/operator/operator-install.md
@@ -115,6 +115,34 @@ Install the Flux Operator and a Flux instance from a configuration file:
 flux-operator install -f flux-instance.yaml
 ```
 
+For air-gapped bootstrap with the Flux Operator CLI container image, mount a
+FluxInstance YAML that omits `spec.distribution.artifact`, use the install
+manifest embedded in the image, and provide a local OCIRepository manifest when
+the auto-update source needs custom fields such as `insecure` or `certSecretRef`:
+
+```shell
+flux-operator install \
+  --install-file=/install-file.yaml \
+  --auto-update-oci-repository-file=/etc/flux-config/auto-update-oci-repository.yaml \
+  -f /etc/flux-config/flux-instance.yaml
+```
+
+Example content for `auto-update-oci-repository.yaml`:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: oci://registry.internal/flux-operator-manifests
+  ref:
+    tag: latest
+  insecure: true
+```
+
 ### Kubectl
 
 The Flux Operator can be installed with `kubectl` by

--- a/internal/install/autoupdate.go
+++ b/internal/install/autoupdate.go
@@ -14,26 +14,27 @@ import (
 	ssautil "github.com/fluxcd/pkg/ssa/utils"
 )
 
-// ApplyAutoUpdate configures automatic updates of the Flux Operator from the distribution artifact.
+// ApplyAutoUpdate configures automatic updates of the Flux Operator from the configured OCIRepository.
 func (in *Installer) ApplyAutoUpdate(ctx context.Context, multitenant bool) (*ssa.ChangeSet, error) {
-	// Strip tag from artifact URL (e.g., "oci://registry/image:tag" -> "oci://registry/image")
-	artifactURL := in.options.artifactURL
-	if idx := strings.LastIndex(artifactURL, ":"); idx > 6 {
-		artifactURL = artifactURL[:idx]
+	artifactURL := artifactRepositoryURL(in.options.artifactURL)
+
+	ociRepository, err := renderAutoUpdateOCIRepository(artifactURL, in.options.autoUpdateOCIRepository)
+	if err != nil {
+		return nil, err
 	}
 
-	// Build template data
 	data := struct {
-		Namespace   string
-		ArtifactURL string
-		Multitenant bool
+		Namespace     string
+		ArtifactURL   string
+		OCIRepository string
+		Multitenant   bool
 	}{
-		Namespace:   in.options.namespace,
-		ArtifactURL: artifactURL,
-		Multitenant: multitenant,
+		Namespace:     in.options.namespace,
+		ArtifactURL:   artifactURL,
+		OCIRepository: yamlListItem(ociRepository),
+		Multitenant:   multitenant,
 	}
 
-	// Execute template
 	tmpl, err := template.New("autoUpdate").Parse(autoUpdateTmpl)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse auto-update template: %w", err)
@@ -52,6 +53,71 @@ func (in *Installer) ApplyAutoUpdate(ctx context.Context, multitenant bool) (*ss
 	return in.kubeClient.Manager.ApplyAllStaged(ctx, autoUpdateObjects, ssa.DefaultApplyOptions())
 }
 
+func renderAutoUpdateOCIRepository(artifactURL, customOCIRepository string) (string, error) {
+	if strings.TrimSpace(customOCIRepository) != "" {
+		return strings.TrimSpace(customOCIRepository), nil
+	}
+
+	data := struct {
+		ArtifactURL string
+	}{
+		ArtifactURL: artifactURL,
+	}
+
+	tmpl, err := template.New("autoUpdateOCIRepository").Parse(autoUpdateOCIRepositoryTmpl)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse auto-update OCIRepository template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("unable to execute auto-update OCIRepository template: %w", err)
+	}
+
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func artifactRepositoryURL(artifactURL string) string {
+	repositoryURL, _, _ := strings.Cut(artifactURL, "@")
+	if idx := strings.LastIndex(repositoryURL, ":"); idx > strings.LastIndex(repositoryURL, "/") {
+		return repositoryURL[:idx]
+	}
+	return repositoryURL
+}
+
+func yamlListItem(manifest string) string {
+	const indent = 4
+
+	lines := strings.Split(strings.TrimSpace(manifest), "\n")
+	if len(lines) == 0 {
+		return ""
+	}
+
+	prefix := strings.Repeat(" ", indent)
+	childPrefix := strings.Repeat(" ", indent+2)
+	lines[0] = prefix + "- " + strings.TrimLeft(lines[0], " ")
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			lines[i] = ""
+			continue
+		}
+		lines[i] = childPrefix + strings.TrimRight(lines[i], " ")
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+const autoUpdateOCIRepositoryTmpl = `apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: << inputs.provider.name >>
+  namespace: << inputs.provider.namespace >>
+spec:
+  interval: << inputs.interval | quote >>
+  url: << inputs.url | quote >>
+  ref:
+    tag: latest
+`
+
 const autoUpdateTmpl = `
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSet
@@ -69,16 +135,7 @@ spec:
     - url: {{.ArtifactURL}}
       interval: "1h"
   resources:
-    - apiVersion: source.toolkit.fluxcd.io/v1
-      kind: OCIRepository
-      metadata:
-        name: << inputs.provider.name >>
-        namespace: << inputs.provider.namespace >>
-      spec:
-        interval: << inputs.interval | quote >>
-        url: << inputs.url | quote >>
-        ref:
-          tag: latest
+{{.OCIRepository}}
     - apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization
       metadata:

--- a/internal/install/autoupdate_test.go
+++ b/internal/install/autoupdate_test.go
@@ -5,24 +5,30 @@ package install
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 	"text/template"
 
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
 	. "github.com/onsi/gomega"
 )
 
 func TestAutoUpdateTemplate_Render(t *testing.T) {
 	g := NewWithT(t)
 
+	artifactURL := "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests"
+	ociRepository, err := renderAutoUpdateOCIRepository(artifactURL, "")
+	g.Expect(err).NotTo(HaveOccurred())
+
 	data := struct {
-		Namespace   string
-		ArtifactURL string
-		Multitenant bool
+		Namespace     string
+		ArtifactURL   string
+		OCIRepository string
+		Multitenant   bool
 	}{
-		Namespace:   "flux-system",
-		ArtifactURL: "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests",
-		Multitenant: false,
+		Namespace:     "flux-system",
+		ArtifactURL:   artifactURL,
+		OCIRepository: yamlListItem(ociRepository),
+		Multitenant:   false,
 	}
 
 	tmpl, err := template.New("autoUpdate").Parse(autoUpdateTmpl)
@@ -33,23 +39,79 @@ func TestAutoUpdateTemplate_Render(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	result := buf.String()
+	objects, err := ssautil.ReadObjects(bytes.NewReader([]byte(result)))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(objects).To(HaveLen(1))
 	g.Expect(result).To(ContainSubstring("kind: ResourceSet"))
 	g.Expect(result).To(ContainSubstring("namespace: flux-system"))
 	g.Expect(result).To(ContainSubstring("url: oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests"))
+	g.Expect(result).To(ContainSubstring("kind: OCIRepository"))
 	g.Expect(result).NotTo(ContainSubstring("DEFAULT_SERVICE_ACCOUNT"))
+}
+
+func TestAutoUpdateTemplate_CustomOCIRepository(t *testing.T) {
+	g := NewWithT(t)
+
+	customOCIRepository := `apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: oci://registry.internal/flux-operator-manifests
+  ref:
+    tag: latest
+  insecure: true
+`
+	ociRepository, err := renderAutoUpdateOCIRepository("oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests", customOCIRepository)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	data := struct {
+		Namespace     string
+		ArtifactURL   string
+		OCIRepository string
+		Multitenant   bool
+	}{
+		Namespace:     "flux-system",
+		ArtifactURL:   "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests",
+		OCIRepository: yamlListItem(ociRepository),
+		Multitenant:   false,
+	}
+
+	tmpl, err := template.New("autoUpdate").Parse(autoUpdateTmpl)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, data)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	result := buf.String()
+	objects, err := ssautil.ReadObjects(bytes.NewReader([]byte(result)))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(objects).To(HaveLen(1))
+	g.Expect(result).To(ContainSubstring("url: oci://registry.internal/flux-operator-manifests"))
+	g.Expect(result).To(ContainSubstring("insecure: true"))
+	g.Expect(result).NotTo(ContainSubstring("url: << inputs.url | quote >>"))
 }
 
 func TestAutoUpdateTemplate_Multitenant(t *testing.T) {
 	g := NewWithT(t)
 
+	artifactURL := "oci://ghcr.io/custom/manifests"
+	ociRepository, err := renderAutoUpdateOCIRepository(artifactURL, "")
+	g.Expect(err).NotTo(HaveOccurred())
+
 	data := struct {
-		Namespace   string
-		ArtifactURL string
-		Multitenant bool
+		Namespace     string
+		ArtifactURL   string
+		OCIRepository string
+		Multitenant   bool
 	}{
-		Namespace:   "custom-ns",
-		ArtifactURL: "oci://ghcr.io/custom/manifests",
-		Multitenant: true,
+		Namespace:     "custom-ns",
+		ArtifactURL:   artifactURL,
+		OCIRepository: yamlListItem(ociRepository),
+		Multitenant:   true,
 	}
 
 	tmpl, err := template.New("autoUpdate").Parse(autoUpdateTmpl)
@@ -60,6 +122,9 @@ func TestAutoUpdateTemplate_Multitenant(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	result := buf.String()
+	objects, err := ssautil.ReadObjects(bytes.NewReader([]byte(result)))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(objects).To(HaveLen(1))
 	g.Expect(result).To(ContainSubstring("namespace: custom-ns"))
 	g.Expect(result).To(ContainSubstring("DEFAULT_SERVICE_ACCOUNT"))
 }
@@ -90,18 +155,48 @@ func TestAutoUpdateTemplate_TagStripping(t *testing.T) {
 			url:      "oci://localhost:5000/repo:v1.0.0",
 			expected: "oci://localhost:5000/repo",
 		},
+		{
+			name:     "URL with port without tag",
+			url:      "oci://localhost:5000/repo",
+			expected: "oci://localhost:5000/repo",
+		},
+		{
+			name:     "URL with digest",
+			url:      "oci://ghcr.io/org/repo@sha256:abcdef",
+			expected: "oci://ghcr.io/org/repo",
+		},
+		{
+			name:     "URL with tag and digest",
+			url:      "oci://ghcr.io/org/repo:v1.0.0@sha256:abcdef",
+			expected: "oci://ghcr.io/org/repo",
+		},
+		{
+			name:     "URL with port, tag and digest",
+			url:      "oci://localhost:5000/repo:v1.0.0@sha256:abcdef",
+			expected: "oci://localhost:5000/repo",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			// Replicate the tag stripping logic from ApplyAutoUpdate
-			artifactURL := tt.url
-			if idx := strings.LastIndex(artifactURL, ":"); idx > 6 {
-				artifactURL = artifactURL[:idx]
-			}
-			g.Expect(artifactURL).To(Equal(tt.expected))
+			g.Expect(artifactRepositoryURL(tt.url)).To(Equal(tt.expected))
 		})
 	}
+}
+
+func TestYAMLListItem(t *testing.T) {
+	g := NewWithT(t)
+
+	result := yamlListItem(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+`)
+
+	g.Expect(result).To(Equal(`    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test`))
 }

--- a/internal/install/options.go
+++ b/internal/install/options.go
@@ -34,6 +34,9 @@ type Options struct {
 	// These are used to create a Kubernetes secret for authenticating to Git or OCI repositories.
 	credentials string
 
+	// autoUpdateOCIRepository is the OCIRepository manifest used by the auto-update ResourceSet.
+	autoUpdateOCIRepository string
+
 	// gitHubApp holds the GitHub App credentials for the sync source.
 	// When set, a GitHub App secret is created instead of basic auth/registry secret.
 	gitHubApp *GitHubAppCredentials
@@ -80,6 +83,13 @@ func WithArtifactURL(url string) Option {
 func WithCredentials(credentials string) Option {
 	return func(o *Options) {
 		o.credentials = credentials
+	}
+}
+
+// WithAutoUpdateOCIRepository sets the OCIRepository manifest used by the auto-update ResourceSet.
+func WithAutoUpdateOCIRepository(manifest string) Option {
+	return func(o *Options) {
+		o.autoUpdateOCIRepository = manifest
 	}
 }
 
@@ -161,6 +171,11 @@ func (o *Options) ArtifactURL() string {
 // Credentials returns the sync credentials.
 func (o *Options) Credentials() string {
 	return o.credentials
+}
+
+// AutoUpdateOCIRepository returns the OCIRepository manifest used by the auto-update ResourceSet.
+func (o *Options) AutoUpdateOCIRepository() string {
+	return o.autoUpdateOCIRepository
 }
 
 // Owner returns the field manager name.

--- a/internal/install/options_test.go
+++ b/internal/install/options_test.go
@@ -25,6 +25,7 @@ func TestMakeOptions_Defaults(t *testing.T) {
 	g.Expect(opts.Namespace()).To(Equal(DefaultNamespace))
 	g.Expect(opts.TerminationTimeout()).To(Equal(DefaultTerminationTimeout))
 	g.Expect(opts.Credentials()).To(BeEmpty())
+	g.Expect(opts.AutoUpdateOCIRepository()).To(BeEmpty())
 }
 
 func TestMakeOptions_CustomValues(t *testing.T) {
@@ -35,10 +36,12 @@ func TestMakeOptions_CustomValues(t *testing.T) {
 	owner := "my-cli"
 	ns := "custom-ns"
 	timeout := 60 * time.Second
+	autoUpdateOCIRepository := "apiVersion: source.toolkit.fluxcd.io/v1\nkind: OCIRepository\n"
 
 	opts, err := MakeOptions(
 		WithArtifactURL(url),
 		WithCredentials(creds),
+		WithAutoUpdateOCIRepository(autoUpdateOCIRepository),
 		WithOwner(owner),
 		WithNamespace(ns),
 		WithTerminationTimeout(timeout),
@@ -46,6 +49,7 @@ func TestMakeOptions_CustomValues(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(opts.ArtifactURL()).To(Equal(url))
 	g.Expect(opts.Credentials()).To(Equal(creds))
+	g.Expect(opts.AutoUpdateOCIRepository()).To(Equal(autoUpdateOCIRepository))
 	g.Expect(opts.Owner()).To(Equal(owner))
 	g.Expect(opts.Namespace()).To(Equal(ns))
 	g.Expect(opts.TerminationTimeout()).To(Equal(timeout))


### PR DESCRIPTION
Closes: #951

This PR:

1. Introduces an `--install-file` flag for pointing to a file with the operator install manifests.
2. Builds the operator install kustomization and embeds the file in the `flux-operator-cli` image.
3. Introduces an `--auto-update-oci-repository-file` flag for allowing a custom OCIRepository inside the auto-update ResourceSet. You may alternatively disable the entire ResourceSet with `--auto-update=false`.

I tested this inside an air-gapped kind cluster created using a bridge docker network with SNAT disabled (setting `com.docker.network.bridge.enable_ip_masquerade` to `false`).

Example Job:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: flux-operator-bootstrap
  namespace: default
spec:
  backoffLimit: 0
  template:
    spec:
      serviceAccountName: flux-operator-bootstrap
      restartPolicy: Never
      containers:
      - name: flux-operator-cli
        image: ghcr.io/controlplaneio-fluxcd/flux-operator-cli
        imagePullPolicy: Never
        args:
        - --timeout=12m
        - install
        - --install-file=/install-file.yaml
        - --instance-file=/etc/flux-config/flux-instance.yaml
        # or --auto-update=false
        - --auto-update-oci-repository-file=/etc/flux-config/auto-update-oci-repository.yaml
        volumeMounts:
        - name: flux-config
          mountPath: /etc/flux-config
          readOnly: true
      volumes:
      - name: flux-config
        configMap:
          name: flux-operator-bootstrap
```