### PR TITLE
web: Add OAuth2 autoLogin to skip login page

### DIFF
--- a/api/v1/webconfig_types.go
+++ b/api/v1/webconfig_types.go
@@ -241,6 +241,11 @@ type OAuth2AuthenticationSpec struct {
 	// +optional
 	AuthURLParams map[string]string `json:"authURLParams"`
 
+	// AutoLogin redirects unauthenticated users straight to the OAuth2
+	// provider instead of showing the login page. Default: false.
+	// +optional
+	AutoLogin bool `json:"autoLogin,omitempty"`
+
 	// IssuerURL is used for OIDC provider discovery.
 	// Required for the OIDC provider.
 	// Used only by the OIDC provider.

--- a/docs/web/web-config-api.md
+++ b/docs/web/web-config-api.md
@@ -91,6 +91,10 @@ spec:
         access_type: offline
         prompt: consent
 
+      # Optional: redirect unauthenticated users straight to the OIDC provider
+      # instead of showing the login page. Default: false.
+      autoLogin: false
+
       # CEL expressions to extract information from the ID token claims
       # into named variables that can be reused in other expressions.
       variables: # Optional
@@ -209,6 +213,10 @@ spec:
       authURLParams:
         access_type: offline
         prompt: consent
+
+      # Optional: skip the login page and redirect to the OIDC provider
+      # immediately. Useful for SSO-only setups. Default: false.
+      autoLogin: false
 ```
 
 The default scopes requested are `openid`, `offline_access`, `profile`, `email` and `groups`.

--- a/internal/web/auth/cookies.go
+++ b/internal/web/auth/cookies.go
@@ -93,13 +93,12 @@ func setAuthLogoutCookie(w http.ResponseWriter) {
 // It first clears any existing auth provider cookie to avoid duplicates.
 func setAuthProviderCookie(w http.ResponseWriter, provider, loginURL string, authenticated, autoLogin bool) {
 	clearCookieFromResponse(w, cookieNameAuthProvider)
-	payload := map[string]any{
+	setCookie(w, cookieNameAuthProvider, map[string]any{
 		"provider":      provider,
 		"url":           loginURL,
 		"authenticated": authenticated,
 		"autoLogin":     autoLogin,
-	}
-	setCookie(w, cookieNameAuthProvider, payload)
+	})
 }
 
 // SetAnonymousAuthProviderCookie sets the anonymous auth provider cookie in the response.

--- a/internal/web/auth/cookies.go
+++ b/internal/web/auth/cookies.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	cookieNameAuthError        = "auth-error"
+	cookieNameAuthLogout       = "auth-logout"
 	cookieNameAuthProvider     = "auth-provider"
 	cookieNameAuthStorage      = "auth-storage"
 	cookieNameOAuth2LoginState = "oauth2-state"
@@ -80,20 +81,30 @@ func setAuthErrorCookie(w http.ResponseWriter, err error) {
 	})
 }
 
+// setAuthLogoutCookie sets a cookie that tells the login page to skip auto-login
+// after an explicit user logout.
+func setAuthLogoutCookie(w http.ResponseWriter) {
+	setCookie(w, cookieNameAuthLogout, map[string]any{
+		"suppressAutoLogin": true,
+	})
+}
+
 // setAuthProviderCookie sets the auth provider cookie in the response.
 // It first clears any existing auth provider cookie to avoid duplicates.
-func setAuthProviderCookie(w http.ResponseWriter, provider, loginURL string, authenticated bool) {
+func setAuthProviderCookie(w http.ResponseWriter, provider, loginURL string, authenticated, autoLogin bool) {
 	clearCookieFromResponse(w, cookieNameAuthProvider)
-	setCookie(w, cookieNameAuthProvider, map[string]any{
+	payload := map[string]any{
 		"provider":      provider,
 		"url":           loginURL,
 		"authenticated": authenticated,
-	})
+		"autoLogin":     autoLogin,
+	}
+	setCookie(w, cookieNameAuthProvider, payload)
 }
 
 // SetAnonymousAuthProviderCookie sets the anonymous auth provider cookie in the response.
 func SetAnonymousAuthProviderCookie(w http.ResponseWriter) {
-	setAuthProviderCookie(w, fluxcdv1.AuthenticationTypeAnonymous, "", true)
+	setAuthProviderCookie(w, fluxcdv1.AuthenticationTypeAnonymous, "", true, false)
 }
 
 // authStorage holds the authentication information stored in cookies.

--- a/internal/web/auth/cookies_test.go
+++ b/internal/web/auth/cookies_test.go
@@ -132,7 +132,7 @@ func TestSetAuthProviderCookie(t *testing.T) {
 	g := NewWithT(t)
 
 	rec := httptest.NewRecorder()
-	setAuthProviderCookie(rec, "OIDC", "/oauth2/authorize", true)
+	setAuthProviderCookie(rec, "OIDC", "/oauth2/authorize", true, false)
 
 	cookies := rec.Result().Cookies()
 	g.Expect(cookies).To(HaveLen(1))
@@ -152,16 +152,68 @@ func TestSetAuthProviderCookie(t *testing.T) {
 	g.Expect(result["authenticated"]).To(BeTrue())
 }
 
+func TestSetAuthProviderCookie_AutoLogin(t *testing.T) {
+	g := NewWithT(t)
+
+	rec := httptest.NewRecorder()
+	setAuthProviderCookie(rec, "OIDC", "/oauth2/authorize", false, true)
+
+	cookies := rec.Result().Cookies()
+	g.Expect(cookies).To(HaveLen(1))
+
+	decoded, err := base64.RawURLEncoding.DecodeString(cookies[0].Value)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var result map[string]any
+	err = json.Unmarshal(decoded, &result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result["autoLogin"]).To(BeTrue())
+}
+
+func TestSetAuthProviderCookie_AutoLoginFalse(t *testing.T) {
+	g := NewWithT(t)
+
+	rec := httptest.NewRecorder()
+	setAuthProviderCookie(rec, "OIDC", "/oauth2/authorize", false, false)
+
+	decoded, err := base64.RawURLEncoding.DecodeString(rec.Result().Cookies()[0].Value)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var result map[string]any
+	err = json.Unmarshal(decoded, &result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result["autoLogin"]).To(BeFalse())
+}
+
+func TestSetAuthLogoutCookie(t *testing.T) {
+	g := NewWithT(t)
+
+	rec := httptest.NewRecorder()
+	setAuthLogoutCookie(rec)
+
+	cookies := rec.Result().Cookies()
+	g.Expect(cookies).To(HaveLen(1))
+	g.Expect(cookies[0].Name).To(Equal(cookieNameAuthLogout))
+
+	decoded, err := base64.RawURLEncoding.DecodeString(cookies[0].Value)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var result map[string]any
+	err = json.Unmarshal(decoded, &result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result["suppressAutoLogin"]).To(BeTrue())
+}
+
 func TestSetAuthProviderCookie_ClearsExisting(t *testing.T) {
 	g := NewWithT(t)
 
 	rec := httptest.NewRecorder()
 
 	// Set first cookie
-	setAuthProviderCookie(rec, "First", "/first", false)
+	setAuthProviderCookie(rec, "First", "/first", false, false)
 
 	// Set second cookie (should clear first)
-	setAuthProviderCookie(rec, "Second", "/second", true)
+	setAuthProviderCookie(rec, "Second", "/second", true, false)
 
 	cookies := rec.Result().Cookies()
 	// Should only have one auth-provider cookie

--- a/internal/web/auth/middlewares.go
+++ b/internal/web/auth/middlewares.go
@@ -77,6 +77,7 @@ func NewMiddleware(conf *fluxcdv1.WebConfigSpec, kubeClient *kubeclient.Client,
 					return
 				}
 				deleteAuthStorage(w)
+				setAuthLogoutCookie(w)
 				http.Redirect(w, r, "/", http.StatusSeeOther)
 			default:
 				// Inject logger into context.

--- a/internal/web/auth/middlewares_test.go
+++ b/internal/web/auth/middlewares_test.go
@@ -76,6 +76,7 @@ func TestLogoutHandling(t *testing.T) {
 						return
 					}
 					deleteAuthStorage(w)
+					setAuthLogoutCookie(w)
 					http.Redirect(w, r, "/", http.StatusSeeOther)
 				default:
 					next.ServeHTTP(w, r)
@@ -107,6 +108,22 @@ func TestLogoutHandling(t *testing.T) {
 			}
 		}
 		g.Expect(storageDeleted).To(BeTrue())
+
+		var logoutCookie *http.Cookie
+		for _, c := range cookies {
+			if c.Name == cookieNameAuthLogout {
+				logoutCookie = c
+				break
+			}
+		}
+		g.Expect(logoutCookie).NotTo(BeNil())
+
+		decoded, err := base64.RawURLEncoding.DecodeString(logoutCookie.Value)
+		g.Expect(err).NotTo(HaveOccurred())
+		var result map[string]any
+		err = json.Unmarshal(decoded, &result)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result["suppressAutoLogin"]).To(BeTrue())
 	})
 
 	t.Run("GET /logout returns 405 Method Not Allowed", func(t *testing.T) {
@@ -121,6 +138,7 @@ func TestLogoutHandling(t *testing.T) {
 						return
 					}
 					deleteAuthStorage(w)
+					setAuthLogoutCookie(w)
 					http.Redirect(w, r, "/", http.StatusSeeOther)
 				default:
 					next.ServeHTTP(w, r)

--- a/internal/web/auth/oauth2.go
+++ b/internal/web/auth/oauth2.go
@@ -481,7 +481,8 @@ func (o *oauth2Authenticator) setAuthProvider(w http.ResponseWriter, authenticat
 	setAuthProviderCookie(w,
 		o.conf.Authentication.OAuth2.Provider,
 		o.conf.BaseURL+oauth2PathAuthorize,
-		authenticated)
+		authenticated,
+		o.conf.Authentication.OAuth2.AutoLogin)
 }
 
 // oauth2LoginState holds the OAuth2 login state information.

--- a/web/src/components/auth/LoginPage.jsx
+++ b/web/src/components/auth/LoginPage.jsx
@@ -2,9 +2,29 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 import { useEffect, useState } from 'preact/hooks'
-import { parseAuthProviderCookie, parseAuthErrorCookie, deleteCookie } from '../../utils/cookies'
+import { parseAuthProviderCookie, parseAuthErrorCookie, parseAuthLogoutCookie, deleteCookie } from '../../utils/cookies'
 import { usePageMeta } from '../../utils/meta'
 import { FluxOperatorIcon, OpenIDIcon } from '../layout/Icons'
+
+/**
+ * Build the OAuth2 authorize URL with the original path preserved for post-login redirect.
+ * @param {string} providerURL - Absolute or relative authorize URL from the auth-provider cookie
+ * @param {string} path - Path to return to after authentication
+ * @returns {string|null}
+ */
+function buildLoginUrl(providerURL, path) {
+  if (!providerURL || !path) return null
+  try {
+    // Try as absolute URL first (external IDP), fall back to relative (local proxy)
+    const loginUrl = providerURL.startsWith('http')
+      ? new window.URL(providerURL)
+      : new window.URL(providerURL, window.location.origin)
+    loginUrl.searchParams.set('originalPath', path)
+    return loginUrl.toString()
+  } catch {
+    return null
+  }
+}
 
 /**
  * LoginPage component - Authentication required page
@@ -16,6 +36,10 @@ import { FluxOperatorIcon, OpenIDIcon } from '../layout/Icons'
  * - Error messages from auth-error cookie (if any)
  * - Login button that redirects to OIDC provider
  * - Link to documentation
+ *
+ * When autoLogin is enabled in the auth-provider cookie, unauthenticated users
+ * are redirected straight to the OIDC provider (same as clicking the button),
+ * except after an explicit logout (auth-logout cookie) or auth error.
  */
 export function LoginPage() {
   usePageMeta('Login', 'Sign in to monitor your GitOps pipelines')
@@ -29,11 +53,6 @@ export function LoginPage() {
   useEffect(() => {
     // Parse auth-provider cookie
     const provider = parseAuthProviderCookie()
-    setAuthProvider(provider)
-
-    if (!provider) {
-      setCookieError('Authentication configuration unavailable. Please contact your administrator.')
-    }
 
     // Parse and clear auth-error cookie
     const error = parseAuthErrorCookie()
@@ -41,6 +60,16 @@ export function LoginPage() {
       setAuthError(error)
       deleteCookie('auth-error')
     }
+
+    // Parse auth-logout cookie (set after explicit user logout).
+    // Keep it until the user explicitly chooses to sign in.
+    const logout = parseAuthLogoutCookie()
+
+    if (!provider) {
+      setCookieError('Authentication configuration unavailable. Please contact your administrator.')
+      return
+    }
+    setAuthProvider(provider)
 
     // Get original path from sessionStorage (set by logout) or current location
     let storedPath = window.sessionStorage.getItem('flux-originalPath')
@@ -50,26 +79,24 @@ export function LoginPage() {
       storedPath = window.location.pathname + window.location.search
     }
     setOriginalPath(storedPath)
+
+    // Auto-login: skip the login page when configured and there is no auth error
+    // or explicit logout (user must click the button to sign in again).
+    if (provider.autoLogin === true && provider.url && storedPath && !error && !logout) {
+      const loginUrl = buildLoginUrl(provider.url, storedPath)
+      if (loginUrl) {
+        setIsLoading(true)
+        window.location.href = loginUrl
+      }
+    }
   }, [])
 
-  // Build login URL with originalPath
-  const getLoginUrl = () => {
-    if (!authProvider?.url || !originalPath) return null
-    try {
-      // Try as absolute URL first (external IDP), fall back to relative (local proxy)
-      const loginUrl = authProvider.url.startsWith('http')
-        ? new window.URL(authProvider.url)
-        : new window.URL(authProvider.url, window.location.origin)
-      loginUrl.searchParams.set('originalPath', originalPath)
-      return loginUrl.toString()
-    } catch {
-      return null
-    }
-  }
+  const getLoginUrl = () => buildLoginUrl(authProvider?.url, originalPath)
 
   const handleLogin = () => {
     const loginUrl = getLoginUrl()
     if (loginUrl) {
+      deleteCookie('auth-logout')
       setIsLoading(true)
       window.location.href = loginUrl
     }

--- a/web/src/components/auth/LoginPage.test.jsx
+++ b/web/src/components/auth/LoginPage.test.jsx
@@ -10,6 +10,7 @@ import * as cookies from '../../utils/cookies'
 vi.mock('../../utils/cookies', () => ({
   parseAuthProviderCookie: vi.fn(),
   parseAuthErrorCookie: vi.fn(),
+  parseAuthLogoutCookie: vi.fn(),
   deleteCookie: vi.fn()
 }))
 
@@ -50,6 +51,7 @@ describe('LoginPage', () => {
       authenticated: false
     })
     cookies.parseAuthErrorCookie.mockReturnValue(null)
+    cookies.parseAuthLogoutCookie.mockReturnValue(null)
   })
 
   afterEach(() => {
@@ -384,6 +386,119 @@ describe('LoginPage', () => {
         const loginIcon = document.querySelector('button svg[viewBox="0 0 20 20"]')
         expect(loginIcon).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('Auto Login', () => {
+    it('should redirect automatically when autoLogin is enabled', async () => {
+      cookies.parseAuthProviderCookie.mockReturnValue({
+        provider: 'oidc',
+        url: 'http://localhost:9080/oauth2/authorize',
+        authenticated: false,
+        autoLogin: true
+      })
+      window.location.pathname = '/favorites'
+      window.location.search = ''
+
+      render(<LoginPage />)
+
+      await waitFor(() => {
+        expect(window.location.href).toContain('http://localhost:9080/oauth2/authorize')
+        expect(window.location.href).toContain('originalPath=%2Ffavorites')
+      })
+    })
+
+    it('should not redirect automatically when autoLogin is disabled', async () => {
+      cookies.parseAuthProviderCookie.mockReturnValue({
+        provider: 'oidc',
+        url: 'http://localhost:9080/oauth2/authorize',
+        authenticated: false,
+        autoLogin: false
+      })
+
+      render(<LoginPage />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Continue with SSO/ })).toBeInTheDocument()
+      })
+      expect(window.location.href).toBe('')
+    })
+
+    it('should not redirect automatically when auth-error cookie is present', async () => {
+      cookies.parseAuthProviderCookie.mockReturnValue({
+        provider: 'oidc',
+        url: 'http://localhost:9080/oauth2/authorize',
+        authenticated: false,
+        autoLogin: true
+      })
+      cookies.parseAuthErrorCookie.mockReturnValue({
+        msg: 'Access denied'
+      })
+
+      render(<LoginPage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Access denied')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Continue with SSO/ })).toBeInTheDocument()
+      })
+      expect(window.location.href).toBe('')
+    })
+
+    it('should not redirect automatically after explicit logout', async () => {
+      cookies.parseAuthProviderCookie.mockReturnValue({
+        provider: 'oidc',
+        url: 'http://localhost:9080/oauth2/authorize',
+        authenticated: false,
+        autoLogin: true
+      })
+      cookies.parseAuthLogoutCookie.mockReturnValue({ suppressAutoLogin: true })
+
+      render(<LoginPage />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Continue with SSO/ })).toBeInTheDocument()
+      })
+      expect(cookies.deleteCookie).not.toHaveBeenCalledWith('auth-logout')
+      expect(window.location.href).toBe('')
+    })
+
+    it('should keep suppressing auto-login across remounts until sign in', async () => {
+      cookies.parseAuthProviderCookie.mockReturnValue({
+        provider: 'oidc',
+        url: 'http://localhost:9080/oauth2/authorize',
+        authenticated: false,
+        autoLogin: true
+      })
+      cookies.parseAuthLogoutCookie.mockReturnValue({ suppressAutoLogin: true })
+
+      const { unmount } = render(<LoginPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Continue with SSO/ })).toBeInTheDocument()
+      })
+      unmount()
+
+      render(<LoginPage />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Continue with SSO/ })).toBeInTheDocument()
+      })
+      expect(window.location.href).toBe('')
+    })
+
+    it('should clear auth-logout cookie when user clicks sign in', async () => {
+      cookies.parseAuthProviderCookie.mockReturnValue({
+        provider: 'oidc',
+        url: 'http://localhost:9080/oauth2/authorize',
+        authenticated: false,
+        autoLogin: true
+      })
+      cookies.parseAuthLogoutCookie.mockReturnValue({ suppressAutoLogin: true })
+
+      render(<LoginPage />)
+
+      const button = await screen.findByRole('button', { name: /Continue with SSO/ })
+      fireEvent.click(button)
+
+      expect(cookies.deleteCookie).toHaveBeenCalledWith('auth-logout')
     })
   })
 

--- a/web/src/utils/cookies.js
+++ b/web/src/utils/cookies.js
@@ -44,7 +44,7 @@ export function deleteCookie(name) {
 /**
  * Parse the auth-provider cookie
  * @returns {Object|null} - Parsed auth provider object or null if invalid
- * Expected format: { provider: string, url: string, authenticated: boolean }
+ * Expected format: { provider: string, url: string, authenticated: boolean, autoLogin?: boolean }
  */
 export function parseAuthProviderCookie() {
   const value = getCookie('auth-provider')
@@ -57,6 +57,9 @@ export function parseAuthProviderCookie() {
     const parsed = JSON.parse(decoded)
     // Validate required fields
     if (typeof parsed.provider !== 'string' || typeof parsed.url !== 'string' || typeof parsed.authenticated !== 'boolean') {
+      return null
+    }
+    if (parsed.autoLogin !== undefined && typeof parsed.autoLogin !== 'boolean') {
       return null
     }
     return parsed
@@ -81,6 +84,28 @@ export function parseAuthErrorCookie() {
     const parsed = JSON.parse(decoded)
     // Validate required fields
     if (typeof parsed.msg !== 'string') {
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse the auth-logout cookie set after an explicit user logout.
+ * @returns {Object|null} - Parsed logout object or null if invalid
+ * Expected format: { suppressAutoLogin: true }
+ */
+export function parseAuthLogoutCookie() {
+  const value = getCookie('auth-logout')
+  if (!value) {
+    return null
+  }
+  try {
+    const decoded = decodeBase64Url(value)
+    const parsed = JSON.parse(decoded)
+    if (parsed.suppressAutoLogin !== true) {
       return null
     }
     return parsed

--- a/web/src/utils/cookies.test.js
+++ b/web/src/utils/cookies.test.js
@@ -6,6 +6,7 @@ import {
   deleteCookie,
   parseAuthProviderCookie,
   parseAuthErrorCookie,
+  parseAuthLogoutCookie,
   isOIDCProvider
 } from './cookies'
 
@@ -158,6 +159,32 @@ describe('cookies utilities', () => {
       expect(result.authenticated).toBe(false)
     })
 
+    it('should parse optional autoLogin field', () => {
+      const payload = {
+        provider: 'oidc',
+        url: 'https://auth.example.com/login',
+        authenticated: false,
+        autoLogin: true
+      }
+      const encoded = encodeBase64Url(JSON.stringify(payload))
+      document.cookie = `auth-provider=${encoded}`
+
+      expect(parseAuthProviderCookie()).toEqual(payload)
+    })
+
+    it('should return null when autoLogin is not a boolean', () => {
+      const payload = {
+        provider: 'oidc',
+        url: 'https://auth.example.com/login',
+        authenticated: false,
+        autoLogin: 'yes'
+      }
+      const encoded = encodeBase64Url(JSON.stringify(payload))
+      document.cookie = `auth-provider=${encoded}`
+
+      expect(parseAuthProviderCookie()).toBeNull()
+    })
+
     it('should handle base64url special characters (- and _)', () => {
       // Create a payload that produces base64 with + and / characters
       const payload = { provider: 'oidc', url: 'https://auth.example.com/login?redirect=/', authenticated: true }
@@ -209,6 +236,29 @@ describe('cookies utilities', () => {
       document.cookie = `auth-error=${encoded}`
 
       expect(parseAuthErrorCookie()).toBeNull()
+    })
+  })
+
+  describe('parseAuthLogoutCookie', () => {
+    it('should return null when cookie does not exist', () => {
+      document.cookie = ''
+      expect(parseAuthLogoutCookie()).toBeNull()
+    })
+
+    it('should parse valid auth-logout cookie', () => {
+      const payload = { suppressAutoLogin: true }
+      const encoded = encodeBase64Url(JSON.stringify(payload))
+      document.cookie = `auth-logout=${encoded}`
+
+      expect(parseAuthLogoutCookie()).toEqual(payload)
+    })
+
+    it('should return null when suppressAutoLogin is not true', () => {
+      const payload = { suppressAutoLogin: false }
+      const encoded = encodeBase64Url(JSON.stringify(payload))
+      document.cookie = `auth-logout=${encoded}`
+
+      expect(parseAuthLogoutCookie()).toBeNull()
     })
   })
 


### PR DESCRIPTION
## Summary

Add optional `oauth2.autoLogin` to the Web UI config (default `false`). When enabled, unauthenticated users skip the login page and redirect to the OIDC provider, preserving `originalPath` for deep links.

After explicit logout, auto-redirect is suppressed via an `auth-logout` cookie so users are not immediately signed back in through the IdP session.

Closes #953

## Config

```yaml
spec:
  authentication:
    type: OAuth2
    oauth2:
      autoLogin: true
```

## Test plan

- [x] `go test ./internal/web/auth/... ./internal/web/config/...`
- [x] `make web-test`
- [x] Manual OIDC test on cluster (via local build and live test)
- [x] Manual logout → login page shown, no instant re-login

## AI disclosure

Assisted-by: Cursor/Composer2.5
