### PR TITLE
Add tag pattern/extract filtering for RSIP

### DIFF
--- a/api/v1/resourcesetinputprovider_types.go
+++ b/api/v1/resourcesetinputprovider_types.go
@@ -181,6 +181,19 @@ type ResourceSetInputFilter struct {
 	// +optional
 	ExcludeTag string `json:"excludeTag,omitempty"`
 
+	// Pattern specifies a regular expression used to match tags and optionally
+	// extract a sortable value from them using Extract.
+	// Supported only for tags.
+	// +optional
+	Pattern string `json:"pattern,omitempty"`
+
+	// Extract specifies the replacement template used with Pattern to extract a
+	// sortable value from a tag, e.g. "$ts" for a named capture group.
+	// This field requires Pattern to be set.
+	// Supported only for tags.
+	// +optional
+	Extract string `json:"extract,omitempty"`
+
 	// IncludeEnvironment specifies the regular expression to filter the environments
 	// that the input provider should include.
 	// +optional

--- a/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
+++ b/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
@@ -102,6 +102,13 @@ spec:
                       ExcludeTag specifies the regular expression to filter the tags
                       that the input provider should exclude.
                     type: string
+                  extract:
+                    description: |-
+                      Extract specifies the replacement template used with Pattern to extract a
+                      sortable value from a tag, e.g. "$ts" for a named capture group.
+                      This field requires Pattern to be set.
+                      Supported only for tags.
+                    type: string
                   includeBranch:
                     description: |-
                       IncludeBranch specifies the regular expression to filter the branches
@@ -130,6 +137,12 @@ spec:
                       When not set, the default limit is 100.
                     maximum: 10000
                     type: integer
+                  pattern:
+                    description: |-
+                      Pattern specifies a regular expression used to match tags and optionally
+                      extract a sortable value from them using Extract.
+                      Supported only for tags.
+                    type: string
                   semver:
                     description: |-
                       Semver specifies a semantic version range to filter and sort the tags.

--- a/docs/api/v1/resourcesetinputprovider.md
+++ b/docs/api/v1/resourcesetinputprovider.md
@@ -232,9 +232,11 @@ The following filters are supported:
 - `excludeBranch`: regular expression to exclude branches by name.
 - `includeTag`: regular expression to include tags by name.
 - `excludeTag`: regular expression to exclude tags by name.
+- `pattern`: regular expression used to match tags and optionally extract a sortable value.
+- `extract`: replacement template (e.g. `$ts`) used with `pattern` to extract the sortable value from a tag.
 - `includeEnvironment`: regular expression to include environments by name.
 - `excludeEnvironment`: regular expression to exclude environments by name.
-- `semver`: sematic version range to filter and sort tags.
+- `semver`: semantic version range to filter and sort tags.
 
 Example of a filter configuration for change requests:
 
@@ -264,6 +266,16 @@ spec:
   filter:
     limit: 1
     semver: ">=1.0.0"
+```
+
+Example of a filter configuration for matching artifact tags and sorting by extracted timestamp:
+
+```yaml
+spec:
+  filter:
+    limit: 1
+    pattern: "^master-.+-ts(?P<ts>[0-9]+)$"
+    extract: "$ts"
 ```
 
 ### Skip

--- a/internal/controller/resourcesetinputprovider_controller.go
+++ b/internal/controller/resourcesetinputprovider_controller.go
@@ -537,6 +537,16 @@ func (r *ResourceSetInputProviderReconciler) makeFilters(
 		}
 		filters.Exclude = exRx
 	}
+	if obj.Spec.Filter.Pattern != "" {
+		patternRx, err := regexp.Compile(obj.Spec.Filter.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid pattern regex: %w", err)
+		}
+		filters.Pattern = patternRx
+		filters.Extract = obj.Spec.Filter.Extract
+	} else if obj.Spec.Filter.Extract != "" {
+		return nil, fmt.Errorf("extract requires pattern to be set")
+	}
 
 	// SemVer.
 	if obj.Spec.Filter.Semver != "" {

--- a/internal/controller/resourcesetinputprovider_controller_test.go
+++ b/internal/controller/resourcesetinputprovider_controller_test.go
@@ -486,6 +486,8 @@ func TestResourceSetInputProviderReconciler_makeFilters(t *testing.T) {
 			filter  *fluxcdv1.ResourceSetInputFilter
 			include string
 			exclude string
+			pattern string
+			extract string
 		}{
 			{
 				name: "branch",
@@ -506,10 +508,14 @@ func TestResourceSetInputProviderReconciler_makeFilters(t *testing.T) {
 					Labels:     []string{"env=production"},
 					IncludeTag: "^v[0-9]+\\.[0-9]+\\.[0-9]+$",
 					ExcludeTag: "^v[0-9]+\\.[0-9]+\\.[0-9]+-beta$",
+					Pattern:    "^release-(?P<ver>v[0-9]+\\.[0-9]+\\.[0-9]+)$",
+					Extract:    "$ver",
 					Semver:     ">=1.0.0 <2.0.0",
 				},
 				include: "^v[0-9]+\\.[0-9]+\\.[0-9]+$",
 				exclude: "^v[0-9]+\\.[0-9]+\\.[0-9]+-beta$",
+				pattern: "^release-(?P<ver>v[0-9]+\\.[0-9]+\\.[0-9]+)$",
+				extract: "$ver",
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
@@ -530,10 +536,32 @@ func TestResourceSetInputProviderReconciler_makeFilters(t *testing.T) {
 				g.Expect(filters.Include.String()).To(Equal(tt.include))
 				g.Expect(filters.Exclude).NotTo(BeNil())
 				g.Expect(filters.Exclude.String()).To(Equal(tt.exclude))
+				if tt.pattern != "" {
+					g.Expect(filters.Pattern).NotTo(BeNil())
+					g.Expect(filters.Pattern.String()).To(Equal(tt.pattern))
+					g.Expect(filters.Extract).To(Equal(tt.extract))
+				}
 				g.Expect(filters.SemVer).NotTo(BeNil())
 				g.Expect(filters.SemVer.String()).To(Equal(">=1.0.0 <2.0.0"))
 			})
 		}
+	})
+
+	t.Run("invalid extract without pattern", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &fluxcdv1.ResourceSetInputProvider{
+			Spec: fluxcdv1.ResourceSetInputProviderSpec{
+				Type: fluxcdv1.InputProviderOCIArtifactTag,
+				Filter: &fluxcdv1.ResourceSetInputFilter{
+					Extract: "$ts",
+				},
+			},
+		}
+
+		_, err := r.makeFilters(obj)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("extract requires pattern"))
 	})
 }
 

--- a/internal/filtering/filters.go
+++ b/internal/filtering/filters.go
@@ -32,6 +32,13 @@ type Filters struct {
 	// Supported only for tags at the moment.
 	SemVer *semver.Constraints
 
+	// Pattern is used to match tags before sorting.
+	Pattern *regexp.Regexp
+
+	// Extract is the replacement template applied to Pattern matches to derive
+	// the sortable value for tags.
+	Extract string
+
 	// Limit is used to limit the number of results.
 	Limit int
 }
@@ -64,29 +71,39 @@ func (f *Filters) MatchString(s string) bool {
 // Tags applies all the filters supported for tags to a list of tags.
 // nolint:prealloc
 func (f *Filters) Tags(tags []string) []string {
-
-	var filtered []string
+	type parsedTag struct {
+		name string
+		key  string
+	}
+	filtered := make([]parsedTag, 0, len(tags))
 
 	// Apply include and exclude.
 	for _, tag := range tags {
-		if f.MatchString(tag) {
-			filtered = append(filtered, tag)
+		if !f.MatchString(tag) {
+			continue
 		}
+
+		key, ok := f.extractTagSortKey(tag)
+		if !ok {
+			continue
+		}
+
+		filtered = append(filtered, parsedTag{name: tag, key: key})
 	}
 
 	// Apply semver or sort in reverse alphabetical order. Keep input order
 	// stable for tags with equal semantic-version precedence.
 	switch {
 	case f.SemVer != nil:
-		type parsedTag struct {
+		type semverTag struct {
 			name    string
 			version *semver.Version
 		}
-		parsed := make([]parsedTag, 0, len(filtered))
+		parsed := make([]semverTag, 0, len(filtered))
 		for _, tag := range filtered {
-			parsedVersion, err := version.ParseVersion(tag)
+			parsedVersion, err := version.ParseVersion(tag.key)
 			if err == nil && f.SemVer.Check(parsedVersion) {
-				parsed = append(parsed, parsedTag{name: tag, version: parsedVersion})
+				parsed = append(parsed, semverTag{name: tag.name, version: parsedVersion})
 			}
 		}
 		sort.SliceStable(parsed, func(i, j int) bool {
@@ -94,11 +111,12 @@ func (f *Filters) Tags(tags []string) []string {
 		})
 		filtered = filtered[:0]
 		for _, tag := range parsed {
-			filtered = append(filtered, tag.name)
+			filtered = append(filtered, parsedTag{name: tag.name})
 		}
 	default:
-		slices.Sort(filtered)
-		slices.Reverse(filtered)
+		sort.SliceStable(filtered, func(i, j int) bool {
+			return filtered[i].key > filtered[j].key
+		})
 	}
 
 	// Apply limit.
@@ -107,5 +125,30 @@ func (f *Filters) Tags(tags []string) []string {
 		lim = f.Limit
 	}
 	lim = min(lim, len(filtered))
-	return slices.Clone(filtered[:lim])
+	res := make([]string, 0, lim)
+	for _, tag := range filtered[:lim] {
+		res = append(res, tag.name)
+	}
+	return res
+}
+
+// extractTagSortKey returns the sortable key for a tag.
+// When Pattern is set, only matching tags are included. If Extract is set, the
+// sortable key is derived from the replacement template.
+func (f *Filters) extractTagSortKey(tag string) (string, bool) {
+	if f.Pattern == nil {
+		return tag, true
+	}
+
+	match := f.Pattern.FindStringSubmatchIndex(tag)
+	if match == nil {
+		return "", false
+	}
+
+	if f.Extract == "" {
+		return tag, true
+	}
+
+	key := f.Pattern.ExpandString(nil, f.Extract, tag, match)
+	return string(key), true
 }

--- a/internal/filtering/filters_test.go
+++ b/internal/filtering/filters_test.go
@@ -218,6 +218,31 @@ func TestFilters_Tags(t *testing.T) {
 			tags:     []string{"2024.01.01", "2024.01.02", "2024.01.03"},
 			expected: []string{"2024.01.03"},
 		},
+		{
+			name: "pattern and extract sort by extracted value and keep original tags",
+			filters: &filtering.Filters{
+				Pattern: regexp.MustCompile(`^master-.+-ts(?P<ts>[0-9]+)$`),
+				Extract: "$ts",
+				Limit:   2,
+			},
+			tags: []string{
+				"master-main-ts123",
+				"master-main-ts9",
+				"release-1.0.0",
+				"master-main-ts45",
+			},
+			expected: []string{"master-main-ts9", "master-main-ts45"},
+		},
+		{
+			name: "pattern and extract with semver filter",
+			filters: &filtering.Filters{
+				Pattern: regexp.MustCompile(`^release-(?P<ver>v[0-9]+\.[0-9]+\.[0-9]+)$`),
+				Extract: "$ver",
+				SemVer:  newConstraint(">= 1.0.0 < 2.0.0"),
+			},
+			tags:     []string{"release-v1.0.0", "release-v2.0.0", "release-v1.2.0"},
+			expected: []string{"release-v1.2.0", "release-v1.0.0"},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)


### PR DESCRIPTION
Add support for pattern/extract tag filtering in ResourceSetInputFilter.

Allow matching tags with regex pattern and sorting/filtering using extracted capture values while keeping original tag output for exported inputs. Validate that extract requires pattern. Update CRD schema, docs, and tests.
anandshashijoshi