### PR TITLE
mcp: Add `diff_kubernetes_manifest` tool 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ test-olm-e2e: build-olm-manifests operator-sdk ## Test OLM manifests for current
 CLI_IMG ?= ghcr.io/controlplaneio-fluxcd/flux-operator-cli:latest
 
 .PHONY: cli-test
-cli-test: tidy fmt vet ## Run CLI tests.
+cli-test: tidy fmt vet envtest ## Run CLI tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./cmd/cli/... -v
 
 .PHONY: cli-build
@@ -211,7 +211,7 @@ mcp-build-search-index: ## Build search database for MCP docs tool.
 	@echo "MCP search database built successfully"
 
 .PHONY: mcp-test
-mcp-test: tidy fmt vet ## Run MCP tests.
+mcp-test: tidy fmt vet envtest ## Run MCP tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./cmd/mcp/... -v
 
 .PHONY: mcp-build

--- a/cmd/mcp/k8s/actions.go
+++ b/cmd/mcp/k8s/actions.go
@@ -6,7 +6,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/fluxcd/pkg/ssa"
@@ -58,8 +57,8 @@ func (k *Client) Apply(ctx context.Context, manifest string, overwrite bool) (st
 	return changeSet.String(), nil
 }
 
-// IsManagedByFlux checks if a Kubernetes resource is managed by Flux by inspecting specific Flux-related labels.
-func (k *Client) IsManagedByFlux(ctx context.Context, gvk schema.GroupVersionKind, name, namespace string) bool {
+// GetFluxOwner returns the Flux owner encoded in the resource's ownership labels.
+func (k *Client) GetFluxOwner(ctx context.Context, gvk schema.GroupVersionKind, name, namespace string) (*DiffOwnerRef, bool) {
 	resource := &metav1.PartialObjectMetadata{}
 	resource.SetGroupVersionKind(gvk)
 
@@ -69,23 +68,53 @@ func (k *Client) IsManagedByFlux(ctx context.Context, gvk schema.GroupVersionKin
 	}
 
 	if err := k.Client.Get(ctx, objectKey, resource); err != nil {
+		return nil, false
+	}
+
+	return fluxOwnerFromLabels(resource.GetLabels())
+}
+
+// IsManagedByFlux checks if a Kubernetes resource is managed by Flux by inspecting specific Flux-related labels.
+func (k *Client) IsManagedByFlux(ctx context.Context, gvk schema.GroupVersionKind, name, namespace string) bool {
+	resource := &metav1.PartialObjectMetadata{}
+	resource.SetGroupVersionKind(gvk)
+	if err := k.Client.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: name}, resource); err != nil {
 		return false
 	}
