### PR TITLE
operator: fix workload identity for Azure DevOps

### DIFF
--- a/internal/controller/resourcesetinputprovider_controller.go
+++ b/internal/controller/resourcesetinputprovider_controller.go
@@ -752,7 +752,9 @@ func (r *ResourceSetInputProviderReconciler) getGiteaToken(
 	return password, err
 }
 
-// getAzureDevOpsToken returns the appropriate AzureDevOps token by reading the secrets in authData.
+// getAzureDevOpsToken returns the appropriate AzureDevOps token, either the personal
+// access token from the secrets in authData, or an Entra ID token issued through
+// workload identity federation.
 func (r *ResourceSetInputProviderReconciler) getAzureDevOpsToken(
 	ctx context.Context, obj *fluxcdv1.ResourceSetInputProvider,
 	authData map[string][]byte) (string, error) {
@@ -767,21 +769,14 @@ func (r *ResourceSetInputProviderReconciler) getAzureDevOpsToken(
 	// Handle workload identity.
 	default:
 
-		opts := []auth.Option{
-			auth.WithClient(r.Client),
-			auth.WithServiceAccountNamespace(obj.GetNamespace()),
-		}
+		opts := r.getAuthOptions(obj)
 
-		// Configure service account.
-		if s := obj.Spec.ServiceAccountName; s != "" {
-			opts = append(opts, auth.WithServiceAccountName(s))
+		// The auth package requires a Git URL
+		gitURL, err := url.Parse(obj.Spec.URL)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse AzureDevOps URL: %w", err)
 		}
-
-		// Configure token cache.
-		if r.TokenCache != nil {
-			involvedObject := getInputProviderInvolvedObject(obj)
-			opts = append(opts, auth.WithCache(*r.TokenCache, involvedObject))
-		}
+		opts = append(opts, auth.WithGitURL(*gitURL))
 
 		// Get token.
 		t, err := authutils.GetGitCredentials(ctx, azure.ProviderName, opts...)

--- a/internal/controller/resourcesetinputprovider_controller.go
+++ b/internal/controller/resourcesetinputprovider_controller.go
@@ -456,7 +456,7 @@ func (r *ResourceSetInputProviderReconciler) newGitProvider(ctx context.Context,
 			Token:     token,
 		})
 	case obj.Spec.Type == fluxcdv1.InputProviderAWSCodeCommitPullRequest:
-		credsProvider, region, err := r.getAWSCodeCommitAccessToken(ctx, obj)
+		credsProvider, region, err := r.getAWSCodeCommitCredentialsProvider(ctx, obj)
 		if err != nil {
 			return nil, err
 		}
@@ -465,7 +465,7 @@ func (r *ResourceSetInputProviderReconciler) newGitProvider(ctx context.Context,
 			TLSConfig: tlsConfig,
 		}, credsProvider, region, nil)
 	case strings.HasPrefix(obj.Spec.Type, "AWSCodeCommit"):
-		gitCreds, err := r.getAWSCodeCommitGitCredentials(ctx, obj)
+		gitCreds, err := r.getGitCredentials(ctx, obj, aws.ProviderName)
 		if err != nil {
 			return nil, err
 		}
@@ -768,22 +768,11 @@ func (r *ResourceSetInputProviderReconciler) getAzureDevOpsToken(
 
 	// Handle workload identity.
 	default:
-
-		opts := r.getAuthOptions(obj)
-
-		// The auth package requires a Git URL
-		gitURL, err := url.Parse(obj.Spec.URL)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse AzureDevOps URL: %w", err)
-		}
-		opts = append(opts, auth.WithGitURL(*gitURL))
-
-		// Get token.
-		t, err := authutils.GetGitCredentials(ctx, azure.ProviderName, opts...)
+		gitCreds, err := r.getGitCredentials(ctx, obj, azure.ProviderName)
 		if err != nil {
 			return "", err
 		}
-		return t.BearerToken, nil
+		return gitCreds.BearerToken, nil
 	}
 }
 
