### PR TITLE
mcp: add field selection to `get_kubernetes_resources` tool

### DIFF
--- a/cmd/mcp/k8s/actions_test.go
+++ b/cmd/mcp/k8s/actions_test.go
@@ -116,6 +116,7 @@ func TestAnnotateResource(t *testing.T) {
 					"app.kubernetes.io/name=flux",
 					0,
 					false,
+					nil,
 				)
 				g.Expect(rErr).NotTo(HaveOccurred())
 				g.Expect(result).To(ContainSubstring(tt.value))
@@ -217,6 +218,7 @@ func TestDeleteResource(t *testing.T) {
 					"app.kubernetes.io/name=flux",
 					0,
 					false,
+					nil,
 				)
 				g.Expect(rErr).NotTo(HaveOccurred())
 				g.Expect(result).NotTo(BeEmpty())
@@ -231,6 +233,7 @@ func TestDeleteResource(t *testing.T) {
 					"app.kubernetes.io/name=flux",
 					0,
 					false,
+					nil,
 				)
 				g.Expect(rErr).NotTo(HaveOccurred())
 				g.Expect(result).To(BeEmpty())

--- a/cmd/mcp/k8s/export.go
+++ b/cmd/mcp/k8s/export.go
@@ -25,12 +25,18 @@ import (
 
 // Export retrieves resources based on provided criteria and returns them as a YAML multi-document string.
 // Supports filtering by GroupVersionKind, name, namespace, labels, and limit.
-// Allows masking secrets and includes additional metadata for Flux resource types.
+// Allows masking secrets and includes additional metadata for Flux resource types:
+// the inventory for HelmRelease, the events for all Flux resources and the
+// controllers metrics for FluxReport.
+// When fieldPaths is set, each resource is projected to the values selected by
+// the given kubectl JSONPath expressions (see FieldPaths.Project) and the
+// additional metadata is included only when referenced by the expressions.
 func (k *Client) Export(ctx context.Context,
 	gvks []schema.GroupVersionKind,
 	name, namespace, labelSelector string,
 	limit int,
-	maskSecrets bool) (string, error) {
+	maskSecrets bool,
+	fieldPaths FieldPaths) (string, error) {
 	var strBuilder strings.Builder
 	for _, gvk := range gvks {
 		list := unstructured.UnstructuredList{
@@ -84,7 +90,7 @@ func (k *Client) Export(ctx context.Context,
 				}
 
 				// Add inventory for HelmRelease resources
-				if item.GetKind() == fluxcdv1.FluxHelmReleaseKind {
+				if item.GetKind() == fluxcdv1.FluxHelmReleaseKind && fieldPaths.Covers("status", "inventory") {
 					inventory, err := k.GetHelmInventory(ctx, item.GetAPIVersion(), ctrlclient.ObjectKey{
 						Namespace: item.GetNamespace(),
 						Name:      item.GetName(),
@@ -118,7 +124,7 @@ func (k *Client) Export(ctx context.Context,
 				}
 
 				// Add Kubernetes events for Flux resources
-				if fluxcdv1.IsFluxAPI(item.GetAPIVersion()) {
+				if fluxcdv1.IsFluxAPI(item.GetAPIVersion()) && fieldPaths.Covers("status", "events") {
 					events, err := k.GetEvents(ctx, item.GetKind(), item.GetName(), item.GetNamespace(), "ReconciliationSucceeded")
 					if err == nil && len(events) > 0 {
 						ev := make([]any, len(events))
@@ -133,15 +139,15 @@ func (k *Client) Export(ctx context.Context,
 					}
 				}
 
-				itemBytes, err := yaml.Marshal(item.Object)
+				itemBytes, err := yaml.Marshal(fieldPaths.Project(item.Object))
 				if err != nil {
 					return "", fmt.Errorf("error marshalling item: %w", err)
 				}
 				strBuilder.WriteString("---\n")
 				strBuilder.Write(itemBytes)
 
-				// Add CPU and Memory usage to Flux report
-				if item.GetKind() == fluxcdv1.FluxReportKind {
+				// Add CPU and Memory usage to Flux report unless the output is projected
+				if item.GetKind() == fluxcdv1.FluxReportKind && len(fieldPaths) == 0 {
 					if metrics, err := k.GetMetrics(ctx, "", item.GetNamespace(), "", 100); err == nil {
 						metricsBytes, err := yaml.Marshal(metrics.Object)
 						if err != nil {

--- a/cmd/mcp/k8s/export_test.go
+++ b/cmd/mcp/k8s/export_test.go
@@ -5,6 +5,7 @@ package k8s
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,7 +14,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 )
@@ -109,20 +112,84 @@ func TestExport(t *testing.T) {
 		},
 	}
 
+	mockEvent := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flux.1",
+			Namespace: "flux-system",
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      fluxcdv1.FluxInstanceKind,
+			Name:      "flux",
+			Namespace: "flux-system",
+		},
+		Type:    corev1.EventTypeWarning,
+		Reason:  "ReconciliationFailed",
+		Message: "Reconciliation failed with timeout",
+	}
+
+	mockHelmRelease := makeHelmRelease("flux-system", "helm.toolkit.fluxcd.io/v2", "flux-system", []any{
+		map[string]any{
+			"name":      "my-release",
+			"chartName": "podinfo",
+			"version":   int64(1),
+			"namespace": "flux-system",
+		},
+	}, false)
+
+	mockReport := &fluxcdv1.FluxReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flux",
+			Namespace: "flux-system",
+		},
+		Spec: fluxcdv1.FluxReportSpec{
+			Distribution: fluxcdv1.FluxDistributionStatus{
+				Entitlement: "Unknown",
+				Status:      "Installed",
+				Version:     "v2.3.0",
+			},
+		},
+	}
+
+	// The fake client does not support the field selectors used to list events,
+	// so the events are served by an interceptor that also counts the lookups.
+	eventLookups := 0
+	listEvents := func(ctx context.Context, c ctrlclient.WithWatch, list ctrlclient.ObjectList, opts ...ctrlclient.ListOption) error {
+		if el, ok := list.(*corev1.EventList); ok {
+			eventLookups++
+			el.Items = []corev1.Event{*mockEvent}
+			return nil
+		}
+		return c.List(ctx, list, opts...)
+	}
+
+	// The Helm storage lookups are counted by intercepting the Secret reads.
+	helmLookups := 0
+	getSecret := func(ctx context.Context, c ctrlclient.WithWatch, key ctrlclient.ObjectKey, obj ctrlclient.Object, opts ...ctrlclient.GetOption) error {
+		if _, ok := obj.(*corev1.Secret); ok {
+			helmLookups++
+		}
+		return c.Get(ctx, key, obj, opts...)
+	}
+
 	kubeClient := Client{
 		Client: fake.NewClientBuilder().
 			WithScheme(NewTestScheme()).
-			WithObjects(mockNamespace, mockInstance, mockSecret).
+			WithObjects(mockNamespace, mockInstance, mockSecret, mockHelmRelease, mockReport).
 			WithStatusSubresource(&fluxcdv1.FluxInstance{}).
+			WithInterceptorFuncs(interceptor.Funcs{List: listEvents, Get: getSecret}).
 			Build(),
 	}
 
 	tests := []struct {
-		testName    string
-		matchResult string
-		missResults []string
-		matchErr    string
-		emptyResult bool
+		testName     string
+		matchResult  string
+		matchResults []string
+		missResults  []string
+		matchErr     string
+		emptyResult  bool
+		eventLookups int
+		helmLookups  int
+		docCount     int
 
 		apiVersion  string
 		kind        string
@@ -131,17 +198,20 @@ func TestExport(t *testing.T) {
 		selector    string
 		maskSecrets bool
 		limit       int
+		fields      []string
 	}{
 		{
-			testName:    "match kind",
-			matchResult: "1057d9a5afdbed028350a4a4921b6f9a81e567a85a5e2b133244511be578fc75",
+			testName:     "match kind",
+			eventLookups: 1,
+			matchResult:  "1057d9a5afdbed028350a4a4921b6f9a81e567a85a5e2b133244511be578fc75",
 
 			apiVersion: "fluxcd.controlplane.io/v1",
 			kind:       "FluxInstance",
 		},
 		{
-			testName:    "match selector",
-			matchResult: "161da425b16b64dda4b3cec2ba0f8d7442973aba29bb446db3b340626181a0bc",
+			testName:     "match selector",
+			eventLookups: 1,
+			matchResult:  "161da425b16b64dda4b3cec2ba0f8d7442973aba29bb446db3b340626181a0bc",
 
 			apiVersion: "fluxcd.controlplane.io/v1",
 			kind:       "FluxInstance",
@@ -172,6 +242,148 @@ func TestExport(t *testing.T) {
 			kind:       "Secret",
 		},
 		{
+			testName:     "include events by default",
+			eventLookups: 1,
+			matchResults: []string{"events:", "Reconciliation failed with timeout"},
+
+			apiVersion: "fluxcd.controlplane.io/v1",
+			kind:       "FluxInstance",
+		},
+		{
+			testName: "project fields",
+			matchResults: []string{
+				"apiVersion: fluxcd.controlplane.io/v1",
+				"kind: FluxInstance",
+				"name: flux",
+				"namespace: flux-system",
+				"version: 2.3.x",
+				"lastAppliedRevision:",
+			},
+			missResults: []string{
+				"components:",
+				"registry:",
+				"conditions:",
+				"lastAttemptedRevision:",
+				"events:",
+				"labels:",
+			},
+
+			apiVersion: "fluxcd.controlplane.io/v1",
+			kind:       "FluxInstance",
+			fields:     []string{"spec.distribution.version", "status.lastAppliedRevision"},
+		},
+		{
+			testName:     "project fields with prefix covering events",
+			eventLookups: 1,
+			matchResults: []string{"conditions:", "lastAttemptedRevision:", "events:", "Reconciliation failed with timeout"},
+			missResults:  []string{"spec:"},
+
+			apiVersion: "fluxcd.controlplane.io/v1",
+			kind:       "FluxInstance",
+			fields:     []string{"status"},
+		},
+		{
+			testName:     "project fields ignores unknown paths",
+			matchResults: []string{"kind: FluxInstance", "name: flux"},
+			missResults:  []string{"spec:", "status:"},
+
+			apiVersion: "fluxcd.controlplane.io/v1",
+			kind:       "FluxInstance",
+			fields:     []string{"spec.unknown", ".status.conditions.type"},
+		},
+		{
+			testName: "project fields with jsonpath filter and wildcard",
+			matchResults: []string{
+				"status.conditions[?(@.type==\"Ready\")].message: Reconciliation finished in 52s",
+				"status.components[*].name:",
+				"- source-controller",
+				"- kustomize-controller",
+				"- helm-controller",
+			},
+			missResults: []string{"events:", "repository:", "lastAppliedRevision:"},
+
+			apiVersion: "fluxcd.controlplane.io/v1",
+			kind:       "FluxInstance",
+			fields:     []string{"{.status.conditions[?(@.type==\"Ready\")].message}", ".status.components[*].name"},
+		},
+		{
+			testName:     "project fields with jsonpath index",
+			matchResults: []string{"status.components[0].repository: ghcr.io/fluxcd/source-controller"},
+			missResults:  []string{"kustomize-controller", "events:"},
+
+			apiVersion: "fluxcd.controlplane.io/v1",
+			kind:       "FluxInstance",
+			fields:     []string{"status.components[0].repository"},
+		},
+		{
+			testName:     "project fields with jsonpath on events",
+			eventLookups: 1,
+			matchResults: []string{"status.events[*].message: Reconciliation failed with timeout"},
+			missResults:  []string{"conditions:", "lastTimestamp:"},
+
+			apiVersion: "fluxcd.controlplane.io/v1",
+			kind:       "FluxInstance",
+			fields:     []string{"status.events[*].message"},
+		},
+		{
+			testName:     "project fields with recursive descent covers events",
+			eventLookups: 1,
+			matchResults: []string{"..message:", "- Reconciliation finished in 52s", "- Reconciliation failed with timeout"},
+			missResults:  []string{"events:", "conditions:"},
+
+			apiVersion: "fluxcd.controlplane.io/v1",
+			kind:       "FluxInstance",
+			fields:     []string{"..message"},
+		},
+		{
+			testName:     "project fields keeps secret masked",
+			matchResults: []string{"password: '****'", "username: '****'"},
+			missResults:  []string{"annotations:", "cGFzc3dvcmQ="},
+
+			apiVersion:  "v1",
+			kind:        "Secret",
+			maskSecrets: true,
+			fields:      []string{"data"},
+		},
+		{
+			testName:     "include helm inventory by default",
+			eventLookups: 1,
+			helmLookups:  1,
+			matchResults: []string{"kind: HelmRelease", "chartName: podinfo", "inventory: []"},
+
+			apiVersion: "helm.toolkit.fluxcd.io/v2",
+			kind:       "HelmRelease",
+		},
+		{
+			testName:     "project fields skips helm inventory",
+			matchResults: []string{"kind: HelmRelease", "chartName: podinfo"},
+			missResults:  []string{"inventory:", "events:", "storageNamespace:"},
+
+			apiVersion: "helm.toolkit.fluxcd.io/v2",
+			kind:       "HelmRelease",
+			fields:     []string{"status.history"},
+		},
+		{
+			testName:     "project fields includes helm inventory when covered",
+			helmLookups:  1,
+			matchResults: []string{"kind: HelmRelease", "inventory: []"},
+			missResults:  []string{"history:", "events:"},
+
+			apiVersion: "helm.toolkit.fluxcd.io/v2",
+			kind:       "HelmRelease",
+			fields:     []string{"status.inventory"},
+		},
+		{
+			testName:     "project fields skips report metrics",
+			docCount:     1,
+			matchResults: []string{"kind: FluxReport", "version: v2.3.0"},
+			missResults:  []string{"entitlement:", "events:"},
+
+			apiVersion: "fluxcd.controlplane.io/v1",
+			kind:       "FluxReport",
+			fields:     []string{"spec.distribution.version"},
+		},
+		{
 			testName:    "no match for kind",
 			emptyResult: true,
 
@@ -191,8 +403,13 @@ func TestExport(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			g := NewWithT(t)
+			eventLookups = 0
+			helmLookups = 0
 
 			gvk, err := kubeClient.ParseGroupVersionKind(tt.apiVersion, tt.kind)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			fieldPaths, err := ParseFieldPaths(tt.fields)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			result, err := kubeClient.Export(
@@ -203,6 +420,7 @@ func TestExport(t *testing.T) {
 				tt.selector,
 				tt.limit,
 				tt.maskSecrets,
+				fieldPaths,
 			)
 			if tt.matchErr != "" {
 				g.Expect(err).To(HaveOccurred())
@@ -210,6 +428,17 @@ func TestExport(t *testing.T) {
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(result).To(ContainSubstring(tt.matchResult))
+			}
+
+			for _, matchResult := range tt.matchResults {
+				g.Expect(result).To(ContainSubstring(matchResult))
+			}
+
+			g.Expect(eventLookups).To(Equal(tt.eventLookups))
+			g.Expect(helmLookups).To(Equal(tt.helmLookups))
+
+			if tt.docCount > 0 {
+				g.Expect(strings.Count(result, "---\n")).To(Equal(tt.docCount))
 			}
 
 			for _, missResult := range tt.missResults {

--- a/cmd/mcp/k8s/fields.go
+++ b/cmd/mcp/k8s/fields.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// FieldPath is a kubectl JSONPath expression used to select
+// values from an exported Kubernetes object.
+type FieldPath struct {
+	// expr is the expression in its bare form without the surrounding
+	// braces and the leading dot, used as the key of the selected values.
+	expr string
+
+	// prefix holds the leading field names of the expression,
+	// used to determine which fields are referenced by the expression.
+	// It is empty when the expression starts with a wildcard
+	// or with a recursive descent.
+	prefix []string
+
+	// jsonPath is the parsed expression used to select the values.
+	jsonPath *jsonpath.JSONPath
+}
+
+// FieldPaths is a list of kubectl JSONPath expressions
+// used to project exported Kubernetes objects.
+type FieldPaths []FieldPath
+
+// ParseFieldPaths parses the given kubectl JSONPath expressions.
+// The curly braces and the leading dot are optional, so the expressions
+// spec.chart.spec.version, .status.conditions[*].type and
+// {.status.conditions[?(@.type=="Ready")].message} are all valid
+// and are normalised to their bare form e.g. status.conditions[*].type.
+// Each field must contain a single expression, the templates
+// with multiple expressions are rejected.
+func ParseFieldPaths(fields []string) (FieldPaths, error) {
+	paths := make(FieldPaths, 0, len(fields))
+	for _, field := range fields {
+		expr := bareFieldPath(field)
+		if expr == "" {
+			return nil, errors.New("field path must not be empty")
+		}
+
+		text := "{." + expr + "}"
+		if strings.HasPrefix(expr, "[") || strings.HasPrefix(expr, "..") {
+			text = "{" + expr + "}"
+		}
+
+		parser, err := jsonpath.Parse("fields", text)
+		if err != nil {
+			return nil, fmt.Errorf("invalid field path '%s': %w", strings.TrimSpace(field), err)
+		}
+
+		prefix, err := fieldPrefix(parser.Root)
+		if err != nil {
+			return nil, fmt.Errorf("invalid field path '%s': %w", strings.TrimSpace(field), err)
+		}
+
+		jp := jsonpath.New("fields").AllowMissingKeys(true)
+		if err := jp.Parse(text); err != nil {
+			return nil, fmt.Errorf("invalid field path '%s': %w", strings.TrimSpace(field), err)
+		}
+
+		paths = append(paths, FieldPath{
+			expr:     expr,
+			prefix:   prefix,
+			jsonPath: jp,
+		})
+	}
+	return paths, nil
+}
+
+// bareFieldPath trims the given kubectl JSONPath expression and strips
+// its surrounding braces and its leading dot, while preserving the
+// recursive descent operator.
+func bareFieldPath(field string) string {
+	expr := strings.TrimSpace(field)
+	if strings.HasPrefix(expr, "{") && strings.HasSuffix(expr, "}") {
+		expr = strings.TrimSpace(expr[1 : len(expr)-1])
+	}
+	if strings.HasPrefix(expr, ".") && !strings.HasPrefix(expr, "..") {
+		expr = expr[1:]
+	}
+	return expr
+}
+
+// fieldPrefix returns the leading field names of a parsed expression,
+// or nil when the expression starts with a wildcard or with a recursive
+// descent. It returns an error when the parsed template
+// contains multiple expressions.
+func fieldPrefix(root *jsonpath.ListNode) ([]string, error) {
+	if root == nil || len(root.Nodes) != 1 {
+		return nil, errors.New("must contain a single expression")
+	}
+	list, ok := root.Nodes[0].(*jsonpath.ListNode)
+	if !ok {
+		return nil, errors.New("must contain a single expression")
+	}
+
+	var prefix []string
+	for _, node := range list.Nodes {
+		field, ok := node.(*jsonpath.FieldNode)
+		if !ok {
+			break
+		}
+		prefix = append(prefix, field.Value)
+	}
+	return prefix, nil
+}
+
+// Covers reports whether the given field is referenced by any of the field paths,
+// which is the case when the leading field names of an expression and the given
+// field are a prefix of each other. An empty set of field paths covers everything,
+// as do the expressions whose leading field names cannot be determined.
+func (f FieldPaths) Covers(field ...string) bool {
+	if len(f) == 0 {
+		return true
+	}
+	for _, path := range f {
+		if len(path.prefix) == 0 {
+			return true
+		}
+		matched := true
+		for i := 0; i < min(len(path.prefix), len(field)); i++ {
+			if path.prefix[i] != field[i] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+// Project returns a new object containing the apiVersion, kind, metadata.name
+// and metadata.namespace (when present) of the given object, along with the
+// values selected by the field paths keyed by their expression. A single selected
+// value is set as is, multiple values are set as a list and expressions that
+// select nothing are omitted. The selected values are not copied and reference
+// the given object. When no field paths are set, the object is returned unchanged.
+func (f FieldPaths) Project(obj map[string]any) map[string]any {
+	if len(f) == 0 {
+		return obj
+	}
+
+	result := make(map[string]any)
+	for _, path := range [][]string{
+		{"apiVersion"},
+		{"kind"},
+		{"metadata", "name"},
+		{"metadata", "namespace"},
+	} {
+		if value, found, err := unstructured.NestedFieldCopy(obj, path...); err == nil && found {
+			_ = unstructured.SetNestedField(result, value, path...)
+		}
+	}
+
+	for _, path := range f {
+		results, err := path.jsonPath.FindResults(obj)
+		if err != nil {
+			continue
+		}
+
+		values := make([]any, 0)
+		for _, group := range results {
+			for _, value := range group {
+				if value.IsValid() && value.CanInterface() {
+					values = append(values, value.Interface())
+				}
+			}
+		}
+
+		switch len(values) {
+		case 0:
+			continue
+		case 1:
+			result[path.expr] = values[0]
+		default:
+			result[path.expr] = values
+		}
+	}
+	return result
+}

--- a/cmd/mcp/k8s/fields_test.go
+++ b/cmd/mcp/k8s/fields_test.go
@@ -1,0 +1,293 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestParseFieldPaths(t *testing.T) {
+	tests := []struct {
+		testName string
+		fields   []string
+		exprs    []string
+		prefixes [][]string
+		matchErr string
+	}{
+		{
+			testName: "no fields",
+			exprs:    []string{},
+			prefixes: [][]string{},
+		},
+		{
+			testName: "optional braces and leading dot",
+			fields:   []string{"spec.chart.spec.version", " .status.conditions ", "{.metadata.name}"},
+			exprs:    []string{"spec.chart.spec.version", "status.conditions", "metadata.name"},
+			prefixes: [][]string{
+				{"spec", "chart", "spec", "version"},
+				{"status", "conditions"},
+				{"metadata", "name"},
+			},
+		},
+		{
+			testName: "prefix stops at the first non-field node",
+			fields: []string{
+				"status.conditions[?(@.type=='Ready')].message",
+				".status.history[0].chartVersion",
+				"{.status.conditions[?(@.message==\"{}\")].type}",
+				"{..message}",
+				"['spec'].interval",
+			},
+			exprs: []string{
+				"status.conditions[?(@.type=='Ready')].message",
+				"status.history[0].chartVersion",
+				"status.conditions[?(@.message==\"{}\")].type",
+				"..message",
+				"['spec'].interval",
+			},
+			prefixes: [][]string{
+				{"status", "conditions"},
+				{"status", "history"},
+				{"status", "conditions"},
+				nil,
+				{"spec", "interval"},
+			},
+		},
+		{
+			testName: "empty field",
+			fields:   []string{"spec", " "},
+			matchErr: "field path must not be empty",
+		},
+		{
+			testName: "empty field after normalisation",
+			fields:   []string{"{ . }"},
+			matchErr: "field path must not be empty",
+		},
+		{
+			testName: "multiple expressions",
+			fields:   []string{"{.spec}{.status}"},
+			matchErr: "invalid field path '{.spec}{.status}': must contain a single expression",
+		},
+		{
+			testName: "range template",
+			fields:   []string{"{range .status.conditions[*]}{.type}{end}"},
+			matchErr: "must contain a single expression",
+		},
+		{
+			testName: "invalid expression",
+			fields:   []string{"{.spec"},
+			matchErr: "invalid field path '{.spec'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+
+			paths, err := ParseFieldPaths(tt.fields)
+			if tt.matchErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.matchErr))
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(paths).To(HaveLen(len(tt.prefixes)))
+			for i, path := range paths {
+				g.Expect(path.expr).To(Equal(tt.exprs[i]))
+				g.Expect(path.prefix).To(Equal(tt.prefixes[i]))
+			}
+		})
+	}
+}
+
+func TestFieldPaths_Covers(t *testing.T) {
+	tests := []struct {
+		testName string
+		fields   []string
+		field    []string
+		covered  bool
+	}{
+		{
+			testName: "empty covers everything",
+			field:    []string{"status", "events"},
+			covered:  true,
+		},
+		{
+			testName: "exact match",
+			fields:   []string{"spec", "status.events"},
+			field:    []string{"status", "events"},
+			covered:  true,
+		},
+		{
+			testName: "expression is a prefix of the field",
+			fields:   []string{"status"},
+			field:    []string{"status", "events"},
+			covered:  true,
+		},
+		{
+			testName: "field is a prefix of the expression",
+			fields:   []string{"status.events[*].message"},
+			field:    []string{"status", "events"},
+			covered:  true,
+		},
+		{
+			testName: "sibling does not match",
+			fields:   []string{"status.conditions[?(@.type=='Ready')].message", "spec"},
+			field:    []string{"status", "events"},
+			covered:  false,
+		},
+		{
+			testName: "recursive descent covers everything",
+			fields:   []string{"{..message}"},
+			field:    []string{"status", "events"},
+			covered:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+
+			paths, err := ParseFieldPaths(tt.fields)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(paths.Covers(tt.field...)).To(Equal(tt.covered))
+		})
+	}
+}
+
+func TestFieldPaths_Project(t *testing.T) {
+	obj := map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata": map[string]any{
+			"name":      "podinfo",
+			"namespace": "default",
+			"labels":    map[string]any{"app": "podinfo"},
+		},
+		"spec": map[string]any{
+			"interval": "10m",
+			"chart": map[string]any{
+				"spec": map[string]any{
+					"chart":   "podinfo",
+					"version": "6.x",
+				},
+			},
+		},
+		"status": map[string]any{
+			"lastAttemptedRevision": "6.9.0",
+			"observedGeneration":    nil,
+			"conditions": []any{
+				map[string]any{"type": "Ready", "status": "True", "message": "install succeeded"},
+				map[string]any{"type": "Released", "status": "True", "message": "release succeeded"},
+			},
+			"history": []any{
+				map[string]any{"version": int64(2), "chartVersion": "6.9.0"},
+				map[string]any{"version": int64(1), "chartVersion": "6.8.0"},
+			},
+		},
+	}
+
+	identity := map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata": map[string]any{
+			"name":      "podinfo",
+			"namespace": "default",
+		},
+	}
+
+	withIdentity := func(fields map[string]any) map[string]any {
+		result := make(map[string]any, len(identity)+len(fields))
+		for k, v := range identity {
+			result[k] = v
+		}
+		for k, v := range fields {
+			result[k] = v
+		}
+		return result
+	}
+
+	tests := []struct {
+		testName string
+		fields   []string
+		expected map[string]any
+	}{
+		{
+			testName: "no fields returns object unchanged",
+			expected: obj,
+		},
+		{
+			testName: "nested fields keyed by expression",
+			fields:   []string{"spec.chart.spec.version", ".status.lastAttemptedRevision", "status.observedGeneration"},
+			expected: withIdentity(map[string]any{
+				"spec.chart.spec.version":      "6.x",
+				"status.lastAttemptedRevision": "6.9.0",
+				"status.observedGeneration":    nil,
+			}),
+		},
+		{
+			testName: "top level fields keep their shape",
+			fields:   []string{"spec", "status.conditions"},
+			expected: withIdentity(map[string]any{
+				"spec": obj["spec"],
+				"status.conditions": []any{
+					map[string]any{"type": "Ready", "status": "True", "message": "install succeeded"},
+					map[string]any{"type": "Released", "status": "True", "message": "release succeeded"},
+				},
+			}),
+		},
+		{
+			testName: "filter index and wildcard",
+			fields: []string{
+				"status.conditions[?(@.type=='Ready')].message",
+				"{.status.conditions[?(@.type==\"Released\")].status}",
+				"status.history[0].chartVersion",
+				"status.history[*].chartVersion",
+				"status.history[-1:].version",
+				"status.history[0:2].version",
+				"status.conditions[0,1].type",
+				"..chartVersion",
+				"['spec'].interval",
+			},
+			expected: withIdentity(map[string]any{
+				"status.conditions[?(@.type=='Ready')].message":     "install succeeded",
+				"status.conditions[?(@.type==\"Released\")].status": "True",
+				"status.history[0].chartVersion":                    "6.9.0",
+				"status.history[*].chartVersion":                    []any{"6.9.0", "6.8.0"},
+				"status.history[-1:].version":                       int64(1),
+				"status.history[0:2].version":                       []any{int64(2), int64(1)},
+				"status.conditions[0,1].type":                       []any{"Ready", "Released"},
+				"..chartVersion":                                    []any{"6.9.0", "6.8.0"},
+				"['spec'].interval":                                 "10m",
+			}),
+		},
+		{
+			testName: "unknown fields and paths into lists are omitted",
+			fields:   []string{"spec.values", "status.inventory", "status.conditions.type", "status.history[5].version"},
+			expected: identity,
+		},
+		{
+			testName: "metadata replaces the identity",
+			fields:   []string{"metadata"},
+			expected: map[string]any{
+				"apiVersion": "helm.toolkit.fluxcd.io/v2",
+				"kind":       "HelmRelease",
+				"metadata":   obj["metadata"],
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+
+			paths, err := ParseFieldPaths(tt.fields)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(paths.Project(obj)).To(Equal(tt.expected))
+		})
+	}
+}

--- a/cmd/mcp/toolbox/get_instance.go
+++ b/cmd/mcp/toolbox/get_instance.go
@@ -49,7 +49,7 @@ func (m *Manager) HandleGetFluxInstance(ctx context.Context, request *mcp.CallTo
 			Version: fluxcdv1.GroupVersion.Version,
 			Kind:    fluxcdv1.FluxReportKind,
 		},
-	}, "", "", "", 1, true)
+	}, "", "", "", 1, true, nil)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to determine the Flux status", err)
 	}

--- a/cmd/mcp/toolbox/get_resource.go
+++ b/cmd/mcp/toolbox/get_resource.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
 )
 
 const (
@@ -24,12 +26,13 @@ func init() {
 
 // getKubernetesResourcesInput defines the input parameters for retrieving Kubernetes resources.
 type getKubernetesResourcesInput struct {
-	APIVersion string  `json:"apiVersion" jsonschema:"The apiVersion of the Kubernetes resource. Use the get_kubernetes_api_versions tool to get the available apiVersions."`
-	Kind       string  `json:"kind" jsonschema:"The kind of the Kubernetes resource. Use the get_kubernetes_api_versions tool to get the available kinds."`
-	Name       string  `json:"name,omitempty" jsonschema:"The name of the Kubernetes resource."`
-	Namespace  string  `json:"namespace,omitempty" jsonschema:"The namespace of the Kubernetes resource."`
-	Selector   string  `json:"selector,omitempty" jsonschema:"The label selector in the format key1=value1 key2=value2."`
-	Limit      float64 `json:"limit,omitempty" jsonschema:"The maximum number of resources to return."`
+	APIVersion string   `json:"apiVersion" jsonschema:"The apiVersion of the Kubernetes resource. Use the get_kubernetes_api_versions tool to get the available apiVersions."`
+	Kind       string   `json:"kind" jsonschema:"The kind of the Kubernetes resource. Use the get_kubernetes_api_versions tool to get the available kinds."`
+	Name       string   `json:"name,omitempty" jsonschema:"The name of the Kubernetes resource."`
+	Namespace  string   `json:"namespace,omitempty" jsonschema:"The namespace of the Kubernetes resource."`
+	Selector   string   `json:"selector,omitempty" jsonschema:"The label selector in the format key1=value1 key2=value2."`
+	Limit      float64  `json:"limit,omitempty" jsonschema:"The maximum number of resources to return."`
+	Fields     []string `json:"fields,omitempty" jsonschema:"The list of kubectl JSONPath expressions to include in the result to reduce its size e.g. spec.sourceRef.name or status.conditions[?(@.type=='Ready')].message."`
 }
 
 // HandleGetKubernetesResources is the handler function for the get_kubernetes_resources tool.
@@ -45,6 +48,11 @@ func (m *Manager) HandleGetKubernetesResources(ctx context.Context, request *mcp
 		return NewToolResultError("kind is required")
 	}
 	limit := int(input.Limit)
+
+	fieldPaths, err := k8s.ParseFieldPaths(input.Fields)
+	if err != nil {
+		return NewToolResultErrorFromErr("Invalid fields", err)
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
@@ -65,7 +73,8 @@ func (m *Manager) HandleGetKubernetesResources(ctx context.Context, request *mcp
 		input.Namespace,
 		input.Selector,
 		limit,
-		m.maskSecrets)
+		m.maskSecrets,
+		fieldPaths)
 	if err != nil {
 		return NewToolResultErrorFromErr("Failed to export resources", err)
 	}

--- a/cmd/mcp/toolbox/get_resource_test.go
+++ b/cmd/mcp/toolbox/get_resource_test.go
@@ -53,6 +53,24 @@ func TestManager_HandleGetKubernetesResources(t *testing.T) {
 			matchErr: "kind is required",
 		},
 		{
+			testName: "fails with empty field path",
+			arguments: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"fields":     []string{"spec", " "},
+			},
+			matchErr: "Invalid fields: field path must not be empty",
+		},
+		{
+			testName: "fails with invalid field path",
+			arguments: map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"fields":     []string{"{.spec"},
+			},
+			matchErr: "Invalid fields: invalid field path",
+		},
+		{
 			testName: "fails with invalid kubeconfig",
 			arguments: map[string]any{
 				"apiVersion": "apps/v1",

--- a/cmd/mcp/toolbox/manager_test.go
+++ b/cmd/mcp/toolbox/manager_test.go
@@ -73,7 +73,7 @@ func TestManager_ToolSchemasIncludeProperties(t *testing.T) {
 			required:   []string{"pod_namespace"},
 		},
 		ToolGetKubernetesResources: {
-			properties: []string{"apiVersion", "kind", "name", "namespace", "selector", "limit"},
+			properties: []string{"apiVersion", "kind", "name", "namespace", "selector", "limit", "fields"},
 			required:   []string{"apiVersion", "kind"},
 		},
 		ToolSearchFluxDocs: {

--- a/docs/mcp/instructions.md
+++ b/docs/mcp/instructions.md
@@ -39,6 +39,7 @@ For Flux API guidance, call the `search_flux_docs` tool with targeted questions.
 
 - When asked about the Flux installation status, call the `get_flux_instance` tool.
 - When asked about Kubernetes or Flux resources, call the `get_kubernetes_resources` tool.
+- When listing many resources or when only specific fields are relevant, set the `fields` parameter of the `get_kubernetes_resources` tool to kubectl JSONPath expressions (e.g. `spec.chart.spec.version`, `status.conditions[?(@.type=="Ready")].message`) to reduce the result size. Include `status.events` and `status.inventory` in `fields` when the events or the inventory are needed.
 - Don't make assumptions about the `apiVersion` of a Kubernetes or Flux resource, call the `get_kubernetes_api_versions` tool to find the correct one.
 - When asked to use a specific cluster, call the `get_kubeconfig_contexts` tool to find the cluster context before switching to it with the `set_kubeconfig_context` tool.
 - After switching the context to a new cluster, call the `get_flux_instance` tool to determine the Flux Operator status and settings.

--- a/docs/mcp/mcp-prompting.md
+++ b/docs/mcp/mcp-prompting.md
@@ -5,38 +5,23 @@ description: FluxCD MCP Server prompt engineering guide
 
 # Flux MCP Server Prompting Guide
 
-This guide provides recommendations for configuring your AI assistants with instructions
-and offers effective prompting strategies to get the most out of the Flux MCP Server.
+This guide explains how to equip your AI agent with Flux expertise using the
+official GitOps Agent Skills and offers example prompts for the Flux MCP Server.
 
-## AI Instructions
+## Agent Skills
 
-Providing instructions is crucial for guiding the behavior of your AI assistant
-when interacting with the Flux MCP Server. We've created a set of [instructions](instructions.md) (1400 tokens)
-that you can use as a starting point.
+The Flux project maintains the official [GitOps Agent Skills](https://github.com/fluxcd/agent-skills)
+which give AI agents deep expertise in Flux CD, Kubernetes, and GitOps best practices.
+The skills are designed to work together, and the agent automatically selects the right one based on context:
 
-Copy the rules from the
-[instructions.md](https://raw.githubusercontent.com/controlplaneio-fluxcd/flux-operator/refs/heads/main/docs/mcp/instructions.md)
-file and place them into the appropriate settings for your assistant as follows:
-
-- **Claude**: Use the `Project Instructions` section in Claude Desktop
-- **Cursor**: Use the `.cursor/rules` dir in your Git repository
-- **Windsurf**: Use the `.windsurf/rules` dir in your Git repository
-- **GitHub Copilot**: Use the `.github/copilot-instructions.md` file in your Git repository
-
-It is recommended to enhance the instructions with relevant information about your clusters to help the
-AI assistant understand your context better. For example, Kubernetes distribution, Cloud provider,
-what type of applications are deployed, how secrets are managed.
-
-## AI Agent Skills
-
-For agents that support the [Agent Skills Open Standard](https://agentskills.io/specification),
-the Flux project maintains the official [GitOps Agent Skills](https://github.com/fluxcd/agent-skills)
-which give coding agents deep expertise in Flux CD, Kubernetes, and GitOps best practices.
-
-The skill relevant to the Flux MCP is **gitops-cluster-debug**, which helps
-troubleshoot live Kubernetes clusters using the MCP Server. This skill follows dedicated
-workflows for HelmRelease, Kustomization, and ResourceSet debugging, and produces a root
-cause analysis report with a dependency chain and prioritized remediation steps.
+- **gitops-knowledge**: answers questions about Flux CD and generates up-to-date YAML
+  for all Flux custom resources, including the Flux Operator APIs.
+- **gitops-repo-audit**: audits Flux GitOps repositories for structure, security,
+  and operational best practices, and generates a report with prioritized recommendations.
+- **gitops-cluster-debug**: debugs and troubleshoots Flux on live Kubernetes clusters using
+  the Flux MCP Server. It inspects the Flux installation health, diagnoses HelmRelease and
+  Kustomization failures, analyzes pod logs, traces dependency chains, and produces
+  a root cause analysis report with prioritized remediation steps.
 
 The fastest way to install the skills is with the [Flux Operator CLI](cli.md).
 Navigate to your GitOps repository root and run:
@@ -46,37 +31,38 @@ flux-operator skills install ghcr.io/fluxcd/agent-skills --agent claude-code
 ```
 
 The skills work across compatible agents including Claude Code, Codex, Gemini, and GitHub Copilot.
-For other agents and installation methods,
+For the plugin marketplace installation and other methods,
 refer to the [agent-skills README](https://github.com/fluxcd/agent-skills#install).
 
-## Prompting Strategies
+The skills work best in the context of a GitOps repository that contains an `AGENTS.md`
+or `CLAUDE.md` file with details about your organization's structure, cluster topology,
+Kubernetes distribution, cloud provider, and secret management approach. The agent combines
+the skills with the repository context to tailor the analysis and the generated manifests to your setup.
 
-For the best experience with the Flux MCP Server [tools](tools.md):
+## AI Instructions
 
-- **Start broad, then narrow**: Begin with general queries about your Flux installation before drilling down
-- **Include context**: Mention the namespace, cluster, and relevant details in your requests
-- **Chain operations**: For complex workflows, ask the AI to perform a sequence of related operations
-- **Verify changes**: After performing modifications, ask for verification of the new state
-- **Use documentation**: When in doubt about Flux features, explicitly ask to search the Flux API documentation
+For AI assistants that don't support agent skills, we've created a set of
+[instructions](instructions.md) (1400 tokens) that guide the assistant when
+interacting with the Flux MCP Server tools.
 
-## Repository Context
+Copy the rules from the
+[instructions.md](https://raw.githubusercontent.com/controlplaneio-fluxcd/flux-operator/refs/heads/main/docs/mcp/instructions.md)
+file and place them into the `AGENTS.md` or `CLAUDE.md` file at the root of your GitOps repository,
+or into the appropriate settings for your assistant, such as the `Project Instructions` in Claude Desktop,
+the `.cursor/rules` directory for Cursor, or the `.github/copilot-instructions.md` file for GitHub Copilot.
 
-When using an AI chat within your IDE, you can leverage the context of your Git repositories
-that contain Kubernetes and Flux resources. This will enable the AI assistant to compare
-manifest files with cluster state and provide an accurate analysis.
-
-When using Claude Desktop, you can install the
-[filesystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem)
-MCP server and allow the assistant to access the Kubernetes manifests in your Git repository.
-
-In the Claude project knowledge, add the Flux Operator documentation using the
-`https://github.com/controlplaneio-fluxcd/distribution` repository and select
-the `docs/operator` folder. This will ensure that the latest Flux Operator API
-specifications are available to the model along with guides and examples.
+It is recommended to enhance the instructions with relevant information about your clusters,
+such as the Kubernetes distribution, cloud provider, deployed applications, and how secrets are managed.
 
 ## Example Prompts
 
-Reporting and troubleshooting:
+Troubleshooting with the `gitops-cluster-debug` skill:
+
+- Check the Flux installation on my current cluster.
+- Debug the failing HelmRelease podinfo in the apps namespace.
+- Troubleshoot the Kustomization flux-system/infra-controllers in the staging cluster.
+
+Reporting and analysis:
 
 - Analyze the Flux installation in my current cluster and report the status of all components.
 - List the clusters in my kubeconfig and compare the Flux instances across them.
@@ -87,6 +73,7 @@ Reporting and troubleshooting:
 - What is the Git source and revision of the Flux OCI repositories?
 - Which Kubernetes deployments are managed by Flux in the current cluster?
 - Which images are deployed by Flux in the monitoring namespace?
+- List the Helm releases in the cluster with their chart version constraints and the versions currently deployed.
 - Perform a root cause analysis of the last failed deployment in the frontend namespace.
 
 Actions:
@@ -102,12 +89,5 @@ Actions:
 Learning:
 
 - How to configure mutual TLS for Git? Answer using the latest Flux docs.
-- What is the role of the interval setting in a Flux Kustomization?  Search the latest docs.
+- What is the role of the interval setting in a Flux Kustomization? Search the latest docs.
 - How to trigger a Flux reconciliation with a webhook? Search the latest docs.
-
-## Agent Skills
-
-For guided troubleshooting of Flux Kustomizations, HelmReleases and their sources,
-install the [Flux Agent Skills](https://github.com/fluxcd/agent-skills) in your AI assistant.
-The `gitops-cluster-debug` skill provides a step-by-step debugging workflow
-that uses the Flux MCP Server tools to identify and resolve issues in your GitOps pipeline.

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -36,14 +36,33 @@ Retrieves Kubernetes resources from the cluster, including Flux custom resources
 - `namespace` (optional): The namespace to query
 - `selector` (optional): Label selector in the format `key1=value1,key2=value2`
 - `limit` (optional): Maximum number of resources to return
+- `fields` (optional): List of kubectl JSONPath expressions to include in the result, e.g. `spec.chart.spec.version`, `status.conditions[?(@.type=="Ready")].message` or `status.inventory`
 
 **Output:**
 
 Returns the requested resources in YAML format, including:
 - Resource specifications
 - Status conditions
-- Related events
+- Related events (`status.events`)
+- HelmRelease inventory (`status.inventory`)
 - Metadata including Flux source references
+
+When `fields` is set, each resource is reduced to its `apiVersion`, `kind`, `metadata.name`
+and `metadata.namespace`, along with the values selected by the expressions. For example, the fields
+`["spec.chart.spec.version", "status.conditions[?(@.type==\"Ready\")].message"]` return:
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: podinfo
+  namespace: apps
+spec.chart.spec.version: 6.x
+status.conditions[?(@.type=="Ready")].message: Helm upgrade succeeded for release apps/podinfo.v3 with chart podinfo@6.9.0
+```
+
+Use `fields` to reduce the size of the result when
+listing many resources or when only a few fields are relevant.
 
 ### get_kubernetes_logs
 


### PR DESCRIPTION
Add the optional fields parameter to `get_kubernetes_resources` which accepts kubectl JSONPath expressions to reduce the size of the result when listing many resources or when only a few fields are relevant.

When `fields` is set, each resource is reduced to its `apiVersion`, `kind`, `metadata.name` and `metadata.namespace`, along with the values selected by the expressions.

For example, the fields `["spec.chart.spec.version", "status.conditions[?(@.type==\"Ready\")].message"]` return:

```yaml
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  name: podinfo
  namespace: apps
spec.chart.spec.version: 6.x
status.conditions[?(@.type=="Ready")].message: Helm upgrade succeeded for release apps/podinfo.v3 with chart podinfo@6.9.0
```

Closes: #894