### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # flux-operator
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fcontrolplaneio-fluxcd%2Fflux-operator.svg)](https://mcptoplist.com/server/glama%2Fcontrolplaneio-fluxcd%2Fflux-operator)
+
 [![release](https://img.shields.io/github/release/controlplaneio-fluxcd/flux-operator/all.svg)](https://github.com/controlplaneio-fluxcd/flux-operator/releases)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/flux-operator)](https://artifacthub.io/packages/helm/flux-operator/flux-operator)
 [![Operator Hub](https://img.shields.io/badge/Operator_Hub-flux--operator-9cf.svg)](https://operatorhub.io/operator/flux-operator)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,852 MCP servers across the major
registries, and **FluxCD MCP Server** is currently ranked **#275**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fcontrolplaneio-fluxcd%2Fflux-operator.svg)](https://mcptoplist.com/server/glama%2Fcontrolplaneio-fluxcd%2Fflux-operator)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building FluxCD MCP Server!