-
-	fluxLabels := []string{
-		"fluxcd.controlplane.io/namespace",
-		"resourceset.fluxcd.controlplane.io/namespace",
-		fluxcdv1.FluxKustomizeGroup + "/namespace",
-		fluxcdv1.FluxHelmGroup + "/namespace",
-	}
-
-	for key := range resource.GetLabels() {
-		if slices.Contains(fluxLabels, key) {
+	for _, group := range []string{
+		fluxcdv1.GroupVersion.Group,
+		fluxcdv1.GroupOwnerLabelResourceSet,
+		fluxcdv1.FluxKustomizeGroup,
+		fluxcdv1.FluxHelmGroup,
+	} {
+		if resource.GetLabels()[group+"/namespace"] != "" {
 			return true
 		}
 	}
-
 	return false
+}
+
+// fluxOwnerFromLabels returns the first recognized Flux owner reference from labels.
+func fluxOwnerFromLabels(labels map[string]string) (*DiffOwnerRef, bool) {
+	owners := []struct {
+		group string
+		kind  string
+	}{
+		{fluxcdv1.FluxKustomizeGroup, fluxcdv1.FluxKustomizationKind},
+		{fluxcdv1.GroupOwnerLabelResourceSet, fluxcdv1.ResourceSetKind},
+		{fluxcdv1.FluxHelmGroup, fluxcdv1.FluxHelmReleaseKind},
+		{fluxcdv1.GroupVersion.Group, "FluxInstance"},
+	}
+
+	for _, owner := range owners {
+		name := labels[owner.group+"/name"]
+		namespace := labels[owner.group+"/namespace"]
+		if name != "" && namespace != "" {
+			return &DiffOwnerRef{Kind: owner.kind, Name: name, Namespace: namespace}, true
+		}
+	}
+
+	return nil, false
 }
 
 // Annotate sets annotations on a Kubernetes resource identified by GroupVersionKind, name, and namespace.

--- a/cmd/mcp/k8s/client.go
+++ b/cmd/mcp/k8s/client.go
@@ -38,16 +38,22 @@ func init() {
 // extended functionality for interacting with Kubernetes resources.
 type Client struct {
 	ctrlclient.Client
-	cfg *rest.Config
-	rm  *ssa.ResourceManager
+	cfg    *rest.Config
+	poller *polling.StatusPoller
+	rm     *ssa.ResourceManager
 }
 
 // NewClient creates a new Kubernetes client using the provided objects.
 func NewClient(kubeClient ctrlclient.Client, cfg *rest.Config, restMapper meta.RESTMapper) *Client {
+	poller := polling.NewStatusPoller(kubeClient, restMapper, polling.Options{})
 	return &Client{
 		Client: kubeClient,
 		cfg:    cfg,
-		rm:     newResourceManager(kubeClient, restMapper),
+		poller: poller,
+		rm: newResourceManagerWithOwner(kubeClient, poller, ssa.Owner{
+			Field: "kubectl-flux-mcp",
+			Group: fluxcdv1.GroupVersion.Group,
+		}),
 	}
 }
 
@@ -72,19 +78,22 @@ func newClientFromFlags(flags *cli.ConfigFlags) (*Client, error) {
 		return nil, err
 	}
 
+	poller := polling.NewStatusPoller(kubeClient, restMapper, polling.Options{})
 	return &Client{
 		Client: ctrlclient.WithFieldOwner(kubeClient, "flux-operator-mcp"),
 		cfg:    cfg,
-		rm:     newResourceManager(kubeClient, restMapper),
+		poller: poller,
+		rm: newResourceManagerWithOwner(kubeClient, poller, ssa.Owner{
+			Field: "kubectl-flux-mcp",
+			Group: fluxcdv1.GroupVersion.Group,
+		}),
 	}, nil
 }
 
-func newResourceManager(kubeClient ctrlclient.Client, restMapper meta.RESTMapper) *ssa.ResourceManager {
-	kubePoller := polling.NewStatusPoller(kubeClient, restMapper, polling.Options{})
-	return ssa.NewResourceManager(kubeClient, kubePoller, ssa.Owner{
-		Field: "kubectl-flux-mcp",
-		Group: fluxcdv1.GroupVersion.Group,
-	})
+// newResourceManagerWithOwner creates an SSA manager with a call-specific owner
+// while reusing the client's status poller.
+func newResourceManagerWithOwner(kubeClient ctrlclient.Client, poller *polling.StatusPoller, owner ssa.Owner) *ssa.ResourceManager {
+	return ssa.NewResourceManager(kubeClient, poller, owner)
 }
 
 // GetConfig returns the REST config used by the Kubernetes client.

--- a/cmd/mcp/k8s/diff.go
+++ b/cmd/mcp/k8s/diff.go
@@ -1,0 +1,590 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	objectutil "github.com/fluxcd/cli-utils/pkg/object"
+	"github.com/fluxcd/pkg/ssa"
+	ssadiff "github.com/fluxcd/pkg/ssa/jsondiff"
+	"github.com/fluxcd/pkg/ssa/normalize"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	"github.com/wI2L/jsondiff"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/inventory"
+)
+
+// diffExecution retains non-rendered state needed for dependent-resource recovery and pruning.
+type diffExecution struct {
+	result       diffObjectResult
+	object       *unstructured.Unstructured
+	live         *unstructured.Unstructured
+	err          error
+	preGetAbsent bool
+}
+
+// readDiffObjects mirrors ssautil.ReadObjects but preserves generateName-only
+// objects so Diff can render the required per-object validation error.
+func readDiffObjects(reader io.Reader) ([]*unstructured.Unstructured, error) {
+	decoder := yaml.NewYAMLOrJSONDecoder(reader, 2048)
+	objects := make([]*unstructured.Unstructured, 0)
+	appendObject := func(resource *unstructured.Unstructured) {
+		if resource.GetAPIVersion() == "" || resource.GetKind() == "" {
+			return
+		}
+		isGenerateNameObject := resource.GetGenerateName() != ""
+		if (ssautil.IsKubernetesObject(resource) || isGenerateNameObject) && !ssautil.IsKustomization(resource) {
+			objects = append(objects, resource)
+		}
+	}
+
+	for {
+		var document any
+		if err := decoder.Decode(&document); err != nil {
+			if err == io.EOF {
+				return objects, nil
+			}
+			return objects, err
+		}
+		objectMap, ok := document.(map[string]any)
+		if !ok {
+			continue
+		}
+		object := &unstructured.Unstructured{Object: objectMap}
+		if object.IsList() {
+			if err := object.EachListItem(func(item runtime.Object) error {
+				appendObject(item.(*unstructured.Unstructured))
+				return nil
+			}); err != nil {
+				return objects, err
+			}
+			continue
+		}
+		appendObject(object)
+	}
+}
+
+// Diff previews a Kubernetes manifest using server-side apply dry-run with the selected Flux owner.
+func (k *Client) Diff(ctx context.Context, req DiffRequest) (string, error) {
+	objects, err := readDiffObjects(strings.NewReader(req.Manifest))
+	if err != nil {
+		return "", fmt.Errorf("unable to parse YAML manifest: %w", err)
+	}
+	if len(objects) == 0 {
+		return "", fmt.Errorf("no Kubernetes objects found in manifest")
+	}
+
+	owner, err := k.resolveDiffOwner(ctx, req)
+	if err != nil {
+		return "", err
+	}
+
+	rm := k.rm
+	fieldManager := "kubectl-flux-mcp"
+	diffOptions := ssa.DefaultDiffOptions()
+	if owner != nil {
+		fieldManager = owner.ssaOwner.Field
+		diffOptions = owner.diffOptions
+		rm = newResourceManagerWithOwner(k.Client, k.poller, owner.ssaOwner)
+	}
+	if rm == nil {
+		rm = newResourceManagerWithOwner(k.Client, k.poller, ssa.Owner{
+			Field: fieldManager,
+			Group: fluxcdv1.GroupVersion.Group,
+		})
+	}
+
+	if err := prepareDiffObjects(ctx, k.Client, &objects, owner, rm); err != nil {
+		return "", fmt.Errorf("unable to prepare objects: %w", err)
+	}
+	sopsKeySets := sanitizeSOPSObjects(objects)
+	if err := normalize.UnstructuredList(objects); err != nil {
+		return "", fmt.Errorf("unable to normalize objects: %w", err)
+	}
+
+	executions := make([]diffExecution, 0, len(objects))
+	pruneManifestObjects := make([]*unstructured.Unstructured, 0, len(objects))
+	for _, desired := range objects {
+		execution := diffExecution{
+			object: desired,
+			result: diffObjectResult{Subject: ssautil.FmtUnstructured(desired)},
+		}
+		if hook, ok := helmHookValue(owner, desired); ok {
+			execution.result.State = diffStateSkipped
+			execution.result.Detail = "helm.sh/hook: " + hook
+			executions = append(executions, execution)
+			continue
+		}
+		pruneManifestObjects = append(pruneManifestObjects, desired)
+		if desired.GetName() == "" {
+			if desired.GetGenerateName() != "" {
+				execution.result.Subject = generatedSubject(desired)
+				execution.err = fmt.Errorf("metadata.generateName is not supported without metadata.name")
+			} else {
+				execution.err = fmt.Errorf("metadata.name is required")
+			}
+			execution.result.State = diffStateError
+			execution.result.Detail = execution.err.Error()
+			executions = append(executions, execution)
+			continue
+		}
+
+		live := &unstructured.Unstructured{}
+		live.SetGroupVersionKind(desired.GroupVersionKind())
+		getErr := k.Client.Get(ctx, ctrlclient.ObjectKeyFromObject(desired), live)
+		present := getErr == nil
+		execution.preGetAbsent = apierrors.IsNotFound(getErr) || isNoMatchError(getErr)
+		switch {
+		case present:
+			execution.live = live
+			execution.result.Hint = managedByHint(live, owner)
+		case apierrors.IsNotFound(getErr):
+			// Absence is an expected input to server-side apply.
+		default:
+			execution.err = getErr
+			execution.result.State = diffStateError
+			execution.result.Detail = diffErrorMessage(desired, getErr, true)
+			executions = append(executions, execution)
+			continue
+		}
+		if present {
+			applyHelmMetadataForLiveCRD(desired, live, owner)
+		}
+
+		if desiredKeys, encrypted := sopsKeySets[desired]; encrypted {
+			if !present {
+				execution.result.State = diffStateCreate
+			} else if equalStringSets(desiredKeys, objectDataKeys(live)) {
+				execution.result.State = diffStateUnchanged
+			} else {
+				execution.result.State = diffStateUpdate
+				execution.result.Detail = "sops encrypted: keys compared only"
+			}
+			executions = append(executions, execution)
+			continue
+		}
+
+		entry, liveDiff, merged, diffErr := rm.Diff(ctx, desired, diffOptions)
+		if diffErr != nil {
+			execution.err = diffErr
+			execution.result.State = diffStateError
+			execution.result.Detail = diffErrorMessage(desired, diffErr, false)
+			executions = append(executions, execution)
+			continue
+		}
+
+		switch entry.Action {
+		case ssa.ConfiguredAction:
+			patch, err := diffPatch(liveDiff, merged, diffOptions.DriftIgnoreRules)
+			if err != nil {
+				execution.err = err
+				execution.result.State = diffStateError
+				execution.result.Detail = err.Error()
+			} else if len(patch) == 0 {
+				execution.result.State = diffStateUnchanged
+			} else {
+				execution.result.State = diffStateUpdate
+				execution.result.Patch = patch
+			}
+		case ssa.UnchangedAction:
+			execution.result.State = diffStateUnchanged
+		case ssa.SkippedAction:
+			execution.result.State = diffStateSkipped
+			execution.result.Detail = skippedBy(desired, live, present, diffOptions)
+		case ssa.CreatedAction:
+			if present {
+				execution.result.State = diffStateRecreate
+				execution.result.Detail = "forced, not validated"
+			} else {
+				execution.result.State = diffStateCreate
+			}
+		default:
+			execution.err = fmt.Errorf("unexpected dry-run action %q", entry.Action)
+			execution.result.State = diffStateError
+			execution.result.Detail = execution.err.Error()
+		}
+		executions = append(executions, execution)
+	}
+
+	result := diffResult{
+		FieldManager: fieldManager,
+		Objects:      make([]diffObjectResult, 0, len(executions)),
+	}
+	if owner != nil {
+		result.Owner = owner.ref
+		result.PruneEnabled = owner.prune
+		result.FutureSuspend = owner.futureSuspend
+		result.LiveSuspend = owner.liveSuspend
+		result.Warnings = append(result.Warnings, owner.warnings...)
+	}
+	recoverDependentCreates(executions, &result.Warnings)
+	hasErrors := false
+	for _, execution := range executions {
+		result.Objects = append(result.Objects, execution.result)
+		if execution.result.State == diffStateError {
+			hasErrors = true
+		}
+	}
+
+	if owner != nil && owner.prune && !hasErrors {
+		pruneObjects, pruneStatus := k.diffPrune(ctx, owner, rm, pruneManifestObjects)
+		result.PruneObjects = pruneObjects
+		result.PruneStatus = pruneStatus
+	}
+	return renderDiff(result)
+}
+
+// helmHookValue returns a Helm hook annotation only for HelmRelease-owned objects.
+func helmHookValue(owner *diffOwner, object *unstructured.Unstructured) (string, bool) {
+	if owner == nil || owner.ref.Kind != fluxcdv1.FluxHelmReleaseKind {
+		return "", false
+	}
+	value, found := object.GetAnnotations()["helm.sh/hook"]
+	return value, found
+}
+
+// sanitizeSOPSObjects removes encrypted payloads and returns their desired key sets.
+func sanitizeSOPSObjects(objects []*unstructured.Unstructured) map[*unstructured.Unstructured]map[string]struct{} {
+	result := make(map[*unstructured.Unstructured]map[string]struct{})
+	for _, object := range objects {
+		if _, found := object.Object["sops"]; !found {
+			continue
+		}
+		result[object] = objectDataKeys(object)
+		delete(object.Object, "sops")
+		delete(object.Object, "data")
+		delete(object.Object, "stringData")
+	}
+	return result
+}
+
+// objectDataKeys returns the union of top-level data and stringData keys.
+func objectDataKeys(object *unstructured.Unstructured) map[string]struct{} {
+	result := make(map[string]struct{})
+	for _, field := range []string{"data", "stringData"} {
+		if values, found, _ := unstructured.NestedMap(object.Object, field); found {
+			for key := range values {
+				result[key] = struct{}{}
+			}
+		}
+	}
+	return result
+}
+
+// equalStringSets reports whether two string sets contain identical keys.
+func equalStringSets(left, right map[string]struct{}) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key := range left {
+		if _, found := right[key]; !found {
+			return false
+		}
+	}
+	return true
+}
+
+// diffPatch computes spec and add-or-replace metadata JSON patch operations.
+func diffPatch(live, merged *unstructured.Unstructured, ignoreRules []ssadiff.IgnoreRule) (jsondiff.Patch, error) {
+	if live == nil || merged == nil {
+		return nil, fmt.Errorf("dry-run returned no objects for configured change")
+	}
+	if err := normalize.DryRunUnstructured(merged); err != nil {
+		return nil, fmt.Errorf("normalizing dry-run object: %w", err)
+	}
+	filteredLive := live.DeepCopy()
+	filteredMerged := merged.DeepCopy()
+	if err := removeDiffIgnoredFields(merged, []*unstructured.Unstructured{filteredLive, filteredMerged}, ignoreRules); err != nil {
+		return nil, err
+	}
+	metadataPatch, err := diffUnstructuredMetadata(filteredLive, filteredMerged, nil, jsondiff.Rationalize())
+	if err != nil {
+		return nil, err
+	}
+	resourcePatch, err := ssadiff.DiffUnstructured(filteredLive, filteredMerged, jsondiff.Rationalize())
+	if err != nil {
+		return nil, err
+	}
+	return append(metadataPatch, resourcePatch...), nil
+}
+
+// diffUnstructuredMetadata mirrors pkg/ssa's metadata diff while excluding remove operations.
+func diffUnstructuredMetadata(live, merged *unstructured.Unstructured, ignoreRules []ssadiff.IgnoreRule,
+	opts ...jsondiff.Option) (jsondiff.Patch, error) {
+	filteredLive := live.DeepCopy()
+	filteredMerged := merged.DeepCopy()
+	if err := removeDiffIgnoredFields(merged, []*unstructured.Unstructured{filteredLive, filteredMerged}, ignoreRules); err != nil {
+		return nil, err
+	}
+	patch, err := jsondiff.Compare(metadataOnly(filteredLive).Object, metadataOnly(filteredMerged).Object, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to compare annotations and labels of objects: %w", err)
+	}
+	filtered := make(jsondiff.Patch, 0, len(patch))
+	for _, operation := range patch {
+		if operation.Type == jsondiff.OperationAdd || operation.Type == jsondiff.OperationReplace {
+			filtered = append(filtered, operation)
+		}
+	}
+	return filtered, nil
+}
+
+// removeDiffIgnoredFields applies rules selected against matchObject to every object.
+func removeDiffIgnoredFields(matchObject *unstructured.Unstructured, objects []*unstructured.Unstructured,
+	rules []ssadiff.IgnoreRule) error {
+	if len(rules) == 0 {
+		return nil
+	}
+	compiled, err := ssadiff.CompileIgnoreRules(rules)
+	if err != nil {
+		return err
+	}
+	var paths []string
+	for selector, rulePaths := range compiled {
+		if selector.MatchUnstructured(matchObject) {
+			paths = append(paths, rulePaths...)
+		}
+	}
+	if len(paths) == 0 {
+		return nil
+	}
+	patch := ssadiff.GenerateRemovePatch(paths...)
+	for _, object := range objects {
+		if err := ssadiff.ApplyPatchToUnstructured(object, patch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// metadataOnly copies name, annotations and labels into a fresh object.
+func metadataOnly(source *unstructured.Unstructured) *unstructured.Unstructured {
+	result := &unstructured.Unstructured{Object: make(map[string]any)}
+	for _, field := range []string{"name", "annotations", "labels"} {
+		if value, found, _ := unstructured.NestedFieldCopy(source.Object, "metadata", field); found {
+			_ = unstructured.SetNestedField(result.Object, value, "metadata", field)
+		}
+	}
+	return result
+}
+
+// generatedSubject formats an object that has generateName but no SSA-compatible name.
+func generatedSubject(object *unstructured.Unstructured) string {
+	if object.GetNamespace() == "" {
+		return fmt.Sprintf("%s/%s*", object.GetKind(), object.GetGenerateName())
+	}
+	return fmt.Sprintf("%s/%s/%s*", object.GetKind(), object.GetNamespace(), object.GetGenerateName())
+}
+
+// diffErrorMessage applies permission guidance and Secret-safe API error redaction.
+func diffErrorMessage(object *unstructured.Unstructured, err error, get bool) string {
+	if apierrors.IsForbidden(err) {
+		return fmt.Sprintf("dry-run requires get and patch permission on %s", ssautil.FmtUnstructured(object))
+	}
+	if object.GetAPIVersion() == "v1" && object.GetKind() == "Secret" {
+		for current := err; current != nil; current = errors.Unwrap(current) {
+			if reason := apierrors.ReasonForError(current); reason != metav1.StatusReasonUnknown && reason != "" {
+				return string(reason)
+			}
+		}
+		return "API error"
+	}
+	if get {
+		return fmt.Sprintf("unable to get live object: %v", err)
+	}
+	return err.Error()
+}
+
+// skippedBy identifies the selector annotation or label responsible for a skipped dry-run.
+func skippedBy(desired, live *unstructured.Unstructured, present bool, opts ssa.DiffOptions) string {
+	selectors := []map[string]string{opts.Exclusions}
+	if present {
+		selectors = append(selectors, opts.IfNotPresentSelector)
+	}
+	for _, selector := range selectors {
+		for key, expected := range selector {
+			for _, candidate := range []*unstructured.Unstructured{desired, live} {
+				if candidate == nil {
+					continue
+				}
+				if value := candidate.GetAnnotations()[key]; value != "" && strings.EqualFold(value, expected) {
+					return key + ": " + value
+				}
+				if value := candidate.GetLabels()[key]; value != "" && strings.EqualFold(value, expected) {
+					return key + ": " + value
+				}
+			}
+		}
+	}
+	return "excluded"
+}
+
+// managedByHint returns a live Flux owner when it differs from the selected owner.
+func managedByHint(live *unstructured.Unstructured, selected *diffOwner) *DiffOwnerRef {
+	current, ok := fluxOwnerFromLabels(live.GetLabels())
+	if !ok {
+		return nil
+	}
+	if selected != nil && *current == *selected.ref {
+		return nil
+	}
+	return current
+}
+
+// recoverDependentCreates marks absent objects which cannot be dry-run before their Namespace or CRD exists.
+func recoverDependentCreates(executions []diffExecution, warnings *[]string) {
+	for i := range executions {
+		execution := &executions[i]
+		if execution.result.State != diffStateError || execution.err == nil || !execution.preGetAbsent {
+			continue
+		}
+
+		namespace := execution.object.GetNamespace()
+		if isMissingNamespaceError(execution.err, namespace) {
+			execution.err = nil
+			execution.result.State = diffStateCreate
+			execution.result.Detail = fmt.Sprintf("not validated: namespace %s does not exist yet", namespace)
+			appendDiffWarning(warnings, fmt.Sprintf("namespace %s does not exist in the cluster, objects in it are not validated", namespace))
+			continue
+		}
+
+		if isNoMatchError(execution.err) {
+			groupKind := execution.object.GroupVersionKind().Group + "/" + execution.object.GetKind()
+			execution.err = nil
+			execution.result.State = diffStateCreate
+			execution.result.Detail = fmt.Sprintf("not validated: CRD for %s does not exist yet", groupKind)
+			appendDiffWarning(warnings, fmt.Sprintf("CRD for %s does not exist in the cluster, objects of that kind are not validated", groupKind))
+		}
+	}
+}
+
+// isMissingNamespaceError checks for the structured NotFound response returned for an absent namespace.
+func isMissingNamespaceError(err error, namespace string) bool {
+	if namespace == "" {
+		return false
+	}
+	expectedMessage := fmt.Sprintf("namespaces %q not found", namespace)
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		if !apierrors.IsNotFound(current) {
+			continue
+		}
+		statusError, ok := current.(apierrors.APIStatus)
+		if !ok {
+			continue
+		}
+		status := statusError.Status()
+		if status.Details != nil && status.Details.Kind == "namespaces" &&
+			(status.Details.Name == namespace || status.Message == expectedMessage) {
+			return true
+		}
+	}
+	return false
+}
+
+// isNoMatchError checks an error chain for a REST mapping failure.
+func isNoMatchError(err error) bool {
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		if meta.IsNoMatchError(current) {
+			return true
+		}
+	}
+	return false
+}
+
+// diffPrune computes and live-filters owner inventory entries absent from the manifest.
+func (k *Client) diffPrune(ctx context.Context, owner *diffOwner, rm *ssa.ResourceManager,
+	objects []*unstructured.Unstructured) ([]diffObjectResult, string) {
+	if owner.live == nil {
+		return nil, "prune: skipped (owner not in cluster)"
+	}
+	inventoryValue, found, err := unstructured.NestedFieldCopy(owner.live.Object, "status", "inventory")
+	if err != nil || !found || inventoryValue == nil {
+		return nil, "prune: unavailable"
+	}
+	inventoryMap, ok := inventoryValue.(map[string]any)
+	if !ok {
+		return nil, "prune: unavailable"
+	}
+	liveInventory := &fluxcdv1.ResourceInventory{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(inventoryMap, liveInventory); err != nil {
+		return nil, "prune: unavailable"
+	}
+
+	targetInventory := inventory.New()
+	for _, item := range objects {
+		targetInventory.Entries = append(targetInventory.Entries, fluxcdv1.ResourceRef{
+			ID:      objectutil.UnstructuredToObjMetadata(item).String(),
+			Version: item.GroupVersionKind().Version,
+		})
+	}
+	candidates, err := inventory.Diff(liveInventory, targetInventory)
+	if err != nil {
+		return nil, "prune: unavailable"
+	}
+
+	results := make([]diffObjectResult, 0, len(candidates))
+	ownerLabels := rm.GetOwnerLabels(owner.ref.Name, owner.ref.Namespace)
+	for _, candidate := range candidates {
+		metadata := &metav1.PartialObjectMetadata{}
+		metadata.SetGroupVersionKind(candidate.GroupVersionKind())
+		err := k.Client.Get(ctx, ctrlclient.ObjectKeyFromObject(candidate), metadata)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			results = append(results, diffObjectResult{
+				Subject: ssautil.FmtUnstructured(candidate),
+				State:   diffStateError,
+				Detail:  diffErrorMessage(candidate, err, true),
+			})
+			continue
+		}
+		if !hasOwnerLabels(metadata.GetLabels(), ownerLabels) || pruneDisabled(metadata, owner.ref.Kind) {
+			continue
+		}
+		results = append(results, diffObjectResult{Subject: ssautil.FmtUnstructured(candidate), State: diffStateDelete})
+	}
+	return results, ""
+}
+
+// hasOwnerLabels checks that every expected owner label matches the live object.
+func hasOwnerLabels(labels, expected map[string]string) bool {
+	for key, value := range expected {
+		if labels[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+// pruneDisabled applies controller-specific garbage-collection exclusions.
+func pruneDisabled(object *metav1.PartialObjectMetadata, ownerKind string) bool {
+	annotations := object.GetAnnotations()
+	switch ownerKind {
+	case fluxcdv1.FluxKustomizationKind:
+		return strings.EqualFold(annotations[fluxcdv1.FluxKustomizeGroup+"/prune"], "disabled") ||
+			strings.EqualFold(annotations[fluxcdv1.FluxKustomizeGroup+"/reconcile"], "disabled") ||
+			strings.EqualFold(annotations[fluxcdv1.FluxKustomizeGroup+"/ssa"], "ignore")
+	case fluxcdv1.ResourceSetKind:
+		return strings.EqualFold(annotations[fluxcdv1.PruneAnnotation], fluxcdv1.DisabledValue)
+	case fluxcdv1.FluxHelmReleaseKind:
+		return object.GetObjectKind().GroupVersionKind().Kind == "CustomResourceDefinition" ||
+			strings.EqualFold(annotations["helm.sh/resource-policy"], "keep")
+	default:
+		return false
+	}
+}

--- a/cmd/mcp/k8s/diff_envtest_test.go
+++ b/cmd/mcp/k8s/diff_envtest_test.go
@@ -1,0 +1,652 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fluxcd/cli-utils/pkg/object"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func TestDiffEnvtestEngine(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	namespace := createDiffNamespace(t)
+	owner := createDiffOwner(t, "Kustomization", namespace, "apps", map[string]any{"prune": false})
+	ownerRef := &DiffOwnerRef{Kind: "Kustomization", Namespace: namespace, Name: owner.GetName()}
+	ownerLabels := map[string]string{
+		"kustomize.toolkit.fluxcd.io/name":      owner.GetName(),
+		"kustomize.toolkit.fluxcd.io/namespace": namespace,
+	}
+
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: create
+  namespace: %s
+data:
+  value: one
+`, namespace)
+	output, err := testClient.Diff(ctx, DiffRequest{Manifest: manifest})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("ConfigMap/" + namespace + "/create create"))
+
+	live := configMapUnstructured(namespace, "owned", ownerLabels, map[string]any{"keep": "one", "remove": "old"})
+	g.Expect(applyDiffObject(ctx, live, "kustomize-controller")).To(Succeed())
+	manifest = fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: owned
+  namespace: %s
+data:
+  keep: one
+`, namespace)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest, OwnerRef: ownerRef})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("ConfigMap/" + namespace + "/owned update"))
+	g.Expect(output).To(ContainSubstring("path: /data/remove"))
+	g.Expect(output).To(ContainSubstring("op: remove"))
+
+	live = configMapUnstructured(namespace, "foreign", ownerLabels, map[string]any{"keep": "one", "foreign": "preserved"})
+	g.Expect(applyDiffObject(ctx, live, "foreign-manager")).To(Succeed())
+	manifest = fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foreign
+  namespace: %s
+data:
+  keep: one
+`, namespace)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest, OwnerRef: ownerRef})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("No changes detected"))
+	g.Expect(output).NotTo(ContainSubstring("path: /data/foreign"))
+
+	metadataOnly := configMapUnstructured(namespace, "metadata-only", ownerLabels, map[string]any{"keep": "one"})
+	metadataOnly.SetAnnotations(map[string]string{"removed-by-apply": "old"})
+	g.Expect(applyDiffObject(ctx, metadataOnly, "kustomize-controller")).To(Succeed())
+	manifest = fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metadata-only
+  namespace: %s
+data:
+  keep: one
+`, namespace)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest, OwnerRef: ownerRef})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("No changes detected"))
+	g.Expect(output).NotTo(ContainSubstring("ConfigMap/" + namespace + "/metadata-only update"))
+
+	manifest = fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: owned
+  namespace: %s
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: ignore
+data:
+  keep: two
+`, namespace)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest, OwnerRef: ownerRef})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("skipped (kustomize.toolkit.fluxcd.io/ssa: ignore)"))
+
+	manifest = fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: owned
+  namespace: %s
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+data:
+  keep: changed
+`, namespace)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest, OwnerRef: ownerRef})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("skipped (kustomize.toolkit.fluxcd.io/ssa: IfNotPresent)"))
+
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "token", Namespace: namespace, Labels: ownerLabels}, Data: map[string][]byte{"token": []byte("before")}}
+	g.Expect(testClient.Client.Create(ctx, secret)).To(Succeed())
+	manifest = fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: token
+  namespace: %s
+stringData:
+  token: after
+`, namespace)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest, OwnerRef: ownerRef})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("Secret/" + namespace + "/token update"))
+	g.Expect(output).To(ContainSubstring("*** (after)"))
+	g.Expect(output).NotTo(ContainSubstring("before"))
+
+	manifest = fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: invalid
+  namespace: %s
+data:
+  token: 'TOP-SECRET-%%%%%%'
+`, namespace)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest, OwnerRef: ownerRef})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("Secret/" + namespace + "/invalid error:"))
+	g.Expect(output).NotTo(ContainSubstring("TOP-SECRET"))
+
+	immutable := true
+	immutableCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "immutable", Namespace: namespace, Labels: ownerLabels},
+		Immutable:  &immutable,
+		Data:       map[string]string{"value": "before"},
+	}
+	g.Expect(testClient.Client.Create(ctx, immutableCM)).To(Succeed())
+	manifest = fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: immutable
+  namespace: %s
+immutable: true
+data:
+  value: after
+`, namespace)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest, OwnerRef: ownerRef})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("ConfigMap/" + namespace + "/immutable error:"))
+
+	forcedOwner := owner.DeepCopy()
+	forcedOwner.Object["spec"].(map[string]any)["force"] = true
+	forcedYAML := mustObjectsYAML(t, forcedOwner)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest, FluxObject: forcedYAML})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("ConfigMap/" + namespace + "/immutable recreate (forced, not validated)"))
+}
+
+func TestDiffEnvtestHelmReleasePolish(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	namespace := createDiffNamespace(t)
+	owner := createDiffOwner(t, "HelmRelease", namespace, "app", map[string]any{})
+	ownerRef := &DiffOwnerRef{Kind: "HelmRelease", Namespace: namespace, Name: owner.GetName()}
+	labels := map[string]string{
+		"app.kubernetes.io/managed-by":     "Helm",
+		"helm.sh/chart":                    "app-1.0.0_deadbeef",
+		"helm.toolkit.fluxcd.io/name":      owner.GetName(),
+		"helm.toolkit.fluxcd.io/namespace": namespace,
+	}
+	live := configMapUnstructured(namespace, "app", labels, map[string]any{"value": "live"})
+	live.SetAnnotations(map[string]string{
+		"meta.helm.sh/release-name":      owner.GetName(),
+		"meta.helm.sh/release-namespace": namespace,
+	})
+	g.Expect(applyDiffObject(ctx, live, "helm-controller")).To(Succeed())
+	setOwnerInventory(t, owner, live)
+
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app
+  namespace: %s
+  labels:
+    helm.sh/chart: app-v1.0.0
+data:
+  value: live
+---
+apiVersion: hooks.example.com/v1
+kind: StartupCheck
+metadata:
+  name: startup
+  namespace: %s
+  annotations:
+    helm.sh/hook: post-install
+`, namespace, namespace)
+	output, err := testClient.Diff(ctx, DiffRequest{Manifest: manifest, OwnerRef: ownerRef})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("StartupCheck/" + namespace + "/startup skipped (helm.sh/hook: post-install)"))
+	g.Expect(output).To(ContainSubstring("Summary: 1 unchanged, 1 skipped"))
+	g.Expect(output).NotTo(ContainSubstring("app-1.0.0_deadbeef"))
+	g.Expect(output).NotTo(ContainSubstring("app-v1.0.0"))
+
+	manifest = strings.Replace(manifest, "value: live", "value: desired", 1)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest, OwnerRef: ownerRef})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("ConfigMap/" + namespace + "/app update"))
+	g.Expect(output).To(ContainSubstring("path: /data/value"))
+	g.Expect(output).NotTo(ContainSubstring("helm.sh/chart"))
+	g.Expect(output).NotTo(ContainSubstring("app-1.0.0_deadbeef"))
+	g.Expect(output).NotTo(ContainSubstring("app-v1.0.0"))
+}
+
+func TestDiffEnvtestDependentResourcesAndOwnership(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	missingNamespace := fmt.Sprintf("diff-missing-%d", time.Now().UnixNano())
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-one
+  namespace: %s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-two
+  namespace: %s
+`, missingNamespace, missingNamespace)
+	output, err := testClient.Diff(ctx, DiffRequest{Manifest: manifest})
+	g.Expect(err).NotTo(HaveOccurred())
+	warning := fmt.Sprintf("namespace %s does not exist in the cluster, objects in it are not validated", missingNamespace)
+	g.Expect(strings.Count(output, warning)).To(Equal(1))
+	g.Expect(output).To(ContainSubstring("ConfigMap/" + missingNamespace + "/app-one create (not validated: namespace " + missingNamespace + " does not exist yet)"))
+	g.Expect(output).To(ContainSubstring("ConfigMap/" + missingNamespace + "/app-two create (not validated: namespace " + missingNamespace + " does not exist yet)"))
+	g.Expect(output).NotTo(ContainSubstring(" error:"))
+
+	inManifestNamespace := fmt.Sprintf("diff-in-manifest-%d", time.Now().UnixNano())
+	manifest = fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app
+  namespace: %s
+`, inManifestNamespace, inManifestNamespace)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("namespace " + inManifestNamespace + " does not exist in the cluster, objects in it are not validated"))
+	g.Expect(output).To(ContainSubstring("ConfigMap/" + inManifestNamespace + "/app create (not validated: namespace " + inManifestNamespace + " does not exist yet)"))
+
+	widgetManifest := func(group string, includeCRD bool) string {
+		resources := fmt.Sprintf(`apiVersion: %s/v1
+kind: Widget
+metadata:
+  name: app-one
+---
+apiVersion: %s/v1
+kind: Widget
+metadata:
+  name: app-two
+`, group, group)
+		if !includeCRD {
+			return resources
+		}
+		return fmt.Sprintf(`apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.%s
+spec:
+  group: %s
+  names:
+    kind: Widget
+    plural: widgets
+    singular: widget
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+---
+%s`, group, group, resources)
+	}
+
+	group := fmt.Sprintf("diff%d.example.com", time.Now().UnixNano())
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: widgetManifest(group, false)})
+	g.Expect(err).NotTo(HaveOccurred())
+	warning = fmt.Sprintf("CRD for %s/Widget does not exist in the cluster, objects of that kind are not validated", group)
+	g.Expect(strings.Count(output, warning)).To(Equal(1))
+	g.Expect(output).To(ContainSubstring("Widget/app-one create (not validated: CRD for " + group + "/Widget does not exist yet)"))
+	g.Expect(output).To(ContainSubstring("Widget/app-two create (not validated: CRD for " + group + "/Widget does not exist yet)"))
+	g.Expect(output).NotTo(ContainSubstring(" error:"))
+
+	inManifestGroup := fmt.Sprintf("diff%d.example.com", time.Now().UnixNano()+1)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: widgetManifest(inManifestGroup, true)})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("CRD for " + inManifestGroup + "/Widget does not exist in the cluster, objects of that kind are not validated"))
+	g.Expect(output).To(ContainSubstring("Widget/app-one create (not validated: CRD for " + inManifestGroup + "/Widget does not exist yet)"))
+
+	namespace := createDiffNamespace(t)
+	owner := createDiffOwner(t, "Kustomization", namespace, "suspended", map[string]any{"suspend": true, "prune": false})
+	ownerRef := &DiffOwnerRef{Kind: "Kustomization", Namespace: namespace, Name: owner.GetName()}
+	manifest = fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hinted
+  namespace: %s
+  labels:
+    kustomize.toolkit.fluxcd.io/name: other
+    kustomize.toolkit.fluxcd.io/namespace: %s
+data: {value: live}
+`, namespace, namespace)
+	objects, err := readTestObjects(manifest)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(applyDiffObject(ctx, objects[0], "other-manager")).To(Succeed())
+	manifest = strings.Replace(manifest, "value: live", "value: desired", 1)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest, OwnerRef: ownerRef})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("suspended: changes are not applied until resumed"))
+	g.Expect(output).To(ContainSubstring("currently managed by Kustomization/" + namespace + "/other"))
+
+	future := ownerObject("HelmRelease", "future", namespace, false)
+	output, err = testClient.Diff(ctx, DiffRequest{
+		Manifest:   fmt.Sprintf("apiVersion: v1\nkind: ConfigMap\nmetadata: {name: precedence, namespace: %s}\n", namespace),
+		FluxObject: mustObjectsYAML(t, future),
+		OwnerRef:   ownerRef,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("Diff for HelmRelease/" + namespace + "/future"))
+
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  generateName: generated-
+  namespace: %s
+`, namespace)})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("error: metadata.generateName is not supported without metadata.name"))
+
+	user, err := testEnv.AddUser(envtest.User{Name: "diff-no-rbac"}, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	restrictedConfig := user.Config()
+	httpClient, err := rest.HTTPClientFor(restrictedConfig)
+	g.Expect(err).NotTo(HaveOccurred())
+	mapper, err := apiutil.NewDynamicRESTMapper(restrictedConfig, httpClient)
+	g.Expect(err).NotTo(HaveOccurred())
+	restrictedClient, err := ctrlclient.New(restrictedConfig, ctrlclient.Options{Scheme: NewTestScheme(), Mapper: mapper})
+	g.Expect(err).NotTo(HaveOccurred())
+	output, err = NewClient(restrictedClient, restrictedConfig, mapper).Diff(ctx, DiffRequest{Manifest: fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: forbidden
+  namespace: %s
+`, namespace)})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("error: dry-run requires get and patch permission on ConfigMap/" + namespace + "/forbidden"))
+}
+
+func TestDiffEnvtestPruneFiltering(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	namespace := createDiffNamespace(t)
+	owner := createDiffOwner(t, "Kustomization", namespace, "pruner", map[string]any{"prune": true})
+	ownerLabels := map[string]string{
+		"kustomize.toolkit.fluxcd.io/name":      owner.GetName(),
+		"kustomize.toolkit.fluxcd.io/namespace": namespace,
+	}
+
+	deleteObject := configMapUnstructured(namespace, "delete-me", ownerLabels, map[string]any{"value": "old"})
+	mismatch := configMapUnstructured(namespace, "mismatch", map[string]string{
+		"kustomize.toolkit.fluxcd.io/name": "other", "kustomize.toolkit.fluxcd.io/namespace": namespace,
+	}, map[string]any{"value": "old"})
+	disabled := configMapUnstructured(namespace, "disabled", ownerLabels, map[string]any{"value": "old"})
+	disabled.SetAnnotations(map[string]string{"kustomize.toolkit.fluxcd.io/prune": "disabled"})
+	for _, item := range []*unstructured.Unstructured{deleteObject, mismatch, disabled} {
+		g.Expect(testClient.Client.Create(ctx, item)).To(Succeed())
+	}
+	missing := configMapUnstructured(namespace, "missing", ownerLabels, nil)
+	setOwnerInventory(t, owner, deleteObject, mismatch, disabled, missing)
+
+	missingPruneNamespace := fmt.Sprintf("diff-prune-missing-%d", time.Now().UnixNano())
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: current
+  namespace: %s
+data: {value: current}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unvalidated
+  namespace: %s
+`, namespace, missingPruneNamespace)
+	output, err := testClient.Diff(ctx, DiffRequest{
+		Manifest: manifest,
+		OwnerRef: &DiffOwnerRef{Kind: "Kustomization", Namespace: namespace, Name: owner.GetName()},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("ConfigMap/" + missingPruneNamespace + "/unvalidated create (not validated: namespace " + missingPruneNamespace + " does not exist yet)"))
+	g.Expect(output).To(ContainSubstring("ConfigMap/" + namespace + "/delete-me delete"))
+	g.Expect(output).NotTo(ContainSubstring("mismatch delete"))
+	g.Expect(output).NotTo(ContainSubstring("disabled delete"))
+	g.Expect(output).NotTo(ContainSubstring("missing delete"))
+
+	helmOwner := createDiffOwner(t, "HelmRelease", namespace, "helm-pruner", map[string]any{})
+	helmLabels := map[string]string{
+		"helm.toolkit.fluxcd.io/name":      helmOwner.GetName(),
+		"helm.toolkit.fluxcd.io/namespace": namespace,
+	}
+	helmKeep := configMapUnstructured(namespace, "helm-keep", helmLabels, map[string]any{"value": "old"})
+	helmKeep.SetAnnotations(map[string]string{"helm.sh/resource-policy": "keep"})
+	g.Expect(testClient.Client.Create(ctx, helmKeep)).To(Succeed())
+	crdGroup := fmt.Sprintf("prune%d.example.com", time.Now().UnixNano())
+	crdObjects, err := readTestObjects(fmt.Sprintf(`apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kepts.%s
+  labels:
+    helm.toolkit.fluxcd.io/name: helm-pruner
+    helm.toolkit.fluxcd.io/namespace: %s
+spec:
+  group: %s
+  names:
+    kind: Kept
+    plural: kepts
+    singular: kept
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+`, crdGroup, namespace, crdGroup))
+	g.Expect(err).NotTo(HaveOccurred())
+	helmCRD := crdObjects[0]
+	g.Expect(testClient.Client.Create(ctx, helmCRD)).To(Succeed())
+	setOwnerInventory(t, helmOwner, helmKeep, helmCRD)
+
+	manifest = fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: helm-current
+  namespace: %s
+data: {value: current}
+`, namespace)
+	output, err = testClient.Diff(ctx, DiffRequest{
+		Manifest: manifest,
+		OwnerRef: &DiffOwnerRef{Kind: "HelmRelease", Namespace: namespace, Name: helmOwner.GetName()},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).NotTo(ContainSubstring("helm-keep delete"))
+	g.Expect(output).NotTo(ContainSubstring("CustomResourceDefinition/" + helmCRD.GetName() + " delete"))
+}
+
+func createDiffNamespace(t *testing.T) string {
+	t.Helper()
+	g := NewWithT(t)
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "diff-"}}
+	g.Expect(testClient.Client.Create(context.Background(), namespace)).To(Succeed())
+	return namespace.Name
+}
+
+func createDiffOwner(t *testing.T, kind, namespace, name string, spec map[string]any) *unstructured.Unstructured {
+	t.Helper()
+	g := NewWithT(t)
+	owner := ownerObject(kind, name, namespace, false)
+	for key, value := range spec {
+		owner.Object["spec"].(map[string]any)[key] = value
+	}
+	g.Expect(testClient.Client.Create(context.Background(), owner)).To(Succeed())
+	return owner
+}
+
+func configMapUnstructured(namespace, name string, labels map[string]string, data map[string]any) *unstructured.Unstructured {
+	resource := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+	}}
+	resource.SetLabels(labels)
+	if data != nil {
+		resource.Object["data"] = data
+	}
+	return resource
+}
+
+func applyDiffObject(ctx context.Context, resource *unstructured.Unstructured, manager string) error {
+	return testClient.Client.Patch(ctx, resource, ctrlclient.Apply, ctrlclient.FieldOwner(manager), ctrlclient.ForceOwnership)
+}
+
+func mustObjectsYAML(t *testing.T, objects ...*unstructured.Unstructured) string {
+	t.Helper()
+	result, err := ssautil.ObjectsToYAML(objects)
+	NewWithT(t).Expect(err).NotTo(HaveOccurred())
+	return result
+}
+
+func readTestObjects(manifest string) ([]*unstructured.Unstructured, error) {
+	return ssautil.ReadObjects(strings.NewReader(manifest))
+}
+
+func setOwnerInventory(t *testing.T, owner *unstructured.Unstructured, objects ...*unstructured.Unstructured) {
+	t.Helper()
+	g := NewWithT(t)
+	current := &unstructured.Unstructured{}
+	current.SetGroupVersionKind(owner.GroupVersionKind())
+	g.Expect(testClient.Client.Get(context.Background(), ctrlclient.ObjectKeyFromObject(owner), current)).To(Succeed())
+	entries := make([]any, 0, len(objects))
+	for _, item := range objects {
+		entries = append(entries, map[string]any{
+			"id": object.UnstructuredToObjMetadata(item).String(), "v": item.GroupVersionKind().Version,
+		})
+	}
+	g.Expect(unstructured.SetNestedSlice(current.Object, entries, "status", "inventory", "entries")).To(Succeed())
+	g.Expect(testClient.Client.Status().Update(context.Background(), current)).To(Succeed())
+}
+
+func TestDiffEnvtestMonorepoConformance(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "apps-staging"}}
+	g.Expect(testClient.Client.Create(ctx, namespace)).To(Succeed())
+	vars := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "flux-vars", Namespace: namespace.Name},
+		Data: map[string]string{
+			"env": "dev", "cluster_registry": "flux-registry:5000", "app_registry": "flux-registry:5000",
+			"app_registry_insecure": "true", "cluster_name": "kind-flux",
+		},
+	}
+	g.Expect(testClient.Client.Create(ctx, vars)).To(Succeed())
+
+	fluxBuild := readFixture(t, "testdata/monorepo/backend-staging-fluxbuild.yaml")
+	liveObjects, err := readTestObjects(fluxBuild)
+	g.Expect(err).NotTo(HaveOccurred())
+	for _, resource := range liveObjects {
+		g.Expect(applyDiffObject(ctx, resource, "kustomize-controller")).To(Succeed())
+	}
+
+	ownerObjects, err := readTestObjects(readFixture(t, "testdata/monorepo/ks-backend-staging-live.yaml"))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ownerObjects).To(HaveLen(1))
+	owner := ownerObjects[0]
+	owner.SetCreationTimestamp(metav1.Time{})
+	owner.SetFinalizers(nil)
+	owner.SetGeneration(0)
+	owner.SetResourceVersion("")
+	owner.SetUID("")
+	g.Expect(testClient.Client.Create(ctx, owner)).To(Succeed())
+	setOwnerInventory(t, owner, liveObjects...)
+
+	request := DiffRequest{
+		Manifest: readFixture(t, "testdata/monorepo/backend-staging-build.yaml"),
+		OwnerRef: &DiffOwnerRef{Kind: "Kustomization", Namespace: namespace.Name, Name: "backend"},
+	}
+	output, err := testClient.Diff(ctx, request)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(Equal("Diff for Kustomization/apps-staging/backend (field manager: kustomize-controller, prune: enabled)\n\nNo changes detected\n"))
+
+	// This represents the raw output after rebuilding the overlay with one
+	// ConfigMap value changed; Kustomize updates both the hash and its reference.
+	request.Manifest = strings.Replace(request.Manifest, "PODINFO_LEVEL: info", "PODINFO_LEVEL: debug", 1)
+	request.Manifest = strings.ReplaceAll(request.Manifest, "backend-m759gh88kd", "backend-6d225hh94m")
+	output, err = testClient.Diff(ctx, request)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("ConfigMap/apps-staging/backend-6d225hh94m create"))
+	g.Expect(output).To(ContainSubstring("Deployment/apps-staging/backend update"))
+	g.Expect(output).To(ContainSubstring("path: /spec/template/spec/containers/0/envFrom/0/configMapRef/name"))
+	g.Expect(output).To(ContainSubstring("value: backend-6d225hh94m"))
+	g.Expect(strings.Count(output, "- op:")).To(Equal(1))
+	g.Expect(output).To(ContainSubstring("ConfigMap/apps-staging/backend-m759gh88kd delete"))
+	g.Expect(output).To(ContainSubstring("Summary: 1 create, 1 update, 2 unchanged, 1 delete"))
+}
+
+func TestDiffEnvtestSOPSKeyComparison(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	namespace := createDiffNamespace(t)
+	live := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "encrypted", Namespace: namespace},
+		Data:       map[string][]byte{"token": []byte("cleartext")},
+	}
+	g.Expect(testClient.Client.Create(ctx, live)).To(Succeed())
+
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: encrypted
+  namespace: %s
+stringData:
+  token: ENC[AES256_GCM,data:ciphertext]
+sops:
+  mac: ENC[AES256_GCM,data:secret-ciphertext]
+`, namespace)
+	output, err := testClient.Diff(ctx, DiffRequest{Manifest: manifest})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("No changes detected"))
+	g.Expect(output).NotTo(ContainSubstring("ciphertext"))
+
+	manifest = strings.Replace(manifest, "  token: ENC", "  added: ENC[AES256_GCM,data:other]\n  token: ENC", 1)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("Secret/" + namespace + "/encrypted update (sops encrypted: keys compared only)"))
+	g.Expect(output).NotTo(ContainSubstring("ciphertext"))
+
+	manifest = strings.Replace(manifest, "name: encrypted", "name: encrypted-new", 1)
+	output, err = testClient.Diff(ctx, DiffRequest{Manifest: manifest})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("Secret/" + namespace + "/encrypted-new create"))
+	g.Expect(output).NotTo(ContainSubstring("ciphertext"))
+}
+
+func readFixture(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	NewWithT(t).Expect(err).NotTo(HaveOccurred())
+	return string(data)
+}

