### PR TITLE
cli: fix breakage after Go 1.26.5 fix for CVE-2026-39822

### DIFF
--- a/cmd/cli/distro_decrypt_manifests.go
+++ b/cmd/cli/distro_decrypt_manifests.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/go-jose/go-jose/v4"
@@ -110,7 +111,8 @@ func distroDecryptManifestsCmdRun(cmd *cobra.Command, args []string) error {
 }
 
 // extractZipArchive extracts a zip archive from bytes to the specified directory.
-// Returns the list of extracted files.
+// Directory entries are normalized before root operations, and the list of
+// extracted files is returned.
 func extractZipArchive(zipData []byte, destDir string, overwrite bool) ([]string, error) {
 	reader := bytes.NewReader(zipData)
 	zipReader, err := zip.NewReader(reader, int64(len(zipData)))
@@ -128,21 +130,25 @@ func extractZipArchive(zipData []byte, destDir string, overwrite bool) ([]string
 	defer func() { _ = rootDir.Close() }()
 
 	for _, file := range zipReader.File {
-		// Check for file conflicts
-		if !overwrite {
-			if _, err := rootDir.Stat(file.Name); err == nil {
-				return nil, fmt.Errorf("file %s already exists (use --overwrite to replace)", file.Name)
-			}
-		}
-
 		if file.FileInfo().IsDir() {
-			// Create directory
-			err := rootDir.MkdirAll(file.Name, 0755)
+			// ZIP directory names use trailing slashes; os.Root expects clean names.
+			dirName := path.Clean(file.Name)
+			if dirName == "." {
+				continue
+			}
+			err := rootDir.MkdirAll(dirName, 0755)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create directory %s: %w", file.Name, err)
 			}
 			// Don't add directories to the extracted files list for counting
 		} else {
+			// Check for file conflicts
+			if !overwrite {
+				if _, err := rootDir.Stat(file.Name); err == nil {
+					return nil, fmt.Errorf("file %s already exists (use --overwrite to replace)", file.Name)
+				}
+			}
+
 			// Extract file
 			err := extractFileSecure(rootDir, file)
 			if err != nil {

--- a/cmd/cli/distro_decrypt_manifests_test.go
+++ b/cmd/cli/distro_decrypt_manifests_test.go
@@ -502,6 +502,36 @@ func TestDistroDecryptManifestsCmd(t *testing.T) { //nolint:gocyclo
 	}
 }
 
+func TestExtractZipArchiveAllowsExistingDirectoriesWithoutOverwrite(t *testing.T) {
+	g := NewWithT(t)
+
+	tempDir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(tempDir, "apps"), 0755)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var buf bytes.Buffer
+	zipWriter := zip.NewWriter(&buf)
+
+	_, err = zipWriter.Create("apps/")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	configMap, err := zipWriter.Create("apps/configmap.yaml")
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = configMap.Write([]byte("apiVersion: v1\nkind: ConfigMap"))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = zipWriter.Close()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	extractedFiles, err := extractZipArchive(buf.Bytes(), tempDir, false)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(extractedFiles).To(Equal([]string{"apps/configmap.yaml"}))
+
+	content, err := os.ReadFile(filepath.Join(tempDir, "apps", "configmap.yaml"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(content)).To(Equal("apiVersion: v1\nkind: ConfigMap"))
+}
+
 func TestDistroDecryptManifestsCmdWithEnvVar(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
https://pkg.go.dev/vuln/GO-2026-4970