### PR TITLE
cli: sync the CLI image and instance chart with `distro mirror` command

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -404,6 +404,7 @@ The source registry (`ghcr.io`) can be authenticated with `--pull-token` or
     - `--variant`: Distribution variant (`upstream-alpine`, `enterprise-alpine`,
       `enterprise-distroless`, `enterprise-distroless-fips`). Default `upstream-alpine`.
     - `--include-operator-image`: Also mirror the Flux Operator container image (default `true`).
+    - `--include-operator-cli-image`: Also mirror the Flux Operator CLI container image (default `true`).
     - `--include-operator-chart`: Also mirror the Flux Operator Helm chart (default `true`).
     - `--include-instance-chart`: Also mirror the Flux Instance Helm chart (default `true`).
     - `--immutable`: Treat destination tags as immutable (default `false`). When set,

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -405,6 +405,7 @@ The source registry (`ghcr.io`) can be authenticated with `--pull-token` or
       `enterprise-distroless`, `enterprise-distroless-fips`). Default `upstream-alpine`.
     - `--include-operator-image`: Also mirror the Flux Operator container image (default `true`).
     - `--include-operator-chart`: Also mirror the Flux Operator Helm chart (default `true`).
+    - `--include-instance-chart`: Also mirror the Flux Instance Helm chart (default `true`).
     - `--immutable`: Treat destination tags as immutable (default `false`). When set,
       existing tags are never overwritten; new images are pushed under a unique tag
       suffix (`<tag>-<unix-timestamp>`).

--- a/cmd/cli/distro_mirror.go
+++ b/cmd/cli/distro_mirror.go
@@ -38,7 +38,7 @@ The command performs the following steps:
   1. Pulls the Flux distribution manifests OCI artifact to read the image list.
   2. Resolves the requested version against the available distribution releases.
   3. Mirrors every controller image and (optionally) the Flux Operator image
-     and Helm chart to the destination registry.
+     and the Flux Operator and Flux Instance Helm charts to the destination registry.
 
 Authentication for the destination registry uses the local Docker config file.
 The source registry (ghcr.io) can be authenticated with --pull-token or
@@ -65,10 +65,11 @@ The source registry (ghcr.io) can be authenticated with --pull-token or
   # Mirror to an immutable registry (push by digest with a unique tag suffix)
   flux-operator distro mirror registry.example.com/flux --immutable
 
-  # Mirror without the Flux Operator image and chart (controllers only)
+  # Mirror without the Flux Operator image and charts (controllers only)
   flux-operator distro mirror registry.example.com/flux \
     --include-operator-image=false \
-    --include-operator-chart=false
+    --include-operator-chart=false \
+    --include-instance-chart=false
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: distroMirrorCmdRun,
@@ -80,6 +81,7 @@ type distroMirrorFlags struct {
 	variant              string
 	includeOperatorImage bool
 	includeOperatorChart bool
+	includeInstanceChart bool
 	dryRun               bool
 	immutable            bool
 	pullToken            string
@@ -92,6 +94,7 @@ var distroMirrorArgs = distroMirrorFlags{
 	variant:              builder.UpstreamAlpine,
 	includeOperatorImage: true,
 	includeOperatorChart: true,
+	includeInstanceChart: true,
 }
 
 var (
@@ -106,6 +109,7 @@ const (
 	distroMirrorManifestsArtifact = "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
 	distroMirrorOperatorRepo      = "ghcr.io/controlplaneio-fluxcd/flux-operator"
 	distroMirrorChartRepo         = "ghcr.io/controlplaneio-fluxcd/charts/flux-operator"
+	distroMirrorInstanceChartRepo = "ghcr.io/controlplaneio-fluxcd/charts/flux-instance"
 	// distroMirrorMinTimeout is the minimum operation timeout. The default
 	// rootArgs.timeout (1m) is too short to pull the manifests artifact and
 	// copy every controller image, so we floor it.
@@ -131,6 +135,8 @@ func init() {
 		"also mirror the Flux Operator container image")
 	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.includeOperatorChart, "include-operator-chart", distroMirrorArgs.includeOperatorChart,
 		"also mirror the Flux Operator Helm chart")
+	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.includeInstanceChart, "include-instance-chart", distroMirrorArgs.includeInstanceChart,
+		"also mirror the Flux Instance Helm chart")
 	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.dryRun, "dry-run", false,
 		"list source→destination pairs without writing anything")
 	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.immutable, "immutable", distroMirrorArgs.immutable,
