### PR TITLE
web: add more keyboard shortcuts and help modal

### DIFF
--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -22,6 +22,8 @@ import { FavoritesPage } from './components/favorites/FavoritesPage'
 import { favorites } from './utils/favorites'
 import { ProfilePage } from './components/user/ProfilePage'
 import { NotFoundPage } from './components/layout/NotFoundPage'
+import { KeyboardShortcutsModal } from './components/layout/KeyboardShortcutsModal'
+import { useKeyboardShortcuts } from './utils/useKeyboardShortcuts'
 import { FluxOperatorIcon } from './components/layout/Icons'
 import { Spinner } from './components/common/rowKit'
 
@@ -308,6 +310,8 @@ function AppContent({ spec, namespace }) {
   const currentPath = location.path
   const isTabView = currentPath === '/favorites' || currentPath === '/events' || currentPath === '/resources' || currentPath === '/workloads'
 
+  useKeyboardShortcuts()
+
   return (
     <div
       class="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors flex flex-col"
@@ -318,6 +322,8 @@ function AppContent({ spec, namespace }) {
     >
       {/* Connection status banner (only visible when disconnected) */}
       <ConnectionStatus />
+
+      <KeyboardShortcutsModal />
 
       {/* Sticky top chrome on desktop: the header and tab nav pin to the top so
           the list scrolls behind them. On mobile they stay in normal flow. The

--- a/web/src/app.test.jsx
+++ b/web/src/app.test.jsx
@@ -47,19 +47,29 @@ vi.mock('./components/dashboards/cluster/ClusterPage', () => ({
 vi.mock('./components/search/EventList', () => ({
   EventList: () => <div data-testid="event-list">EventList</div>,
   eventsData: { value: [] },
-  eventsLoading: { value: false }
+  eventsLoading: { value: false },
+  fetchEvents: vi.fn()
 }))
 
 vi.mock('./components/search/ResourceList', () => ({
   ResourceList: () => <div data-testid="resource-list">ResourceList</div>,
   resourcesData: { value: [] },
-  resourcesLoading: { value: false }
+  resourcesLoading: { value: false },
+  fetchResourcesStatus: vi.fn()
 }))
 
 vi.mock('./components/search/WorkloadList', () => ({
   WorkloadList: () => <div data-testid="workload-list">WorkloadList</div>,
   workloadsData: { value: [] },
-  workloadsLoading: { value: false }
+  workloadsLoading: { value: false },
+  fetchWorkloadsStatus: vi.fn()
+}))
+
+vi.mock('./components/favorites/FavoritesPage', () => ({
+  FavoritesPage: () => <div data-testid="favorites-page">FavoritesPage</div>,
+  favoritesData: { value: {} },
+  favoritesFetching: { value: false },
+  fetchFavoritesData: vi.fn()
 }))
 
 vi.mock('./components/dashboards/resource/ResourcePage', () => ({

--- a/web/src/components/dashboards/resource/ArtifactPanel.jsx
+++ b/web/src/components/dashboards/resource/ArtifactPanel.jsx
@@ -1,11 +1,9 @@
 // Copyright 2025 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
+import { useMemo } from 'preact/hooks'
 import { DashboardPanel, TabButton } from '../common/panel'
 import { useHashTab } from '../../../utils/hash'
-
-// Valid tabs for the ArtifactPanel
-const ARTIFACT_TABS = ['overview', 'metadata']
 
 /**
  * Get the source reference display string
@@ -71,18 +69,25 @@ function formatSize(bytes) {
  * ArtifactPanel - Displays artifact information for Flux source resources
  */
 export function ArtifactPanel({ resourceData }) {
+  const metadata = resourceData?.status?.artifact?.metadata
+  const hasMetadata = metadata && Object.keys(metadata).length > 0
+
+  const visibleTabs = useMemo(() => {
+    const tabs = ['overview']
+    if (hasMetadata) {
+      tabs.push('metadata')
+    }
+    return tabs
+  }, [hasMetadata])
+
   // Tab state synced with URL hash (e.g., #artifact-metadata)
-  const [activeTab, setActiveTab] = useHashTab('artifact', 'overview', ARTIFACT_TABS, 'artifact-panel')
+  const [activeTab, setActiveTab] = useHashTab('artifact', 'overview', visibleTabs, 'artifact-panel')
 
   // Extract data
   const kind = resourceData?.kind
   const namespace = resourceData?.metadata?.namespace
   const spec = resourceData?.spec
   const artifact = resourceData?.status?.artifact
-  const metadata = artifact?.metadata
-
-  // Check if metadata tab should be shown
-  const hasMetadata = metadata && Object.keys(metadata).length > 0
 
   // Source info
   const sourceUrl = spec?.url || spec?.endpoint

--- a/web/src/components/dashboards/resource/ManagedObjectsPanel.jsx
+++ b/web/src/components/dashboards/resource/ManagedObjectsPanel.jsx
@@ -10,30 +10,35 @@ import { InventoryTabContent } from './InventoryTabContent'
 import { GraphTabContent } from './GraphTabContent'
 import { useHashTab } from '../../../utils/hash'
 
-// Valid tabs for the ManagedObjectsPanel
-const INVENTORY_TABS = ['overview', 'graph', 'inventory']
-
 /**
  * ManagedObjectsPanel - Displays the managed objects for a Flux resource
  * Handles its own state management and statistics calculations
  */
 export function ManagedObjectsPanel({ resourceData, onNavigate }) {
+  const shouldShowPanel = isKindWithInventory(resourceData?.kind)
+  const hasInventory = resourceData?.status?.inventory && resourceData.status.inventory.length > 0
+
+  const visibleTabs = useMemo(() => {
+    if (!shouldShowPanel) {
+      return []
+    }
+    const tabs = ['overview', 'graph']
+    if (hasInventory) {
+      tabs.push('inventory')
+    }
+    return tabs
+  }, [shouldShowPanel, hasInventory])
+
   // Tab state synced with URL hash (e.g., #inventory-graph)
-  const [activeTab, setActiveTab] = useHashTab('inventory', 'overview', INVENTORY_TABS, 'inventory-panel')
+  const [activeTab, setActiveTab] = useHashTab('inventory', 'overview', visibleTabs, 'inventory-panel')
 
   // Inventory tab filter state, lifted to the panel so the category and search
   // query survive tab switches (the tab content unmounts while inactive).
   const [inventoryCategory, setInventoryCategory] = useState('all')
   const [inventoryQuery, setInventoryQuery] = useState('')
 
-  // Check if inventory exists
-  const hasInventory = resourceData?.status?.inventory && resourceData.status.inventory.length > 0
-
   // Check for inventory error
   const inventoryError = resourceData?.status?.inventoryError
-
-  // Check if this kind should have inventory panel
-  const shouldShowPanel = isKindWithInventory(resourceData?.kind)
 
   // Don't render if this kind doesn't support inventory
   if (!shouldShowPanel) {

--- a/web/src/components/dashboards/resource/ReconcilerPanel.jsx
+++ b/web/src/components/dashboards/resource/ReconcilerPanel.jsx
@@ -14,12 +14,34 @@ import { HistoryTimeline } from './HistoryTimeline'
 import { FluxOperatorIcon } from '../../layout/Icons'
 import { useHashTab } from '../../../utils/hash'
 
-// Valid tabs for the ReconcilerPanel
-const RECONCILER_TABS = ['overview', 'history', 'events', 'values', 'spec', 'status']
-
 export function ReconcilerPanel({ kind, name, namespace, resourceData }) {
+  const valuesYaml = useMemo(() => {
+    if (kind !== 'HelmRelease' || !resourceData) return null
+    if (resourceData.status?.helmValues) return resourceData.status.helmValues
+    if (resourceData.spec?.values) return resourceData.spec.values
+    return null
+  }, [resourceData, kind])
+
+  const valuesError = useMemo(() => {
+    if (kind !== 'HelmRelease' || !resourceData) return null
+    return resourceData.status?.helmValuesError || null
+  }, [resourceData, kind])
+
+  const visibleTabs = useMemo(() => {
+    const tabs = ['overview']
+    if (resourceData?.status?.history?.length > 0) {
+      tabs.push('history')
+    }
+    tabs.push('events')
+    if (kind === 'HelmRelease' && (valuesError || valuesYaml)) {
+      tabs.push('values')
+    }
+    tabs.push('spec', 'status')
+    return tabs
+  }, [resourceData, kind, valuesError, valuesYaml])
+
   // Tab state synced with URL hash (e.g., #reconciler-events)
-  const [reconcilerTab, setReconcilerTab] = useHashTab('reconciler', 'overview', RECONCILER_TABS, 'reconciler-panel')
+  const [reconcilerTab, setReconcilerTab] = useHashTab('reconciler', 'overview', visibleTabs, 'reconciler-panel')
 
   // Events data state
   const [eventsData, setEventsData] = useState([])
@@ -51,18 +73,6 @@ export function ReconcilerPanel({ kind, name, namespace, resourceData }) {
       spec: resourceData.spec
     }
   }, [resourceData])
-
-  const valuesYaml = useMemo(() => {
-    if (kind !== 'HelmRelease' || !resourceData) return null
-    if (resourceData.status?.helmValues) return resourceData.status.helmValues
-    if (resourceData.spec?.values) return resourceData.spec.values
-    return null
-  }, [resourceData, kind])
-
-  const valuesError = useMemo(() => {
-    if (kind !== 'HelmRelease' || !resourceData) return null
-    return resourceData.status?.helmValuesError || null
-  }, [resourceData, kind])
 
   const statusYaml = useMemo(() => {
     if (!resourceData?.status) return null

--- a/web/src/components/dashboards/resource/ResourcePage.jsx
+++ b/web/src/components/dashboards/resource/ResourcePage.jsx
@@ -18,6 +18,7 @@ import { ExportedInputsPanel } from './ExportedInputsPanel'
 import { InputsPanel } from './InputsPanel'
 import { isKindWithInventory, POLL_INTERVAL_MS, FAST_POLL_INTERVAL_MS, FAST_POLL_TIMEOUT_MS } from '../../../utils/constants'
 import { getDashboardUrl } from '../../../utils/routing'
+import { useRegisterPageShortcuts } from '../../../utils/useRegisterPageShortcuts'
 
 /**
  * Get loading status styling info with spinning refresh icon
@@ -202,6 +203,8 @@ export function ResourcePage({ kind, namespace, name }) {
     const interval = setInterval(fetchData, currentPollInterval)
     return () => clearInterval(interval)
   }, [kind, namespace, name, currentPollInterval])
+
+  useRegisterPageShortcuts({ onRefresh: fetchData })
 
   // Cleanup fast poll timeout on unmount
   useEffect(() => {

--- a/web/src/components/dashboards/resource/SourcePanel.jsx
+++ b/web/src/components/dashboards/resource/SourcePanel.jsx
@@ -12,9 +12,6 @@ import { getStatusBadgeClass, getEventBadgeClass } from '../../../utils/status'
 import { FluxOperatorIcon } from '../../layout/Icons'
 import { useHashTab } from '../../../utils/hash'
 
-// Valid tabs for the SourcePanel
-const SOURCE_TABS = ['overview', 'chart', 'events', 'spec', 'status']
-
 /**
  * SourcePanel - Displays source information for a Flux resource
  * Handles its own data fetching and state management
@@ -39,8 +36,22 @@ export function SourcePanel({ resourceData }) {
   // Track initial mount to avoid refetching on first render
   const isInitialMount = useRef(true)
 
+  const hasHelmChart = resourceData?.kind === 'HelmRelease' && resourceData?.status?.helmChart
+
+  const visibleTabs = useMemo(() => {
+    const tabs = ['overview']
+    if (hasHelmChart) {
+      tabs.push('chart')
+    }
+    tabs.push('events')
+    if (sourceData) {
+      tabs.push('spec', 'status')
+    }
+    return tabs
+  }, [hasHelmChart, sourceData])
+
   // Tab state synced with URL hash (e.g., #source-events)
-  const [sourceTab, setSourceTab] = useHashTab('source', 'overview', SOURCE_TABS, 'source-panel')
+  const [sourceTab, setSourceTab] = useHashTab('source', 'overview', visibleTabs, 'source-panel')
 
   // Fetch source data when component mounts (initial fetch only)
   useEffect(() => {
@@ -164,9 +175,6 @@ export function SourcePanel({ resourceData }) {
 
     refetchSourceData()
   }, [resourceData])
-
-  // Determine if HelmChart info is available
-  const hasHelmChart = resourceData?.kind === 'HelmRelease' && resourceData?.status?.helmChart
 
   // Parse HelmChart reference (format: "namespace/name")
   const helmChartRef = useMemo(() => {

--- a/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadDetailPanel.jsx
@@ -14,6 +14,7 @@ import { LOGS_QUERY_PARAM, ALL_PODS_VALUE } from './WorkloadLogsAction'
 import { FluxOperatorIcon } from '../../layout/Icons'
 import { useHashTab } from '../../../utils/hash'
 import { urlWithParam } from '../../../utils/routing'
+import { useWorkloadLogsOverlay } from '../../../utils/useWorkloadLogsOverlay'
 
 // Valid tabs for the WorkloadDetailPanel
 const WORKLOAD_TABS = ['overview', 'pods', 'events', 'spec', 'status']
@@ -130,6 +131,8 @@ export function WorkloadDetailPanel({
     setLogsSession(null)
     window.history.replaceState(null, '', urlWithParam(LOGS_QUERY_PARAM, null))
   }
+
+  useWorkloadLogsOverlay(!!logsSession)
 
   // Whether the user is allowed to view pod logs
   const canViewLogs = workloadInfo?.userActions?.includes('logs')

--- a/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
+++ b/web/src/components/dashboards/workload/WorkloadLogsAction.jsx
@@ -4,6 +4,8 @@
 import { useState, useRef, useMemo, useEffect, useCallback } from 'preact/hooks'
 import { WorkloadLogsViewer } from './WorkloadLogsViewer'
 import { urlWithParam } from '../../../utils/routing'
+import { useRegisterPageShortcuts } from '../../../utils/useRegisterPageShortcuts'
+import { useWorkloadLogsOverlay } from '../../../utils/useWorkloadLogsOverlay'
 
 // LOGS_QUERY_PARAM carries the open viewer in the URL so a session is shareable:
 // a pod name, or ALL_PODS_VALUE for "All pods". Shared with WorkloadDetailPanel,
@@ -81,18 +83,25 @@ export function WorkloadLogsAction({ kind, namespace, name, pods = [], userActio
     setSession({ key: sessionKeyRef.current, pod: logs === ALL_PODS_VALUE ? null : logs })
   }, [])
 
-  if (!canViewLogs) {
-    return null
-  }
-
   // No pods to inspect (e.g. scaled to zero): the button is shown but disabled.
   const hasPods = logsPods.length > 0
 
   // Open the viewer on "All pods"; its pod selector narrows from there.
-  const openAllPods = () => {
+  const openAllPods = useCallback(() => {
+    if (logsPods.length === 0) {
+      return
+    }
     sessionKeyRef.current += 1
     setSession({ key: sessionKeyRef.current, pod: null })
     syncLogFilterToUrl(null)
+  }, [syncLogFilterToUrl, logsPods.length])
+
+  useRegisterPageShortcuts({ onOpenLogs: canViewLogs && hasPods ? openAllPods : undefined })
+
+  useWorkloadLogsOverlay(!!session)
+
+  if (!canViewLogs) {
+    return null
   }
 
   const closeSession = () => {

--- a/web/src/components/dashboards/workload/WorkloadPage.jsx
+++ b/web/src/components/dashboards/workload/WorkloadPage.jsx
@@ -14,6 +14,7 @@ import { WorkloadLogsAction } from './WorkloadLogsAction'
 import { WorkloadReconcilerPanel } from './WorkloadReconcilerPanel'
 import { WorkloadPipelinePanel } from './WorkloadPipelinePanel'
 import { WorkloadDetailPanel } from './WorkloadDetailPanel'
+import { useRegisterPageShortcuts } from '../../../utils/useRegisterPageShortcuts'
 
 // Polling intervals
 const POLL_INTERVAL_MS = 10000  // 10 seconds (workloads change more frequently)
@@ -212,6 +213,8 @@ export function WorkloadPage({ kind, namespace, name }) {
     const interval = setInterval(fetchData, currentPollInterval)
     return () => clearInterval(interval)
   }, [kind, namespace, name, currentPollInterval])
+
+  useRegisterPageShortcuts({ onRefresh: fetchData })
 
   // Cleanup fast poll timeout on unmount
   useEffect(() => {

--- a/web/src/components/dashboards/workload/WorkloadReconcilerPanel.jsx
+++ b/web/src/components/dashboards/workload/WorkloadReconcilerPanel.jsx
@@ -11,16 +11,25 @@ import { getStatusBadgeClass, getEventBadgeClass } from '../../../utils/status'
 import { FluxOperatorIcon } from '../../layout/Icons'
 import { useHashTab } from '../../../utils/hash'
 
-// Valid tabs for the WorkloadReconcilerPanel
-const RECONCILER_TABS = ['overview', 'source', 'events']
-
 /**
  * WorkloadReconcilerPanel - Displays reconciler info for a workload's parent Flux resource.
  * Owns tab state, events lazy-loading, and auto-refresh on workloadData changes.
  */
 export function WorkloadReconcilerPanel({ reconciler, workloadData }) {
+  const reconcilerRef = reconciler?.status?.reconcilerRef
+  const sourceRef = reconciler?.status?.sourceRef
+
+  const visibleTabs = useMemo(() => {
+    const tabs = ['overview']
+    if (sourceRef) {
+      tabs.push('source')
+    }
+    tabs.push('events')
+    return tabs
+  }, [sourceRef])
+
   // Tab state synced with URL hash
-  const [reconcilerTab, setReconcilerTab] = useHashTab('reconciler', 'overview', RECONCILER_TABS, 'reconciler-panel')
+  const [reconcilerTab, setReconcilerTab] = useHashTab('reconciler', 'overview', visibleTabs, 'reconciler-panel')
 
   // Events data state (lazy-loaded)
   const [eventsData, setEventsData] = useState([])
@@ -31,8 +40,6 @@ export function WorkloadReconcilerPanel({ reconciler, workloadData }) {
   const isInitialMount = useRef(true)
 
   // Derived data
-  const reconcilerRef = reconciler?.status?.reconcilerRef
-  const sourceRef = reconciler?.status?.sourceRef
   const reconcilerStatus = reconcilerRef?.status || 'Unknown'
   const reconcilerMessage = reconcilerRef?.message || reconciler?.status?.conditions?.[0]?.message || ''
   const reconcilerLastReconciled = reconcilerRef?.lastReconciled || reconciler?.status?.conditions?.[0]?.lastTransitionTime

--- a/web/src/components/favorites/FavoritesPage.jsx
+++ b/web/src/components/favorites/FavoritesPage.jsx
@@ -22,6 +22,71 @@ export const favoritesData = signal({})
 // fetch. On warm return visits hasCachedData suppresses the pulse regardless.
 export const favoritesFetching = signal(true)
 
+// Monotonic generation so overlapping polls / Shift+R refreshes discard stale
+// responses instead of overwriting newer favoritesData or clearing favoritesFetching
+// while a later request is still in flight.
+let favoritesFetchGeneration = 0
+
+/**
+ * Fetches current status for all favorites from the API.
+ * Used by the page poll interval and the Shift+R keyboard shortcut.
+ */
+export async function fetchFavoritesData() {
+  const generation = ++favoritesFetchGeneration
+  const currentFavorites = favorites.value
+
+  if (currentFavorites.length === 0) {
+    if (generation === favoritesFetchGeneration) {
+      favoritesData.value = {}
+      favoritesFetching.value = false
+    }
+    return
+  }
+
+  if (generation === favoritesFetchGeneration) {
+    favoritesFetching.value = true
+  }
+
+  try {
+    const data = await fetchWithMock({
+      endpoint: '/api/v1/favorites',
+      mockPath: '../mock/resources',
+      mockExport: 'getMockFavorites',
+      method: 'POST',
+      body: { favorites: currentFavorites }
+    })
+
+    if (generation !== favoritesFetchGeneration) {
+      return
+    }
+
+    const results = {}
+    const resources = data.resources || []
+
+    resources.forEach(resource => {
+      const key = getFavoriteKey(resource.kind, resource.namespace, resource.name)
+      results[key] = {
+        status: resource.status,
+        lastReconciled: resource.lastReconciled,
+        message: resource.message
+      }
+    })
+
+    favoritesData.value = results
+  } catch (err) {
+    if (generation !== favoritesFetchGeneration) {
+      return
+    }
+    if (Object.keys(favoritesData.value).length === 0) {
+      throw err
+    }
+  } finally {
+    if (generation === favoritesFetchGeneration) {
+      favoritesFetching.value = false
+    }
+  }
+}
+
 /**
  * Normalize a favorite's status to the Flux vocabulary (Ready/Failed/Progressing/
  * Suspended/Unknown) used by the status chart and status filter. Workload favorites
@@ -75,47 +140,17 @@ export function FavoritesPage() {
     return [...new Set(currentFavorites.map(f => f.kind))].sort()
   }, [currentFavorites])
 
-  // Fetch data on mount, when favorites change, and auto-refresh
+  // Fetch data on mount, when favorites change, and auto-refresh.
+  // Signal writes live in fetchFavoritesData (generation-guarded); cancelled only
+  // protects local error state after unmount / favorites change.
   useEffect(() => {
     let cancelled = false
 
     const fetchData = async () => {
-      if (currentFavorites.length === 0) {
-        // Reset the cache so deleting every favorite doesn't resurrect stale
-        // statuses on the next add.
-        favoritesData.value = {}
-        favoritesFetching.value = false
-        return
-      }
-
-      favoritesFetching.value = true
       if (!cancelled) setError(null)
 
       try {
-        // Send all favorites in a single POST request
-        const data = await fetchWithMock({
-          endpoint: '/api/v1/favorites',
-          mockPath: '../mock/resources',
-          mockExport: 'getMockFavorites',
-          method: 'POST',
-          body: { favorites: currentFavorites }
-        })
-
-        // Build results map from returned resources
-        const results = {}
-        const resources = data.resources || []
-
-        // Then, update with found resources
-        resources.forEach(resource => {
-          const key = getFavoriteKey(resource.kind, resource.namespace, resource.name)
-          results[key] = {
-            status: resource.status,
-            lastReconciled: resource.lastReconciled,
-            message: resource.message
-          }
-        })
-
-        if (!cancelled) favoritesData.value = results
+        await fetchFavoritesData()
       } catch (err) {
         // Surface the error panel only when there is no cached status to fall
         // back on; background refreshes (and any visit with a warm cache) fail
@@ -123,8 +158,6 @@ export function FavoritesPage() {
         if (!cancelled && Object.keys(favoritesData.value).length === 0) {
           setError(err.message)
         }
-      } finally {
-        if (!cancelled) favoritesFetching.value = false
       }
     }
 

--- a/web/src/components/favorites/FavoritesPage.test.jsx
+++ b/web/src/components/favorites/FavoritesPage.test.jsx
@@ -3,7 +3,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/preact'
-import { FavoritesPage, favoritesData, favoritesFetching } from './FavoritesPage'
+import { FavoritesPage, favoritesData, favoritesFetching, fetchFavoritesData } from './FavoritesPage'
 import { favorites, reorderFavorites, removeFavorite } from '../../utils/favorites'
 import { fetchWithMock } from '../../utils/fetch'
 import { POLL_INTERVAL_MS } from '../../utils/constants'
@@ -682,5 +682,60 @@ describe('FavoritesPage component', () => {
 
       expect(clearIntervalSpy).toHaveBeenCalled()
     })
+  })
+})
+
+describe('fetchFavoritesData race handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    favorites.value = [
+      { kind: 'FluxInstance', namespace: 'flux-system', name: 'flux' }
+    ]
+    favoritesData.value = {}
+    favoritesFetching.value = false
+  })
+
+  it('discards a stale response when a newer fetch completes first', async () => {
+    let resolveSlow
+    const slow = new Promise((resolve) => {
+      resolveSlow = resolve
+    })
+
+    fetchWithMock
+      .mockImplementationOnce(() => slow)
+      .mockImplementationOnce(() => Promise.resolve({
+        resources: [{
+          kind: 'FluxInstance',
+          namespace: 'flux-system',
+          name: 'flux',
+          status: 'Ready',
+          lastReconciled: '2024-01-15T10:00:00Z',
+          message: 'latest'
+        }]
+      }))
+
+    const slowPromise = fetchFavoritesData()
+    const fastPromise = fetchFavoritesData()
+
+    await fastPromise
+    expect(favoritesData.value['FluxInstance/flux-system/flux'].status).toBe('Ready')
+    expect(favoritesData.value['FluxInstance/flux-system/flux'].message).toBe('latest')
+    expect(favoritesFetching.value).toBe(false)
+
+    resolveSlow({
+      resources: [{
+        kind: 'FluxInstance',
+        namespace: 'flux-system',
+        name: 'flux',
+        status: 'Failed',
+        lastReconciled: '2024-01-15T09:00:00Z',
+        message: 'stale'
+      }]
+    })
+    await slowPromise
+
+    expect(favoritesData.value['FluxInstance/flux-system/flux'].status).toBe('Ready')
+    expect(favoritesData.value['FluxInstance/flux-system/flux'].message).toBe('latest')
+    expect(favoritesFetching.value).toBe(false)
   })
 })

--- a/web/src/components/layout/KeyboardShortcutsModal.jsx
+++ b/web/src/components/layout/KeyboardShortcutsModal.jsx
@@ -1,0 +1,176 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useRef, useEffect } from 'preact/hooks'
+import { keyboardShortcutsOpen } from '../../utils/keyboardShortcuts'
+import { useDismiss } from '../../utils/useDismiss'
+
+const KBD_CLS = 'px-1.5 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded'
+
+function Kbd({ children }) {
+  return <kbd class={KBD_CLS}>{children}</kbd>
+}
+
+function KeySequence({ keys, join }) {
+  if (join === '+') {
+    return (
+      <div class="flex items-center gap-1 flex-shrink-0">
+        {keys.map((key, index) => (
+          <span key={`${key}-${index}`} class="inline-flex items-center gap-1">
+            {index > 0 && <span class="text-xs text-gray-400">+</span>}
+            <Kbd>{key}</Kbd>
+          </span>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div class="inline-flex items-center gap-1 flex-shrink-0">
+      {keys.map((key) => (
+        <Kbd key={key}>{key}</Kbd>
+      ))}
+    </div>
+  )
+}
+
+function ShortcutRow({ keys, description }) {
+  return (
+    <div class="flex items-center justify-between gap-4 py-1.5">
+      <span class="text-sm text-gray-600 dark:text-gray-400">{description}</span>
+      <div class="flex items-center gap-1 flex-shrink-0">{keys}</div>
+    </div>
+  )
+}
+
+function ShortcutSection({ title, children }) {
+  return (
+    <section>
+      <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+        {title}
+      </h3>
+      <div class="divide-y divide-gray-100 dark:divide-gray-800">
+        {children}
+      </div>
+    </section>
+  )
+}
+
+const SHORTCUT_SECTIONS = [
+  {
+    title: 'Help',
+    rows: [
+      { description: 'Show this dialog', keys: <Kbd>?</Kbd> },
+    ],
+  },
+  {
+    title: 'Navigation',
+    rows: [
+      { description: 'Go to Dashboard', keys: <KeySequence keys={['g', 'd']} /> },
+      { description: 'Go to Favorites', keys: <KeySequence keys={['g', 'f']} /> },
+      { description: 'Go to Resources', keys: <KeySequence keys={['g', 'r']} /> },
+      { description: 'Go to Workloads', keys: <KeySequence keys={['g', 'w']} /> },
+      { description: 'Go to Events', keys: <KeySequence keys={['g', 'e']} /> },
+    ],
+  },
+  {
+    title: 'Search',
+    rows: [
+      { description: 'Open quick search', keys: <Kbd>/</Kbd> },
+      { description: 'Move up in results', keys: <Kbd>↑</Kbd> },
+      { description: 'Move down in results', keys: <Kbd>↓</Kbd> },
+      { description: 'Select result', keys: <Kbd>Enter</Kbd> },
+      { description: 'Filter by namespace', keys: <Kbd>ns:</Kbd> },
+      { description: 'Filter by kind', keys: <Kbd>kind:</Kbd> },
+      { description: 'Show most recent', keys: <Kbd>**</Kbd> },
+    ],
+  },
+  {
+    title: 'General',
+    rows: [
+      { description: 'Close dialogs and menus', keys: <Kbd>Esc</Kbd> },
+      { description: 'Refresh current view', keys: <KeySequence keys={['Shift', 'R']} join="+" /> },
+      { description: 'Previous tab', keys: <Kbd>[</Kbd> },
+      { description: 'Next tab', keys: <Kbd>]</Kbd> },
+    ],
+  },
+  {
+    title: 'Detail pages',
+    rows: [
+      { description: 'Copy page link', keys: <Kbd>c</Kbd> },
+      { description: 'Toggle favorite', keys: <Kbd>s</Kbd> },
+      { description: 'Open logs (workloads)', keys: <Kbd>l</Kbd> },
+    ],
+  },
+]
+
+/**
+ * KeyboardShortcutsModal - help dialog listing all keyboard shortcuts.
+ */
+export function KeyboardShortcutsModal() {
+  const dialogRef = useRef(null)
+
+  const handleClose = () => {
+    keyboardShortcutsOpen.value = false
+  }
+
+  useDismiss(dialogRef, handleClose, keyboardShortcutsOpen.value)
+
+  useEffect(() => {
+    if (keyboardShortcutsOpen.value) {
+      document.body.style.overflow = 'hidden'
+      return () => {
+        document.body.style.overflow = ''
+      }
+    }
+  }, [keyboardShortcutsOpen.value])
+
+  if (!keyboardShortcutsOpen.value) {
+    return null
+  }
+
+  return (
+    <div
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 sm:p-6"
+      onClick={handleClose}
+      data-testid="keyboard-shortcuts-overlay"
+    >
+      <div
+        ref={dialogRef}
+        class="bg-white dark:bg-gray-900 shadow-xl flex flex-col overflow-hidden border border-gray-200 dark:border-gray-700 w-full max-w-2xl max-h-[calc(100vh-2rem)] rounded-lg"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Keyboard shortcuts"
+        data-testid="keyboard-shortcuts-modal"
+      >
+        <div class="flex items-center justify-between gap-2 px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+          <h2 class="text-sm font-semibold text-gray-900 dark:text-white">Keyboard shortcuts</h2>
+          <button
+            type="button"
+            onClick={handleClose}
+            class="inline-flex items-center p-1 rounded text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200"
+            aria-label="Close keyboard shortcuts"
+            data-testid="keyboard-shortcuts-close"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div class="overflow-y-auto px-4 py-4">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-6">
+            {SHORTCUT_SECTIONS.map(section => (
+              <ShortcutSection key={section.title} title={section.title}>
+                {section.rows.map(row => (
+                  <ShortcutRow key={row.description} keys={row.keys} description={row.description} />
+                ))}
+              </ShortcutSection>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/layout/KeyboardShortcutsModal.test.jsx
+++ b/web/src/components/layout/KeyboardShortcutsModal.test.jsx
@@ -1,0 +1,69 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/preact'
+import { KeyboardShortcutsModal } from './KeyboardShortcutsModal'
+import { keyboardShortcutsOpen } from '../../utils/keyboardShortcuts'
+
+describe('KeyboardShortcutsModal', () => {
+  beforeEach(() => {
+    keyboardShortcutsOpen.value = false
+  })
+
+  afterEach(() => {
+    cleanup()
+    keyboardShortcutsOpen.value = false
+    document.body.style.overflow = ''
+  })
+
+  it('does not render when closed', () => {
+    render(<KeyboardShortcutsModal />)
+    expect(screen.queryByTestId('keyboard-shortcuts-modal')).not.toBeInTheDocument()
+  })
+
+  it('renders shortcut groups when open', () => {
+    keyboardShortcutsOpen.value = true
+    render(<KeyboardShortcutsModal />)
+
+    expect(screen.getByRole('dialog', { name: 'Keyboard shortcuts' })).toBeInTheDocument()
+    expect(screen.getByText('Navigation')).toBeInTheDocument()
+    expect(screen.getByText('Go to Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Go to Favorites')).toBeInTheDocument()
+    expect(screen.getByText('Open quick search')).toBeInTheDocument()
+  })
+
+  it('closes when the close button is clicked', () => {
+    keyboardShortcutsOpen.value = true
+    render(<KeyboardShortcutsModal />)
+
+    fireEvent.click(screen.getByTestId('keyboard-shortcuts-close'))
+    expect(keyboardShortcutsOpen.value).toBe(false)
+  })
+
+  it('closes on Escape', () => {
+    keyboardShortcutsOpen.value = true
+    render(<KeyboardShortcutsModal />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(keyboardShortcutsOpen.value).toBe(false)
+  })
+
+  it('closes when clicking the overlay', () => {
+    keyboardShortcutsOpen.value = true
+    render(<KeyboardShortcutsModal />)
+
+    fireEvent.click(screen.getByTestId('keyboard-shortcuts-overlay'))
+    expect(keyboardShortcutsOpen.value).toBe(false)
+  })
+
+  it('locks body scroll while open', () => {
+    keyboardShortcutsOpen.value = true
+    const { rerender } = render(<KeyboardShortcutsModal />)
+    expect(document.body.style.overflow).toBe('hidden')
+
+    keyboardShortcutsOpen.value = false
+    rerender(<KeyboardShortcutsModal />)
+    expect(document.body.style.overflow).toBe('')
+  })
+})

--- a/web/src/components/layout/UserMenu.jsx
+++ b/web/src/components/layout/UserMenu.jsx
@@ -10,6 +10,7 @@ import { resetLogSettings } from '../../utils/logSettings'
 import { writeSessionStorage } from '../../utils/storage'
 import { reportData } from '../../app'
 import { parseAuthProviderCookie } from '../../utils/cookies'
+import { openKeyboardShortcuts } from '../../utils/keyboardShortcuts'
 import { OpenIDIcon, KubernetesIcon } from './Icons'
 
 // Exported signal to track menu open state
@@ -196,6 +197,17 @@ export function UserMenu() {
               {getThemeIcon()}
             </span>
             <span>Theme: {getThemeLabel()}</span>
+          </button>
+
+          {/* Keyboard shortcuts */}
+          <button
+            onClick={openKeyboardShortcuts}
+            class="w-full px-4 py-2 flex items-center gap-3 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          >
+            <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+            </svg>
+            <span>Keyboard shortcuts</span>
           </button>
 
           {/* Separator */}

--- a/web/src/components/layout/UserMenu.test.jsx
+++ b/web/src/components/layout/UserMenu.test.jsx
@@ -8,6 +8,7 @@ import { themeMode, appliedTheme, themes } from '../../utils/theme'
 import { clearFavorites } from '../../utils/favorites'
 import { logSettings, DEFAULT_LOG_SETTINGS } from '../../utils/logSettings'
 import { reportData } from '../../app'
+import { keyboardShortcutsOpen } from '../../utils/keyboardShortcuts'
 
 // Mock the favorites module (app.jsx reads the favorites signal for the tab count)
 vi.mock('../../utils/favorites', () => ({
@@ -19,6 +20,7 @@ describe('UserMenu', () => {
   beforeEach(() => {
     // Reset signals
     userMenuOpen.value = false
+    keyboardShortcutsOpen.value = false
     themeMode.value = themes.light
     appliedTheme.value = themes.light
 
@@ -157,6 +159,18 @@ describe('UserMenu', () => {
 
       // auto -> dark
       expect(themeMode.value).toBe(themes.dark)
+    })
+  })
+
+  describe('Keyboard shortcuts', () => {
+    it('should open the keyboard shortcuts modal and close the menu', () => {
+      userMenuOpen.value = true
+      render(<UserMenu />)
+
+      fireEvent.click(screen.getByText('Keyboard shortcuts'))
+
+      expect(userMenuOpen.value).toBe(false)
+      expect(keyboardShortcutsOpen.value).toBe(true)
     })
   })
 

--- a/web/src/utils/hash.js
+++ b/web/src/utils/hash.js
@@ -1,7 +1,75 @@
 // Copyright 2025 Stefan Prodan.
 // SPDX-License-Identifier: AGPL-3.0
 
-import { useState, useEffect, useCallback } from 'preact/hooks'
+import { useState, useEffect, useCallback, useRef } from 'preact/hooks'
+
+/** @typedef {{ getValidTabs: () => string[], getActiveTab: () => string, setActiveTab: (tab: string) => void }} HashPanelHandlers */
+
+const hashPanelRegistry = new Map()
+
+/**
+ * Registers a hash-synced panel for keyboard tab cycling.
+ *
+ * @param {string} panel
+ * @param {HashPanelHandlers} handlers
+ */
+export function registerHashPanel(panel, handlers) {
+  hashPanelRegistry.set(panel, handlers)
+}
+
+/**
+ * Unregisters a hash-synced panel.
+ *
+ * @param {string} panel
+ */
+export function unregisterHashPanel(panel) {
+  hashPanelRegistry.delete(panel)
+}
+
+/** Clears all registered hash panels (for tests). */
+export function clearHashPanelRegistry() {
+  hashPanelRegistry.clear()
+}
+
+/**
+ * Cycles the active tab in the current or first visible hash panel.
+ *
+ * @param {number} direction - -1 for previous, 1 for next
+ * @returns {boolean} True when a tab was cycled
+ */
+export function cycleHashTab(direction) {
+  const parsed = parseHash(window.location.hash)
+  let panel = parsed?.panel
+  let entry = panel ? hashPanelRegistry.get(panel) : null
+
+  if (!entry || entry.getValidTabs().length === 0) {
+    for (const [name, handlers] of hashPanelRegistry) {
+      if (handlers.getValidTabs().length > 0) {
+        panel = name
+        entry = handlers
+        break
+      }
+    }
+  }
+
+  if (!entry) {
+    return false
+  }
+
+  const validTabs = entry.getValidTabs()
+  if (validTabs.length === 0) {
+    return false
+  }
+
+  const { getActiveTab, setActiveTab } = entry
+  const hashTab = parsed?.panel === panel ? parsed.tab : null
+  const activeTab = hashTab && validTabs.includes(hashTab) ? hashTab : getActiveTab()
+  const idx = validTabs.indexOf(activeTab)
+  const currentIdx = idx === -1 ? 0 : idx
+  const nextIdx = (currentIdx + direction + validTabs.length) % validTabs.length
+  setActiveTab(validTabs[nextIdx])
+  return true
+}
 
 /**
  * Parses a URL hash fragment into panel and tab parts
@@ -49,7 +117,8 @@ export function buildHash(panel, tab) {
  * - Updates URL hash when tab changes (using replaceState, not pushState)
  * - Listens for hashchange events (browser back/forward, manual URL edit)
  * - Only responds to hash changes matching the panel prefix
- * - Optionally scrolls the panel element into view when hash matches on load
+ * - Optionally scrolls the panel element into view on mount and hash navigation
+ *   (not when validTabs identity alone changes)
  *
  * @param {string} panel - Panel identifier (e.g., 'reconciler', 'inventory')
  * @param {string} defaultTab - Default tab when hash doesn't match this panel
@@ -75,9 +144,14 @@ export function useHashTab(panel, defaultTab, validTabs, scrollElementId) {
   }
 
   const [activeTab, setActiveTabState] = useState(getInitialTab)
+  const validTabsRef = useRef(validTabs)
+  validTabsRef.current = validTabs
 
   // Setter that also updates the URL hash
   const setActiveTab = useCallback((newTab) => {
+    if (!validTabsRef.current.includes(newTab)) {
+      return
+    }
     setActiveTabState(newTab)
 
     if (typeof window === 'undefined') return
@@ -97,7 +171,7 @@ export function useHashTab(panel, defaultTab, validTabs, scrollElementId) {
     const handleHashChange = () => {
       const parsed = parseHash(window.location.hash)
 
-      if (parsed && parsed.panel === panel && validTabs.includes(parsed.tab)) {
+      if (parsed && parsed.panel === panel && validTabsRef.current.includes(parsed.tab)) {
         // Hash matches our panel - update tab
         setActiveTabState(parsed.tab)
       }
@@ -106,32 +180,73 @@ export function useHashTab(panel, defaultTab, validTabs, scrollElementId) {
 
     window.addEventListener('hashchange', handleHashChange)
     return () => window.removeEventListener('hashchange', handleHashChange)
-  }, [panel, validTabs])
+  }, [panel])
 
-  // Sync with hash on mount and when panel/validTabs change
-  // This handles navigation to a different resource that has the same panel
+  // Sync tab state with hash on mount and when panel/validTabs change.
+  // Scroll is intentionally separate so poll-driven validTabs identity changes
+  // do not yank the viewport back to the hashed panel.
   useEffect(() => {
     if (typeof window === 'undefined') return
 
     const parsed = parseHash(window.location.hash)
     if (parsed && parsed.panel === panel && validTabs.includes(parsed.tab)) {
       setActiveTabState(parsed.tab)
-
-      // Scroll the panel element into view if scrollElementId is provided
-      if (scrollElementId) {
-        // Use requestAnimationFrame to ensure DOM is ready
-        window.requestAnimationFrame(() => {
-          const element = document.getElementById(scrollElementId)
-          if (element) {
-            element.scrollIntoView({ behavior: 'smooth', block: 'start' })
-          }
-        })
-      }
     } else {
       // Reset to default if hash doesn't match this panel
       setActiveTabState(defaultTab)
     }
-  }, [panel, defaultTab, validTabs, scrollElementId])
+  }, [panel, defaultTab, validTabs])
+
+  // Scroll into view only on initial mount and actual hash navigation.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !scrollElementId) return
+
+    const scrollIfHashMatches = () => {
+      const parsed = parseHash(window.location.hash)
+      if (!parsed || parsed.panel !== panel || !validTabsRef.current.includes(parsed.tab)) {
+        return
+      }
+      window.requestAnimationFrame(() => {
+        const element = document.getElementById(scrollElementId)
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        }
+      })
+    }
+
+    scrollIfHashMatches()
+    window.addEventListener('hashchange', scrollIfHashMatches)
+    return () => window.removeEventListener('hashchange', scrollIfHashMatches)
+  }, [panel, scrollElementId])
+
+  const activeTabRef = useRef(activeTab)
+  activeTabRef.current = activeTab
+
+  useEffect(() => {
+    const tabs = validTabsRef.current
+    if (tabs.length === 0) {
+      unregisterHashPanel(panel)
+      return
+    }
+
+    if (!tabs.includes(activeTabRef.current)) {
+      const fallback = tabs.includes(defaultTab) ? defaultTab : tabs[0]
+      setActiveTab(fallback)
+    }
+  }, [validTabs, defaultTab, panel, setActiveTab])
+
+  useEffect(() => {
+    if (validTabsRef.current.length === 0) {
+      return
+    }
+
+    registerHashPanel(panel, {
+      getValidTabs: () => validTabsRef.current,
+      getActiveTab: () => activeTabRef.current,
+      setActiveTab,
+    })
+    return () => unregisterHashPanel(panel)
+  }, [panel, validTabs, setActiveTab])
 
   return [activeTab, setActiveTab]
 }

--- a/web/src/utils/hash.test.js
+++ b/web/src/utils/hash.test.js
@@ -3,7 +3,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/preact'
-import { parseHash, buildHash, useHashTab, clearHash } from './hash'
+import { parseHash, buildHash, useHashTab, clearHash, registerHashPanel, clearHashPanelRegistry, cycleHashTab } from './hash'
 
 describe('parseHash', () => {
   it('should parse valid hash with panel and tab', () => {
@@ -225,6 +225,101 @@ describe('useHashTab', () => {
 
     // Hash doesn't match new panel, should reset to default
     expect(result.current[0]).toBe('overview')
+  })
+
+  it('should scroll into view on mount when hash matches, but not when validTabs identity changes', async () => {
+    window.location.hash = '#reconciler-events'
+
+    const scrollIntoView = vi.fn()
+    const panelEl = document.createElement('div')
+    panelEl.id = 'reconciler-panel'
+    panelEl.scrollIntoView = scrollIntoView
+    document.body.appendChild(panelEl)
+
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb()
+      return 0
+    })
+
+    const { rerender } = renderHook(
+      ({ validTabs }) => useHashTab('reconciler', 'overview', validTabs, 'reconciler-panel'),
+      { initialProps: { validTabs: [...validTabs] } }
+    )
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+
+    rerender({ validTabs: [...validTabs] })
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+
+    await act(() => {
+      window.location.hash = '#reconciler-history'
+      window.dispatchEvent(new window.Event('hashchange'))
+    })
+    expect(scrollIntoView).toHaveBeenCalledTimes(2)
+
+    raf.mockRestore()
+    document.body.removeChild(panelEl)
+  })
+})
+
+describe('cycleHashTab', () => {
+  beforeEach(() => {
+    clearHashPanelRegistry()
+    Object.defineProperty(window, 'location', {
+      value: { hash: '#reconciler-overview', pathname: '/resource/Kustomization/default/flux' },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    clearHashPanelRegistry()
+  })
+
+  it('cycles tabs in the panel from the current hash', () => {
+    const setActiveTab = vi.fn()
+    registerHashPanel('reconciler', {
+      getValidTabs: () => ['overview', 'events', 'spec'],
+      getActiveTab: () => 'overview',
+      setActiveTab,
+    })
+
+    expect(cycleHashTab(1)).toBe(true)
+    expect(setActiveTab).toHaveBeenCalledWith('events')
+
+    window.location.hash = '#reconciler-events'
+    expect(cycleHashTab(-1)).toBe(true)
+    expect(setActiveTab).toHaveBeenCalledWith('overview')
+  })
+
+  it('uses the first registered panel when the hash is missing', () => {
+    window.location.hash = ''
+    const setActiveTab = vi.fn()
+    registerHashPanel('reconciler', {
+      getValidTabs: () => ['overview', 'events'],
+      getActiveTab: () => 'overview',
+      setActiveTab,
+    })
+
+    expect(cycleHashTab(1)).toBe(true)
+    expect(setActiveTab).toHaveBeenCalledWith('events')
+  })
+
+  it('skips hidden panels with no visible tabs', () => {
+    const setActiveTab = vi.fn()
+    registerHashPanel('inventory', {
+      getValidTabs: () => [],
+      getActiveTab: () => 'overview',
+      setActiveTab,
+    })
+    registerHashPanel('reconciler', {
+      getValidTabs: () => ['overview', 'events'],
+      getActiveTab: () => 'overview',
+      setActiveTab,
+    })
+
+    expect(cycleHashTab(1)).toBe(true)
+    expect(setActiveTab).toHaveBeenCalledWith('events')
   })
 })
 

--- a/web/src/utils/keyboardShortcutActions.js
+++ b/web/src/utils/keyboardShortcutActions.js
@@ -1,0 +1,110 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { fetchFluxReport } from '../app'
+import { fetchEvents } from '../components/search/EventList'
+import { fetchResourcesStatus } from '../components/search/ResourceList'
+import { fetchWorkloadsStatus } from '../components/search/WorkloadList'
+import { fetchFavoritesData } from '../components/favorites/FavoritesPage'
+import { toggleFavorite } from './favorites'
+import { copyCurrentUrl, parseDetailRoute } from './routing'
+import {
+  getRegisteredOpenWorkloadLogs,
+  getRegisteredPageRefresh,
+} from './keyboardShortcuts'
+
+const REFRESH_BY_PATH = {
+  '/': fetchFluxReport,
+  '/favorites': fetchFavoritesData,
+  '/resources': fetchResourcesStatus,
+  '/workloads': fetchWorkloadsStatus,
+  '/events': fetchEvents,
+}
+
+/** Section tab views cycled by `[` and `]`. */
+export const SECTION_TAB_PATHS = ['/favorites', '/resources', '/workloads', '/events']
+
+/**
+ * Refreshes data for the view at the given router path.
+ *
+ * @param {string} path
+ */
+export async function refreshCurrentView(path) {
+  const refresh = REFRESH_BY_PATH[path]
+  if (refresh) {
+    return refresh()
+  }
+
+  if (parseDetailRoute(path)) {
+    const pageRefresh = getRegisteredPageRefresh()
+    if (pageRefresh) {
+      return pageRefresh()
+    }
+  }
+}
+
+/**
+ * Toggles favorite state when `s` is pressed on a detail page.
+ *
+ * @param {string} path
+ * @returns {boolean} True when the shortcut was handled
+ */
+export function toggleFavoriteFromShortcut(path) {
+  const detail = parseDetailRoute(path)
+  if (!detail) {
+    return false
+  }
+  toggleFavorite(detail.kind, detail.namespace, detail.name)
+  return true
+}
+
+/**
+ * Copies the current page URL when `c` is pressed on a detail page.
+ *
+ * @param {string} path
+ * @returns {Promise<boolean>} True when the shortcut was handled
+ */
+export async function copyLinkFromShortcut(path) {
+  if (!parseDetailRoute(path)) {
+    return false
+  }
+  await copyCurrentUrl()
+  return true
+}
+
+/**
+ * Opens workload logs when `l` is pressed on a workload detail page.
+ *
+ * @param {string} path
+ * @returns {boolean} True when the shortcut was handled
+ */
+export function openLogsFromShortcut(path) {
+  const detail = parseDetailRoute(path)
+  if (!detail || detail.type !== 'workload') {
+    return false
+  }
+  const openLogs = getRegisteredOpenWorkloadLogs()
+  if (!openLogs) {
+    return false
+  }
+  openLogs()
+  return true
+}
+
+/**
+ * Cycles section tabs on list views.
+ *
+ * @param {string} path - Current router path
+ * @param {number} direction - -1 for previous, 1 for next
+ * @param {Function} route - preact-iso route function
+ * @returns {boolean} True when navigation occurred
+ */
+export function cycleSectionTab(path, direction, route) {
+  const idx = SECTION_TAB_PATHS.indexOf(path)
+  if (idx === -1) {
+    return false
+  }
+  const next = (idx + direction + SECTION_TAB_PATHS.length) % SECTION_TAB_PATHS.length
+  route(SECTION_TAB_PATHS[next])
+  return true
+}

--- a/web/src/utils/keyboardShortcutActions.test.js
+++ b/web/src/utils/keyboardShortcutActions.test.js
@@ -1,0 +1,175 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { toggleFavorite } from './favorites'
+import { copyCurrentUrl, parseDetailRoute } from './routing'
+import {
+  refreshCurrentView,
+  toggleFavoriteFromShortcut,
+  copyLinkFromShortcut,
+  openLogsFromShortcut,
+  cycleSectionTab,
+  SECTION_TAB_PATHS,
+} from './keyboardShortcutActions'
+import {
+  registerPageRefresh,
+  unregisterPageRefresh,
+  registerOpenWorkloadLogs,
+  unregisterOpenWorkloadLogs,
+} from './keyboardShortcuts'
+
+vi.mock('../app', () => ({
+  fetchFluxReport: vi.fn(),
+}))
+
+vi.mock('../components/search/EventList', () => ({
+  fetchEvents: vi.fn(),
+}))
+
+vi.mock('../components/search/ResourceList', () => ({
+  fetchResourcesStatus: vi.fn(),
+}))
+
+vi.mock('../components/search/WorkloadList', () => ({
+  fetchWorkloadsStatus: vi.fn(),
+}))
+
+vi.mock('../components/favorites/FavoritesPage', () => ({
+  fetchFavoritesData: vi.fn(),
+}))
+
+vi.mock('./favorites', () => ({
+  toggleFavorite: vi.fn(),
+}))
+
+vi.mock('./routing', async () => {
+  const actual = await vi.importActual('./routing')
+  return {
+    ...actual,
+    copyCurrentUrl: vi.fn(),
+  }
+})
+
+import { fetchFluxReport } from '../app'
+import { fetchEvents } from '../components/search/EventList'
+import { fetchResourcesStatus } from '../components/search/ResourceList'
+import { fetchWorkloadsStatus } from '../components/search/WorkloadList'
+import { fetchFavoritesData } from '../components/favorites/FavoritesPage'
+
+describe('keyboardShortcutActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('refreshCurrentView', () => {
+    it('refreshes the dashboard', async () => {
+      await refreshCurrentView('/')
+      expect(fetchFluxReport).toHaveBeenCalledTimes(1)
+    })
+
+    it('refreshes list and favorites views', async () => {
+      await refreshCurrentView('/favorites')
+      await refreshCurrentView('/resources')
+      await refreshCurrentView('/workloads')
+      await refreshCurrentView('/events')
+
+      expect(fetchFavoritesData).toHaveBeenCalledTimes(1)
+      expect(fetchResourcesStatus).toHaveBeenCalledTimes(1)
+      expect(fetchWorkloadsStatus).toHaveBeenCalledTimes(1)
+      expect(fetchEvents).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses the registered page refresh handler on detail pages', async () => {
+      const onRefresh = vi.fn()
+      registerPageRefresh(onRefresh)
+
+      await refreshCurrentView('/resource/Kustomization/default/flux-system')
+
+      expect(onRefresh).toHaveBeenCalledTimes(1)
+      unregisterPageRefresh(onRefresh)
+    })
+  })
+
+  describe('toggleFavoriteFromShortcut', () => {
+    it('toggles favorites on detail pages', () => {
+      expect(toggleFavoriteFromShortcut('/workload/Deployment/default/my-app')).toBe(true)
+      expect(toggleFavorite).toHaveBeenCalledWith('Deployment', 'default', 'my-app')
+    })
+
+    it('ignores non-detail pages', () => {
+      expect(toggleFavoriteFromShortcut('/resources')).toBe(false)
+      expect(toggleFavorite).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('copyLinkFromShortcut', () => {
+    it('copies the current URL on detail pages', async () => {
+      copyCurrentUrl.mockResolvedValue(true)
+
+      await expect(copyLinkFromShortcut('/resource/GitRepository/flux-system/flux-system')).resolves.toBe(true)
+      expect(copyCurrentUrl).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores non-detail pages', async () => {
+      await expect(copyLinkFromShortcut('/events')).resolves.toBe(false)
+      expect(copyCurrentUrl).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('openLogsFromShortcut', () => {
+    it('opens logs on workload detail pages', () => {
+      const openLogs = vi.fn()
+      registerOpenWorkloadLogs(openLogs)
+
+      expect(openLogsFromShortcut('/workload/Deployment/default/my-app')).toBe(true)
+      expect(openLogs).toHaveBeenCalledTimes(1)
+
+      unregisterOpenWorkloadLogs(openLogs)
+    })
+
+    it('ignores resource detail pages', () => {
+      const openLogs = vi.fn()
+      registerOpenWorkloadLogs(openLogs)
+
+      expect(openLogsFromShortcut('/resource/Kustomization/default/flux-system')).toBe(false)
+      expect(openLogs).not.toHaveBeenCalled()
+
+      unregisterOpenWorkloadLogs(openLogs)
+    })
+  })
+
+  describe('parseDetailRoute', () => {
+    it('parses encoded detail routes', () => {
+      expect(parseDetailRoute('/resource/Kustomization/default/flux%2Dsystem')).toEqual({
+        type: 'resource',
+        kind: 'Kustomization',
+        namespace: 'default',
+        name: 'flux-system',
+      })
+    })
+  })
+
+  describe('cycleSectionTab', () => {
+    it('cycles section tabs forward and backward', () => {
+      const route = vi.fn()
+
+      expect(cycleSectionTab('/resources', 1, route)).toBe(true)
+      expect(route).toHaveBeenCalledWith('/workloads')
+
+      route.mockClear()
+      expect(cycleSectionTab('/favorites', -1, route)).toBe(true)
+      expect(route).toHaveBeenCalledWith('/events')
+    })
+
+    it('ignores non-section paths', () => {
+      const route = vi.fn()
+      expect(cycleSectionTab('/', 1, route)).toBe(false)
+      expect(route).not.toHaveBeenCalled()
+    })
+
+    it('exports the section tab order used by the tab bar', () => {
+      expect(SECTION_TAB_PATHS).toEqual(['/favorites', '/resources', '/workloads', '/events'])
+    })
+  })
+})

--- a/web/src/utils/keyboardShortcuts.js
+++ b/web/src/utils/keyboardShortcuts.js
@@ -1,0 +1,139 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { signal } from '@preact/signals'
+import { quickSearchOpen } from '../components/search/QuickSearch'
+import { userMenuOpen } from '../components/layout/UserMenu'
+
+/** Whether the keyboard shortcuts help modal is open. */
+export const keyboardShortcutsOpen = signal(false)
+
+/** Whether the workload logs viewer modal is open. */
+export const workloadLogsOpen = signal(false)
+
+let workloadLogsOpenCount = 0
+
+/**
+ * Tracks an open workload logs overlay for global shortcut guards.
+ * Supports multiple viewers registering independently via refcounting.
+ *
+ * @param {boolean} open
+ */
+export function setWorkloadLogsOverlayOpen(open) {
+  if (open) {
+    workloadLogsOpenCount += 1
+  } else {
+    workloadLogsOpenCount = Math.max(0, workloadLogsOpenCount - 1)
+  }
+  workloadLogsOpen.value = workloadLogsOpenCount > 0
+}
+
+/** Resets logs overlay refcount state (for tests). */
+export function resetWorkloadLogsOverlayState() {
+  workloadLogsOpenCount = 0
+  workloadLogsOpen.value = false
+}
+
+/** Timeout for `g`-chord second key (GitHub-style navigation). */
+export const G_CHORD_TIMEOUT_MS = 1000
+
+/** Second-key → route mapping for `g`-chord navigation. */
+export const NAV_ROUTES = {
+  d: '/',
+  f: '/favorites',
+  r: '/resources',
+  w: '/workloads',
+  e: '/events',
+}
+
+let registeredPageRefresh = null
+let registeredOpenWorkloadLogs = null
+
+/**
+ * Registers the active page's refresh handler (favorites and detail pages).
+ *
+ * @param {Function} handler
+ */
+export function registerPageRefresh(handler) {
+  registeredPageRefresh = handler
+}
+
+/**
+ * Clears the active page refresh handler when it unmounts.
+ *
+ * @param {Function} handler
+ */
+export function unregisterPageRefresh(handler) {
+  if (registeredPageRefresh === handler) {
+    registeredPageRefresh = null
+  }
+}
+
+/**
+ * Registers the workload detail page logs opener.
+ *
+ * @param {Function} handler
+ */
+export function registerOpenWorkloadLogs(handler) {
+  registeredOpenWorkloadLogs = handler
+}
+
+/**
+ * Clears the workload logs opener when it unmounts.
+ *
+ * @param {Function} handler
+ */
+export function unregisterOpenWorkloadLogs(handler) {
+  if (registeredOpenWorkloadLogs === handler) {
+    registeredOpenWorkloadLogs = null
+  }
+}
+
+/** Returns the registered page refresh handler, if any. */
+export function getRegisteredPageRefresh() {
+  return registeredPageRefresh
+}
+
+/** Returns the registered workload logs opener, if any. */
+export function getRegisteredOpenWorkloadLogs() {
+  return registeredOpenWorkloadLogs
+}
+
+/**
+ * Returns true when global shortcuts should not fire (e.g. typing in a field
+ * or when another overlay owns the keyboard).
+ *
+ * @param {KeyboardEvent} e
+ * @param {object} [options]
+ * @param {boolean} [options.allowOverlays=false] - When true, ignore only text inputs
+ *   (and still block when the logs viewer is open). Search and user menu may be dismissed
+ *   by g-chords via closeOverlays().
+ * @returns {boolean}
+ */
+export function shouldIgnoreShortcut(e, { allowOverlays = false } = {}) {
+  const tag = e.target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) {
+    return true
+  }
+  // Logs always own the keyboard; allowOverlays only bypasses search/user menu
+  // so g-chords can dismiss those overlays without navigating away from logs.
+  if (workloadLogsOpen.value) {
+    return true
+  }
+  if (!allowOverlays && (quickSearchOpen.value || userMenuOpen.value)) {
+    return true
+  }
+  return false
+}
+
+/** Closes search and user menu before navigating via a shortcut. */
+export function closeOverlays() {
+  quickSearchOpen.value = false
+  userMenuOpen.value = false
+}
+
+/** Opens the keyboard shortcuts help modal and closes the user menu. */
+export function openKeyboardShortcuts() {
+  userMenuOpen.value = false
+  keyboardShortcutsOpen.value = true
+}

--- a/web/src/utils/keyboardShortcuts.test.js
+++ b/web/src/utils/keyboardShortcuts.test.js
@@ -1,0 +1,27 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  workloadLogsOpen,
+  setWorkloadLogsOverlayOpen,
+  resetWorkloadLogsOverlayState,
+} from './keyboardShortcuts'
+
+describe('workload logs overlay guard', () => {
+  afterEach(() => {
+    resetWorkloadLogsOverlayState()
+  })
+
+  it('tracks multiple open viewers with a refcount', () => {
+    setWorkloadLogsOverlayOpen(true)
+    setWorkloadLogsOverlayOpen(true)
+    expect(workloadLogsOpen.value).toBe(true)
+
+    setWorkloadLogsOverlayOpen(false)
+    expect(workloadLogsOpen.value).toBe(true)
+
+    setWorkloadLogsOverlayOpen(false)
+    expect(workloadLogsOpen.value).toBe(false)
+  })
+})

--- a/web/src/utils/routing.js
+++ b/web/src/utils/routing.js
@@ -21,6 +21,45 @@ export function getDashboardUrl(kind, namespace, name) {
 }
 
 /**
+ * Parses a resource or workload detail route into its path segments.
+ *
+ * @param {string} path - Router path (e.g. `/resource/Kustomization/ns/name`)
+ * @returns {{ type: 'resource' | 'workload', kind: string, namespace: string, name: string } | null}
+ */
+export function parseDetailRoute(path) {
+  for (const [type, prefix] of [['resource', '/resource/'], ['workload', '/workload/']]) {
+    if (!path.startsWith(prefix)) {
+      continue
+    }
+    const parts = path.slice(prefix.length).split('/')
+    if (parts.length !== 3) {
+      return null
+    }
+    return {
+      type,
+      kind: decodeURIComponent(parts[0]),
+      namespace: decodeURIComponent(parts[1]),
+      name: decodeURIComponent(parts[2]),
+    }
+  }
+  return null
+}
+
+/**
+ * Copies the current page URL (path, query, and hash) to the clipboard.
+ *
+ * @returns {Promise<boolean>} True when the URL was copied successfully
+ */
+export async function copyCurrentUrl() {
+  const url = window.location.href
+  if (!window.navigator.clipboard?.writeText) {
+    return false
+  }
+  await window.navigator.clipboard.writeText(url)
+  return true
+}
+
+/**
  * Serializes filter object to URL query string
  * Omits empty/null/undefined values
  *

--- a/web/src/utils/routing.test.js
+++ b/web/src/utils/routing.test.js
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/preact'
 import { signal } from '@preact/signals'
-import { serializeFilters, urlWithParam } from './routing'
+import { serializeFilters, urlWithParam, parseDetailRoute, copyCurrentUrl } from './routing'
 
 describe('serializeFilters', () => {
   it('should serialize simple filter object to query string', () => {
@@ -59,6 +59,44 @@ describe('serializeFilters', () => {
   it('should handle numeric string values', () => {
     const filters = { limit: '10', offset: '0' }
     expect(serializeFilters(filters)).toBe('limit=10&offset=0')
+  })
+})
+
+describe('parseDetailRoute', () => {
+  it('parses resource detail routes', () => {
+    expect(parseDetailRoute('/resource/Kustomization/default/flux-system')).toEqual({
+      type: 'resource',
+      kind: 'Kustomization',
+      namespace: 'default',
+      name: 'flux-system',
+    })
+  })
+
+  it('parses workload detail routes', () => {
+    expect(parseDetailRoute('/workload/Deployment/default/my-app')).toEqual({
+      type: 'workload',
+      kind: 'Deployment',
+      namespace: 'default',
+      name: 'my-app',
+    })
+  })
+
+  it('returns null for non-detail routes', () => {
+    expect(parseDetailRoute('/resources')).toBeNull()
+    expect(parseDetailRoute('/resource/Kustomization/default')).toBeNull()
+  })
+})
+
+describe('copyCurrentUrl', () => {
+  it('copies the current page URL', async () => {
+    window.history.replaceState(null, '', '/resource/Kustomization/default/flux-system#overview')
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    await expect(copyCurrentUrl()).resolves.toBe(true)
+    expect(writeText).toHaveBeenCalledWith(window.location.href)
+
+    vi.unstubAllGlobals()
   })
 })
 

--- a/web/src/utils/useKeyboardShortcuts.js
+++ b/web/src/utils/useKeyboardShortcuts.js
@@ -1,0 +1,131 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useEffect, useRef } from 'preact/hooks'
+import { useLocation } from 'preact-iso'
+import { parseDetailRoute } from './routing'
+import { cycleHashTab } from './hash'
+import {
+  keyboardShortcutsOpen,
+  G_CHORD_TIMEOUT_MS,
+  NAV_ROUTES,
+  shouldIgnoreShortcut,
+  closeOverlays,
+} from './keyboardShortcuts'
+import { refreshCurrentView, toggleFavoriteFromShortcut, copyLinkFromShortcut, openLogsFromShortcut, cycleSectionTab, SECTION_TAB_PATHS } from './keyboardShortcutActions'
+
+/**
+ * useKeyboardShortcuts - registers global keyboard shortcuts for the Flux Status Page.
+ *
+ * Phase 1: `?` help modal toggle, `g`-chord view navigation.
+ * Phase 2: `Shift+R` refresh, `s` favorite, `c` copy link, `l` open logs.
+ * Phase 3: `[` / `]` tab cycling on section and detail views.
+ */
+export function useKeyboardShortcuts() {
+  const location = useLocation()
+  const pendingG = useRef(false)
+  const chordTimer = useRef(null)
+
+  useEffect(() => {
+    const clearChord = () => {
+      pendingG.current = false
+      if (chordTimer.current) {
+        clearTimeout(chordTimer.current)
+        chordTimer.current = null
+      }
+    }
+
+    const handleKeyDown = (e) => {
+      if (e.key === '?' || (e.key === '/' && e.shiftKey)) {
+        if (!shouldIgnoreShortcut(e) || keyboardShortcutsOpen.value) {
+          e.preventDefault()
+          keyboardShortcutsOpen.value = !keyboardShortcutsOpen.value
+        }
+        return
+      }
+
+      if (keyboardShortcutsOpen.value) {
+        return
+      }
+
+      if (e.key === 'g' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (shouldIgnoreShortcut(e, { allowOverlays: true })) {
+          return
+        }
+        e.preventDefault()
+        closeOverlays()
+        clearChord()
+        pendingG.current = true
+        chordTimer.current = setTimeout(clearChord, G_CHORD_TIMEOUT_MS)
+        return
+      }
+
+      if (pendingG.current) {
+        const route = NAV_ROUTES[e.key]
+        if (route) {
+          e.preventDefault()
+          clearChord()
+          closeOverlays()
+          location.route(route)
+        } else {
+          clearChord()
+        }
+        return
+      }
+
+      if (shouldIgnoreShortcut(e)) {
+        return
+      }
+
+      if (e.key === 'R' && e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault()
+        void refreshCurrentView(location.path).catch(() => {})
+        return
+      }
+
+      if (e.key === 's' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (toggleFavoriteFromShortcut(location.path)) {
+          e.preventDefault()
+        }
+        return
+      }
+
+      if (e.key === 'c' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (parseDetailRoute(location.path)) {
+          e.preventDefault()
+          void copyLinkFromShortcut(location.path)
+        }
+        return
+      }
+
+      if (e.key === 'l' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (openLogsFromShortcut(location.path)) {
+          e.preventDefault()
+        }
+        return
+      }
+
+      // Allow Option/AltGr (needed to type [ ] on DE and other layouts). Still
+      // block Cmd+[ (browser back/forward) and Ctrl+[ without Alt.
+      if ((e.key === '[' || e.key === ']') && !e.metaKey && !(e.ctrlKey && !e.altKey)) {
+        const direction = e.key === ']' ? 1 : -1
+        let handled = false
+        if (SECTION_TAB_PATHS.includes(location.path)) {
+          handled = cycleSectionTab(location.path, direction, location.route)
+        } else if (parseDetailRoute(location.path)) {
+          handled = cycleHashTab(direction)
+        }
+        if (handled) {
+          e.preventDefault()
+        }
+        return
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      clearChord()
+    }
+  }, [location])
+}

--- a/web/src/utils/useKeyboardShortcuts.test.js
+++ b/web/src/utils/useKeyboardShortcuts.test.js
@@ -1,0 +1,272 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/preact'
+import { useKeyboardShortcuts } from './useKeyboardShortcuts'
+import { keyboardShortcutsOpen, G_CHORD_TIMEOUT_MS } from './keyboardShortcuts'
+import { quickSearchOpen } from '../components/search/QuickSearch'
+import { userMenuOpen } from '../components/layout/UserMenu'
+
+const mockRoute = vi.fn()
+const mockLocation = { path: '/', route: mockRoute }
+
+vi.mock('preact-iso', () => ({
+  useLocation: () => mockLocation,
+}))
+
+vi.mock('../app', () => ({
+  fetchFluxReport: vi.fn(),
+}))
+
+vi.mock('../components/search/EventList', () => ({
+  fetchEvents: vi.fn(),
+}))
+
+vi.mock('../components/search/ResourceList', () => ({
+  fetchResourcesStatus: vi.fn(),
+}))
+
+vi.mock('../components/search/WorkloadList', () => ({
+  fetchWorkloadsStatus: vi.fn(),
+}))
+
+vi.mock('../components/favorites/FavoritesPage', () => ({
+  fetchFavoritesData: vi.fn(),
+}))
+
+vi.mock('./favorites', () => ({
+  toggleFavorite: vi.fn(),
+}))
+
+vi.mock('./routing', async () => {
+  const actual = await vi.importActual('./routing')
+  return {
+    ...actual,
+    copyCurrentUrl: vi.fn().mockResolvedValue(true),
+  }
+})
+
+vi.mock('./hash', async () => {
+  const actual = await vi.importActual('./hash')
+  return {
+    ...actual,
+    cycleHashTab: vi.fn(() => true),
+  }
+})
+
+import { fetchFluxReport } from '../app'
+import { fetchEvents } from '../components/search/EventList'
+import { toggleFavorite } from './favorites'
+import { copyCurrentUrl } from './routing'
+import { cycleHashTab } from './hash'
+import {
+  registerOpenWorkloadLogs,
+  unregisterOpenWorkloadLogs,
+  workloadLogsOpen,
+} from './keyboardShortcuts'
+
+function ShortcutHarness() {
+  useKeyboardShortcuts()
+  return <div data-testid="harness" />
+}
+
+describe('useKeyboardShortcuts', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockLocation.path = '/'
+    keyboardShortcutsOpen.value = false
+    quickSearchOpen.value = false
+    userMenuOpen.value = false
+    workloadLogsOpen.value = false
+    vi.clearAllMocks()
+    mockRoute.mockClear()
+    render(<ShortcutHarness />)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    keyboardShortcutsOpen.value = false
+    quickSearchOpen.value = false
+    userMenuOpen.value = false
+    workloadLogsOpen.value = false
+  })
+
+  it('opens the help modal on ?', () => {
+    fireEvent.keyDown(document, { key: '?' })
+    expect(keyboardShortcutsOpen.value).toBe(true)
+  })
+
+  it('opens the help modal on Shift+/', () => {
+    fireEvent.keyDown(document, { key: '/', shiftKey: true })
+    expect(keyboardShortcutsOpen.value).toBe(true)
+  })
+
+  it('toggles the help modal closed on ? when already open', () => {
+    keyboardShortcutsOpen.value = true
+    fireEvent.keyDown(document, { key: '?' })
+    expect(keyboardShortcutsOpen.value).toBe(false)
+  })
+
+  it('does not open help when quick search is open', () => {
+    quickSearchOpen.value = true
+    fireEvent.keyDown(document, { key: '?' })
+    expect(keyboardShortcutsOpen.value).toBe(false)
+  })
+
+  it('ignores shortcuts while typing in an input', () => {
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+
+    fireEvent.keyDown(input, { key: '?' })
+    expect(keyboardShortcutsOpen.value).toBe(false)
+
+    fireEvent.keyDown(input, { key: 'g' })
+    fireEvent.keyDown(input, { key: 'f' })
+    expect(mockRoute).not.toHaveBeenCalled()
+
+    document.body.removeChild(input)
+  })
+
+  it('navigates with g-chord shortcuts', () => {
+    const chords = [
+      ['d', '/'],
+      ['f', '/favorites'],
+      ['r', '/resources'],
+      ['w', '/workloads'],
+      ['e', '/events'],
+    ]
+
+    for (const [key, path] of chords) {
+      mockRoute.mockClear()
+      fireEvent.keyDown(document, { key: 'g' })
+      fireEvent.keyDown(document, { key })
+      expect(mockRoute).toHaveBeenCalledWith(path)
+    }
+  })
+
+  it('closes overlays before g-chord navigation', () => {
+    quickSearchOpen.value = true
+    userMenuOpen.value = true
+
+    fireEvent.keyDown(document, { key: 'g' })
+    fireEvent.keyDown(document, { key: 'f' })
+
+    expect(quickSearchOpen.value).toBe(false)
+    expect(userMenuOpen.value).toBe(false)
+    expect(mockRoute).toHaveBeenCalledWith('/favorites')
+  })
+
+  it('expires g-chord after timeout', () => {
+    fireEvent.keyDown(document, { key: 'g' })
+    vi.advanceTimersByTime(G_CHORD_TIMEOUT_MS + 1)
+    fireEvent.keyDown(document, { key: 'f' })
+    expect(mockRoute).not.toHaveBeenCalled()
+  })
+
+  it('cancels g-chord on an unknown second key', () => {
+    fireEvent.keyDown(document, { key: 'g' })
+    fireEvent.keyDown(document, { key: 'x' })
+    fireEvent.keyDown(document, { key: 'f' })
+    expect(mockRoute).not.toHaveBeenCalled()
+  })
+
+  it('refreshes the current view on Shift+R', () => {
+    fireEvent.keyDown(document, { key: 'R', shiftKey: true })
+    expect(fetchFluxReport).toHaveBeenCalledTimes(1)
+
+    mockLocation.path = '/events'
+    fireEvent.keyDown(document, { key: 'R', shiftKey: true })
+    expect(fetchEvents).toHaveBeenCalledTimes(1)
+  })
+
+  it('toggles favorite on detail pages with s', () => {
+    mockLocation.path = '/resource/Kustomization/default/flux-system'
+    fireEvent.keyDown(document, { key: 's' })
+    expect(toggleFavorite).toHaveBeenCalledWith('Kustomization', 'default', 'flux-system')
+  })
+
+  it('copies the page link on detail pages with c', () => {
+    mockLocation.path = '/workload/Deployment/default/my-app'
+    fireEvent.keyDown(document, { key: 'c' })
+    expect(copyCurrentUrl).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens workload logs on detail pages with l', () => {
+    const openLogs = vi.fn()
+    registerOpenWorkloadLogs(openLogs)
+    mockLocation.path = '/workload/Deployment/default/my-app'
+
+    fireEvent.keyDown(document, { key: 'l' })
+
+    expect(openLogs).toHaveBeenCalledTimes(1)
+    unregisterOpenWorkloadLogs(openLogs)
+  })
+
+  it('ignores context shortcuts while the logs viewer is open', () => {
+    workloadLogsOpen.value = true
+    mockLocation.path = '/workload/Deployment/default/my-app'
+
+    fireEvent.keyDown(document, { key: 'R', shiftKey: true })
+    fireEvent.keyDown(document, { key: 's' })
+
+    expect(fetchFluxReport).not.toHaveBeenCalled()
+    expect(toggleFavorite).not.toHaveBeenCalled()
+  })
+
+  it('suppresses g-chord navigation while the logs viewer is open', () => {
+    workloadLogsOpen.value = true
+
+    fireEvent.keyDown(document, { key: 'g' })
+    fireEvent.keyDown(document, { key: 'f' })
+
+    expect(mockRoute).not.toHaveBeenCalled()
+  })
+
+  it('cycles section tabs with [ and ]', () => {
+    mockLocation.path = '/resources'
+
+    fireEvent.keyDown(document, { key: ']' })
+    expect(mockRoute).toHaveBeenCalledWith('/workloads')
+
+    mockRoute.mockClear()
+    fireEvent.keyDown(document, { key: '[' })
+    expect(mockRoute).toHaveBeenCalledWith('/favorites')
+  })
+
+  it('cycles detail page tabs with [ and ]', () => {
+    mockLocation.path = '/resource/Kustomization/default/flux-system'
+
+    fireEvent.keyDown(document, { key: ']' })
+    expect(cycleHashTab).toHaveBeenCalledWith(1)
+
+    vi.mocked(cycleHashTab).mockClear()
+    fireEvent.keyDown(document, { key: '[' })
+    expect(cycleHashTab).toHaveBeenCalledWith(-1)
+  })
+
+  it('does not cycle tabs for Cmd+[ or Ctrl+[ (browser / reserved chords)', () => {
+    mockLocation.path = '/resources'
+    fireEvent.keyDown(document, { key: ']', metaKey: true })
+    fireEvent.keyDown(document, { key: '[', ctrlKey: true })
+    expect(mockRoute).not.toHaveBeenCalled()
+
+    mockLocation.path = '/resource/Kustomization/default/flux-system'
+    fireEvent.keyDown(document, { key: ']', metaKey: true })
+    fireEvent.keyDown(document, { key: '[', ctrlKey: true })
+    expect(cycleHashTab).not.toHaveBeenCalled()
+  })
+
+  it('cycles tabs when [ or ] are typed via Option or AltGr', () => {
+    // German Mac: Option+5/6 → [ ]; Windows DE: AltGr (ctrl+alt) → [ ]
+    mockLocation.path = '/resources'
+    fireEvent.keyDown(document, { key: ']', altKey: true })
+    expect(mockRoute).toHaveBeenCalledWith('/workloads')
+
+    mockRoute.mockClear()
+    fireEvent.keyDown(document, { key: '[', ctrlKey: true, altKey: true })
+    expect(mockRoute).toHaveBeenCalledWith('/favorites')
+  })
+})

--- a/web/src/utils/useRegisterPageShortcuts.js
+++ b/web/src/utils/useRegisterPageShortcuts.js
@@ -1,0 +1,45 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useEffect, useRef } from 'preact/hooks'
+import {
+  registerPageRefresh,
+  unregisterPageRefresh,
+  registerOpenWorkloadLogs,
+  unregisterOpenWorkloadLogs,
+} from './keyboardShortcuts'
+
+/**
+ * useRegisterPageShortcuts - registers page-local handlers for global shortcuts.
+ *
+ * @param {object} options
+ * @param {Function} [options.onRefresh] - Called by Shift+R on this page
+ * @param {Function} [options.onOpenLogs] - Called by `l` on workload detail pages
+ */
+export function useRegisterPageShortcuts({ onRefresh, onOpenLogs } = {}) {
+  const refreshRef = useRef(onRefresh)
+  const openLogsRef = useRef(onOpenLogs)
+  refreshRef.current = onRefresh
+  openLogsRef.current = onOpenLogs
+
+  useEffect(() => {
+    const refreshHandler = onRefresh ? () => refreshRef.current?.() : null
+    const openLogsHandler = onOpenLogs ? () => openLogsRef.current?.() : null
+
+    if (refreshHandler) {
+      registerPageRefresh(refreshHandler)
+    }
+    if (openLogsHandler) {
+      registerOpenWorkloadLogs(openLogsHandler)
+    }
+
+    return () => {
+      if (refreshHandler) {
+        unregisterPageRefresh(refreshHandler)
+      }
+      if (openLogsHandler) {
+        unregisterOpenWorkloadLogs(openLogsHandler)
+      }
+    }
+  }, [Boolean(onRefresh), Boolean(onOpenLogs)])
+}

--- a/web/src/utils/useWorkloadLogsOverlay.js
+++ b/web/src/utils/useWorkloadLogsOverlay.js
@@ -1,0 +1,20 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+import { useEffect } from 'preact/hooks'
+import { setWorkloadLogsOverlayOpen } from './keyboardShortcuts'
+
+/**
+ * useWorkloadLogsOverlay - marks the workload logs viewer as open for shortcut guards.
+ *
+ * @param {boolean} active - Whether this component currently shows the logs viewer
+ */
+export function useWorkloadLogsOverlay(active) {
+  useEffect(() => {
+    if (!active) {
+      return
+    }
+    setWorkloadLogsOverlayOpen(true)
+    return () => setWorkloadLogsOverlayOpen(false)
+  }, [active])
+}


### PR DESCRIPTION
## Summary

Closes #955.

Adds keyboard shortcuts to the Flux Status Page:

- `?` — help modal listing all shortcuts (also linked from the user menu)
- `g` + letter — navigate between Dashboard, Favorites, Resources, Workloads, and Events
- `Shift+R` — refresh the current view
- `s` / `c` / `l` — toggle favorite, copy link, and open logs on detail pages
- `[` / `]` — cycle tabs on list and detail views

Shortcuts are suppressed while typing, when overlays are open, and when RBAC blocks an action (e.g. logs without the `logs` permission).

## Test plan

- [ ] Press `?` and confirm the help modal opens and lists shortcuts
- [ ] Use `g` chords to jump between main views
- [ ] On a resource/workload detail page, try `Shift+R`, `s`, `c`, and `[` / `]`
- [ ] On a workload detail page with logs access, press `l` to open logs
- [ ] Confirm shortcuts do not fire while focused in a search/input field or with logs/search open
- [ ] `make web-test`

Assisted-by: Cursor/Composer 2.5