--- a/cmd/mcp/k8s/diff_owner.go
+++ b/cmd/mcp/k8s/diff_owner.go
@@ -1,0 +1,772 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	apikustomize "github.com/fluxcd/pkg/apis/kustomize"
+	"github.com/fluxcd/pkg/kustomize"
+	"github.com/fluxcd/pkg/ssa"
+	ssadiff "github.com/fluxcd/pkg/ssa/jsondiff"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/kustomize/api/provider"
+	"sigs.k8s.io/kustomize/api/resmap"
+	kustypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/copier"
+)
+
+// DiffOwnerRef identifies a live Flux object which applies a manifest.
+type DiffOwnerRef struct {
+	Kind      string
+	Name      string
+	Namespace string
+}
+
+// DiffRequest contains a manifest and optional Flux ownership information.
+type DiffRequest struct {
+	Manifest   string
+	FluxObject string
+	OwnerRef   *DiffOwnerRef
+}
+
+// diffOwner contains the resolved future and live state of a manifest owner.
+type diffOwner struct {
+	ref           *DiffOwnerRef
+	object        *unstructured.Unstructured
+	live          *unstructured.Unstructured
+	ssaOwner      ssa.Owner
+	diffOptions   ssa.DiffOptions
+	prune         bool
+	futureSuspend bool
+	liveSuspend   bool
+	warnings      []string
+}
+
+// resolveDiffOwner applies flux_object precedence and resolves the live owner used for inventory.
+func (k *Client) resolveDiffOwner(ctx context.Context, req DiffRequest) (*diffOwner, error) {
+	if strings.TrimSpace(req.FluxObject) != "" {
+		objects, err := ssautil.ReadObjects(strings.NewReader(req.FluxObject))
+		if err != nil {
+			return nil, fmt.Errorf("invalid flux_object: %w", err)
+		}
+		if len(objects) != 1 {
+			return nil, fmt.Errorf("invalid flux_object: expected exactly one document")
+		}
+
+		object := objects[0]
+		if object.GetNamespace() == "" {
+			return nil, fmt.Errorf("invalid flux_object: metadata.namespace is required; pass the definition as it exists after the parent build")
+		}
+		if object.GetName() == "" {
+			return nil, fmt.Errorf("invalid flux_object: metadata.name is required")
+		}
+		if err := validateDiffOwner(object); err != nil {
+			return nil, err
+		}
+
+		owner, err := newDiffOwner(object)
+		if err != nil {
+			return nil, err
+		}
+		live := &unstructured.Unstructured{}
+		live.SetGroupVersionKind(object.GroupVersionKind())
+		err = k.Client.Get(ctx, ctrlclient.ObjectKeyFromObject(object), live)
+		switch {
+		case err == nil:
+			owner.live = live
+			owner.liveSuspend, _, _ = unstructured.NestedBool(live.Object, "spec", "suspend")
+		case apierrors.IsNotFound(err):
+			// A future owner may not exist until the parent Flux object applies it.
+		default:
+			return nil, fmt.Errorf("unable to read live owner: %w", err)
+		}
+		return owner, nil
+	}
+
+	if req.OwnerRef == nil {
+		return nil, nil
+	}
+	if req.OwnerRef.Name == "" || req.OwnerRef.Namespace == "" {
+		return nil, fmt.Errorf("invalid owner reference: kind, name and namespace are required")
+	}
+	gvk, err := ownerGVK(req.OwnerRef.Kind)
+	if err != nil {
+		return nil, err
+	}
+	live := &unstructured.Unstructured{}
+	live.SetGroupVersionKind(gvk)
+	if err := k.Client.Get(ctx, ctrlclient.ObjectKey{Name: req.OwnerRef.Name, Namespace: req.OwnerRef.Namespace}, live); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("owner not found in the cluster: %s/%s/%s; if it is new, pass its definition in flux_object",
+				req.OwnerRef.Kind, req.OwnerRef.Namespace, req.OwnerRef.Name)
+		}
+		return nil, fmt.Errorf("unable to read owner reference: %w", err)
+	}
+	if err := validateDiffOwner(live); err != nil {
+		return nil, err
+	}
+	owner, err := newDiffOwner(live)
+	if err != nil {
+		return nil, err
+	}
+	owner.live = live.DeepCopy()
+	owner.liveSuspend = owner.futureSuspend
+	return owner, nil
+}
+
+// ownerGVK returns the canonical v1 GroupVersionKind for a supported owner.
+func ownerGVK(kind string) (schema.GroupVersionKind, error) {
+	switch kind {
+	case fluxcdv1.FluxKustomizationKind:
+		return schema.GroupVersionKind{Group: fluxcdv1.FluxKustomizeGroup, Version: "v1", Kind: kind}, nil
+	case fluxcdv1.ResourceSetKind:
+		return fluxcdv1.GroupVersion.WithKind(kind), nil
+	case fluxcdv1.FluxHelmReleaseKind:
+		return schema.GroupVersionKind{Group: fluxcdv1.FluxHelmGroup, Version: "v2", Kind: kind}, nil
+	default:
+		return schema.GroupVersionKind{}, fmt.Errorf("unsupported diff owner kind %q", kind)
+	}
+}
+
+// validateDiffOwner enforces supported owner kinds and the remote-cluster guard.
+func validateDiffOwner(object *unstructured.Unstructured) error {
+	expected, err := ownerGVK(object.GetKind())
+	if err != nil || object.GroupVersionKind() != expected {
+		return fmt.Errorf("invalid flux_object: supported kinds are Kustomization, ResourceSet and HelmRelease")
+	}
+	if value, found, _ := unstructured.NestedFieldNoCopy(object.Object, "spec", "kubeConfig"); found && value != nil {
+		return fmt.Errorf("diff not supported for owners targeting remote clusters")
+	}
+	return nil
+}
+
+// isEmptyNestedValue reports whether an optional unstructured field has no effective value.
+func isEmptyNestedValue(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case string:
+		return typed == ""
+	case []any:
+		return len(typed) == 0
+	case map[string]any:
+		return len(typed) == 0
+	default:
+		return false
+	}
+}
+
+// newDiffOwner derives the SSA owner, selectors, force setting and prune policy.
+func newDiffOwner(object *unstructured.Unstructured) (*diffOwner, error) {
+	owner := &diffOwner{
+		ref: &DiffOwnerRef{
+			Kind:      object.GetKind(),
+			Name:      object.GetName(),
+			Namespace: object.GetNamespace(),
+		},
+		object:      object.DeepCopy(),
+		diffOptions: ssa.DefaultDiffOptions(),
+	}
+	owner.futureSuspend, _, _ = unstructured.NestedBool(object.Object, "spec", "suspend")
+
+	switch object.GetKind() {
+	case fluxcdv1.FluxKustomizationKind:
+		owner.ssaOwner = ssa.Owner{Field: "kustomize-controller", Group: fluxcdv1.FluxKustomizeGroup}
+		owner.diffOptions.Exclusions = map[string]string{
+			fluxcdv1.FluxKustomizeGroup + "/reconcile": "disabled",
+			fluxcdv1.FluxKustomizeGroup + "/ssa":       "ignore",
+		}
+		owner.diffOptions.IfNotPresentSelector = map[string]string{
+			fluxcdv1.FluxKustomizeGroup + "/ssa": "IfNotPresent",
+		}
+		owner.diffOptions.Force, _, _ = unstructured.NestedBool(object.Object, "spec", "force")
+		owner.diffOptions.ForceSelector = map[string]string{
+			fluxcdv1.FluxKustomizeGroup + "/force": "enabled",
+		}
+		owner.prune, _, _ = unstructured.NestedBool(object.Object, "spec", "prune")
+		rules, err := kustomizationIgnoreRules(object)
+		if err != nil {
+			return nil, err
+		}
+		owner.diffOptions.DriftIgnoreRules = append(rules, buildMetadataIgnoreRules(object)...)
+	case fluxcdv1.ResourceSetKind:
+		owner.ssaOwner = ssa.Owner{Field: "flux-operator", Group: fluxcdv1.GroupOwnerLabelResourceSet}
+		owner.diffOptions.Force = strings.EqualFold(object.GetAnnotations()[fluxcdv1.ForceAnnotation], fluxcdv1.EnabledValue)
+		owner.diffOptions.ForceSelector = map[string]string{fluxcdv1.ForceAnnotation: fluxcdv1.EnabledValue}
+		owner.prune = true
+	case fluxcdv1.FluxHelmReleaseKind:
+		owner.ssaOwner = ssa.Owner{Field: "helm-controller", Group: fluxcdv1.FluxHelmGroup}
+		owner.diffOptions.DriftIgnoreRules = []ssadiff.IgnoreRule{{
+			Paths: []string{
+				"/metadata/labels/helm.sh~1chart",
+				"/spec/template/metadata/labels/helm.sh~1chart",
+				"/spec/jobTemplate/spec/template/metadata/labels/helm.sh~1chart",
+			},
+		}}
+		owner.prune = true
+	default:
+		return nil, fmt.Errorf("unsupported diff owner kind %q", object.GetKind())
+	}
+	return owner, nil
+}
+
+// buildMetadataIgnoreRules returns ignore rules for the labels and annotations
+// that spec.buildMetadata adds at build time. These are not reproduced by the
+// diff and are excluded from the comparison instead.
+func buildMetadataIgnoreRules(object *unstructured.Unstructured) []ssadiff.IgnoreRule {
+	options, _, _ := unstructured.NestedStringSlice(object.Object, "spec", "buildMetadata")
+	var paths []string
+	for _, option := range options {
+		switch option {
+		case "originAnnotations":
+			paths = append(paths, "/metadata/annotations/config.kubernetes.io~1origin")
+		case "transformerAnnotations":
+			paths = append(paths, "/metadata/annotations/config.kubernetes.io~1transformations")
+		case "managedByLabel":
+			paths = append(paths, "/metadata/labels/app.kubernetes.io~1managed-by")
+		}
+	}
+	if len(paths) == 0 {
+		return nil
+	}
+	return []ssadiff.IgnoreRule{{Paths: paths}}
+}
+
+// kustomizationIgnoreRules converts spec.ignore to the pkg/ssa selector model.
+func kustomizationIgnoreRules(object *unstructured.Unstructured) ([]ssadiff.IgnoreRule, error) {
+	rawRules, found, err := unstructured.NestedSlice(object.Object, "spec", "ignore")
+	if err != nil || !found {
+		return nil, err
+	}
+	rules := make([]ssadiff.IgnoreRule, 0, len(rawRules))
+	for _, raw := range rawRules {
+		ruleMap, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("invalid Kustomization spec.ignore rule")
+		}
+		paths, _, err := unstructured.NestedStringSlice(ruleMap, "paths")
+		if err != nil {
+			return nil, fmt.Errorf("invalid Kustomization spec.ignore paths: %w", err)
+		}
+		rule := ssadiff.IgnoreRule{Paths: paths}
+		if target, found, err := unstructured.NestedMap(ruleMap, "target"); err != nil {
+			return nil, fmt.Errorf("invalid Kustomization spec.ignore target: %w", err)
+		} else if found {
+			rule.Selector = &ssadiff.Selector{
+				Group:              nestedString(target, "group"),
+				Version:            nestedString(target, "version"),
+				Kind:               nestedString(target, "kind"),
+				Name:               nestedString(target, "name"),
+				Namespace:          nestedString(target, "namespace"),
+				AnnotationSelector: nestedString(target, "annotationSelector"),
+				LabelSelector:      nestedString(target, "labelSelector"),
+			}
+		}
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+// nestedString returns a string field from an unstructured map.
+func nestedString(object map[string]any, field string) string {
+	value, _, _ := unstructured.NestedString(object, field)
+	return value
+}
+
+// prepareDiffObjects applies build-time transforms and metadata injected by the selected owner.
+func prepareDiffObjects(ctx context.Context, kubeClient ctrlclient.Client, objects *[]*unstructured.Unstructured,
+	owner *diffOwner, rm *ssa.ResourceManager) error {
+	if owner == nil {
+		return nil
+	}
+
+	if err := applyDeferredOwnerTransforms(ctx, kubeClient, objects, owner); err != nil {
+		return err
+	}
+
+	labels, annotations, err := commonMetadata(owner.object)
+	if err != nil {
+		return err
+	}
+	if len(labels) > 0 || len(annotations) > 0 {
+		ssautil.SetCommonMetadata(*objects, labels, annotations)
+	}
+
+	switch owner.ref.Kind {
+	case fluxcdv1.FluxKustomizationKind, fluxcdv1.ResourceSetKind:
+		rm.SetOwnerLabels(*objects, owner.ref.Name, owner.ref.Namespace)
+	case fluxcdv1.FluxHelmReleaseKind:
+		for _, object := range *objects {
+			objectLabels := object.GetLabels()
+			if objectLabels == nil {
+				objectLabels = make(map[string]string)
+			}
+			objectLabels[fluxcdv1.FluxHelmGroup+"/name"] = owner.ref.Name
+			objectLabels[fluxcdv1.FluxHelmGroup+"/namespace"] = owner.ref.Namespace
+			object.SetLabels(objectLabels)
+		}
+		if err := applyHelmReleaseMetadata(kubeClient, *objects, owner.object); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyDeferredOwnerTransforms applies transforms that require the owner spec or cluster reads.
+// ResourceSet checksumFrom and convertKubeConfigFrom remain intentionally unsupported.
+func applyDeferredOwnerTransforms(ctx context.Context, kubeClient ctrlclient.Client,
+	objects *[]*unstructured.Unstructured, owner *diffOwner) error {
+	switch owner.ref.Kind {
+	case fluxcdv1.FluxKustomizationKind:
+		if value, found, _ := unstructured.NestedFieldNoCopy(owner.object.Object, "spec", "components"); found && !isEmptyNestedValue(value) {
+			owner.warnings = append(owner.warnings, "spec.components not applied, diff may be incomplete")
+		}
+
+		resources, rebuilt, err := buildKustomizationResources(*objects, owner.object)
+		if err != nil {
+			return err
+		}
+		postBuild := hasPostBuild(owner.object)
+		if !rebuilt && !postBuild {
+			return nil
+		}
+		if !rebuilt {
+			resources, err = objectsResMap(*objects)
+			if err != nil {
+				return err
+			}
+		}
+		if postBuild {
+			skip, err := warnForMissingSubstituteFrom(ctx, kubeClient, owner)
+			if err != nil {
+				return err
+			}
+			if !skip {
+				strategy, _, _ := unstructured.NestedString(owner.object.Object, "spec", "postBuild", "substituteStrategy")
+				for _, res := range resources.Resources() {
+					outRes, err := kustomize.SubstituteVariables(ctx, kubeClient, *owner.object, res,
+						kustomize.SubstituteWithStrict(true),
+						kustomize.SubstituteWithAlways(strategy == "Always"))
+					if err != nil {
+						return fmt.Errorf("post build failed for '%s/%s': %w", res.GetGvk(), res.GetName(), err)
+					}
+					if outRes != nil {
+						if _, err := resources.Replace(outRes); err != nil {
+							return fmt.Errorf("replacing substituted resource %s: %w", res.GetName(), err)
+						}
+					}
+				}
+			}
+		}
+		builtObjects, err := resMapObjects(resources)
+		if err != nil {
+			return err
+		}
+		*objects = builtObjects
+	case fluxcdv1.ResourceSetKind:
+		if err := copyResourceSetData(ctx, kubeClient, *objects, owner); err != nil {
+			return err
+		}
+	case fluxcdv1.FluxHelmReleaseKind:
+		if err := applyHelmPostRenderers(objects, owner.object); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// kustomizeBuildSpec holds the Kustomize transforms shared by the Kustomization
+// spec and the HelmRelease post-renderers.
+type kustomizeBuildSpec struct {
+	TargetNamespace string               `json:"targetNamespace,omitempty"`
+	NamePrefix      string               `json:"namePrefix,omitempty"`
+	NameSuffix      string               `json:"nameSuffix,omitempty"`
+	Patches         []apikustomize.Patch `json:"patches,omitempty"`
+	Images          []apikustomize.Image `json:"images,omitempty"`
+}
+
+// isEmpty reports whether no transform is configured.
+func (s kustomizeBuildSpec) isEmpty() bool {
+	return s.TargetNamespace == "" && s.NamePrefix == "" && s.NameSuffix == "" &&
+		len(s.Patches) == 0 && len(s.Images) == 0
+}
+
+// helmPostRenderer mirrors a HelmRelease spec.postRenderers entry.
+type helmPostRenderer struct {
+	Kustomize *kustomizeBuildSpec `json:"kustomize,omitempty"`
+}
+
+// applyHelmPostRenderers runs the HelmRelease Kustomize post-renderers over
+// the objects in order, the same way helm-controller post-renders the chart
+// output before Helm adds its release metadata.
+func applyHelmPostRenderers(objects *[]*unstructured.Unstructured, helmRelease *unstructured.Unstructured) error {
+	raw, found, err := unstructured.NestedFieldNoCopy(helmRelease.Object, "spec", "postRenderers")
+	if err != nil || !found {
+		return err
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("encoding postRenderers: %w", err)
+	}
+	var renderers []helmPostRenderer
+	if err := json.Unmarshal(data, &renderers); err != nil {
+		return fmt.Errorf("decoding postRenderers: %w", err)
+	}
+
+	current := *objects
+	for i, renderer := range renderers {
+		if renderer.Kustomize == nil || renderer.Kustomize.isEmpty() {
+			continue
+		}
+		resources, err := kustomizeBuild(current, *renderer.Kustomize)
+		if err != nil {
+			return fmt.Errorf("postRenderers[%d] failed: %w", i, err)
+		}
+		if current, err = resMapObjects(resources); err != nil {
+			return fmt.Errorf("postRenderers[%d] failed: %w", i, err)
+		}
+	}
+	*objects = current
+	return nil
+}
+
+// kustomizeBuild applies the transforms to the objects with a Kustomize build
+// over an in-memory filesystem, like the helm-controller post-renderer.
+func kustomizeBuild(objects []*unstructured.Unstructured, spec kustomizeBuildSpec) (resmap.ResMap, error) {
+	const input = "all.yaml"
+	fs := filesys.MakeFsInMemory()
+	manifest, err := ssautil.ObjectsToYAML(objects)
+	if err != nil {
+		return nil, fmt.Errorf("encoding build input: %w", err)
+	}
+	if err := fs.WriteFile(input, []byte(manifest)); err != nil {
+		return nil, fmt.Errorf("writing build input: %w", err)
+	}
+
+	cfg := kustypes.Kustomization{
+		TypeMeta: kustypes.TypeMeta{
+			APIVersion: kustypes.KustomizationVersion,
+			Kind:       kustypes.KustomizationKind,
+		},
+		Resources:  []string{input},
+		Namespace:  spec.TargetNamespace,
+		NamePrefix: spec.NamePrefix,
+		NameSuffix: spec.NameSuffix,
+	}
+	for _, patch := range spec.Patches {
+		cfg.Patches = append(cfg.Patches, kustypes.Patch{
+			Patch:  patch.Patch,
+			Target: adaptKustomizeSelector(patch.Target),
+		})
+	}
+	for _, image := range spec.Images {
+		cfg.Images = append(cfg.Images, kustypes.Image{
+			Name:    image.Name,
+			NewName: image.NewName,
+			NewTag:  image.NewTag,
+			Digest:  image.Digest,
+		})
+	}
+	kustomization, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("encoding build definition: %w", err)
+	}
+	if err := fs.WriteFile("kustomization.yaml", kustomization); err != nil {
+		return nil, fmt.Errorf("writing build definition: %w", err)
+	}
+	return kustomize.Build(fs, ".")
+}
+
+// adaptKustomizeSelector converts a Flux patch target to a Kustomize selector.
+func adaptKustomizeSelector(selector *apikustomize.Selector) *kustypes.Selector {
+	if selector == nil {
+		return nil
+	}
+	output := &kustypes.Selector{}
+	output.Gvk.Group = selector.Group
+	output.Gvk.Kind = selector.Kind
+	output.Gvk.Version = selector.Version
+	output.Name = selector.Name
+	output.Namespace = selector.Namespace
+	output.LabelSelector = selector.LabelSelector
+	output.AnnotationSelector = selector.AnnotationSelector
+	return output
+}
+
+// warnForMissingSubstituteFrom reports non-optional missing references and
+// skips all substitution so unresolved variables remain visible to dry-run.
+func warnForMissingSubstituteFrom(ctx context.Context, kubeClient ctrlclient.Client, owner *diffOwner) (bool, error) {
+	references, found, err := unstructured.NestedSlice(owner.object.Object, "spec", "postBuild", "substituteFrom")
+	if err != nil || !found {
+		return false, err
+	}
+
+	missing := false
+	for _, reference := range references {
+		ref, ok := reference.(map[string]any)
+		if !ok {
+			continue
+		}
+		optional, _, err := unstructured.NestedBool(ref, "optional")
+		if err != nil {
+			return false, fmt.Errorf("invalid postBuild substituteFrom optional field: %w", err)
+		}
+		if optional {
+			continue
+		}
+		kind := nestedString(ref, "kind")
+		name := nestedString(ref, "name")
+		if name == "" || (kind != "ConfigMap" && kind != "Secret") {
+			continue
+		}
+		source := &unstructured.Unstructured{}
+		source.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: kind})
+		err = kubeClient.Get(ctx, ctrlclient.ObjectKey{Name: name, Namespace: owner.ref.Namespace}, source)
+		switch {
+		case err == nil:
+		case apierrors.IsNotFound(err):
+			missing = true
+			appendDiffWarning(&owner.warnings, fmt.Sprintf("substituteFrom %s %s/%s not found in the cluster, variables left unresolved",
+				kind, owner.ref.Namespace, name))
+		default:
+			return false, fmt.Errorf("failed to read substituteFrom %s %s/%s: %w", kind, owner.ref.Namespace, name, err)
+		}
+	}
+	return missing, nil
+}
+
+// copyResourceSetData resolves copyFrom references while leaving missing
+// sources empty for the dry-run and reporting them in the diff header.
+func copyResourceSetData(ctx context.Context, kubeClient ctrlclient.Client, objects []*unstructured.Unstructured,
+	owner *diffOwner) error {
+	for _, object := range objects {
+		if err := copier.CopyResources(ctx, kubeClient, []*unstructured.Unstructured{object}); err != nil {
+			if apierrors.IsNotFound(err) {
+				source := object.GetAnnotations()[fluxcdv1.CopyFromAnnotation]
+				appendDiffWarning(&owner.warnings, fmt.Sprintf("copyFrom source %s %s not found in the cluster, data left empty",
+					object.GetKind(), source))
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// appendDiffWarning adds a warning once while preserving discovery order.
+func appendDiffWarning(warnings *[]string, warning string) {
+	for _, existing := range *warnings {
+		if existing == warning {
+			return
+		}
+	}
+	*warnings = append(*warnings, warning)
+}
+
+// buildKustomizationResources runs the Kustomization build transforms over the
+// manifest when the owner defines any, and reports whether a build happened.
+func buildKustomizationResources(objects []*unstructured.Unstructured,
+	owner *unstructured.Unstructured) (resmap.ResMap, bool, error) {
+	spec, err := decodeKustomizeBuildSpec(owner)
+	if err != nil {
+		return nil, false, err
+	}
+	if spec.isEmpty() {
+		return nil, false, nil
+	}
+	resources, err := kustomizeBuild(objects, spec)
+	if err != nil {
+		return nil, false, fmt.Errorf("kustomize build failed: %w", err)
+	}
+	return resources, true, nil
+}
+
+// requiresKustomizationBuild reports whether the owner has Kustomization build transforms.
+func requiresKustomizationBuild(owner *unstructured.Unstructured) bool {
+	spec, err := decodeKustomizeBuildSpec(owner)
+	return err == nil && !spec.isEmpty()
+}
+
+// decodeKustomizeBuildSpec extracts the build transforms from a Kustomization spec.
+func decodeKustomizeBuildSpec(owner *unstructured.Unstructured) (kustomizeBuildSpec, error) {
+	var spec kustomizeBuildSpec
+	raw, found, err := unstructured.NestedFieldNoCopy(owner.Object, "spec")
+	if err != nil || !found {
+		return spec, err
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return spec, fmt.Errorf("encoding Kustomization spec: %w", err)
+	}
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return spec, fmt.Errorf("decoding Kustomization spec: %w", err)
+	}
+	return spec, nil
+}
+
+// hasPostBuild reports whether postBuild is explicitly configured.
+func hasPostBuild(owner *unstructured.Unstructured) bool {
+	value, found, _ := unstructured.NestedFieldNoCopy(owner.Object, "spec", "postBuild")
+	return found && value != nil
+}
+
+// objectsResMap converts unstructured objects to a Kustomize resource map in manifest order.
+func objectsResMap(objects []*unstructured.Unstructured) (resmap.ResMap, error) {
+	manifest, err := ssautil.ObjectsToYAML(objects)
+	if err != nil {
+		return nil, fmt.Errorf("encoding objects for postBuild substitution: %w", err)
+	}
+	factory := provider.NewDefaultDepProvider().GetResourceFactory()
+	resources, err := resmap.NewFactory(factory).NewResMapFromBytes([]byte(manifest))
+	if err != nil {
+		return nil, fmt.Errorf("loading objects for postBuild substitution: %w", err)
+	}
+	return resources, nil
+}
+
+// resMapObjects converts a Kustomize resource map to unstructured objects in build order.
+func resMapObjects(resources resmap.ResMap) ([]*unstructured.Unstructured, error) {
+	manifest, err := resources.AsYaml()
+	if err != nil {
+		return nil, fmt.Errorf("encoding transformed objects: %w", err)
+	}
+	objects, err := ssautil.ReadObjects(strings.NewReader(string(manifest)))
+	if err != nil {
+		return nil, fmt.Errorf("decoding transformed objects: %w", err)
+	}
+	return objects, nil
+}
+
+// applyHelmReleaseMetadata sets Helm ownership metadata and default namespaces.
+func applyHelmReleaseMetadata(kubeClient ctrlclient.Client, objects []*unstructured.Unstructured,
+	helmRelease *unstructured.Unstructured) error {
+	releaseName, releaseNamespace := helmReleaseIdentity(helmRelease)
+	crdScopes := manifestCRDScopes(objects)
+	for _, object := range objects {
+		if object.GetKind() != "CustomResourceDefinition" {
+			setHelmStandardMetadata(object, releaseName, releaseNamespace)
+		}
+
+		if object.GetNamespace() != "" {
+			continue
+		}
+		namespaced, err := apiutil.IsObjectNamespaced(object, kubeClient.Scheme(), kubeClient.RESTMapper())
+		if err != nil {
+			if !meta.IsNoMatchError(err) {
+				return fmt.Errorf("failed to determine if %s is namespace scoped: %w", object.GetKind(), err)
+			}
+			var found bool
+			namespaced, found = crdScopes[object.GroupVersionKind().Group+"/"+object.GetKind()]
+			if !found {
+				continue
+			}
+		}
+		if namespaced {
+			object.SetNamespace(releaseNamespace)
+		}
+	}
+	return nil
+}
+
+// applyHelmMetadataForLiveCRD distinguishes CRDs rendered from templates from
+// CRDs shipped in crds/ by checking the Helm release annotation on the live CRD.
+func applyHelmMetadataForLiveCRD(desired, live *unstructured.Unstructured, owner *diffOwner) {
+	if owner == nil || owner.ref.Kind != fluxcdv1.FluxHelmReleaseKind || desired.GetKind() != "CustomResourceDefinition" {
+		return
+	}
+	if _, found := live.GetAnnotations()["meta.helm.sh/release-name"]; !found {
+		return
+	}
+	releaseName, releaseNamespace := helmReleaseIdentity(owner.object)
+	setHelmStandardMetadata(desired, releaseName, releaseNamespace)
+}
+
+// setHelmStandardMetadata sets the labels and annotations added by Helm to
+// release-managed resources.
+func setHelmStandardMetadata(object *unstructured.Unstructured, releaseName, releaseNamespace string) {
+	labels := object.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels["app.kubernetes.io/managed-by"] = "Helm"
+	object.SetLabels(labels)
+
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["meta.helm.sh/release-name"] = releaseName
+	annotations["meta.helm.sh/release-namespace"] = releaseNamespace
+	object.SetAnnotations(annotations)
+}
+
+// helmReleaseIdentity derives the effective Helm release name and namespace.
+func helmReleaseIdentity(helmRelease *unstructured.Unstructured) (string, string) {
+	targetNamespace, _, _ := unstructured.NestedString(helmRelease.Object, "spec", "targetNamespace")
+	releaseNamespace := targetNamespace
+	if releaseNamespace == "" {
+		releaseNamespace = helmRelease.GetNamespace()
+	}
+	releaseName, _, _ := unstructured.NestedString(helmRelease.Object, "spec", "releaseName")
+	if releaseName == "" {
+		releaseName = helmRelease.GetName()
+		if targetNamespace != "" {
+			releaseName = targetNamespace + "-" + releaseName
+		}
+	}
+	return shortenHelmReleaseName(releaseName), releaseNamespace
+}
+
+// shortenHelmReleaseName mirrors helm-controller's release.ShortenName.
+func shortenHelmReleaseName(name string) string {
+	if len(name) <= 53 {
+		return name
+	}
+	sum := fmt.Sprintf("%x", sha256.Sum256([]byte(name)))
+	return name[:40] + "-" + sum[:12]
+}
+
+// manifestCRDScopes indexes namespaced custom kinds declared by manifest CRDs.
+func manifestCRDScopes(objects []*unstructured.Unstructured) map[string]bool {
+	scopes := make(map[string]bool)
+	for _, object := range objects {
+		if object.GetAPIVersion() != "apiextensions.k8s.io/v1" || object.GetKind() != "CustomResourceDefinition" {
+			continue
+		}
+		group, _, _ := unstructured.NestedString(object.Object, "spec", "group")
+		kind, _, _ := unstructured.NestedString(object.Object, "spec", "names", "kind")
+		scope, _, _ := unstructured.NestedString(object.Object, "spec", "scope")
+		if group != "" && kind != "" {
+			scopes[group+"/"+kind] = scope == "Namespaced"
+		}
+	}
+	return scopes
+}
+
+// commonMetadata extracts spec.commonMetadata labels and annotations.
+func commonMetadata(object *unstructured.Unstructured) (map[string]string, map[string]string, error) {
+	labels, _, err := unstructured.NestedStringMap(object.Object, "spec", "commonMetadata", "labels")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid commonMetadata labels: %w", err)
+	}
+	annotations, _, err := unstructured.NestedStringMap(object.Object, "spec", "commonMetadata", "annotations")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid commonMetadata annotations: %w", err)
+	}
+	return labels, annotations, nil
+}

--- a/cmd/mcp/k8s/diff_owner_test.go
+++ b/cmd/mcp/k8s/diff_owner_test.go
@@ -1,0 +1,345 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/fluxcd/pkg/ssa"
+	ssaerrors "github.com/fluxcd/pkg/ssa/errors"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestIsMissingNamespaceError(t *testing.T) {
+	g := NewWithT(t)
+	object := &unstructured.Unstructured{}
+	object.SetAPIVersion("v1")
+	object.SetKind("ConfigMap")
+	object.SetName("backend")
+	object.SetNamespace("apps-qa")
+
+	missingNamespace := ssaerrors.NewDryRunErr(
+		apierrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, "apps-qa"), object)
+	g.Expect(isMissingNamespaceError(missingNamespace, "apps-qa")).To(BeTrue())
+
+	missingObject := ssaerrors.NewDryRunErr(
+		apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "backend"), object)
+	g.Expect(isMissingNamespaceError(missingObject, "apps-qa")).To(BeFalse())
+}
+
+func TestDiffRequestValidationAndGenerateNameDecoding(t *testing.T) {
+	g := NewWithT(t)
+	client := NewClient(fake.NewClientBuilder().WithScheme(NewTestScheme()).Build(), nil, meta.NewDefaultRESTMapper(nil))
+	_, err := client.Diff(context.Background(), DiffRequest{Manifest: "---\n"})
+	g.Expect(err).To(MatchError("no Kubernetes objects found in manifest"))
+
+	objects, err := readDiffObjects(strings.NewReader(`Pulled: registry.example.com/charts/app:1.0.0
+Digest: sha256:0123456789abcdef
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  generateName: generated-
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: named
+`))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(objects).To(HaveLen(2))
+	g.Expect(objects[0].GetGenerateName()).To(Equal("generated-"))
+	g.Expect(objects[1].GetName()).To(Equal("named"))
+}
+
+func TestResolveDiffOwnerAndOptions(t *testing.T) {
+	g := NewWithT(t)
+	live := ownerObject("Kustomization", "live", "flux-system", false)
+	live.Object["spec"].(map[string]any)["force"] = true
+	live.Object["spec"].(map[string]any)["prune"] = true
+	live.Object["spec"].(map[string]any)["ignore"] = []any{map[string]any{
+		"paths":  []any{"/spec/replicas"},
+		"target": map[string]any{"kind": "Deployment", "name": "app"},
+	}}
+	client := NewClient(fake.NewClientBuilder().WithScheme(NewTestScheme()).WithObjects(live).Build(), nil, meta.NewDefaultRESTMapper(nil))
+
+	owner, err := client.resolveDiffOwner(context.Background(), DiffRequest{
+		OwnerRef: &DiffOwnerRef{Kind: "Kustomization", Name: "live", Namespace: "flux-system"},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(owner.ssaOwner).To(Equal(ssa.Owner{Field: "kustomize-controller", Group: "kustomize.toolkit.fluxcd.io"}))
+	g.Expect(owner.diffOptions.Force).To(BeTrue())
+	g.Expect(owner.prune).To(BeTrue())
+	g.Expect(owner.diffOptions.DriftIgnoreRules).To(HaveLen(1))
+	g.Expect(owner.diffOptions.DriftIgnoreRules[0].Selector.Kind).To(Equal("Deployment"))
+
+	future := `apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: future
+  namespace: flux-system
+spec:
+  suspend: true
+`
+	owner, err = client.resolveDiffOwner(context.Background(), DiffRequest{
+		FluxObject: future,
+		OwnerRef:   &DiffOwnerRef{Kind: "Kustomization", Name: "missing", Namespace: "flux-system"},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(owner.ref.Kind).To(Equal("HelmRelease"))
+	g.Expect(owner.ref.Name).To(Equal("future"))
+	g.Expect(owner.futureSuspend).To(BeTrue())
+	g.Expect(owner.ssaOwner).To(Equal(ssa.Owner{Field: "helm-controller", Group: "helm.toolkit.fluxcd.io"}))
+	g.Expect(owner.diffOptions.Exclusions).To(BeNil())
+}
+
+func TestDiffOwnerOptionsByKind(t *testing.T) {
+	g := NewWithT(t)
+	resourceSet := ownerObject("ResourceSet", "apps", "flux-system", false)
+	resourceSet.SetAnnotations(map[string]string{"fluxcd.controlplane.io/force": "enabled"})
+	owner, err := newDiffOwner(resourceSet)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(owner.ssaOwner).To(Equal(ssa.Owner{Field: "flux-operator", Group: "resourceset.fluxcd.controlplane.io"}))
+	g.Expect(owner.diffOptions.Force).To(BeTrue())
+	g.Expect(owner.diffOptions.ForceSelector).To(Equal(map[string]string{"fluxcd.controlplane.io/force": "enabled"}))
+	g.Expect(owner.diffOptions.Exclusions).To(BeNil())
+	g.Expect(owner.prune).To(BeTrue())
+
+	helmRelease := ownerObject("HelmRelease", "app", "flux-system", true)
+	owner, err = newDiffOwner(helmRelease)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(owner.ssaOwner).To(Equal(ssa.Owner{Field: "helm-controller", Group: "helm.toolkit.fluxcd.io"}))
+	g.Expect(owner.diffOptions.DriftIgnoreRules).To(HaveLen(1))
+	g.Expect(owner.diffOptions.DriftIgnoreRules[0].Selector).To(BeNil())
+	g.Expect(owner.diffOptions.DriftIgnoreRules[0].Paths).To(Equal([]string{
+		"/metadata/labels/helm.sh~1chart",
+		"/spec/template/metadata/labels/helm.sh~1chart",
+		"/spec/jobTemplate/spec/template/metadata/labels/helm.sh~1chart",
+	}))
+	g.Expect(owner.prune).To(BeTrue())
+	g.Expect(owner.futureSuspend).To(BeTrue())
+}
+
+func TestHelmReleaseMetadataIgnoreAndHooks(t *testing.T) {
+	g := NewWithT(t)
+	helmOwner, err := newDiffOwner(ownerObject("HelmRelease", "app", "flux-system", false))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	live := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name": "app",
+			"labels": map[string]any{
+				"stable":        "value",
+				"helm.sh/chart": "app-1.0.0_deadbeef",
+			},
+		},
+	}}
+	merged := live.DeepCopy()
+	merged.SetLabels(map[string]string{
+		"stable":                       "value",
+		"helm.sh/chart":                "app-v1.0.0",
+		"app.kubernetes.io/managed-by": "Helm",
+	})
+	patch, err := diffPatch(live, merged, helmOwner.diffOptions.DriftIgnoreRules)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(patch).To(HaveLen(1))
+	g.Expect(patch[0].Path).To(Equal("/metadata/labels/app.kubernetes.io~1managed-by"))
+	g.Expect(patch[0].Value).To(Equal("Helm"))
+
+	for _, path := range [][]string{
+		{"spec", "template", "metadata", "labels", "helm.sh/chart"},
+		{"spec", "jobTemplate", "spec", "template", "metadata", "labels", "helm.sh/chart"},
+	} {
+		liveWorkload := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1", "kind": "Deployment", "metadata": map[string]any{"name": "app"},
+		}}
+		mergedWorkload := liveWorkload.DeepCopy()
+		g.Expect(unstructured.SetNestedField(liveWorkload.Object, "app-1.0.0_deadbeef", path...)).To(Succeed())
+		g.Expect(unstructured.SetNestedField(mergedWorkload.Object, "app-v1.0.0", path...)).To(Succeed())
+		patch, err = diffPatch(liveWorkload, mergedWorkload, helmOwner.diffOptions.DriftIgnoreRules)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(patch).To(BeEmpty())
+	}
+
+	hook := merged.DeepCopy()
+	hook.SetAnnotations(map[string]string{"helm.sh/hook": "pre-install,post-install"})
+	value, found := helmHookValue(helmOwner, hook)
+	g.Expect(found).To(BeTrue())
+	g.Expect(value).To(Equal("pre-install,post-install"))
+
+	kustomizeOwner, err := newDiffOwner(ownerObject("Kustomization", "app", "flux-system", false))
+	g.Expect(err).NotTo(HaveOccurred())
+	_, found = helmHookValue(kustomizeOwner, hook)
+	g.Expect(found).To(BeFalse())
+}
+
+func TestDiffPruneInventoryPresenceAndDecoding(t *testing.T) {
+	g := NewWithT(t)
+	ownerObject := ownerObject("Kustomization", "apps", "flux-system", false)
+	ownerObject.Object["spec"].(map[string]any)["prune"] = true
+	owner, err := newDiffOwner(ownerObject)
+	g.Expect(err).NotTo(HaveOccurred())
+	owner.live = ownerObject.DeepCopy()
+	client := NewClient(fake.NewClientBuilder().WithScheme(NewTestScheme()).Build(), nil, meta.NewDefaultRESTMapper(nil))
+	rm := newResourceManagerWithOwner(client.Client, client.poller, owner.ssaOwner)
+
+	objects, status := client.diffPrune(context.Background(), owner, rm, nil)
+	g.Expect(objects).To(BeEmpty())
+	g.Expect(status).To(Equal("prune: unavailable"))
+
+	g.Expect(unstructured.SetNestedField(owner.live.Object, "invalid", "status", "inventory")).To(Succeed())
+	objects, status = client.diffPrune(context.Background(), owner, rm, nil)
+	g.Expect(objects).To(BeEmpty())
+	g.Expect(status).To(Equal("prune: unavailable"))
+
+	owner.live = nil
+	objects, status = client.diffPrune(context.Background(), owner, rm, nil)
+	g.Expect(objects).To(BeEmpty())
+	g.Expect(status).To(Equal("prune: skipped (owner not in cluster)"))
+}
+
+func TestResolveDiffOwnerReferenceNotFound(t *testing.T) {
+	g := NewWithT(t)
+	client := NewClient(fake.NewClientBuilder().WithScheme(NewTestScheme()).Build(), nil, meta.NewDefaultRESTMapper(nil))
+	_, err := client.resolveDiffOwner(context.Background(), DiffRequest{
+		OwnerRef: &DiffOwnerRef{Kind: "ResourceSet", Name: "missing", Namespace: "flux-system"},
+	})
+	g.Expect(err).To(MatchError("owner not found in the cluster: ResourceSet/flux-system/missing; if it is new, pass its definition in flux_object"))
+}
+
+func TestResolveDiffOwnerGuards(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest string
+		match    string
+	}{
+		{
+			name: "multiple documents",
+			manifest: `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: one, namespace: flux-system}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: two, namespace: flux-system}
+`,
+			match: "expected exactly one document",
+		},
+		{
+			name: "missing namespace",
+			manifest: `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: app}
+`,
+			match: "metadata.namespace is required",
+		},
+		{
+			name: "remote owner",
+			manifest: `apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: app, namespace: flux-system}
+spec:
+  kubeConfig: {secretRef: {name: remote}}
+`,
+			match: "diff not supported for owners targeting remote clusters",
+		},
+		{
+			name: "unsupported kind",
+			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: app, namespace: flux-system}
+`,
+			match: "supported kinds are Kustomization, ResourceSet and HelmRelease",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			client := NewClient(fake.NewClientBuilder().WithScheme(NewTestScheme()).Build(), nil, meta.NewDefaultRESTMapper(nil))
+			_, err := client.resolveDiffOwner(context.Background(), DiffRequest{FluxObject: tt.manifest})
+			g.Expect(err).To(MatchError(ContainSubstring(tt.match)))
+		})
+	}
+}
+
+func TestPrepareDiffObjectsMetadata(t *testing.T) {
+	g := NewWithT(t)
+	for _, kind := range []string{"Kustomization", "ResourceSet", "HelmRelease"} {
+		ownerObject := ownerObject(kind, "owner", "flux-system", false)
+		ownerObject.Object["spec"].(map[string]any)["commonMetadata"] = map[string]any{
+			"labels":      map[string]any{"common": "value", ownerObject.GroupVersionKind().Group + "/name": "wrong"},
+			"annotations": map[string]any{"note": "test"},
+		}
+		owner, err := newDiffOwner(ownerObject)
+		g.Expect(err).NotTo(HaveOccurred())
+		client := NewClient(fake.NewClientBuilder().WithScheme(NewTestScheme()).Build(), nil, meta.NewDefaultRESTMapper(nil))
+		rm := newResourceManagerWithOwner(client.Client, client.poller, owner.ssaOwner)
+		objects := []*unstructured.Unstructured{{Object: map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "app"},
+		}}}
+		g.Expect(prepareDiffObjects(context.Background(), client.Client, &objects, owner, rm)).To(Succeed())
+		g.Expect(objects[0].GetLabels()["common"]).To(Equal("value"))
+		g.Expect(objects[0].GetAnnotations()["note"]).To(Equal("test"))
+		g.Expect(objects[0].GetLabels()[owner.ssaOwner.Group+"/name"]).To(Equal("owner"))
+		g.Expect(objects[0].GetLabels()[owner.ssaOwner.Group+"/namespace"]).To(Equal("flux-system"))
+	}
+}
+
+func TestGetFluxOwner(t *testing.T) {
+	g := NewWithT(t)
+	resource := ownerObject("ResourceSet", "resource", "flux-system", false)
+	resource.SetLabels(map[string]string{
+		"resourceset.fluxcd.controlplane.io/name":      "apps",
+		"resourceset.fluxcd.controlplane.io/namespace": "platform",
+	})
+	client := NewClient(fake.NewClientBuilder().WithScheme(NewTestScheme()).WithObjects(resource).Build(), nil, meta.NewDefaultRESTMapper(nil))
+	owner, ok := client.GetFluxOwner(context.Background(), resource.GroupVersionKind(), resource.GetName(), resource.GetNamespace())
+	g.Expect(ok).To(BeTrue())
+	g.Expect(owner).To(Equal(&DiffOwnerRef{Kind: "ResourceSet", Name: "apps", Namespace: "platform"}))
+}
+
+func TestFluxOwnerFromLabels(t *testing.T) {
+	g := NewWithT(t)
+	owner, ok := fluxOwnerFromLabels(map[string]string{
+		"resourceset.fluxcd.controlplane.io/name":      "apps",
+		"resourceset.fluxcd.controlplane.io/namespace": "flux-system",
+	})
+	g.Expect(ok).To(BeTrue())
+	g.Expect(owner).To(Equal(&DiffOwnerRef{Kind: "ResourceSet", Name: "apps", Namespace: "flux-system"}))
+	_, ok = fluxOwnerFromLabels(map[string]string{"kustomize.toolkit.fluxcd.io/namespace": "flux-system"})
+	g.Expect(ok).To(BeFalse())
+}
+
+func ownerObject(kind, name, namespace string, suspend bool) *unstructured.Unstructured {
+	gvk, err := ownerGVK(kind)
+	if err != nil {
+		panic(err)
+	}
+	object := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gvk.GroupVersion().String(),
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]any{"suspend": suspend},
+	}}
+	object.SetGroupVersionKind(gvk)
+	return object
+}

--- a/cmd/mcp/k8s/diff_render.go
+++ b/cmd/mcp/k8s/diff_render.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/wI2L/jsondiff"
+	"sigs.k8s.io/yaml"
+)
+
+// diffState is a renderer-level manifest change state.
+type diffState string
+
+const (
+	diffStateCreate    diffState = "create"
+	diffStateUpdate    diffState = "update"
+	diffStateRecreate  diffState = "recreate"
+	diffStateUnchanged diffState = "unchanged"
+	diffStateSkipped   diffState = "skipped"
+	diffStateDelete    diffState = "delete"
+	diffStateError     diffState = "error"
+)
+
+// diffObjectResult is the pure renderer model for one manifest or inventory object.
+type diffObjectResult struct {
+	Subject string
+	State   diffState
+	Detail  string
+	Hint    *DiffOwnerRef
+	Patch   jsondiff.Patch
+}
+
+// diffResult is the complete pure renderer model for a diff request.
+type diffResult struct {
+	Owner         *DiffOwnerRef
+	FieldManager  string
+	PruneEnabled  bool
+	FutureSuspend bool
+	LiveSuspend   bool
+	Warnings      []string
+	Objects       []diffObjectResult
+	PruneObjects  []diffObjectResult
+	PruneStatus   string
+}
+
+// renderDiff renders a deterministic human-readable diff and summary.
+func renderDiff(result diffResult) (string, error) {
+	var builder strings.Builder
+	if result.Owner != nil {
+		fmt.Fprintf(&builder, "Diff for %s/%s/%s (field manager: %s, prune: %s)\n",
+			result.Owner.Kind, result.Owner.Namespace, result.Owner.Name,
+			result.FieldManager, enabledDisabled(result.PruneEnabled))
+	} else {
+		fmt.Fprintf(&builder, "Diff for Kubernetes manifest (field manager: %s, prune: disabled)\n", result.FieldManager)
+	}
+
+	if result.FutureSuspend {
+		builder.WriteString("suspended: changes are not applied until resumed\n")
+	} else if result.LiveSuspend {
+		builder.WriteString("currently suspended; the proposed definition resumes it\n")
+	}
+	for _, warning := range result.Warnings {
+		builder.WriteString(warning)
+		builder.WriteString("\n")
+	}
+
+	if noChanges(result) {
+		builder.WriteString("\nNo changes detected\n")
+		return builder.String(), nil
+	}
+
+	builder.WriteString("\n")
+	for _, object := range result.Objects {
+		if err := renderDiffObject(&builder, object); err != nil {
+			return "", err
+		}
+	}
+
+	if result.PruneStatus != "" {
+		if len(result.Objects) > 0 {
+			builder.WriteString("\n")
+		}
+		builder.WriteString(result.PruneStatus)
+		builder.WriteString("\n")
+	}
+	if len(result.PruneObjects) > 0 {
+		builder.WriteString("\nNot in the manifest (pruned if the manifest is complete):\n")
+		for _, object := range result.PruneObjects {
+			if err := renderDiffObject(&builder, object); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	counts := make(map[diffState]int)
+	for _, object := range result.Objects {
+		counts[object.State]++
+	}
+	for _, object := range result.PruneObjects {
+		counts[object.State]++
+	}
+	parts := make([]string, 0, 7)
+	for _, state := range []diffState{
+		diffStateCreate, diffStateUpdate, diffStateRecreate, diffStateUnchanged,
+		diffStateSkipped, diffStateDelete, diffStateError,
+	} {
+		if count := counts[state]; count > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", count, state))
+		}
+	}
+	if len(parts) > 0 {
+		builder.WriteString("\nSummary: ")
+		builder.WriteString(strings.Join(parts, ", "))
+		builder.WriteString("\n")
+	}
+	return builder.String(), nil
+}
+
+// renderDiffObject writes one object state and optional JSON patch in YAML form.
+func renderDiffObject(builder *strings.Builder, object diffObjectResult) error {
+	fmt.Fprintf(builder, "%s %s", object.Subject, object.State)
+	if object.Detail != "" {
+		if object.State == diffStateError {
+			fmt.Fprintf(builder, ": %s", object.Detail)
+		} else {
+			fmt.Fprintf(builder, " (%s)", object.Detail)
+		}
+	}
+	if object.Hint != nil {
+		fmt.Fprintf(builder, " (currently managed by %s/%s/%s)", object.Hint.Kind, object.Hint.Namespace, object.Hint.Name)
+	}
+	builder.WriteString("\n")
+	if len(object.Patch) > 0 {
+		patch, err := yaml.Marshal(object.Patch)
+		if err != nil {
+			return fmt.Errorf("marshalling JSON patch: %w", err)
+		}
+		builder.Write(patch)
+	}
+	return nil
+}
+
+// noChanges reports whether all manifest objects are unchanged and there are no prune candidates.
+func noChanges(result diffResult) bool {
+	if len(result.PruneObjects) > 0 || result.PruneStatus != "" || len(result.Objects) == 0 {
+		return false
+	}
+	for _, object := range result.Objects {
+		if object.State != diffStateUnchanged {
+			return false
+		}
+	}
+	return true
+}
+
+// enabledDisabled renders a boolean policy as enabled or disabled.
+func enabledDisabled(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}

--- a/cmd/mcp/k8s/diff_render_test.go
+++ b/cmd/mcp/k8s/diff_render_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/wI2L/jsondiff"
+)
+
+func TestRenderDiffStatesAndSummary(t *testing.T) {
+	g := NewWithT(t)
+	output, err := renderDiff(diffResult{
+		Owner:         &DiffOwnerRef{Kind: "Kustomization", Namespace: "apps", Name: "backend"},
+		FieldManager:  "kustomize-controller",
+		PruneEnabled:  true,
+		FutureSuspend: true,
+		Objects: []diffObjectResult{
+			{Subject: "ConfigMap/apps/new", State: diffStateCreate},
+			{Subject: "Deployment/apps/backend", State: diffStateUpdate, Patch: jsondiff.Patch{
+				{Type: jsondiff.OperationReplace, Path: "/spec/replicas", Value: float64(3)},
+			}},
+			{Subject: "StatefulSet/apps/db", State: diffStateRecreate, Detail: "forced, not validated"},
+			{Subject: "Service/apps/backend", State: diffStateUnchanged},
+			{Subject: "Job/apps/migrate", State: diffStateSkipped, Detail: "kustomize.toolkit.fluxcd.io/ssa: ignore"},
+			{Subject: "CustomThing/apps/foo", State: diffStateError, Detail: "no matches for kind"},
+			{Subject: "Deployment/apps/legacy", State: diffStateUpdate,
+				Hint: &DiffOwnerRef{Kind: "Kustomization", Namespace: "flux-system", Name: "legacy"}},
+		},
+		PruneObjects: []diffObjectResult{{Subject: "ConfigMap/apps/old", State: diffStateDelete}},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("Diff for Kustomization/apps/backend (field manager: kustomize-controller, prune: enabled)"))
+	g.Expect(output).To(ContainSubstring("suspended: changes are not applied until resumed"))
+	g.Expect(output).To(ContainSubstring("- op: replace\n  path: /spec/replicas\n  value: 3"))
+	g.Expect(output).To(ContainSubstring("StatefulSet/apps/db recreate (forced, not validated)"))
+	g.Expect(output).To(ContainSubstring("Job/apps/migrate skipped (kustomize.toolkit.fluxcd.io/ssa: ignore)"))
+	g.Expect(output).To(ContainSubstring("CustomThing/apps/foo error: no matches for kind"))
+	g.Expect(output).To(ContainSubstring("currently managed by Kustomization/flux-system/legacy"))
+	g.Expect(output).To(ContainSubstring("Not in the manifest (pruned if the manifest is complete):"))
+	g.Expect(output).To(ContainSubstring("Summary: 1 create, 2 update, 1 recreate, 1 unchanged, 1 skipped, 1 delete, 1 error"))
+}
+
+func TestRenderDiffNoChangesAndResume(t *testing.T) {
+	g := NewWithT(t)
+	output, err := renderDiff(diffResult{
+		Owner:        &DiffOwnerRef{Kind: "HelmRelease", Namespace: "flux-system", Name: "app"},
+		FieldManager: "helm-controller",
+		PruneEnabled: true,
+		LiveSuspend:  true,
+		Objects:      []diffObjectResult{{Subject: "Service/apps/app", State: diffStateUnchanged}},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("currently suspended; the proposed definition resumes it"))
+	g.Expect(output).To(ContainSubstring("No changes detected"))
+	g.Expect(output).NotTo(ContainSubstring("Summary:"))
+}
+
+func TestRenderDiffPruneStatuses(t *testing.T) {
+	g := NewWithT(t)
+	for _, status := range []string{"prune: unavailable", "prune: skipped (owner not in cluster)"} {
+		output, err := renderDiff(diffResult{
+			Owner:        &DiffOwnerRef{Kind: "ResourceSet", Namespace: "flux-system", Name: "apps"},
+			FieldManager: "flux-operator",
+			PruneEnabled: true,
+			Objects:      []diffObjectResult{{Subject: "Service/apps/app", State: diffStateUnchanged}},
+			PruneStatus:  status,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(output).To(ContainSubstring(status))
+	}
+}
+
+func TestRenderDiffDependencyWarningsWithoutOwner(t *testing.T) {
+	g := NewWithT(t)
+	output, err := renderDiff(diffResult{
+		FieldManager: "kubectl-flux-mcp",
+		Warnings: []string{
+			"namespace apps-qa does not exist in the cluster, objects in it are not validated",
+			"CRD for example.com/CustomThing does not exist in the cluster, objects of that kind are not validated",
+		},
+		Objects: []diffObjectResult{
+			{Subject: "ConfigMap/apps-qa/backend", State: diffStateCreate,
+				Detail: "not validated: namespace apps-qa does not exist yet"},
+			{Subject: "CustomThing/example", State: diffStateCreate,
+				Detail: "not validated: CRD for example.com/CustomThing does not exist yet"},
+		},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("Diff for Kubernetes manifest"))
+	g.Expect(output).To(ContainSubstring("namespace apps-qa does not exist in the cluster, objects in it are not validated"))
+	g.Expect(output).To(ContainSubstring("CRD for example.com/CustomThing does not exist in the cluster, objects of that kind are not validated"))
+	g.Expect(output).To(ContainSubstring("ConfigMap/apps-qa/backend create (not validated: namespace apps-qa does not exist yet)"))
+	g.Expect(output).To(ContainSubstring("CustomThing/example create (not validated: CRD for example.com/CustomThing does not exist yet)"))
+}

--- a/cmd/mcp/k8s/diff_transforms_test.go
+++ b/cmd/mcp/k8s/diff_transforms_test.go
@@ -1,0 +1,372 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestKustomizationDeferredTransforms(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	ownerObject := ownerObject("Kustomization", "apps", "flux-system", false)
+	ownerObject.Object["spec"].(map[string]any)["namePrefix"] = "preview-"
+	ownerObject.Object["spec"].(map[string]any)["components"] = []any{"../component"}
+	owner, err := newDiffOwner(ownerObject)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	objects := []*unstructured.Unstructured{{Object: map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "app"},
+	}}}
+	kubeClient := fake.NewClientBuilder().WithScheme(NewTestScheme()).Build()
+	g.Expect(applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)).To(Succeed())
+	g.Expect(objects).To(HaveLen(1))
+	g.Expect(objects[0].GetName()).To(Equal("preview-app"))
+	g.Expect(owner.warnings).To(Equal([]string{"spec.components not applied, diff may be incomplete"}))
+
+	output, err := renderDiff(diffResult{
+		Owner:        owner.ref,
+		FieldManager: owner.ssaOwner.Field,
+		Warnings:     owner.warnings,
+		Objects:      []diffObjectResult{{Subject: "ConfigMap/preview-app", State: diffStateUnchanged}},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(output).To(ContainSubstring("spec.components not applied, diff may be incomplete\n\nNo changes detected"))
+}
+
+func TestKustomizationBuildTransforms(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	kubeClient := fake.NewClientBuilder().WithScheme(NewTestScheme()).Build()
+	ownerObject := ownerObject("Kustomization", "apps", "flux-system", false)
+	spec := ownerObject.Object["spec"].(map[string]any)
+	spec["targetNamespace"] = "apps"
+	spec["nameSuffix"] = "-v2"
+	spec["patches"] = []any{
+		map[string]any{
+			"target": map[string]any{"kind": "Deployment", "name": "app"},
+			"patch":  "- op: replace\n  path: /spec/replicas\n  value: 2\n",
+		},
+	}
+	spec["images"] = []any{
+		map[string]any{"name": "ghcr.io/example/app", "newName": "registry.example.com/app", "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+	}
+	owner, err := newDiffOwner(ownerObject)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	objects := []*unstructured.Unstructured{
+		{Object: map[string]any{
+			"apiVersion": "apps/v1", "kind": "Deployment", "metadata": map[string]any{"name": "app"},
+			"spec": map[string]any{
+				"replicas": int64(1),
+				"template": map[string]any{"spec": map[string]any{"containers": []any{
+					map[string]any{"name": "app", "image": "ghcr.io/example/app:1.0.0"},
+				}}},
+			},
+		}},
+		{Object: map[string]any{
+			"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "ClusterRole", "metadata": map[string]any{"name": "reader"},
+		}},
+	}
+	g.Expect(applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)).To(Succeed())
+	g.Expect(objects).To(HaveLen(2))
+	g.Expect(objects[0].GetKind()).To(Equal("Deployment"))
+	g.Expect(objects[0].GetName()).To(Equal("app-v2"))
+	g.Expect(objects[0].GetNamespace()).To(Equal("apps"))
+	replicas, _, _ := unstructured.NestedInt64(objects[0].Object, "spec", "replicas")
+	g.Expect(replicas).To(Equal(int64(2)))
+	containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
+	g.Expect(containers[0].(map[string]any)["image"]).To(Equal("registry.example.com/app@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"))
+	g.Expect(objects[1].GetKind()).To(Equal("ClusterRole"))
+	g.Expect(objects[1].GetName()).To(Equal("reader-v2"))
+	g.Expect(objects[1].GetNamespace()).To(BeEmpty())
+}
+
+func TestKustomizationBuildMetadataIgnoreRules(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	object := ownerObject("Kustomization", "apps", "flux-system", false)
+	object.Object["spec"].(map[string]any)["buildMetadata"] = []any{"originAnnotations", "transformerAnnotations", "managedByLabel"}
+	owner, err := newDiffOwner(object)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(owner.diffOptions.DriftIgnoreRules).To(HaveLen(1))
+	g.Expect(owner.diffOptions.DriftIgnoreRules[0].Paths).To(ConsistOf(
+		"/metadata/annotations/config.kubernetes.io~1origin",
+		"/metadata/annotations/config.kubernetes.io~1transformations",
+		"/metadata/labels/app.kubernetes.io~1managed-by",
+	))
+
+	// buildMetadata alone does not trigger a second build and leaves the objects untouched.
+	g.Expect(requiresKustomizationBuild(object)).To(BeFalse())
+	objects := []*unstructured.Unstructured{{Object: map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "app"},
+	}}}
+	kubeClient := fake.NewClientBuilder().WithScheme(NewTestScheme()).Build()
+	g.Expect(applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)).To(Succeed())
+	g.Expect(objects).To(HaveLen(1))
+	g.Expect(objects[0].GetAnnotations()).To(BeEmpty())
+	g.Expect(objects[0].GetLabels()).To(BeEmpty())
+
+	// A second build for other transforms does not apply buildMetadata either.
+	object.Object["spec"].(map[string]any)["namePrefix"] = "preview-"
+	owner, err = newDiffOwner(object)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)).To(Succeed())
+	g.Expect(objects[0].GetName()).To(Equal("preview-app"))
+	g.Expect(objects[0].GetAnnotations()).To(BeEmpty())
+	g.Expect(objects[0].GetLabels()).To(BeEmpty())
+
+	// Only the configured options are ignored.
+	object = ownerObject("Kustomization", "apps", "flux-system", false)
+	object.Object["spec"].(map[string]any)["buildMetadata"] = []any{"originAnnotations"}
+	owner, err = newDiffOwner(object)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(owner.diffOptions.DriftIgnoreRules).To(HaveLen(1))
+	g.Expect(owner.diffOptions.DriftIgnoreRules[0].Paths).To(Equal([]string{
+		"/metadata/annotations/config.kubernetes.io~1origin",
+	}))
+
+	object = ownerObject("Kustomization", "apps", "flux-system", false)
+	owner, err = newDiffOwner(object)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(owner.diffOptions.DriftIgnoreRules).To(BeEmpty())
+}
+
+func TestKustomizationPostBuildSubstitution(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	source := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "vars", Namespace: "flux-system"},
+		Data:       map[string]string{"cluster": "staging"},
+	}
+	kubeClient := fake.NewClientBuilder().WithScheme(NewTestScheme()).WithObjects(source).Build()
+	object := ownerObject("Kustomization", "apps", "flux-system", false)
+	object.Object["spec"].(map[string]any)["postBuild"] = map[string]any{
+		"substituteFrom": []any{map[string]any{"kind": "ConfigMap", "name": "vars"}},
+	}
+	owner, err := newDiffOwner(object)
+	g.Expect(err).NotTo(HaveOccurred())
+	objects := []*unstructured.Unstructured{{Object: map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "app"},
+		"data": map[string]any{"value": "${cluster}"},
+	}}}
+	g.Expect(applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)).To(Succeed())
+	value, _, _ := unstructured.NestedString(objects[0].Object, "data", "value")
+	g.Expect(value).To(Equal("staging"))
+
+	objects[0].Object["data"] = map[string]any{"value": "${missing}"}
+	err = applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)
+	g.Expect(err).To(MatchError(ContainSubstring("missing")))
+
+	owner.object.Object["spec"].(map[string]any)["postBuild"] = map[string]any{
+		"substituteFrom": []any{map[string]any{"kind": "ConfigMap", "name": "absent"}},
+	}
+	objects[0].Object["data"] = map[string]any{"value": "${cluster}"}
+	g.Expect(applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)).To(Succeed())
+	value, _, _ = unstructured.NestedString(objects[0].Object, "data", "value")
+	g.Expect(value).To(Equal("${cluster}"))
+	g.Expect(owner.warnings).To(ContainElement(
+		"substituteFrom ConfigMap flux-system/absent not found in the cluster, variables left unresolved"))
+
+	owner.object.Object["spec"].(map[string]any)["postBuild"] = map[string]any{
+		"substituteFrom": []any{map[string]any{"kind": "ConfigMap", "name": "absent", "optional": true}},
+		"substitute":     map[string]any{"fallback": "available"},
+	}
+	objects[0].Object["data"] = map[string]any{"value": "${fallback}"}
+	g.Expect(applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)).To(Succeed())
+	value, _, _ = unstructured.NestedString(objects[0].Object, "data", "value")
+	g.Expect(value).To(Equal("available"))
+}
+
+func TestResourceSetCopyFromTransform(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "source", Namespace: "apps"}, Data: map[string]string{"key": "value"}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "source", Namespace: "apps"}, Data: map[string][]byte{"token": []byte("secret")}}
+	kubeClient := fake.NewClientBuilder().WithScheme(NewTestScheme()).WithObjects(cm, secret).Build()
+	ownerObject := ownerObject("ResourceSet", "apps", "flux-system", false)
+	owner, err := newDiffOwner(ownerObject)
+	g.Expect(err).NotTo(HaveOccurred())
+	objects := []*unstructured.Unstructured{
+		{Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{
+			"name": "copy", "annotations": map[string]any{"fluxcd.controlplane.io/copyFrom": "apps/source"},
+		}}},
+		{Object: map[string]any{"apiVersion": "v1", "kind": "Secret", "metadata": map[string]any{
+			"name": "copy", "annotations": map[string]any{"fluxcd.controlplane.io/copyFrom": "apps/source"},
+		}}},
+	}
+	g.Expect(applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)).To(Succeed())
+	data, _, _ := unstructured.NestedStringMap(objects[0].Object, "data")
+	g.Expect(data).To(Equal(map[string]string{"key": "value"}))
+	stringData, _, _ := unstructured.NestedStringMap(objects[1].Object, "stringData")
+	g.Expect(stringData).To(Equal(map[string]string{"token": "secret"}))
+
+	missing := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{
+			"name": "missing-copy", "annotations": map[string]any{"fluxcd.controlplane.io/copyFrom": "apps/absent"},
+		},
+	}}
+	g.Expect(applyDeferredOwnerTransforms(ctx, kubeClient, &[]*unstructured.Unstructured{missing}, owner)).To(Succeed())
+	_, found, err := unstructured.NestedMap(missing.Object, "data")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeFalse())
+	g.Expect(owner.warnings).To(ContainElement(
+		"copyFrom source ConfigMap apps/absent not found in the cluster, data left empty"))
+}
+
+func TestHelmReleaseMetadataAndNamespace(t *testing.T) {
+	g := NewWithT(t)
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{{Version: "v1"}, {Group: "apiextensions.k8s.io", Version: "v1"}})
+	mapper.Add(schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}, meta.RESTScopeNamespace)
+	mapper.Add(schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}, meta.RESTScopeRoot)
+	kubeClient := fake.NewClientBuilder().WithScheme(NewTestScheme()).WithRESTMapper(mapper).Build()
+	ownerObject := ownerObject("HelmRelease", "backend", "flux-system", false)
+	ownerObject.Object["spec"].(map[string]any)["targetNamespace"] = "apps"
+	owner, err := newDiffOwner(ownerObject)
+	g.Expect(err).NotTo(HaveOccurred())
+	objects := []*unstructured.Unstructured{
+		{Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1", "kind": "CustomResourceDefinition",
+			"metadata": map[string]any{"name": "widgets.example.com"},
+			"spec":     map[string]any{"group": "example.com", "scope": "Namespaced", "names": map[string]any{"kind": "Widget"}},
+		}},
+		{Object: map[string]any{"apiVersion": "example.com/v1", "kind": "Widget", "metadata": map[string]any{"name": "app"}}},
+		{Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "app"}}},
+	}
+	rm := newResourceManagerWithOwner(kubeClient, nil, owner.ssaOwner)
+	g.Expect(prepareDiffObjects(context.Background(), kubeClient, &objects, owner, rm)).To(Succeed())
+	g.Expect(objects[0].GetLabels()).To(HaveKeyWithValue("helm.toolkit.fluxcd.io/name", "backend"))
+	g.Expect(objects[0].GetLabels()).NotTo(HaveKey("app.kubernetes.io/managed-by"))
+	g.Expect(objects[0].GetAnnotations()).NotTo(HaveKey("meta.helm.sh/release-name"))
+	g.Expect(objects[0].GetNamespace()).To(BeEmpty())
+	liveTemplateCRD := objects[0].DeepCopy()
+	liveTemplateCRD.SetAnnotations(map[string]string{"meta.helm.sh/release-name": "old-release"})
+	applyHelmMetadataForLiveCRD(objects[0], liveTemplateCRD, owner)
+	g.Expect(objects[0].GetLabels()).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "Helm"))
+	g.Expect(objects[0].GetAnnotations()).To(HaveKeyWithValue("meta.helm.sh/release-name", "apps-backend"))
+	g.Expect(objects[0].GetAnnotations()).To(HaveKeyWithValue("meta.helm.sh/release-namespace", "apps"))
+	crdsDirectoryCRD := objects[0].DeepCopy()
+	crdsDirectoryCRD.SetLabels(map[string]string{"helm.toolkit.fluxcd.io/name": "backend"})
+	crdsDirectoryCRD.SetAnnotations(nil)
+	applyHelmMetadataForLiveCRD(crdsDirectoryCRD, crdsDirectoryCRD.DeepCopy(), owner)
+	g.Expect(crdsDirectoryCRD.GetLabels()).NotTo(HaveKey("app.kubernetes.io/managed-by"))
+	g.Expect(crdsDirectoryCRD.GetAnnotations()).NotTo(HaveKey("meta.helm.sh/release-name"))
+	for _, object := range objects[1:] {
+		g.Expect(object.GetNamespace()).To(Equal("apps"))
+		g.Expect(object.GetLabels()).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "Helm"))
+		g.Expect(object.GetAnnotations()).To(HaveKeyWithValue("meta.helm.sh/release-name", "apps-backend"))
+		g.Expect(object.GetAnnotations()).To(HaveKeyWithValue("meta.helm.sh/release-namespace", "apps"))
+	}
+}
+
+func TestHelmReleasePostRenderers(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	kubeClient := fake.NewClientBuilder().WithScheme(NewTestScheme()).Build()
+	deployment := func() *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1", "kind": "Deployment",
+			"metadata": map[string]any{"name": "app", "labels": map[string]any{"app": "backend"}},
+			"spec": map[string]any{
+				"replicas": int64(1),
+				"template": map[string]any{"spec": map[string]any{"containers": []any{
+					map[string]any{"name": "app", "image": "ghcr.io/example/app:1.0.0"},
+				}}},
+			},
+		}}
+	}
+	service := func() *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1", "kind": "Service", "metadata": map[string]any{"name": "app"},
+		}}
+	}
+
+	// No post-renderers leaves the objects untouched.
+	ownerObject := ownerObject("HelmRelease", "backend", "flux-system", false)
+	owner, err := newDiffOwner(ownerObject)
+	g.Expect(err).NotTo(HaveOccurred())
+	objects := []*unstructured.Unstructured{deployment(), service()}
+	g.Expect(applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)).To(Succeed())
+	g.Expect(objects).To(HaveLen(2))
+	g.Expect(objects[0].Object).To(Equal(deployment().Object))
+
+	// Post-renderers are applied in order with patches and images.
+	ownerObject.Object["spec"].(map[string]any)["postRenderers"] = []any{
+		map[string]any{"kustomize": map[string]any{
+			"patches": []any{
+				map[string]any{
+					"target": map[string]any{"kind": "Deployment", "labelSelector": "app=backend"},
+					"patch":  "- op: replace\n  path: /spec/replicas\n  value: 3\n",
+				},
+				map[string]any{
+					"patch": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\n  labels:\n    tier: web\n",
+				},
+			},
+			"images": []any{
+				map[string]any{"name": "ghcr.io/example/app", "newTag": "2.0.0"},
+			},
+		}},
+		map[string]any{"kustomize": map[string]any{
+			"patches": []any{
+				map[string]any{
+					"target": map[string]any{"kind": "Deployment", "labelSelector": "tier=web"},
+					"patch":  "- op: add\n  path: /metadata/annotations\n  value:\n    rendered: second\n",
+				},
+			},
+		}},
+	}
+	owner, err = newDiffOwner(ownerObject)
+	g.Expect(err).NotTo(HaveOccurred())
+	objects = []*unstructured.Unstructured{deployment(), service()}
+	g.Expect(applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)).To(Succeed())
+	g.Expect(objects).To(HaveLen(2))
+	g.Expect(objects[0].GetKind()).To(Equal("Deployment"))
+	replicas, _, _ := unstructured.NestedInt64(objects[0].Object, "spec", "replicas")
+	g.Expect(replicas).To(Equal(int64(3)))
+	g.Expect(objects[0].GetLabels()).To(HaveKeyWithValue("tier", "web"))
+	g.Expect(objects[0].GetAnnotations()).To(HaveKeyWithValue("rendered", "second"))
+	containers, _, _ := unstructured.NestedSlice(objects[0].Object, "spec", "template", "spec", "containers")
+	g.Expect(containers[0].(map[string]any)["image"]).To(Equal("ghcr.io/example/app:2.0.0"))
+	g.Expect(objects[1].Object).To(Equal(service().Object))
+
+	// Invalid patches surface the renderer index.
+	ownerObject.Object["spec"].(map[string]any)["postRenderers"] = []any{
+		map[string]any{"kustomize": map[string]any{
+			"patches": []any{map[string]any{"patch": "not: [valid"}},
+		}},
+	}
+	owner, err = newDiffOwner(ownerObject)
+	g.Expect(err).NotTo(HaveOccurred())
+	objects = []*unstructured.Unstructured{deployment()}
+	err = applyDeferredOwnerTransforms(ctx, kubeClient, &objects, owner)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(HavePrefix("postRenderers[0] failed"))
+}
+
+func TestHelmReleaseNameShortening(t *testing.T) {
+	g := NewWithT(t)
+	name := "release-name-with-very-long-name-which-is-longer-than-53-characters"
+	g.Expect(shortenHelmReleaseName(name)).To(Equal("release-name-with-very-long-name-which-i-788ca0d0d7b0"))
+	g.Expect(shortenHelmReleaseName("short")).To(Equal("short"))
+}
+
+func TestKustomizationFieldsAreAccepted(t *testing.T) {
+	g := NewWithT(t)
+	object := ownerObject("Kustomization", "apps", "flux-system", false)
+	object.Object["spec"].(map[string]any)["namePrefix"] = "preview-"
+	object.Object["spec"].(map[string]any)["components"] = []any{"component"}
+	object.Object["spec"].(map[string]any)["decryption"] = map[string]any{"provider": "sops"}
+	g.Expect(validateDiffOwner(object)).To(Succeed())
+	g.Expect(strings.Join([]string{object.GetKind(), object.GetName()}, "/")).To(Equal("Kustomization/apps"))
+}

--- a/cmd/mcp/k8s/suite_test.go
+++ b/cmd/mcp/k8s/suite_test.go
@@ -4,12 +4,28 @@
 package k8s
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fluxcd/pkg/runtime/testenv"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+var (
+	testEnv    *testenv.Environment
+	testClient *Client
+	testCtx    = context.Background()
 )
 
 func NewTestScheme() *runtime.Scheme {
@@ -18,4 +34,45 @@ func NewTestScheme() *runtime.Scheme {
 	utilruntime.Must(apiextensionsv1.AddToScheme(s))
 	utilruntime.Must(fluxcdv1.AddToScheme(s))
 	return s
+}
+
+func TestMain(m *testing.M) {
+	testEnv = testenv.New(
+		testenv.WithCRDPath(
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+			filepath.Join("testdata", "crds"),
+		),
+		testenv.WithScheme(NewTestScheme()),
+	)
+
+	go func() {
+		fmt.Println("Starting the test environment")
+		if err := testEnv.Start(testCtx); err != nil {
+			panic(fmt.Sprintf("Failed to start the test environment manager: %v", err))
+		}
+	}()
+	<-testEnv.Manager.Elected()
+
+	httpClient, err := rest.HTTPClientFor(testEnv.Config)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create test environment HTTP client: %v", err))
+	}
+	mapper, err := apiutil.NewDynamicRESTMapper(testEnv.Config, httpClient)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create test environment REST mapper: %v", err))
+	}
+	kubeClient, err := ctrlclient.New(testEnv.Config, ctrlclient.Options{Scheme: NewTestScheme(), Mapper: mapper})
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create test environment client: %v", err))
+	}
+	testClient = NewClient(kubeClient, testEnv.Config, mapper)
+
+	code := m.Run()
+
+	fmt.Println("Stopping the test environment")
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop the test environment: %v", err))
+	}
+
+	os.Exit(code)
 }

--- a/cmd/mcp/k8s/testdata/crds/hr.yaml
+++ b/cmd/mcp/k8s/testdata/crds/hr.yaml
@@ -1,0 +1,36 @@
+# Copyright 2026 Stefan Prodan.
+# SPDX-License-Identifier: AGPL-3.0
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: helmreleases.helm.toolkit.fluxcd.io
+spec:
+  group: helm.toolkit.fluxcd.io
+  names:
+    kind: HelmRelease
+    listKind: HelmReleaseList
+    plural: helmreleases
+    singular: helmrelease
+  scope: Namespaced
+  versions:
+    - name: v2
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/cmd/mcp/k8s/testdata/crds/ks.yaml
+++ b/cmd/mcp/k8s/testdata/crds/ks.yaml
@@ -1,0 +1,36 @@
+# Copyright 2026 Stefan Prodan.
+# SPDX-License-Identifier: AGPL-3.0
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kustomizations.kustomize.toolkit.fluxcd.io
+spec:
+  group: kustomize.toolkit.fluxcd.io
+  names:
+    kind: Kustomization
+    listKind: KustomizationList
+    plural: kustomizations
+    singular: kustomization
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/cmd/mcp/k8s/testdata/monorepo/backend-staging-build.yaml
+++ b/cmd/mcp/k8s/testdata/monorepo/backend-staging-build.yaml
@@ -1,0 +1,125 @@
+apiVersion: v1
+data:
+  PODINFO_LEVEL: info
+  PODINFO_UI_COLOR: '#34577c'
+  PODINFO_UI_MESSAGE: backend (${app_env} on ${cluster_name})
+kind: ConfigMap
+metadata:
+  name: backend-m759gh88kd
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  ports:
+  - name: http
+    port: 9898
+    protocol: TCP
+    targetPort: http
+  - name: grpc
+    port: 9999
+    protocol: TCP
+    targetPort: grpc
+  selector:
+    app: backend
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  minReadySeconds: 3
+  progressDeadlineSeconds: 60
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: backend
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9797"
+        prometheus.io/scrape: "true"
+      labels:
+        app: backend
+    spec:
+      containers:
+      - command:
+        - ./podinfo
+        - --port=9898
+        - --port-metrics=9797
+        - --grpc-port=9999
+        - --grpc-service-name=backend
+        - --random-delay=false
+        - --random-error=false
+        envFrom:
+        - configMapRef:
+            name: backend-m759gh88kd
+        image: backend
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        name: podinfod
+        ports:
+        - containerPort: 9898
+          name: http
+          protocol: TCP
+        - containerPort: 9797
+          name: http-metrics
+          protocol: TCP
+        - containerPort: 9999
+          name: grpc
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/readyz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        volumeMounts:
+        - mountPath: /data
+          name: data
+      volumes:
+      - emptyDir: {}
+        name: data
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: backend
+spec:
+  maxReplicas: 4
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 99
+        type: Utilization
+    type: Resource
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend

--- a/cmd/mcp/k8s/testdata/monorepo/backend-staging-fluxbuild.yaml
+++ b/cmd/mcp/k8s/testdata/monorepo/backend-staging-fluxbuild.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: backend
+    kustomize.toolkit.fluxcd.io/namespace: apps-staging
+  name: backend
+  namespace: apps-staging
+spec:
+  minReadySeconds: 3
+  progressDeadlineSeconds: 60
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: backend
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9797"
+        prometheus.io/scrape: "true"
+      labels:
+        app: backend
+    spec:
+      containers:
+      - command:
+        - ./podinfo
+        - --port=9898
+        - --port-metrics=9797
+        - --grpc-port=9999
+        - --grpc-service-name=backend
+        - --random-delay=false
+        - --random-error=false
+        envFrom:
+        - configMapRef:
+            name: backend-m759gh88kd
+        image: flux-registry:5000/backend:6.14.0@sha256:0a8aa037137c010a75aed8d3fe56931d0edd3bcd0e55acfb96db11e1e96397b1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        name: podinfod
+        ports:
+        - containerPort: 9898
+          name: http
+          protocol: TCP
+        - containerPort: 9797
+          name: http-metrics
+          protocol: TCP
+        - containerPort: 9999
+          name: grpc
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/readyz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        volumeMounts:
+        - mountPath: /data
+          name: data
+      volumes:
+      - emptyDir: {}
+        name: data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: backend
+    kustomize.toolkit.fluxcd.io/namespace: apps-staging
+  name: backend
+  namespace: apps-staging
+spec:
+  ports:
+  - name: http
+    port: 9898
+    protocol: TCP
+    targetPort: http
+  - name: grpc
+    port: 9999
+    protocol: TCP
+    targetPort: grpc
+  selector:
+    app: backend
+  type: ClusterIP
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: backend
+    kustomize.toolkit.fluxcd.io/namespace: apps-staging
+  name: backend
+  namespace: apps-staging
+spec:
+  maxReplicas: 4
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 99
+        type: Utilization
+    type: Resource
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend
+---
+apiVersion: v1
+data:
+  PODINFO_LEVEL: info
+  PODINFO_UI_COLOR: '#34577c'
+  PODINFO_UI_MESSAGE: backend (staging on kind-flux)
+kind: ConfigMap
+metadata:
+  labels:
+    kustomize.toolkit.fluxcd.io/name: backend
+    kustomize.toolkit.fluxcd.io/namespace: apps-staging
+  name: backend-m759gh88kd
+  namespace: apps-staging
+---

--- a/cmd/mcp/k8s/testdata/monorepo/ks-backend-staging-live.yaml
+++ b/cmd/mcp/k8s/testdata/monorepo/ks-backend-staging-live.yaml
@@ -1,0 +1,39 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  creationTimestamp: "2026-08-25T18:31:15Z"
+  finalizers:
+  - finalizers.fluxcd.io
+  generation: 1
+  labels:
+    resourceset.fluxcd.controlplane.io/name: backend
+    resourceset.fluxcd.controlplane.io/namespace: apps-staging
+  name: backend
+  namespace: apps-staging
+  resourceVersion: "8541"
+  uid: 5661ff7d-6814-4714-99f0-57c7ee91b4ec
+spec:
+  force: false
+  images:
+  - digest: sha256:0a8aa037137c010a75aed8d3fe56931d0edd3bcd0e55acfb96db11e1e96397b1
+    name: backend
+    newName: flux-registry:5000/backend
+    newTag: 6.14.0
+  interval: 30m
+  path: ./envs/staging
+  postBuild:
+    substitute:
+      app_env: staging
+    substituteFrom:
+    - kind: ConfigMap
+      name: flux-vars
+      optional: false
+  prune: true
+  retryInterval: 5m
+  sourceRef:
+    kind: ExternalArtifact
+    name: backend-staging
+    namespace: flux-system
+  targetNamespace: apps-staging
+  timeout: 5m
+  wait: true

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -197,7 +197,8 @@ func serveCmdRun(cmd *cobra.Command, args []string) error {
 
 	// Create the MCP server with instructions tailored to the enabled tools
 	kubeClient := k8s.NewClientFactory(kubeconfigArgs)
-	tm := toolbox.NewManager(kubeClient, rootArgs.timeout, rootArgs.maskSecrets, rootArgs.readOnly, nil)
+	tm := toolbox.NewManager(kubeClient, rootArgs.timeout, rootArgs.maskSecrets, rootArgs.readOnly, nil,
+		rootArgs.transport == "stdio" && !inCluster)
 	mcpServer := mcp.NewServer(mcpImpl, &mcp.ServerOptions{
 		Instructions: tm.Instructions(inCluster),
 		Capabilities: &mcp.ServerCapabilities{

--- a/cmd/mcp/main_test.go
+++ b/cmd/mcp/main_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func newTestServer() *mcp.Server {
-	tm := toolbox.NewManager(k8s.NewClientFactory(kubeconfigArgs), time.Minute, true, true, nil)
+	tm := toolbox.NewManager(k8s.NewClientFactory(kubeconfigArgs), time.Minute, true, true, nil, false)
 	mcpServer := mcp.NewServer(mcpImpl, &mcp.ServerOptions{
 		Instructions: tm.Instructions(true),
 		Capabilities: &mcp.ServerCapabilities{

--- a/cmd/mcp/toolbox/diff_manifest.go
+++ b/cmd/mcp/toolbox/diff_manifest.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
+)
+
+const (
+	// ToolDiffKubernetesManifest is the name of the diff_kubernetes_manifest tool.
+	ToolDiffKubernetesManifest = "diff_kubernetes_manifest"
+
+	maxYAMLPathSize = 64 << 20
+)
+
+func init() {
+	systemTools[ToolDiffKubernetesManifest] = systemTool{
+		readOnly:  true,
+		inCluster: true,
+	}
+}
+
+// diffKubernetesManifestInput defines the input parameters for diffing a Kubernetes manifest.
+type diffKubernetesManifestInput struct {
+	YAMLContent    string `json:"yaml_content,omitempty" jsonschema:"Multi-doc YAML content to diff."`
+	YAMLPath       string `json:"yaml_path,omitempty" jsonschema:"Absolute path to a local multi-doc YAML file to diff."`
+	FluxObject     string `json:"flux_object,omitempty" jsonschema:"YAML of the owning Flux resource, when new or changed."`
+	OwnerKind      string `json:"owner_kind,omitempty" jsonschema:"Owning Flux resource kind: Kustomization, HelmRelease or ResourceSet."`
+	OwnerName      string `json:"owner_name,omitempty" jsonschema:"Name of the owning Flux resource."`
+	OwnerNamespace string `json:"owner_namespace,omitempty" jsonschema:"Namespace of the owning Flux resource."`
+}
+
+// HandleDiffKubernetesManifest is the handler function for the diff_kubernetes_manifest tool.
+func (m *Manager) HandleDiffKubernetesManifest(ctx context.Context, request *mcp.CallToolRequest, input diffKubernetesManifestInput) (*mcp.CallToolResult, any, error) {
+	if err := CheckScopes(ctx, ToolDiffKubernetesManifest, m.readOnly); err != nil {
+		return NewToolResultError(err.Error())
+	}
+
+	if (input.YAMLContent == "") == (input.YAMLPath == "") {
+		return NewToolResultError("exactly one of yaml_content or yaml_path must be set")
+	}
+
+	manifest := input.YAMLContent
+	if input.YAMLPath != "" {
+		if !m.localFiles {
+			return NewToolResultError("yaml_path is only available when the MCP server runs locally with the stdio transport, pass yaml_content instead")
+		}
+		if !filepath.IsAbs(input.YAMLPath) {
+			return NewToolResultError("yaml_path must be an absolute path because the server's working directory is unknown to the agent")
+		}
+
+		fileInfo, err := os.Stat(input.YAMLPath)
+		if err != nil {
+			return NewToolResultErrorFromErr("Failed to read yaml_path", err)
+		}
+		if !fileInfo.Mode().IsRegular() {
+			return NewToolResultError("yaml_path must point to a regular file")
+		}
+		if fileInfo.Size() > maxYAMLPathSize {
+			return NewToolResultError(fmt.Sprintf("yaml_path exceeds the 64 MiB size limit (%d bytes)", fileInfo.Size()))
+		}
+
+		file, err := os.Open(input.YAMLPath)
+		if err != nil {
+			return NewToolResultErrorFromErr("Failed to read yaml_path", err)
+		}
+		content, readErr := io.ReadAll(io.LimitReader(file, maxYAMLPathSize+1))
+		closeErr := file.Close()
+		if readErr != nil {
+			return NewToolResultErrorFromErr("Failed to read yaml_path", readErr)
+		}
+		if closeErr != nil {
+			return NewToolResultErrorFromErr("Failed to read yaml_path", closeErr)
+		}
+		if len(content) > maxYAMLPathSize {
+			return NewToolResultError(fmt.Sprintf("yaml_path exceeds the 64 MiB size limit (%d bytes)", len(content)))
+		}
+		manifest = string(content)
+	}
+
+	hasOwnerKind := input.OwnerKind != ""
+	hasOwnerName := input.OwnerName != ""
+	hasOwnerNamespace := input.OwnerNamespace != ""
+	if hasOwnerKind != hasOwnerName || hasOwnerKind != hasOwnerNamespace {
+		return NewToolResultError("owner_kind, owner_name and owner_namespace must all be set")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
+	kubeClient, err := m.kubeClient.GetClient(ctx)
+	if err != nil {
+		return NewToolResultErrorFromErr("Failed to get Kubernetes client", err)
+	}
+
+	req := k8s.DiffRequest{
+		Manifest:   manifest,
+		FluxObject: input.FluxObject,
+	}
+	if hasOwnerKind {
+		req.OwnerRef = &k8s.DiffOwnerRef{
+			Kind:      input.OwnerKind,
+			Name:      input.OwnerName,
+			Namespace: input.OwnerNamespace,
+		}
+	}
+
+	result, err := kubeClient.Diff(ctx, req)
+	if err != nil {
+		return NewToolResultErrorFromErr("Failed to diff manifest", err)
+	}
+
+	return NewToolResultText(result)
+}

--- a/cmd/mcp/toolbox/diff_manifest_test.go
+++ b/cmd/mcp/toolbox/diff_manifest_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	. "github.com/onsi/gomega"
+	cli "k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
+)
+
+func TestManager_HandleDiffKubernetesManifest(t *testing.T) {
+	g := NewWithT(t)
+	configFile := "testdata/kubeconfig.yaml"
+	t.Setenv("KUBECONFIG", configFile)
+
+	tempDir := t.TempDir()
+	yamlPath := filepath.Join(tempDir, "manifest.yaml")
+	g.Expect(os.WriteFile(yamlPath, []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\n"), 0o600)).To(Succeed())
+
+	oversizedPath := filepath.Join(tempDir, "oversized.yaml")
+	oversizedFile, err := os.Create(oversizedPath)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(oversizedFile.Truncate(int64(maxYAMLPathSize + 1))).To(Succeed())
+	g.Expect(oversizedFile.Close()).To(Succeed())
+
+	m := &Manager{
+		kubeconfig: k8s.NewKubeConfig(),
+		kubeClient: k8s.NewClientFactory(cli.NewConfigFlags(false)),
+		timeout:    time.Second,
+	}
+
+	request := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name: ToolDiffKubernetesManifest,
+		},
+	}
+
+	tests := []struct {
+		testName   string
+		arguments  map[string]any
+		localFiles bool
+		matchErr   string
+	}{
+		{
+			testName: "fails with both yaml inputs",
+			arguments: map[string]any{
+				"yaml_content": "test: test",
+				"yaml_path":    yamlPath,
+			},
+			matchErr: "exactly one of yaml_content or yaml_path must be set",
+		},
+		{
+			testName:  "fails with neither yaml input",
+			arguments: map[string]any{},
+			matchErr:  "exactly one of yaml_content or yaml_path must be set",
+		},
+		{
+			testName: "fails with local files disabled",
+			arguments: map[string]any{
+				"yaml_path": yamlPath,
+			},
+			matchErr: "yaml_path is only available when the MCP server runs locally with the stdio transport, pass yaml_content instead",
+		},
+		{
+			testName: "fails with relative path",
+			arguments: map[string]any{
+				"yaml_path": "manifest.yaml",
+			},
+			localFiles: true,
+			matchErr:   "must be an absolute path because the server's working directory is unknown to the agent",
+		},
+		{
+			testName: "fails with nonexistent file",
+			arguments: map[string]any{
+				"yaml_path": filepath.Join(tempDir, "missing.yaml"),
+			},
+			localFiles: true,
+			matchErr:   "Failed to read yaml_path",
+		},
+		{
+			testName: "fails with directory",
+			arguments: map[string]any{
+				"yaml_path": tempDir,
+			},
+			localFiles: true,
+			matchErr:   "yaml_path must point to a regular file",
+		},
+		{
+			testName: "fails with oversized file",
+			arguments: map[string]any{
+				"yaml_path": oversizedPath,
+			},
+			localFiles: true,
+			matchErr:   "yaml_path exceeds the 64 MiB size limit",
+		},
+		{
+			testName: "reads local yaml before creating client",
+			arguments: map[string]any{
+				"yaml_path": yamlPath,
+			},
+			localFiles: true,
+			matchErr:   "Failed to get Kubernetes client",
+		},
+		{
+			testName: "fails with partial owner reference",
+			arguments: map[string]any{
+				"yaml_content": "test: test",
+				"owner_kind":   "Kustomization",
+			},
+			matchErr: "owner_kind, owner_name and owner_namespace must all be set",
+		},
+		{
+			testName: "fails with invalid kubeconfig",
+			arguments: map[string]any{
+				"yaml_content": "test: test",
+			},
+			matchErr: "Failed to get Kubernetes client",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			m.localFiles = test.localFiles
+			argsJSON, _ := json.Marshal(test.arguments)
+			request.Params.Arguments = argsJSON
+
+			var input diffKubernetesManifestInput
+			err := json.Unmarshal(request.Params.Arguments, &input)
+			g.Expect(err).ToNot(HaveOccurred())
+			result, content, err := m.HandleDiffKubernetesManifest(context.Background(), request, input)
+			g.Expect(err).ToNot(HaveOccurred())
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			g.Expect(ok).To(BeTrue())
+
+			g.Expect(result.IsError).To(BeTrue())
+			g.Expect(textContent.Text).To(ContainSubstring(test.matchErr))
+			_ = content
+		})
+	}
+}

--- a/cmd/mcp/toolbox/instructions.go
+++ b/cmd/mcp/toolbox/instructions.go
@@ -60,11 +60,29 @@ func (m *Manager) Instructions(inCluster bool) string {
 		}
 		b.WriteString(".\n")
 	}
+	if has(ToolDiffKubernetesManifest) {
+		line := "- Before committing GitOps changes, build the manifests locally (kustomize build <path> --load-restrictor=LoadRestrictionsNone, flux-operator build resourceset, helm template) and pass the COMPLETE output to " +
+			ToolDiffKubernetesManifest
+		if m.localFiles {
+			line += "; for large builds, write it to a file and pass the absolute path in yaml_path"
+		}
+		line += ". For manifests managed by Flux, identify the owner (Kustomization, HelmRelease or ResourceSet)"
+		if has(ToolGetKubernetesResources) {
+			line += " that matches spec.path/sourceRef with " + ToolGetKubernetesResources
+		}
+		line += " and set owner_kind/owner_name/owner_namespace, or pass its YAML in flux_object if it is new or not yet on the cluster." +
+			" Skip owner lookup when the user already names the owner; ad-hoc manifests need none."
+		b.WriteString(line + "\n")
+	}
 
 	var actions []string
 	if has(ToolApplyKubernetesManifest) {
-		actions = append(actions, "- To create or update resources, generate a Kubernetes multi-doc YAML and apply it with "+
-			ToolApplyKubernetesManifest+". Avoid changing Flux-managed resources directly unless explicitly asked.\n")
+		line := "- To create or update resources, generate a Kubernetes multi-doc YAML"
+		if has(ToolDiffKubernetesManifest) {
+			line += ", preview the changes with " + ToolDiffKubernetesManifest + " (no owner needed)"
+		}
+		actions = append(actions, line+" and apply it with "+ToolApplyKubernetesManifest+
+			". Avoid changing Flux-managed resources directly unless explicitly asked.\n")
 	}
 	var reconcilers []string
 	for _, tool := range []string{

--- a/cmd/mcp/toolbox/instructions_test.go
+++ b/cmd/mcp/toolbox/instructions_test.go
@@ -12,12 +12,15 @@ import (
 
 func TestManager_Instructions(t *testing.T) {
 	tests := []struct {
-		name      string
-		readOnly  bool
-		inCluster bool
-		enabled   []string
+		name       string
+		readOnly   bool
+		inCluster  bool
+		enabled    []string
+		localFiles bool
 	}{
 		{name: "all tools"},
+		{name: "local files", localFiles: true},
+		{name: "local files without diff", readOnly: true, enabled: []string{ToolGetKubernetesResources}, localFiles: true},
 		{name: "read-only", readOnly: true},
 		{name: "in-cluster", inCluster: true},
 		{name: "read-only in-cluster", readOnly: true, inCluster: true},
@@ -28,7 +31,7 @@ func TestManager_Instructions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			manager := NewManager(nil, 0, false, tt.readOnly, tt.enabled)
+			manager := NewManager(nil, 0, false, tt.readOnly, tt.enabled, tt.localFiles)
 			instructions := manager.Instructions(tt.inCluster)
 			g.Expect(instructions).To(HavePrefix("This server connects to Kubernetes API"))
 			g.Expect(instructions).ToNot(HaveSuffix("\n"))
@@ -45,6 +48,26 @@ func TestManager_Instructions(t *testing.T) {
 				} else {
 					g.Expect(instructions).ToNot(ContainSubstring(tool), "expected %s to be omitted", tool)
 				}
+			}
+
+			if manager.shouldRegisterTool(ToolDiffKubernetesManifest, tt.inCluster) {
+				g.Expect(instructions).To(ContainSubstring("Before committing GitOps changes"))
+				g.Expect(instructions).To(ContainSubstring("COMPLETE output"))
+				g.Expect(instructions).To(ContainSubstring("owner_kind/owner_name/owner_namespace"))
+				g.Expect(instructions).To(ContainSubstring("pass its YAML in flux_object"))
+				g.Expect(instructions).To(ContainSubstring("ad-hoc manifests need none"))
+			}
+
+			localFilesInstruction := "pass the absolute path in yaml_path"
+			if tt.localFiles && manager.shouldRegisterTool(ToolDiffKubernetesManifest, tt.inCluster) {
+				g.Expect(instructions).To(ContainSubstring(localFilesInstruction))
+			} else {
+				g.Expect(instructions).ToNot(ContainSubstring(localFilesInstruction))
+			}
+
+			if manager.shouldRegisterTool(ToolDiffKubernetesManifest, tt.inCluster) &&
+				manager.shouldRegisterTool(ToolApplyKubernetesManifest, tt.inCluster) {
+				g.Expect(instructions).To(ContainSubstring("preview the changes with " + ToolDiffKubernetesManifest))
 			}
 
 			if tt.readOnly {

--- a/cmd/mcp/toolbox/manager.go
+++ b/cmd/mcp/toolbox/manager.go
@@ -37,12 +37,13 @@ type Manager struct {
 	maskSecrets bool
 	readOnly    bool
 	enabled     []string
+	localFiles  bool
 }
 
 // NewManager initializes and returns a new Manager instance
 // with the provided configuration and settings.
 func NewManager(kubeClient *k8s.ClientFactory, timeout time.Duration,
-	maskSecrets bool, readOnly bool, enabled []string) *Manager {
+	maskSecrets bool, readOnly bool, enabled []string, localFiles bool) *Manager {
 
 	return &Manager{
 		kubeconfig:  k8s.NewKubeConfig(),
@@ -51,6 +52,7 @@ func NewManager(kubeClient *k8s.ClientFactory, timeout time.Duration,
 		maskSecrets: maskSecrets,
 		readOnly:    readOnly,
 		enabled:     enabled,
+		localFiles:  localFiles,
 	}
 }
 
@@ -147,6 +149,25 @@ func (m *Manager) RegisterTools(server *mcp.Server, inCluster bool) []string {
 			},
 			m.HandleSearchFluxDocs,
 		)
+	}
+	if m.shouldRegisterTool(ToolDiffKubernetesManifest, inCluster) {
+		tool := &mcp.Tool{
+			Name:        ToolDiffKubernetesManifest,
+			Description: "Diffs a Kubernetes YAML manifest against the cluster using a server-side apply dry-run.",
+		}
+		if !m.localFiles {
+			inputType := reflect.TypeFor[diffKubernetesManifestInput]()
+			schema, err := jsonschema.ForType(inputType, &jsonschema.ForOptions{})
+			if err != nil {
+				panic(fmt.Sprintf("AddTool: tool %q: input schema: %v", tool.Name, err))
+			}
+			delete(schema.Properties, "yaml_path")
+			schema.Required = slices.DeleteFunc(schema.Required, func(field string) bool {
+				return field == "yaml_path"
+			})
+			tool.InputSchema = schema
+		}
+		addTool(server, &recorder, tool, m.HandleDiffKubernetesManifest)
 	}
 	if m.shouldRegisterTool(ToolApplyKubernetesManifest, inCluster) {
 		addTool(server, &recorder,

--- a/cmd/mcp/toolbox/manager_test.go
+++ b/cmd/mcp/toolbox/manager_test.go
@@ -22,7 +22,7 @@ func TestManager_RegisterToolsDoesNotPanic(t *testing.T) {
 		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
 	})
 
-	manager := NewManager(nil, 0, false, false, nil)
+	manager := NewManager(nil, 0, false, false, nil, false)
 	registeredTools := manager.RegisterTools(server, false)
 	g.Expect(registeredTools).To(Equal([]string{
 		"install_flux_instance",
@@ -32,6 +32,7 @@ func TestManager_RegisterToolsDoesNotPanic(t *testing.T) {
 		"get_kubernetes_metrics",
 		"get_kubernetes_resources",
 		"search_flux_docs",
+		"diff_kubernetes_manifest",
 		"apply_kubernetes_manifest",
 		"delete_kubernetes_resource",
 		"reconcile_flux_source",
@@ -43,6 +44,92 @@ func TestManager_RegisterToolsDoesNotPanic(t *testing.T) {
 		"get_kubeconfig_contexts",
 		"set_kubeconfig_context",
 	}))
+}
+
+func TestManager_RegisterDiffKubernetesManifestModes(t *testing.T) {
+	tests := []struct {
+		name      string
+		readOnly  bool
+		inCluster bool
+	}{
+		{name: "read-only", readOnly: true},
+		{name: "in-cluster", inCluster: true},
+		{name: "read-only in-cluster", readOnly: true, inCluster: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			server := mcp.NewServer(&mcp.Implementation{
+				Name:    "flux-operator-mcp",
+				Version: "test-version",
+			}, nil)
+			manager := NewManager(nil, 0, false, tt.readOnly, nil, false)
+			registeredTools := manager.RegisterTools(server, tt.inCluster)
+			g.Expect(registeredTools).To(ContainElement(ToolDiffKubernetesManifest))
+		})
+	}
+}
+
+func TestManager_DiffKubernetesManifestSchemaLocalFiles(t *testing.T) {
+	tests := []struct {
+		name       string
+		localFiles bool
+		hasPath    bool
+	}{
+		{name: "local files disabled", localFiles: false, hasPath: false},
+		{name: "local files enabled", localFiles: true, hasPath: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			server := mcp.NewServer(&mcp.Implementation{
+				Name:    "flux-operator-mcp",
+				Version: "test-version",
+			}, &mcp.ServerOptions{
+				Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
+			})
+			manager := NewManager(nil, 0, false, false, []string{ToolDiffKubernetesManifest}, tt.localFiles)
+			manager.RegisterTools(server, false)
+
+			ctx := context.Background()
+			st, ct := mcp.NewInMemoryTransports()
+			_, err := server.Connect(ctx, st, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			client := mcp.NewClient(&mcp.Implementation{
+				Name:    "test-client",
+				Version: "test-version",
+			}, nil)
+			session, err := client.Connect(ctx, ct, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			result, err := session.ListTools(ctx, &mcp.ListToolsParams{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(result.Tools).To(HaveLen(1))
+			g.Expect(result.Tools[0].Name).To(Equal(ToolDiffKubernetesManifest))
+
+			raw, err := json.Marshal(result.Tools[0].InputSchema)
+			g.Expect(err).NotTo(HaveOccurred())
+			var schema struct {
+				Properties map[string]struct {
+					Description string `json:"description"`
+				} `json:"properties"`
+				Required []string `json:"required"`
+			}
+			err = json.Unmarshal(raw, &schema)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(schema.Properties["yaml_content"].Description).NotTo(ContainSubstring("yaml_path"))
+			g.Expect(schema.Required).NotTo(ContainElement("yaml_path"))
+
+			yamlPath, hasPath := schema.Properties["yaml_path"]
+			g.Expect(hasPath).To(Equal(tt.hasPath))
+			if tt.hasPath {
+				g.Expect(yamlPath.Description).To(Equal("Absolute path to a local multi-doc YAML file to diff."))
+			}
+		})
+	}
 }
 
 func TestManager_ToolSchemasIncludeProperties(t *testing.T) {
@@ -79,6 +166,10 @@ func TestManager_ToolSchemasIncludeProperties(t *testing.T) {
 		ToolSearchFluxDocs: {
 			properties: []string{"query", "limit", "format"},
 			required:   []string{"query"},
+		},
+		ToolDiffKubernetesManifest: {
+			properties: []string{"yaml_content", "flux_object", "owner_kind", "owner_name", "owner_namespace"},
+			required:   []string{},
 		},
 		ToolApplyKubernetesManifest: {
 			properties: []string{"yaml_content", "overwrite"},
@@ -129,7 +220,7 @@ func TestManager_ToolSchemasIncludeProperties(t *testing.T) {
 		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
 	})
 
-	manager := NewManager(nil, 0, false, false, nil)
+	manager := NewManager(nil, 0, false, false, nil, false)
 	manager.RegisterTools(server, false)
 
 	ctx := context.Background()
@@ -202,7 +293,7 @@ func TestManager_RegisterSpecificTools(t *testing.T) {
 	manager := NewManager(nil, 0, false, false, []string{
 		"get_kubeconfig_contexts",
 		"set_kubeconfig_context",
-	})
+	}, false)
 	registeredTools := manager.RegisterTools(server, false)
 	g.Expect(registeredTools).To(Equal([]string{
 		"get_kubeconfig_contexts",

--- a/cmd/mcp/toolbox/scopes.go
+++ b/cmd/mcp/toolbox/scopes.go
@@ -80,6 +80,10 @@ var scopesPerTool = map[string]toolScopes{
 		ownScopeDescription: "Allow getting Kubernetes resources.",
 		extraScopes:         []string{ScopeReadOnly},
 	},
+	ToolDiffKubernetesManifest: {
+		ownScopeDescription: "Allow diffing Kubernetes manifests against the cluster.",
+		extraScopes:         []string{ScopeReadOnly},
+	},
 	ToolApplyKubernetesManifest: {
 		ownScopeDescription: "Allow applying Kubernetes manifests.",
 		extraScopes:         []string{},

--- a/cmd/mcp/toolbox/scopes_test.go
+++ b/cmd/mcp/toolbox/scopes_test.go
@@ -148,6 +148,28 @@ func TestGetToolScopes(t *testing.T) {
 			},
 		},
 		{
+			name:     "read-only diff tool",
+			tool:     ToolDiffKubernetesManifest,
+			readOnly: false,
+			expected: []Scope{
+				{
+					Name:        "toolbox:" + ToolDiffKubernetesManifest,
+					Description: "Allow diffing Kubernetes manifests against the cluster.",
+					Tools:       []string{ToolDiffKubernetesManifest},
+				},
+				{
+					Name:        "toolbox:read_write",
+					Description: "Allow all operations.",
+					Tools:       []string{ToolDiffKubernetesManifest},
+				},
+				{
+					Name:        "toolbox:read_only",
+					Description: "Allow all read-only operations.",
+					Tools:       []string{ToolDiffKubernetesManifest},
+				},
+			},
+		},
+		{
 			name:     "write tool without extra scopes",
 			tool:     ToolApplyKubernetesManifest,
 			readOnly: false,

--- a/docs/mcp/instructions.md
+++ b/docs/mcp/instructions.md
@@ -44,9 +44,41 @@ For Flux API guidance, call the `search_flux_docs` tool with targeted questions.
 - When asked to use a specific cluster, call the `get_kubeconfig_contexts` tool to find the cluster context before switching to it with the `set_kubeconfig_context` tool.
 - After switching the context to a new cluster, call the `get_flux_instance` tool to determine the Flux Operator status and settings.
 - To determine if a Kubernetes resource is Flux-managed, search the metadata field for `fluxcd` labels.
-- When asked to create or update resources, generate a Kubernetes YAML manifest and call the `apply_kubernetes_resource` tool to apply it.
+- When asked to create or update resources, generate a Kubernetes YAML manifest and call the `apply_kubernetes_manifest` tool to apply it.
 - Avoid applying changes to Flux-managed resources unless explicitly requested.
 - When asked about Flux CRDs, call the `search_flux_docs` tool with a targeted query. Prefer the default concise format; use `format: complete` only when the full upstream API docs are needed.
+
+## Previewing changes before committing
+
+Use `diff_kubernetes_manifest` as a pre-commit gate: build locally, send the complete build output,
+review the diff and header warnings, then commit. For large builds, write the output to a file and
+pass its absolute path in `yaml_path` (local `stdio` servers) instead of sending it in `yaml_content`.
+Build according to the owner type:
+
+- For a Kustomization, run `kustomize build <path> --load-restrictor=LoadRestrictionsNone`.
+- For a ResourceSet, run `flux envsubst` first, then `flux-operator build resourceset` with an
+  inputs file made from the live ResourceSetInputProvider `status.exportedInputs`.
+- For a HelmRelease, run
+  `helm template <releaseName> <chart> -n <releaseNamespace> --include-crds`, with `spec.values`
+  merged over the referenced `valuesFrom` values; `postRenderers` are applied by the tool.
+
+Always send the **complete** build output. The owner is the Flux object (Kustomization, HelmRelease,
+or ResourceSet) that applies the manifest, not the kind of the objects inside it. Only Flux-managed
+manifests need an owner; ad-hoc manifests need none. Skip the owner lookup when the user already
+names the owner, otherwise find it with `get_kubernetes_resources`, matching a Kustomization's
+`spec.path` and `sourceRef` to the repository directory, or use `flux operator tree`.
+
+If the owner is not found on the cluster, it is new. Compose its definition from the new repository content and
+pass it in `flux_object` with `metadata.namespace` set. For owners templated by a ResourceSet,
+render the template by hand; when an input provider has not exported an image tag yet, use a
+placeholder image. Preview a new application in two calls: first diff the parent Kustomization to
+show the new owner custom resource as `create`, then diff the application manifests with the new
+owner in `flux_object`. Prune is skipped for the second call because the owner is not yet in the cluster.
+
+Kustomize-controller generates a kustomization for directories without `kustomization.yaml`. For
+these directories, run `kustomize create --autodetect` in a copy before building, or concatenate
+the YAML files. Read all header warnings. Treat `delete` entries as objects that would be pruned
+only when the supplied manifest is complete.
 
 ## Kubernetes logs analysis
 

--- a/docs/mcp/mcp-config.md
+++ b/docs/mcp/mcp-config.md
@@ -47,6 +47,9 @@ Replace `/path/to/.kube/config` with the absolute path to your kubeconfig file.
 ### Streamable HTTP (`http`)
 
 Web-based transport that allows the server to push updates to the client.
+The `diff_kubernetes_manifest` tool's `yaml_path` input is advertised only when the server runs
+locally over the `stdio` transport. It is not included in the tool schema for the `http` transport
+or in-cluster deployments; use `yaml_content` instead.
 The server implements the MCP specification `2026-07-28` and runs in stateless mode:
 no session state is kept between requests, so the server can be scaled horizontally
 behind a load balancer without sticky sessions. Clients using older versions of the
@@ -102,6 +105,11 @@ In production environments, you can run the server in read-only mode to prevent 
 
     In read-only mode, the MCP [tools](tools.md) that modify the cluster state
     (reconcile, suspend, resume, apply, delete) are disabled.
+
+The `diff_kubernetes_manifest` tool is available in read-only mode because it never mutates the
+cluster. Kubernetes authorizes server-side dry-run like a real apply, so the MCP identity needs
+`get` and `patch` on the manifest kinds, plus `get` on owner kinds and on ConfigMaps and Secrets
+used by `substituteFrom` or `copyFrom`. A view-only identity receives per-object forbidden errors.
 
 ### Secret Masking
 

--- a/docs/mcp/mcp-prompting.md
+++ b/docs/mcp/mcp-prompting.md
@@ -72,6 +72,7 @@ Reporting and analysis:
 - Which images are deployed by Flux in the monitoring namespace?
 - List the Helm releases in the cluster with their chart version constraints and the versions currently deployed.
 - Perform a root cause analysis of the last failed deployment in the frontend namespace.
+- Preview what changing the staging app overlay would do on the cluster before committing it.
 
 Actions:
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -226,6 +226,67 @@ Resumes the reconciliation of a previously suspended Flux resource.
 
 Confirmation message indicating the resource has been resumed.
 
+## Diff Tool
+
+This tool previews Kubernetes changes without mutating the cluster.
+
+### diff_kubernetes_manifest
+
+Diffs a multi-document YAML manifest against the cluster using server-side apply dry-run with
+the Flux controller's field manager. Use it to preview a direct apply or the effect of a GitOps
+commit before pushing it to the repo. The owner transforms are applied before the dry-run:
+Kustomization build options and `postBuild` substitutions, ResourceSet `copyFrom`, HelmRelease
+`postRenderers` and release metadata, and the `commonMetadata` and owner labels of all kinds.
+
+**Parameters:**
+
+When `yaml_path` is advertised, exactly one of `yaml_content` or `yaml_path` must be specified;
+otherwise, `yaml_content` must be specified.
+
+- `yaml_content` (optional): The complete multi-document YAML build output to diff
+- `yaml_path` (optional): The absolute path to a local multi-document YAML build output file;
+  mutually exclusive with `yaml_content`, advertised only when the server runs locally over the
+  `stdio` transport, with a 64 MiB file size limit
+- `flux_object` (optional): The YAML definition of the Kustomization, ResourceSet, or HelmRelease
+  that applies the manifest, as it will exist after the change
+- `owner_kind`, `owner_name`, `owner_namespace` (optional): A reference to an existing owner;
+  all three parameters must be specified together
+
+**Output:**
+
+Each manifest object is reported as `create`, `recreate`, `update`, `unchanged`, `skipped`, or
+`error`; inventory objects absent from the manifest are reported as `delete`. Updates include an
+RFC 6902 JSON patch in YAML form, with Secret values masked. The final summary line counts every
+state. For example:
+
+```text
+Diff for Kustomization/apps-staging/backend (field manager: kustomize-controller, prune: enabled)
+
+ConfigMap/apps-staging/backend-7f2k9c4mbt create
+Deployment/apps-staging/backend update
+- op: replace
+  path: /spec/template/spec/containers/0/envFrom/0/configMapRef/name
+  value: backend-7f2k9c4mbt
+Service/apps-staging/backend unchanged
+
+Not in the manifest (pruned if the manifest is complete):
+ConfigMap/apps-staging/backend-m759gh88kd delete
+
+Summary: 1 create, 1 update, 1 unchanged, 1 delete
+```
+
+**Limitations:**
+
+- Owners targeting remote clusters are not supported.
+- Kustomization `spec.components` is not applied.
+- ResourceSet `checksumFrom` and `convertKubeConfigFrom` are not resolved.
+- SOPS-encrypted objects are compared by key set only.
+- Kustomization `namePrefix` and `nameSuffix` are added to the names in the build output, while
+  kustomize-controller replaces the ones set in the source `kustomization.yaml`; when both are set,
+  the diff reports different names than the cluster.
+- Kustomization `buildMetadata` is not applied; the labels and annotations it adds are ignored.
+- Managed-fields cleanup is not simulated.
+
 ## Apply Tool
 
 This tool allows creating or updating Kubernetes resources in the cluster.

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,8 @@ require (
 	k8s.io/client-go v0.36.3
 	k8s.io/metrics v0.36.3
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/kustomize/api v0.21.1
+	sigs.k8s.io/kustomize/kyaml v0.21.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -246,8 +248,6 @@ require (
 	k8s.io/kubectl v0.36.3 // indirect
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/kustomize/api v0.21.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect
 )

--- a/internal/controller/resourceset_controller_configs.go
+++ b/internal/controller/resourceset_controller_configs.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/copier"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/kubeconfig"
 )
 
@@ -31,70 +32,7 @@ const (
 // annotations set on the resources template.
 func (r *ResourceSetReconciler) copyResources(ctx context.Context,
 	kubeClient client.Client, objects []*unstructured.Unstructured) error {
-	for i := range objects {
-		if objects[i].GetAPIVersion() == "v1" {
-			source, found := objects[i].GetAnnotations()[fluxcdv1.CopyFromAnnotation]
-			if !found {
-				continue
-			}
-
-			sourceParts := strings.Split(source, "/")
-			if len(sourceParts) != 2 {
-				return fmt.Errorf("invalid %s annotation value '%s' must be in the format 'namespace/name'",
-					fluxcdv1.CopyFromAnnotation, source)
-			}
-
-			sourceName := types.NamespacedName{
-				Namespace: sourceParts[0],
-				Name:      sourceParts[1],
-			}
-
-			switch objects[i].GetKind() {
-			case kindConfigMap:
-				cm := &corev1.ConfigMap{}
-				if err := kubeClient.Get(ctx, sourceName, cm); err != nil {
-					return fmt.Errorf("failed to copy data from ConfigMap/%s: %w", source, err)
-				}
-				if err := unstructured.SetNestedStringMap(objects[i].Object, cm.Data, "data"); err != nil {
-					return fmt.Errorf("failed to copy data from ConfigMap/%s: %w", source, err)
-				}
-				if len(cm.BinaryData) > 0 {
-					binaryData := make(map[string]string, len(cm.BinaryData))
-					for k, v := range cm.BinaryData {
-						binaryData[k] = base64.StdEncoding.EncodeToString(v)
-					}
-					if err := unstructured.SetNestedStringMap(objects[i].Object, binaryData, "binaryData"); err != nil {
-						return fmt.Errorf("failed to copy binaryData from ConfigMap/%s: %w", source, err)
-					}
-				}
-			case kindSecret:
-				secret := &corev1.Secret{}
-				if err := kubeClient.Get(ctx, sourceName, secret); err != nil {
-					return fmt.Errorf("failed to copy data from Secret/%s: %w", source, err)
-				}
-				_, ok, err := unstructured.NestedString(objects[i].Object, "type")
-				if err != nil {
-					return fmt.Errorf("type field of Secret/%s is not a string: %w", source, err)
-				}
-				if !ok {
-					if secret.Type == "" {
-						secret.Type = corev1.SecretTypeOpaque
-					}
-					if err := unstructured.SetNestedField(objects[i].Object, string(secret.Type), "type"); err != nil {
-						return fmt.Errorf("failed to copy type from Secret/%s: %w", source, err)
-					}
-				}
-				data := make(map[string]string, len(secret.Data))
-				for k, v := range secret.Data {
-					data[k] = string(v)
-				}
-				if err := unstructured.SetNestedStringMap(objects[i].Object, data, "stringData"); err != nil {
-					return fmt.Errorf("failed to copy data from Secret/%s: %w", source, err)
-				}
-			}
-		}
-	}
-	return nil
+	return copier.CopyResources(ctx, kubeClient, objects)
 }
 
 // convertKubeConfigResources converts kubeconfig data stored in Secrets

--- a/internal/copier/resources.go
+++ b/internal/copier/resources.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Package copier provides shared Kubernetes resource data-copy transforms.
+package copier
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+const (
+	kindConfigMap = "ConfigMap"
+	kindSecret    = "Secret"
+)
+
+// CopyResources copies data from ConfigMaps and Secrets referenced by the
+// fluxcd.controlplane.io/copyFrom annotation. It intentionally does not process
+// checksumFrom or convertKubeConfigFrom annotations.
+func CopyResources(ctx context.Context, kubeClient client.Client, objects []*unstructured.Unstructured) error {
+	for i := range objects {
+		if objects[i].GetAPIVersion() == "v1" {
+			source, found := objects[i].GetAnnotations()[fluxcdv1.CopyFromAnnotation]
+			if !found {
+				continue
+			}
+
+			sourceParts := strings.Split(source, "/")
+			if len(sourceParts) != 2 {
+				return fmt.Errorf("invalid %s annotation value '%s' must be in the format 'namespace/name'",
+					fluxcdv1.CopyFromAnnotation, source)
+			}
+
+			sourceName := types.NamespacedName{
+				Namespace: sourceParts[0],
+				Name:      sourceParts[1],
+			}
+
+			switch objects[i].GetKind() {
+			case kindConfigMap:
+				cm := &corev1.ConfigMap{}
+				if err := kubeClient.Get(ctx, sourceName, cm); err != nil {
+					return fmt.Errorf("failed to copy data from ConfigMap/%s: %w", source, err)
+				}
+				if err := unstructured.SetNestedStringMap(objects[i].Object, cm.Data, "data"); err != nil {
+					return fmt.Errorf("failed to copy data from ConfigMap/%s: %w", source, err)
+				}
+				if len(cm.BinaryData) > 0 {
+					binaryData := make(map[string]string, len(cm.BinaryData))
+					for k, v := range cm.BinaryData {
+						binaryData[k] = base64.StdEncoding.EncodeToString(v)
+					}
+					if err := unstructured.SetNestedStringMap(objects[i].Object, binaryData, "binaryData"); err != nil {
+						return fmt.Errorf("failed to copy binaryData from ConfigMap/%s: %w", source, err)
+					}
+				}
+			case kindSecret:
+				secret := &corev1.Secret{}
+				if err := kubeClient.Get(ctx, sourceName, secret); err != nil {
+					return fmt.Errorf("failed to copy data from Secret/%s: %w", source, err)
+				}
+				_, ok, err := unstructured.NestedString(objects[i].Object, "type")
+				if err != nil {
+					return fmt.Errorf("type field of Secret/%s is not a string: %w", source, err)
+				}
+				if !ok {
+					if secret.Type == "" {
+						secret.Type = corev1.SecretTypeOpaque
+					}
+					if err := unstructured.SetNestedField(objects[i].Object, string(secret.Type), "type"); err != nil {
+						return fmt.Errorf("failed to copy type from Secret/%s: %w", source, err)
+					}
+				}
+				data := make(map[string]string, len(secret.Data))
+				for k, v := range secret.Data {
+					data[k] = string(v)
+				}
+				if err := unstructured.SetNestedStringMap(objects[i].Object, data, "stringData"); err != nil {
+					return fmt.Errorf("failed to copy data from Secret/%s: %w", source, err)
+				}
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This RR adds a read-only tool to the MCP Server which allows AI Agents to preview changes made to manifests in a Flux repository. 

The agent is instructed to produce the manifests with changes and call the tool with the multi-doc YAML:

- For a Kustomization, run `kustomize build <path> --load-restrictor=LoadRestrictionsNone`.
- For a ResourceSet, run `flux-operator build resourceset` with an inputs file made from the live ResourceSetInputProvider `status.exportedInputs`.
- For a HelmRelease, run `helm template <releaseName> <chart> -n <releaseNamespace> --include-crds`, with `spec.values` merged over the referenced `valuesFrom` values; `postRenderers` are applied by the tool.


### Tool Specification

Diffs a multi-document YAML manifest against the cluster using server-side apply dry-run with
the Flux controller's field manager. Use it to preview a direct apply or the effect of a GitOps
commit before pushing it to the repo. The owner transforms are applied before the dry-run:
Kustomization build options and `postBuild` substitutions, ResourceSet `copyFrom`, HelmRelease
`postRenderers` and release metadata, and the `commonMetadata` and owner labels of all kinds.

**Parameters:**

When `yaml_path` is advertised, exactly one of `yaml_content` or `yaml_path` must be specified;
otherwise, `yaml_content` must be specified.

- `yaml_content` (optional): The complete multi-document YAML build output to diff
- `yaml_path` (optional): The absolute path to a local multi-document YAML build output file;
  mutually exclusive with `yaml_content`, advertised only when the server runs locally over the
  `stdio` transport, with a 64 MiB file size limit
- `flux_object` (optional): The YAML definition of the Kustomization, ResourceSet, or HelmRelease
  that applies the manifest, as it will exist after the change
- `owner_kind`, `owner_name`, `owner_namespace` (optional): A reference to an existing owner;
  all three parameters must be specified together

**Output:**

Each manifest object is reported as `create`, `recreate`, `update`, `unchanged`, `skipped`, or
`error`; inventory objects absent from the manifest are reported as `delete`. Updates include an
RFC 6902 JSON patch in YAML form, with Secret values masked. The final summary line counts every
state. For example:

```text
Diff for Kustomization/apps-staging/backend (field manager: kustomize-controller, prune: enabled)

ConfigMap/apps-staging/backend-7f2k9c4mbt create
Deployment/apps-staging/backend update
- op: replace
  path: /spec/template/spec/containers/0/envFrom/0/configMapRef/name
  value: backend-7f2k9c4mbt
Service/apps-staging/backend unchanged

Not in the manifest (pruned if the manifest is complete):
ConfigMap/apps-staging/backend-m759gh88kd delete

Summary: 1 create, 1 update, 1 unchanged, 1 delete
```

**Limitations:**

- Owners targeting remote clusters are not supported.
- Kustomization `spec.components` is not applied.
- ResourceSet `checksumFrom` and `convertKubeConfigFrom` are not resolved.
- SOPS-encrypted objects are compared by key set only.
- Kustomization `namePrefix` and `nameSuffix` are added to the names in the build output, while
  kustomize-controller replaces the ones set in the source `kustomization.yaml`; when both are set,
  the diff reports different names than the cluster.
- Kustomization `buildMetadata` is not applied; the labels and annotations it adds are ignored.
- Managed-fields cleanup is not simulated.