@@ -213,7 +219,8 @@ func distroMirrorCmdRun(_ *cobra.Command, args []string) error {
 
 	jobs := buildMirrorJobs(images, dstPrefix,
 		distroMirrorArgs.includeOperatorImage,
-		distroMirrorArgs.includeOperatorChart)
+		distroMirrorArgs.includeOperatorChart,
+		distroMirrorArgs.includeInstanceChart)
 
 	if distroMirrorArgs.verify {
 		rootCmd.Println(`◎`, "Verifying signatures...")
@@ -304,9 +311,11 @@ func (j mirrorJob) dst() string         { return j.dstRepo + ":" + j.tag }
 
 // buildMirrorJobs constructs the ordered list of mirror jobs from the
 // extracted component images, optionally including the Flux Operator
-// container image and Helm chart.
-func buildMirrorJobs(images []builder.ComponentImage, dstPrefix string, includeOperatorImage, includeOperatorChart bool) []mirrorJob {
-	jobs := make([]mirrorJob, 0, len(images)+2)
+// container image, the Flux Operator Helm chart and the Flux Instance
+// Helm chart. Both charts are released in lockstep with the operator
+// and share its version.
+func buildMirrorJobs(images []builder.ComponentImage, dstPrefix string, includeOperatorImage, includeOperatorChart, includeInstanceChart bool) []mirrorJob {
+	jobs := make([]mirrorJob, 0, len(images)+3)
 	for _, img := range images {
 		jobs = append(jobs, mirrorJob{
 			srcRepo: img.Repository,
@@ -317,7 +326,7 @@ func buildMirrorJobs(images []builder.ComponentImage, dstPrefix string, includeO
 	}
 
 	// Operator image is published with a "v" prefix (e.g. v0.46.0),
-	// Helm chart is published without it (e.g. 0.46.0).
+	// Helm charts are published without it (e.g. 0.46.0).
 	bareVersion := strings.TrimPrefix(VERSION, "v")
 
 	if includeOperatorImage {
@@ -332,6 +341,14 @@ func buildMirrorJobs(images []builder.ComponentImage, dstPrefix string, includeO
 		jobs = append(jobs, mirrorJob{
 			srcRepo: distroMirrorChartRepo,
 			dstRepo: dstPrefix + "/charts/flux-operator",
+			tag:     bareVersion,
+		})
+	}
+
+	if includeInstanceChart {
+		jobs = append(jobs, mirrorJob{
+			srcRepo: distroMirrorInstanceChartRepo,
+			dstRepo: dstPrefix + "/charts/flux-instance",
 			tag:     bareVersion,
 		})
 	}

--- a/cmd/cli/distro_mirror.go
+++ b/cmd/cli/distro_mirror.go
@@ -37,8 +37,9 @@ running Flux in air-gapped or private-registry environments.
 The command performs the following steps:
   1. Pulls the Flux distribution manifests OCI artifact to read the image list.
   2. Resolves the requested version against the available distribution releases.
-  3. Mirrors every controller image and (optionally) the Flux Operator image
-     and the Flux Operator and Flux Instance Helm charts to the destination registry.
+  3. Mirrors every controller image and (optionally) the Flux Operator and
+     Flux Operator CLI images and the Flux Operator and Flux Instance Helm
+     charts to the destination registry.
 
 Authentication for the destination registry uses the local Docker config file.
 The source registry (ghcr.io) can be authenticated with --pull-token or
@@ -47,7 +48,7 @@ The source registry (ghcr.io) can be authenticated with --pull-token or
   flux-operator distro mirror registry.example.com/flux
 
   # Mirror a specific Flux version
-  flux-operator distro mirror registry.example.com/flux --version 2.8.x
+  flux-operator distro mirror registry.example.com/flux --version 2.9.x
 
   # Verify signatures and mirror the enterprise distroless variant
   echo "${GITHUB_TOKEN}" | flux-operator distro mirror registry.example.com/flux \
@@ -65,9 +66,10 @@ The source registry (ghcr.io) can be authenticated with --pull-token or
   # Mirror to an immutable registry (push by digest with a unique tag suffix)
   flux-operator distro mirror registry.example.com/flux --immutable
 
-  # Mirror without the Flux Operator image and charts (controllers only)
+  # Mirror without the Flux Operator images and charts (controllers only)
   flux-operator distro mirror registry.example.com/flux \
     --include-operator-image=false \
+    --include-operator-cli-image=false \
     --include-operator-chart=false \
     --include-instance-chart=false
 `,
@@ -76,25 +78,27 @@ The source registry (ghcr.io) can be authenticated with --pull-token or
 }
 
 type distroMirrorFlags struct {
-	version              string
-	components           []string
-	variant              string
-	includeOperatorImage bool
-	includeOperatorChart bool
-	includeInstanceChart bool
-	dryRun               bool
-	immutable            bool
-	pullToken            string
-	pullTokenStdin       bool
-	verify               bool
+	version                 string
+	components              []string
+	variant                 string
+	includeOperatorImage    bool
+	includeOperatorCLIImage bool
+	includeOperatorChart    bool
+	includeInstanceChart    bool
+	dryRun                  bool
+	immutable               bool
+	pullToken               string
+	pullTokenStdin          bool
+	verify                  bool
 }
 
 var distroMirrorArgs = distroMirrorFlags{
-	version:              "2.x",
-	variant:              builder.UpstreamAlpine,
-	includeOperatorImage: true,
-	includeOperatorChart: true,
-	includeInstanceChart: true,
+	version:                 "2.x",
+	variant:                 builder.UpstreamAlpine,
+	includeOperatorImage:    true,
+	includeOperatorCLIImage: true,
+	includeOperatorChart:    true,
+	includeInstanceChart:    true,
 }
 
 var (
@@ -108,6 +112,7 @@ const (
 	distroMirrorSrcRegistry       = "ghcr.io"
 	distroMirrorManifestsArtifact = "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
 	distroMirrorOperatorRepo      = "ghcr.io/controlplaneio-fluxcd/flux-operator"
+	distroMirrorOperatorCLIRepo   = "ghcr.io/controlplaneio-fluxcd/flux-operator-cli"
 	distroMirrorChartRepo         = "ghcr.io/controlplaneio-fluxcd/charts/flux-operator"
 	distroMirrorInstanceChartRepo = "ghcr.io/controlplaneio-fluxcd/charts/flux-instance"
 	// distroMirrorMinTimeout is the minimum operation timeout. The default
@@ -126,13 +131,15 @@ var distroMirrorVariantRegistry = map[string]string{
 
 func init() {
 	distroMirrorCmd.Flags().StringVar(&distroMirrorArgs.version, "version", distroMirrorArgs.version,
-		"Flux distribution version, e.g. 2.8.5 or 2.8.x")
+		"Flux distribution version, e.g. 2.8.8 or 2.9.x")
 	distroMirrorCmd.Flags().StringSliceVar(&distroMirrorArgs.components, "components", nil,
 		"comma-separated list of components to mirror (defaults to all controllers, plus source-watcher for Flux 2.7+)")
 	distroMirrorCmd.Flags().StringVar(&distroMirrorArgs.variant, "variant", distroMirrorArgs.variant,
 		"distribution variant: upstream-alpine, enterprise-alpine, enterprise-distroless, enterprise-distroless-fips")
 	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.includeOperatorImage, "include-operator-image", distroMirrorArgs.includeOperatorImage,
 		"also mirror the Flux Operator container image")
+	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.includeOperatorCLIImage, "include-operator-cli-image", distroMirrorArgs.includeOperatorCLIImage,
+		"also mirror the Flux Operator CLI container image")
 	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.includeOperatorChart, "include-operator-chart", distroMirrorArgs.includeOperatorChart,
 		"also mirror the Flux Operator Helm chart")
 	distroMirrorCmd.Flags().BoolVar(&distroMirrorArgs.includeInstanceChart, "include-instance-chart", distroMirrorArgs.includeInstanceChart,
@@ -219,6 +226,7 @@ func distroMirrorCmdRun(_ *cobra.Command, args []string) error {
 
 	jobs := buildMirrorJobs(images, dstPrefix,
 		distroMirrorArgs.includeOperatorImage,
+		distroMirrorArgs.includeOperatorCLIImage,
 		distroMirrorArgs.includeOperatorChart,
 		distroMirrorArgs.includeInstanceChart)
 
@@ -311,11 +319,11 @@ func (j mirrorJob) dst() string         { return j.dstRepo + ":" + j.tag }
 
 // buildMirrorJobs constructs the ordered list of mirror jobs from the
 // extracted component images, optionally including the Flux Operator
-// container image, the Flux Operator Helm chart and the Flux Instance
-// Helm chart. Both charts are released in lockstep with the operator
-// and share its version.
-func buildMirrorJobs(images []builder.ComponentImage, dstPrefix string, includeOperatorImage, includeOperatorChart, includeInstanceChart bool) []mirrorJob {
-	jobs := make([]mirrorJob, 0, len(images)+3)
+// and Flux Operator CLI container images, the Flux Operator Helm chart
+// and the Flux Instance Helm chart. The CLI image and both charts are
+// released in lockstep with the operator and share its version.
+func buildMirrorJobs(images []builder.ComponentImage, dstPrefix string, includeOperatorImage, includeOperatorCLIImage, includeOperatorChart, includeInstanceChart bool) []mirrorJob {
+	jobs := make([]mirrorJob, 0, len(images)+4)
 	for _, img := range images {
 		jobs = append(jobs, mirrorJob{
 			srcRepo: img.Repository,
@@ -325,7 +333,7 @@ func buildMirrorJobs(images []builder.ComponentImage, dstPrefix string, includeO
 		})
 	}
 
-	// Operator image is published with a "v" prefix (e.g. v0.46.0),
+	// Operator and CLI images are published with a "v" prefix (e.g. v0.46.0),
 	// Helm charts are published without it (e.g. 0.46.0).
 	bareVersion := strings.TrimPrefix(VERSION, "v")
 
@@ -333,6 +341,14 @@ func buildMirrorJobs(images []builder.ComponentImage, dstPrefix string, includeO
 		jobs = append(jobs, mirrorJob{
 			srcRepo: distroMirrorOperatorRepo,
 			dstRepo: dstPrefix + "/flux-operator",
+			tag:     "v" + bareVersion,
+		})
+	}
+
+	if includeOperatorCLIImage {
+		jobs = append(jobs, mirrorJob{
+			srcRepo: distroMirrorOperatorCLIRepo,
+			dstRepo: dstPrefix + "/flux-operator-cli",
 			tag:     "v" + bareVersion,
 		})
 	}

--- a/cmd/cli/distro_mirror_test.go
+++ b/cmd/cli/distro_mirror_test.go
@@ -168,8 +168,8 @@ func TestDistroMirror_BuildJobs(t *testing.T) {
 	VERSION = "0.46.0"
 	defer func() { VERSION = origVersion }()
 
-	jobs := buildMirrorJobs(images, "registry.example.com/flux", true, true)
-	g.Expect(jobs).To(HaveLen(4)) // 2 controllers + operator + chart
+	jobs := buildMirrorJobs(images, "registry.example.com/flux", true, true, true)
+	g.Expect(jobs).To(HaveLen(5)) // 2 controllers + operator + operator chart + instance chart
 
 	// Controllers
 	g.Expect(jobs[0].srcRepo).To(Equal("ghcr.io/fluxcd/source-controller"))
@@ -187,30 +187,42 @@ func TestDistroMirror_BuildJobs(t *testing.T) {
 	g.Expect(jobs[2].dst()).To(Equal("registry.example.com/flux/flux-operator:v0.46.0"))
 	g.Expect(jobs[2].digest).To(BeEmpty())
 
-	// Chart (published without the "v" prefix)
+	// Operator chart (published without the "v" prefix)
 	g.Expect(jobs[3].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/charts/flux-operator:0.46.0"))
 	g.Expect(jobs[3].dst()).To(Equal("registry.example.com/flux/charts/flux-operator:0.46.0"))
 	g.Expect(jobs[3].tag).To(Equal("0.46.0"))
 	g.Expect(jobs[3].digest).To(BeEmpty())
 
-	// Without chart
-	jobs = buildMirrorJobs(images, "registry.example.com/flux", true, false)
+	// Instance chart (same version as the operator chart)
+	g.Expect(jobs[4].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/charts/flux-instance:0.46.0"))
+	g.Expect(jobs[4].dst()).To(Equal("registry.example.com/flux/charts/flux-instance:0.46.0"))
+	g.Expect(jobs[4].tag).To(Equal("0.46.0"))
+	g.Expect(jobs[4].digest).To(BeEmpty())
+
+	// Without charts
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", true, false, false)
 	g.Expect(jobs).To(HaveLen(3))
 	for _, j := range jobs {
 		g.Expect(j.dst()).ToNot(ContainSubstring("/charts/"))
 	}
 
-	// Without operator image (chart only)
-	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, true)
-	g.Expect(jobs).To(HaveLen(3)) // 2 controllers + chart
+	// Without operator image (charts only)
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, true, true)
+	g.Expect(jobs).To(HaveLen(4)) // 2 controllers + 2 charts
 	for _, j := range jobs {
 		g.Expect(j.dst()).ToNot(Equal("registry.example.com/flux/flux-operator:v0.46.0"))
 	}
 	g.Expect(jobs[2].dst()).To(Equal("registry.example.com/flux/charts/flux-operator:0.46.0"))
+	g.Expect(jobs[3].dst()).To(Equal("registry.example.com/flux/charts/flux-instance:0.46.0"))
+
+	// Instance chart only
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, false, true)
+	g.Expect(jobs).To(HaveLen(3)) // 2 controllers + instance chart
+	g.Expect(jobs[2].dst()).To(Equal("registry.example.com/flux/charts/flux-instance:0.46.0"))
 
 	// Controllers only
-	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, false)
-	g.Expect(jobs).To(HaveLen(2)) // 2 controllers, no operator, no chart
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, false, false)
+	g.Expect(jobs).To(HaveLen(2)) // 2 controllers, no operator, no charts
 }
 
 func TestDistroMirror_BuildJobsHandlesNestedSourceRegistry(t *testing.T) {
@@ -231,7 +243,7 @@ func TestDistroMirror_BuildJobsHandlesNestedSourceRegistry(t *testing.T) {
 	VERSION = "0.46.0"
 	defer func() { VERSION = origVersion }()
 
-	jobs := buildMirrorJobs(images, "registry.example.com/flux", true, false)
+	jobs := buildMirrorJobs(images, "registry.example.com/flux", true, false, false)
 	g.Expect(jobs).To(HaveLen(2)) // 1 controller + operator
 	g.Expect(jobs[0].dst()).To(Equal("registry.example.com/flux/source-controller:v1.6.2"))
 }
@@ -245,7 +257,7 @@ func TestDistroMirror_OperatorTagStripsVPrefix(t *testing.T) {
 	// Both with and without "v" prefix should produce the same tag.
 	for _, v := range []string{"0.46.0", "v0.46.0"} {
 		VERSION = v
-		jobs := buildMirrorJobs(nil, "r.example.com", true, false)
+		jobs := buildMirrorJobs(nil, "r.example.com", true, false, false)
 		g.Expect(jobs).To(HaveLen(1)) // operator only
 		g.Expect(jobs[0].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/flux-operator:v0.46.0"))
 		g.Expect(jobs[0].dst()).To(Equal("r.example.com/flux-operator:v0.46.0"))

--- a/cmd/cli/distro_mirror_test.go
+++ b/cmd/cli/distro_mirror_test.go
@@ -168,8 +168,8 @@ func TestDistroMirror_BuildJobs(t *testing.T) {
 	VERSION = "0.46.0"
 	defer func() { VERSION = origVersion }()
 
-	jobs := buildMirrorJobs(images, "registry.example.com/flux", true, true, true)
-	g.Expect(jobs).To(HaveLen(5)) // 2 controllers + operator + operator chart + instance chart
+	jobs := buildMirrorJobs(images, "registry.example.com/flux", true, true, true, true)
+	g.Expect(jobs).To(HaveLen(6)) // 2 controllers + operator + cli + operator chart + instance chart
 
 	// Controllers
 	g.Expect(jobs[0].srcRepo).To(Equal("ghcr.io/fluxcd/source-controller"))
@@ -187,42 +187,54 @@ func TestDistroMirror_BuildJobs(t *testing.T) {
 	g.Expect(jobs[2].dst()).To(Equal("registry.example.com/flux/flux-operator:v0.46.0"))
 	g.Expect(jobs[2].digest).To(BeEmpty())
 
-	// Operator chart (published without the "v" prefix)
-	g.Expect(jobs[3].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/charts/flux-operator:0.46.0"))
-	g.Expect(jobs[3].dst()).To(Equal("registry.example.com/flux/charts/flux-operator:0.46.0"))
-	g.Expect(jobs[3].tag).To(Equal("0.46.0"))
+	// Operator CLI (same "v"-prefixed tag as the operator image)
+	g.Expect(jobs[3].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/flux-operator-cli:v0.46.0"))
+	g.Expect(jobs[3].dst()).To(Equal("registry.example.com/flux/flux-operator-cli:v0.46.0"))
+	g.Expect(jobs[3].tag).To(Equal("v0.46.0"))
 	g.Expect(jobs[3].digest).To(BeEmpty())
 
-	// Instance chart (same version as the operator chart)
-	g.Expect(jobs[4].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/charts/flux-instance:0.46.0"))
-	g.Expect(jobs[4].dst()).To(Equal("registry.example.com/flux/charts/flux-instance:0.46.0"))
+	// Operator chart (published without the "v" prefix)
+	g.Expect(jobs[4].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/charts/flux-operator:0.46.0"))
+	g.Expect(jobs[4].dst()).To(Equal("registry.example.com/flux/charts/flux-operator:0.46.0"))
 	g.Expect(jobs[4].tag).To(Equal("0.46.0"))
 	g.Expect(jobs[4].digest).To(BeEmpty())
 
+	// Instance chart (same version as the operator chart)
+	g.Expect(jobs[5].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/charts/flux-instance:0.46.0"))
+	g.Expect(jobs[5].dst()).To(Equal("registry.example.com/flux/charts/flux-instance:0.46.0"))
+	g.Expect(jobs[5].tag).To(Equal("0.46.0"))
+	g.Expect(jobs[5].digest).To(BeEmpty())
+
 	// Without charts
-	jobs = buildMirrorJobs(images, "registry.example.com/flux", true, false, false)
-	g.Expect(jobs).To(HaveLen(3))
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", true, true, false, false)
+	g.Expect(jobs).To(HaveLen(4)) // 2 controllers + operator + cli
 	for _, j := range jobs {
 		g.Expect(j.dst()).ToNot(ContainSubstring("/charts/"))
 	}
 
-	// Without operator image (charts only)
-	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, true, true)
+	// Without operator images (charts only)
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, false, true, true)
 	g.Expect(jobs).To(HaveLen(4)) // 2 controllers + 2 charts
 	for _, j := range jobs {
 		g.Expect(j.dst()).ToNot(Equal("registry.example.com/flux/flux-operator:v0.46.0"))
+		g.Expect(j.dst()).ToNot(Equal("registry.example.com/flux/flux-operator-cli:v0.46.0"))
 	}
 	g.Expect(jobs[2].dst()).To(Equal("registry.example.com/flux/charts/flux-operator:0.46.0"))
 	g.Expect(jobs[3].dst()).To(Equal("registry.example.com/flux/charts/flux-instance:0.46.0"))
 
+	// CLI image only
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, true, false, false)
+	g.Expect(jobs).To(HaveLen(3)) // 2 controllers + cli
+	g.Expect(jobs[2].dst()).To(Equal("registry.example.com/flux/flux-operator-cli:v0.46.0"))
+
 	// Instance chart only
-	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, false, true)
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, false, false, true)
 	g.Expect(jobs).To(HaveLen(3)) // 2 controllers + instance chart
 	g.Expect(jobs[2].dst()).To(Equal("registry.example.com/flux/charts/flux-instance:0.46.0"))
 
 	// Controllers only
-	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, false, false)
-	g.Expect(jobs).To(HaveLen(2)) // 2 controllers, no operator, no charts
+	jobs = buildMirrorJobs(images, "registry.example.com/flux", false, false, false, false)
+	g.Expect(jobs).To(HaveLen(2)) // 2 controllers, no operator images, no charts
 }
 
 func TestDistroMirror_BuildJobsHandlesNestedSourceRegistry(t *testing.T) {
@@ -243,7 +255,7 @@ func TestDistroMirror_BuildJobsHandlesNestedSourceRegistry(t *testing.T) {
 	VERSION = "0.46.0"
 	defer func() { VERSION = origVersion }()
 
-	jobs := buildMirrorJobs(images, "registry.example.com/flux", true, false, false)
+	jobs := buildMirrorJobs(images, "registry.example.com/flux", true, false, false, false)
 	g.Expect(jobs).To(HaveLen(2)) // 1 controller + operator
 	g.Expect(jobs[0].dst()).To(Equal("registry.example.com/flux/source-controller:v1.6.2"))
 }
@@ -257,10 +269,12 @@ func TestDistroMirror_OperatorTagStripsVPrefix(t *testing.T) {
 	// Both with and without "v" prefix should produce the same tag.
 	for _, v := range []string{"0.46.0", "v0.46.0"} {
 		VERSION = v
-		jobs := buildMirrorJobs(nil, "r.example.com", true, false, false)
-		g.Expect(jobs).To(HaveLen(1)) // operator only
+		jobs := buildMirrorJobs(nil, "r.example.com", true, true, false, false)
+		g.Expect(jobs).To(HaveLen(2)) // operator + cli
 		g.Expect(jobs[0].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/flux-operator:v0.46.0"))
 		g.Expect(jobs[0].dst()).To(Equal("r.example.com/flux-operator:v0.46.0"))
+		g.Expect(jobs[1].src()).To(Equal("ghcr.io/controlplaneio-fluxcd/flux-operator-cli:v0.46.0"))
+		g.Expect(jobs[1].dst()).To(Equal("r.example.com/flux-operator-cli:v0.46.0"))
 	}
 }
 

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -221,5 +221,6 @@ func resetCmdArgs() {
 		variant:              "upstream-alpine",
 		includeOperatorImage: true,
 		includeOperatorChart: true,
+		includeInstanceChart: true,
 	}
 }

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -217,10 +217,11 @@ func resetCmdArgs() {
 		overwrite:  false,
 	}
 	distroMirrorArgs = distroMirrorFlags{
-		version:              "2.x",
-		variant:              "upstream-alpine",
-		includeOperatorImage: true,
-		includeOperatorChart: true,
-		includeInstanceChart: true,
+		version:                 "2.x",
+		variant:                 "upstream-alpine",
+		includeOperatorImage:    true,
+		includeOperatorCLIImage: true,
+		includeOperatorChart:    true,
+		includeInstanceChart:    true,
 	}
 }

--- a/docs/guides/resourcesets/rset-app-definition.md
+++ b/docs/guides/resourcesets/rset-app-definition.md
@@ -366,13 +366,13 @@ flux-operator build rset -f my-resourceset.yaml
 # List all ResourceSets in the cluster
 flux-operator get rset --all-namespaces
 
-# Reconcile a ResourceSet 
+# Reconcile a ResourceSet
 flux-operator -n apps reconcile rset podinfo
 
-# Suspend a ResourceSet 
+# Suspend a ResourceSet
 flux-operator -n apps suspend rset podinfo
 
-# Resume a ResourceSet 
+# Resume a ResourceSet
 flux-operator -n apps resume rset podinfo
 ```
 

--- a/docs/guides/resourcesets/rset-feature-branches.md
+++ b/docs/guides/resourcesets/rset-feature-branches.md
@@ -22,7 +22,7 @@ via the ResourceSetInputProvider
 - A developer creates a feature branch with a naming convention (e.g. `feat/` prefix) in the app repository.
 - The CI builds and pushes the app container image tagged with the Git commit SHA.
 - Flux Operator running in the preview cluster scans the repository and finds branches matching the configured pattern.
-- Flux Operator installs a Helm release for each matching branch to deploy the app changes in the cluster.
+- Flux Operator installs a Helm release for each matching branch to deploy the app changes on the cluster.
 - The app is accessible at a preview URL composed of the branch identifier and the app name.
 - The developers iterate over changes, with each push to the branch triggering a Helm release upgrade in the cluster.
 - The developers are notified of the deployment status via Slack and commit statuses on the Git provider.

--- a/docs/guides/resourcesets/rset-github-pull-requests.md
+++ b/docs/guides/resourcesets/rset-github-pull-requests.md
@@ -107,7 +107,7 @@ spec:
 ### GitHub Webhook
 
 Optionally, we can create a Flux [Webhook Receiver](https://fluxcd.io/flux/components/notification/receivers/)
-that GitHub will call to notify the Flux Operator when a new PR is opened or updated: 
+that GitHub will call to notify the Flux Operator when a new PR is opened or updated:
 
 ```yaml
 apiVersion: notification.toolkit.fluxcd.io/v1
@@ -186,7 +186,7 @@ spec:
               - host: app-<< inputs.id >>.example.com
 ```
 
-The above `ResouceSet` will generate a Flux `GitRepository` and a `HelmRelease` for each opened PR.
+The above `ResourceSet` will generate a Flux `GitRepository` and a `HelmRelease` for each opened PR.
 The PR number passed as `<< inputs.id >>` is used as the name suffix for the Flux objects,
 and is also used to compose the Ingress host name where the app can be accessed.
 

--- a/docs/guides/resourcesets/rset-gitlab-environments.md
+++ b/docs/guides/resourcesets/rset-gitlab-environments.md
@@ -3,7 +3,7 @@ title: Ephemeral Environments for GitLab Environments
 description: Flux Operator preview environments integration with GitLab using GitLab Environments
 ---
 
-# Ephemeral Environments for GitLab Environments 
+# Ephemeral Environments for GitLab Environments
 
 This guide demonstrates how to use the Flux Operator ResourceSet API to automate the deployment of
 [GitLab Environments](https://docs.gitlab.com/ci/environments/) to ephemeral environments for
@@ -16,7 +16,7 @@ also be used dynamic use cases other than merge requests.
 
 ## Development workflow
 
-- A developer opens a Merge Requests with changes to the app code and Helm chart.
+- A developer opens a Merge Request with changes to the app code and Helm chart.
 - The CI builds and pushes the app container image to GitLab Container Registry. The image is tagged with the Git commit SHA.
 - The CI or another developer after review creates a new GitLab Environment with a `review/` name prefix for the Merge Request.
 - Flux Operator running in the preview cluster scans the GitLab project and finds the new environment.
@@ -152,7 +152,7 @@ stop-review:
 ### GitLab Webhook
 
 As an alternative to the synchronous reconciliation, we can create a Flux [Webhook Receiver](https://fluxcd.io/flux/components/notification/receivers/)
-that GitLab will call to notify the Flux Operator when a deployment to an environment starts or gets stopped: 
+that GitLab will call to notify the Flux Operator when a deployment to an environment starts or gets stopped:
 
 ```yaml
 apiVersion: notification.toolkit.fluxcd.io/v1
@@ -228,7 +228,7 @@ spec:
               - host: app-<< inputs.slug >>.example.com
 ```
 
-The above `ResouceSet` will generate a Flux `GitRepository` and a `HelmRelease` for each available environment.
+The above `ResourceSet` will generate a Flux `GitRepository` and a `HelmRelease` for each available environment.
 The environment slug passed as `<< inputs.slug >>` is used as the name suffix for the Flux objects,
 and is also used to compose the Ingress host name where the app can be accessed.
 

--- a/docs/guides/resourcesets/rset-gitlab-merge-requests.md
+++ b/docs/guides/resourcesets/rset-gitlab-merge-requests.md
@@ -14,7 +14,7 @@ option if you need to create dynamic environments that are not linked to merge r
 
 ## Development workflow
 
-- A developer opens a Merge Requests with changes to the app code and Helm chart.
+- A developer opens a Merge Request with changes to the app code and Helm chart.
 - The CI builds and pushes the app container image to GitLab Container Registry. The image is tagged with the Git commit SHA.
 - Another developer reviews the changes and labels the Merge Request with the `deploy/flux-preview` label.
 - Flux Operator running in the preview cluster scans the GitLab project and finds the new MR using the label filter.
@@ -100,7 +100,7 @@ spec:
 ### GitLab Webhook
 
 Optionally, we can create a Flux [Webhook Receiver](https://fluxcd.io/flux/components/notification/receivers/)
-that GitLab will call to notify the Flux Operator when a new MR is opened or updated: 
+that GitLab will call to notify the Flux Operator when a new MR is opened or updated:
 
 ```yaml
 apiVersion: notification.toolkit.fluxcd.io/v1
@@ -178,7 +178,7 @@ spec:
               - host: app-<< inputs.id >>.example.com
 ```
 
-The above `ResouceSet` will generate a Flux `GitRepository` and a `HelmRelease` for each opened MR.
+The above `ResourceSet` will generate a Flux `GitRepository` and a `HelmRelease` for each opened MR.
 The MR number passed as `<< inputs.id >>` is used as the name suffix for the Flux objects,
 and is also used to compose the Ingress host name where the app can be accessed.
 

--- a/docs/guides/resourcesets/rset-image-automation.md
+++ b/docs/guides/resourcesets/rset-image-automation.md
@@ -19,7 +19,7 @@ work together to enable deployment rollouts based on container image updates.
 
 The [ResourceSet](resourceset.md) API allows you to define a set of Flux resources
 for deploying an application, while the [ResourceSetInputProvider](resourcesetinputprovider.md) API
-is used to provide inputs to the `ResourceSet`, such as Helm chart versions and container image tags
+provides inputs for the `ResourceSet`, such as Helm chart versions and container image tags
 that determine which configuration of the application should be deployed.
 
 ## GitOps Workflow
@@ -178,7 +178,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 spec:
   postRenderers:
-    - kustomize:            
+    - kustomize:
         images:
           - name: ghcr.io/stefanprodan/podinfo
             newTag: << inputs.podinfo_image.tag | quote >>

--- a/docs/guides/resourcesets/rset-time-based-delivery.md
+++ b/docs/guides/resourcesets/rset-time-based-delivery.md
@@ -25,7 +25,7 @@ work together to enable controlled deployments.
 
 The [ResourceSet](resourceset.md) API allows you to define a set of Flux resources
 for deploying an application, while the [ResourceSetInputProvider](resourcesetinputprovider.md) API
-is used to provide inputs to the `ResourceSet`, such as Git commit SHA and branch name or tag name,
+provides inputs for the `ResourceSet`, such as Git commit SHA and branch name or tag name,
 that determine what version of the application should be deployed.
 
 Instead of using a Flux `GitRepository` and `Kustomization` directly, we'll generate these
@@ -47,7 +47,7 @@ at the defined reconciliation schedule.
 ### ResourceSetInputProvider Definition
 
 Assuming the Kubernetes deployment manifests for an application are stored in a Git repository,
-you can define a input provider that scans a branch for changes
+you can define an input provider that scans a branch for changes
 and exports the commit SHA:
 
 ```yaml


### PR DESCRIPTION
Add opt-out mirroring for the Flux Operator CLI image the Flux Instance chart.

- `flux-operator distro mirror <destination>`: Mirrors the Flux distribution to a destination registry.
    - `--include-operator-cli-image`: Mirror the Flux Operator CLI container image (default `true`).
    - `--include-instance-chart`: Mirror the Flux Instance Helm chart (default `true`).