@@ -801,28 +790,33 @@ func (r *ResourceSetInputProviderReconciler) getAuthOptions(obj *fluxcdv1.Resour
 
 	// Configure token cache.
 	if r.TokenCache != nil {
-		involvedObject := getInputProviderInvolvedObject(obj)
+		involvedObject := cache.InvolvedObject{
+			Kind:      fluxcdv1.ResourceSetInputProviderKind,
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+			Operation: cache.OperationReconcile,
+		}
 		opts = append(opts, auth.WithCache(*r.TokenCache, involvedObject))
 	}
 
 	return opts
 }
 
-// getAWSCodeCommitGitCredentials returns the SigV4-signed Git credentials for AWSCodeCommit.
-func (r *ResourceSetInputProviderReconciler) getAWSCodeCommitGitCredentials(
-	ctx context.Context, obj *fluxcdv1.ResourceSetInputProvider) (*auth.GitCredentials, error) {
+// getGitCredentials returns Git credentials for the object.
+func (r *ResourceSetInputProviderReconciler) getGitCredentials(
+	ctx context.Context, obj *fluxcdv1.ResourceSetInputProvider,
+	provider string) (*auth.GitCredentials, error) {
 
 	opts := r.getAuthOptions(obj)
 
-	// Set the Git URL for SigV4 credential generation.
 	gitURL, err := url.Parse(obj.Spec.URL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse AWSCodeCommit URL: %w", err)
+		return nil, fmt.Errorf("failed to parse .spec.url: %w", err)
 	}
 	opts = append(opts, auth.WithGitURL(*gitURL))
 
 	// Get the SigV4-signed Git credentials.
-	gitCreds, err := authutils.GetGitCredentials(ctx, aws.ProviderName, opts...)
+	gitCreds, err := authutils.GetGitCredentials(ctx, provider, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -830,8 +824,8 @@ func (r *ResourceSetInputProviderReconciler) getAWSCodeCommitGitCredentials(
 	return gitCreds, nil
 }
 
-// getAWSCodeCommitAccessToken returns the AWS credentials provider for AWSCodeCommit.
-func (r *ResourceSetInputProviderReconciler) getAWSCodeCommitAccessToken(
+// getAWSCodeCommitCredentialsProvider returns the AWS credentials provider for AWSCodeCommit.
+func (r *ResourceSetInputProviderReconciler) getAWSCodeCommitCredentialsProvider(
 	ctx context.Context, obj *fluxcdv1.ResourceSetInputProvider) (awssdk.CredentialsProvider, string, error) {
 
 	opts := r.getAuthOptions(obj)
@@ -1210,21 +1204,7 @@ func (r *ResourceSetInputProviderReconciler) buildOCIOptions(ctx context.Context
 
 	// Configure workload identity for cloud providers.
 	case obj.Spec.Type != fluxcdv1.InputProviderOCIArtifactTag:
-		authOpts := []auth.Option{
-			auth.WithClient(r.Client),
-			auth.WithServiceAccountNamespace(obj.GetNamespace()),
-		}
-
-		// Configure service account.
-		if s := obj.Spec.ServiceAccountName; s != "" {
-			authOpts = append(authOpts, auth.WithServiceAccountName(s))
-		}
-
-		// Configure token cache.
-		if r.TokenCache != nil {
-			involvedObject := getInputProviderInvolvedObject(obj)
-			authOpts = append(authOpts, auth.WithCache(*r.TokenCache, involvedObject))
-		}
+		authOpts := r.getAuthOptions(obj)
 
 		// Build authenticator.
 		provider := inputProviderToCloudProvider[obj.Spec.Type]
@@ -1382,15 +1362,4 @@ func requeueAfterResourceSetInputProvider(obj *fluxcdv1.ResourceSetInputProvider
 	}
 
 	return ctrl.Result{RequeueAfter: requeueAfter}
-}
-
-// getInputProviderInvolvedObject returns the involved object for the input provider
-// for cache operations.
-func getInputProviderInvolvedObject(obj *fluxcdv1.ResourceSetInputProvider) cache.InvolvedObject {
-	return cache.InvolvedObject{
-		Kind:      fluxcdv1.ResourceSetInputProviderKind,
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-		Operation: cache.OperationReconcile,
-	}
 }

--- a/internal/controller/resourcesetinputprovider_controller_git_test.go
+++ b/internal/controller/resourcesetinputprovider_controller_git_test.go
@@ -1104,7 +1104,7 @@ func TestResouceSetInputProviderReconciler_getAzureDevOpsToken(t *testing.T) {
 			},
 		}, nil)
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("failed to parse AzureDevOps URL"))
+		g.Expect(err.Error()).To(ContainSubstring("failed to parse .spec.url"))
 		g.Expect(res).To(BeEmpty())
 	})
 }

