### PR TITLE
operator: optimize `inventory.Diff` with map lookup

### DIFF
--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -111,13 +111,12 @@ func ListMetadata(inv *fluxcdv1.ResourceInventory) (object.ObjMetadataSet, error
 
 // Diff returns the slice of objects that do not exist in the target inventory.
 func Diff(inv *fluxcdv1.ResourceInventory, target *fluxcdv1.ResourceInventory) ([]*unstructured.Unstructured, error) {
-	versionOf := func(i *fluxcdv1.ResourceInventory, objMetadata object.ObjMetadata) string {
-		for _, entry := range i.Entries {
-			if entry.ID == objMetadata.String() {
-				return entry.Version
-			}
-		}
-		return ""
+	versionMap := make(map[string]string, len(inv.Entries))
+	for _, entry := range inv.Entries {
+		versionMap[entry.ID] = entry.Version
+	}
+	versionOf := func(objMetadata object.ObjMetadata) string {
+		return versionMap[objMetadata.String()]
 	}
 
 	objects := make([]*unstructured.Unstructured, 0)
@@ -141,7 +140,7 @@ func Diff(inv *fluxcdv1.ResourceInventory, target *fluxcdv1.ResourceInventory) (
 		u.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   metadata.GroupKind.Group,
 			Kind:    metadata.GroupKind.Kind,
-			Version: versionOf(inv, metadata),
+			Version: versionOf(metadata),
 		})
 		u.SetName(metadata.Name)
 		u.SetNamespace(metadata.Namespace)


### PR DESCRIPTION
Closes #980

## What does this change do?

`Diff` used a `versionOf` closure that performed a linear scan through
`inv.Entries` on every call — once per item in the diff list. For an
inventory with n entries and a diff list of m items, this is O(n*m).

This change builds a version map once upfront (O(n)), then uses O(1)
map lookups per diff item, reducing overall complexity to O(n+m).

On clusters with large inventories this avoids redundant linear scans
on every reconciliation cycle where pruning is needed.

## Testing

Existing `Test_Inventory/diff_objects_in_inventory` passes without
modification — behavior is identical, only the lookup strategy changed.

## Notes

This is the same optimization applied to kustomize-controller in
fluxcd/kustomize-controller#1720.

Assisted-by: Claude/claude-sonnet-4-6