### PR TITLE
web: update docs for user actions after `FineGrained` mode

### DIFF
--- a/docs/web/web-actions.md
+++ b/docs/web/web-actions.md
@@ -19,6 +19,54 @@ two predefined roles: `flux-web-user` (read-only) and `flux-web-admin`
 [Role-Based Access Control](web-user-management.md#role-based-access-control) section
 for details on assigning roles to users and groups.
 
+## Access Modes
+
+The `.spec.userActions.access` field in the
+[Web Config API](web-config-api.md#access-mode) determines which Kubernetes
+identity performs user actions that use per-action RBAC verbs:
+
+- `Impersonated` (default): The Web UI checks that the user has the per-action
+  RBAC verb, then performs the action as that user. The user must also have
+  every native Kubernetes verb required by the operation.
+- `FineGrained`: The Web UI checks that the user has the per-action verb,
+  then performs the native Kubernetes operations using the Web UI service
+  account. The user does not need the corresponding native verbs unless the
+  action verb is itself native, as with `delete` for Pod deletion.
+
+In both modes, users still need read permissions to find and view resources in
+the Web UI. The access mode only changes the permissions used to perform an
+action. Viewing pod logs is a Web UI user action and is disabled when
+authentication is not configured. It has no per-action RBAC verb: the user must
+hold the native `get` verb on `pods/log` in either access mode, and the request
+is always performed with the user's identity.
+
+To enable fine-grained access with the Flux Operator Helm chart, configure:
+
+```yaml
+web:
+  config:
+    userActions:
+      access: FineGrained
+```
+
+For a [standalone Web UI deployment](web-standalone.md), also set the chart's
+`web.userActions.access` value so that the Web UI service account is granted the
+native permissions it needs:
+
+```yaml
+web:
+  config:
+    userActions:
+      access: FineGrained
+  userActions:
+    access: FineGrained
+```
+
+The embedded Web UI uses the Flux Operator service account, which already has
+the necessary cluster-wide permissions. If the standalone service account lacks
+a required permission, the action returns an internal error explaining that the
+Web UI application, rather than the user, needs additional RBAC.
+
 ## GitOps Actions
 
 GitOps actions operate on Flux resources such as Kustomizations, HelmReleases,
@@ -35,9 +83,14 @@ or the schedule hasn't elapsed.
 
 !!! note "RBAC"
 
-    Requires the `reconcile` and `patch` verbs on the target resource.
-    For example, to allow reconciling Kustomizations, the user needs
-    `reconcile` and `patch` on `kustomizations` in the `kustomize.toolkit.fluxcd.io` API group.
+    The user always needs the `reconcile` verb on the target resource.
+    With `Impersonated` access, the user also needs `get` and `patch`.
+    With `FineGrained` access, the Web UI service account needs `get` and
+    `patch` instead.
+
+    For example, to allow reconciling Kustomizations with fine-grained access,
+    grant the user `reconcile` on `kustomizations` in the
+    `kustomize.toolkit.fluxcd.io` API group.
 
 ### Pull
 
@@ -51,9 +104,10 @@ or when the source is an ExternalArtifact.
 
 !!! note "RBAC"
 
-    Requires the `reconcile` and `patch` verbs on the source resource.
-    For example, to pull a GitRepository, the user needs `reconcile` and `patch`
-    on `gitrepositories` in the `source.toolkit.fluxcd.io` API group.
+    The user always needs the `reconcile` verb on the source resource.
+    With `Impersonated` access, the user also needs `get` and `patch`.
+    With `FineGrained` access, the Web UI service account needs `get` and
+    `patch` instead.
 
 ### Suspend and Resume
 
@@ -66,8 +120,10 @@ reconciliation request. Resuming removes the suspension tracking annotation.
 
 !!! note "RBAC"
 
-    Requires the `suspend` and `patch` verbs to suspend, and the `resume` and `patch`
-    verbs to resume. These verbs apply to the target resource's API group and kind.
+    The user always needs `suspend` to suspend a resource and `resume` to
+    resume it. With `Impersonated` access, the user also needs `get` and
+    `patch` on the target resource. With `FineGrained` access, the Web UI
+    service account needs `get` and `patch` instead.
 
 ### Download Artifact
 
@@ -81,9 +137,14 @@ can be downloaded individually.
 
 !!! note "RBAC"
 
-    Requires the `download` verb on the source resource.
-    For example, to download an OCIRepository artifact, the user needs `download`
-    on `ocirepositories` in the `source.toolkit.fluxcd.io` API group.
+    The user always needs the `download` verb on the source resource.
+    With `Impersonated` access, the user also needs `get` so the Web UI can
+    read the artifact URL from the resource status. With `FineGrained` access,
+    the Web UI service account needs `get` instead.
+
+    For example, to download an OCIRepository artifact with fine-grained
+    access, grant the user `download` on `ocirepositories` in the
+    `source.toolkit.fluxcd.io` API group.
 
 ## Workload Actions
 
@@ -99,7 +160,11 @@ a "View logs" button that aggregates the logs of all the workload's pods.
 
 !!! note "RBAC"
 
-    Requires the `get` verb on the `pods/log` subresource in the core API group.
+    Authentication must be configured to enable the action, and the user must
+    have the `get` verb on the `pods/log` subresource in the core API group.
+    This requirement is the same for both access modes because viewing logs
+    does not use a custom RBAC verb and is not controlled by
+    `.spec.userActions.access`.
 
 ### Rollout Restart
 
@@ -110,9 +175,12 @@ to recreate all pods in a rolling fashion, similar to `kubectl rollout restart`.
 
 !!! note "RBAC"
 
-    Requires the `restart` and `patch` verbs on the workload resource.
-    For example, to restart a Deployment, the user needs
-    `restart` and `patch` on `deployments` in the `apps` API group.
+    The user always needs the `restart` verb on the workload resource.
+    With `Impersonated` access, the user also needs `patch`. With
+    `FineGrained` access, the Web UI service account needs `patch` instead.
+
+    For example, to restart a Deployment with fine-grained access, grant the
+    user `restart` on `deployments` in the `apps` API group.
 
 ### Run Job
 
@@ -124,8 +192,10 @@ created the Job.
 
 !!! note "RBAC"
 
-    Requires the `restart` verb on `cronjobs` and the `create` verb on `jobs`
-    in the `batch` API group.
+    The user always needs the `restart` verb on `cronjobs`. With
+    `Impersonated` access, the user also needs `get` on `cronjobs` and `create`
+    on `jobs`. With `FineGrained` access, the Web UI service account needs
+    those native permissions instead.
 
 ### Delete Pod
 
@@ -136,20 +206,25 @@ is performed.
 
 !!! note "RBAC"
 
-    Requires the `delete` verb on `pods` in the core API group.
+    Requires the `delete` verb on `pods` in the core API group in both access
+    modes. For this action, the action verb is also the native Kubernetes verb,
+    so granting it allows the user to delete pods directly with other
+    Kubernetes clients as well as through the Web UI.
 
 ## Audit
 
-The Web UI can generate audit events for user actions, providing a trail
-of who performed what action and when. Audit events are recorded as
-Kubernetes Events and forwarded to Flux's notification-controller,
-enabling integration with external notification systems.
+The Web UI can generate audit events for user actions that have per-action
+RBAC verbs, providing a trail of who performed what action and when. Audit
+events are recorded as Kubernetes Events and forwarded to Flux's
+notification-controller, enabling integration with external notification
+systems. Viewing pod logs is not audited because it relies only on the native
+`get` verb and is not part of the configurable audit actions.
 
 ### Enabling Audit
 
 To enable auditing, set `spec.userActions.audit` in the
 [web configuration](web-config-api.md) to a list of actions to audit.
-Use the special value `["*"]` to audit all actions.
+Use the special value `["*"]` to audit all actions that support auditing.
 
 ```yaml
 web:

--- a/docs/web/web-least-privilege-rbac.md
+++ b/docs/web/web-least-privilege-rbac.md
@@ -192,18 +192,41 @@ memory utilization of Flux controllers helps users understand whether Flux itsel
 
 ---
 
-## 7. Fine-Grained GitOps Actions
+## 7. Fine-Grained User Actions
 
-**Where:** Any GitOps action (e.g. suspend, resume, reconcile, download) triggered via the Web UI when `.spec.userActions.access` is configured as `FineGrained`.
+**Where:** Flux resource actions, artifact downloads, workload restarts, CronJob
+job runs, and Pod deletions triggered through the Web UI when
+`.spec.userActions.access` is configured as `FineGrained`. Pod log viewing is a
+Web UI user action and is disabled when authentication is not configured, but
+it is not part of this elevated path: it has no custom RBAC verb and always uses
+the user's native `get` permission on `pods/log`.
 
 **Internal operation:**
-The system performs the actual `patch` operation on the target resource, as long as the user possesses the specific custom action verb (e.g. `suspend`).
+The system performs the native Kubernetes reads and mutations required by an
+action after confirming that the user possesses its specific action verb, such
+as `suspend`, `download`, or `restart`.
 
 **How it works:**
-Normally, GitOps actions are executed by patching the object using the user's impersonated client, which requires the user to hold the native Kubernetes `patch` verb. When fine-grained access control is enabled, the backend verifies that the user holds the specific custom verb for the action, and if so, it uses the privileged client to perform the patch operation, removing the need for user impersonation during the patch.
+In the default `Impersonated` mode, the backend verifies the action verb and
+performs the operation using the user's impersonated client. The user must
+therefore hold both the action verb and all native verbs used by the operation,
+such as `get`, `patch`, or `create`. In `FineGrained` mode, the action verb is
+still checked against the user's identity, but the backend uses its privileged
+client for the supporting reads and the action itself. For artifact downloads,
+only the requested artifact is returned to the authorized user; data from other
+privileged reads is not exposed.
+
+Pod deletion is a special case: its action verb, `delete`, is also the native
+Kubernetes verb. Granting that action therefore permits direct Pod deletion in
+either access mode.
 
 **Least privilege benefit:**
-This feature is crucial for least-privilege security scenarios. If users were required to have the native `patch` verb to suspend or resume resources, they could potentially bypass the Web UI and perform unauthorized modifications via `kubectl` or other SSO-integrated tools. By handling the patch internally, cluster administrators can assign restrictive, fine-grained access policies ensuring tenants can solely perform permitted actions.
+Without fine-grained access, native verbs such as `patch` can let users bypass
+the action boundaries enforced by the Web UI and make unrelated changes with
+`kubectl` or other SSO-integrated tools. Moving those native operations to the
+Web UI service account lets administrators grant individual action verbs while
+keeping users' direct Kubernetes access read-only, except where the action verb
+is itself native, as with Pod deletion.
 
 ---
 
@@ -240,5 +263,5 @@ Users do not need cluster-wide `list` permissions on namespaces just to populate
 | 4 | Audit pod-owner resolution  | System reads owner chain                           | None (server-side only)                                                       |
 | 5 | Dashboard report and workloads index | System scans Flux resources and applier inventories | Aggregated stats and workload reference + parent reconciler status, filtered by user namespace |
 | 6 | Controller metrics          | System reads metrics API                           | CPU/memory usage of Flux controllers                                          |
-| 7 | Fine-Grained GitOps Actions | System patches resource                            | None (server-side mutation only)                                              |
+| 7 | Fine-grained user actions   | System performs native action operations           | Requested artifact for downloads; action result only otherwise                |
 | 8 | Namespace visibility        | Wrapper lists namespaces with privileged base client | Visible namespace names after RBAC filtering                                  |


### PR DESCRIPTION
Some docs were outdated after the introduction of `.spec.userActions.access: FineGrained`.