--- a/internal/controller/resourcesetinputprovider_controller_git_test.go
+++ b/internal/controller/resourcesetinputprovider_controller_git_test.go
@@ -1045,18 +1045,66 @@ func TestResouceSetInputProviderReconciler_getAzureDevOpsToken(t *testing.T) {
 		g.Expect(res).To(Equal("pass"))
 	})
 
-	t.Run("with workload identity", func(t *testing.T) {
+	t.Run("with object-level workload identity", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ns, err := testEnv.CreateNamespace(ctx, "test-azure-devops-wi")
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Create a ServiceAccount without the Azure workload identity annotations.
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sa",
+				Namespace: ns.Name,
+			},
+		}
+		g.Expect(testEnv.Create(ctx, sa)).To(Succeed())
+
+		res, err := r.getAzureDevOpsToken(ctx, &fluxcdv1.ResourceSetInputProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: ns.Name,
+			},
+			Spec: fluxcdv1.ResourceSetInputProviderSpec{
+				Type:               "AzureDevOpsBranch",
+				URL:                "https://dev.azure.com/org/project/_git/repo",
+				ServiceAccountName: "test-sa",
+			},
+		}, nil)
+
+		// The Git URL must reach the auth package, otherwise the request is
+		// rejected before the Azure provider reads the ServiceAccount.
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).NotTo(ContainSubstring("a Git repository URL is required"))
+		g.Expect(err.Error()).To(ContainSubstring("azure tenant ID is not set in the service account annotation"))
+		g.Expect(res).To(BeEmpty())
+	})
+
+	t.Run("with controller-level workload identity", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		res, err := r.getAzureDevOpsToken(ctx, &fluxcdv1.ResourceSetInputProvider{
 			Spec: fluxcdv1.ResourceSetInputProviderSpec{
 				Type: "AzureDevOpsBranch",
-				URL:  "https://dev.azure.com/org/repo",
+				URL:  "https://dev.azure.com/org/project/_git/repo",
 			},
 		}, nil)
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("a Git repository URL is required for issuing Git credentials"))
+		g.Expect(err.Error()).NotTo(ContainSubstring("a Git repository URL is required"))
+		g.Expect(res).To(BeEmpty())
+	})
+
+	t.Run("with invalid URL", func(t *testing.T) {
+		g := NewWithT(t)
+		res, err := r.getAzureDevOpsToken(ctx, &fluxcdv1.ResourceSetInputProvider{
+			Spec: fluxcdv1.ResourceSetInputProviderSpec{
+				Type: "AzureDevOpsBranch",
+				URL:  "https://dev.azure.com/\x7f",
+			},
+		}, nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to parse AzureDevOps URL"))
 		g.Expect(res).To(BeEmpty())
 	})
 }


### PR DESCRIPTION
Assisted-by: <claude/opus 5>

Resolves #985 

built and tested against a dev cluster; seems to resolve the issues I was having. 

Also considered adding the git url to the standard opts in getAuthOptions since both code commit and ado needs this (and theortically any git provider), but it seems like that function is also being used by a non-git provider as far as I can tell. For this reason and my newness to the project I decided to make a more conservative change.