### PR TITLE
operator: honor reconcile   disabled annotation on in-cluster objects

### DIFF
--- a/docs/api/v1/resourceset.md
+++ b/docs/api/v1/resourceset.md
@@ -672,6 +672,25 @@ spec:
 
 In the above example, the `ServiceAccount` resource is generated only for the `team1` tenant.
 
+#### Freezing a resource in-cluster
+
+The `fluxcd.controlplane.io/reconcile: disabled` annotation is also honored when set on a
+live object in the cluster. When the operator finds the annotation on an existing resource,
+it skips it from server-side apply and leaves any manual changes in place. 
+
+This allows freezing a single resource without suspending the whole ResourceSet:
+
+```shell
+kubectl annotate ocirepository/podinfo fluxcd.controlplane.io/reconcile=disabled
+```
+
+Removing the annotation resumes the reconciliation, and any manual changes are
+reverted on the next apply:
+
+```shell
+kubectl annotate ocirepository/podinfo fluxcd.controlplane.io/reconcile-
+```
+
 #### Built-in input fields
 
 When computing all the input sets for generating the resource matrix, the operator

--- a/internal/controller/resourceset_controller.go
+++ b/internal/controller/resourceset_controller.go
@@ -545,6 +545,12 @@ func (r *ResourceSetReconciler) apply(ctx context.Context,
 	applyOpts.ForceSelector = map[string]string{
 		fluxcdv1.ForceAnnotation: fluxcdv1.EnabledValue,
 	}
+	// Skip the in-cluster objects annotated with reconcile disabled,
+	// to allow users to freeze a resource managed by a ResourceSet
+	// without suspending the reconciliation of the whole set.
+	applyOpts.ExclusionSelector = map[string]string{
+		fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue,
+	}
 	applyOpts.Cleanup = ssa.ApplyCleanupOptions{
 		// Remove the kubectl and helm annotations.
 		Annotations: []string{
@@ -815,6 +821,15 @@ func (r *ResourceSetReconciler) deleteFailedJobs(ctx context.Context,
 
 		// Skip the Jobs which have not failed.
 		if !isJobFailed(job) {
+			continue
+		}
+
+		// Skip the Jobs frozen with the reconcile disabled annotation,
+		// as they are excluded from the server-side apply and would
+		// not be recreated after deletion.
+		if ssautil.AnyInMetadata(job, map[string]string{
+			fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue,
+		}) {
 			continue
 		}
 

--- a/internal/controller/resourceset_controller_steps_test.go
+++ b/internal/controller/resourceset_controller_steps_test.go
@@ -1796,3 +1796,85 @@ spec:
 		}
 	}
 }
+
+func TestResourceSetReconciler_KeepsFrozenFailedJobs(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	objDef := fmt.Sprintf(`
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: frozen-jobs
+  namespace: "%[1]s"
+spec:
+  resourcesTemplate: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: job-frozen
+      namespace: "%[1]s"
+      annotations:
+        fluxcd.controlplane.io/recreateOnFailure: enabled
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: main
+              image: busybox
+              command: ["true"]
+`, ns.Name)
+
+	obj := &fluxcdv1.ResourceSet{}
+	err = yaml.Unmarshal([]byte(objDef), obj)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Initialize and reconcile the Job.
+	err = testEnv.Create(ctx, obj)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	for range 2 {
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(obj),
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
+	jobKey := client.ObjectKey{Name: "job-frozen", Namespace: ns.Name}
+	job := &batchv1.Job{}
+	err = testClient.Get(ctx, jobKey, job)
+	g.Expect(err).ToNot(HaveOccurred())
+	jobUID := string(job.UID)
+
+	// Mark the Job as failed, as no Job controller is running in envtest.
+	markJobFailed(ctx, g, job)
+
+	// Freeze the failed Job with the reconcile disabled annotation.
+	err = testClient.Get(ctx, jobKey, job)
+	g.Expect(err).ToNot(HaveOccurred())
+	jobP := job.DeepCopy()
+	jobP.SetAnnotations(map[string]string{
+		fluxcdv1.RecreateOnFailureAnnotation: fluxcdv1.EnabledValue,
+		fluxcdv1.ReconcileAnnotation:         fluxcdv1.DisabledValue,
+	})
+	err = testClient.Patch(ctx, jobP, client.MergeFrom(job), client.FieldOwner("kubectl-annotate"))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Check that the frozen Job was not deleted for recreation.
+	err = testClient.Get(ctx, jobKey, job)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(job.DeletionTimestamp.IsZero()).To(BeTrue())
+	g.Expect(string(job.UID)).To(Equal(jobUID))
+	g.Expect(job.Annotations).To(HaveKeyWithValue(fluxcdv1.ReconcileAnnotation, fluxcdv1.DisabledValue))
+}

--- a/internal/controller/resourceset_controller_test.go
+++ b/internal/controller/resourceset_controller_test.go
@@ -1528,6 +1528,131 @@ metadata:
 	g.Expect(err).ToNot(HaveOccurred())
 }
 
+func TestResourceSetReconciler_ReconcileDisabledOnLiveObject(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := getResourceSetReconciler(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ns, err := testEnv.CreateNamespace(ctx, "test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	objDef := fmt.Sprintf(`
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: test
+  namespace: "%[1]s"
+spec:
+  resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: frozen
+        namespace: "%[1]s"
+      data:
+        key: "from-template"
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: tracked
+        namespace: "%[1]s"
+      data:
+        key: "from-template"
+`, ns.Name)
+
+	obj := &fluxcdv1.ResourceSet{}
+	err = yaml.Unmarshal([]byte(objDef), obj)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = testEnv.Create(ctx, obj)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Initialize the resource set and apply the resources.
+	for range 2 {
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(obj),
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
+	frozenKey := client.ObjectKey{Namespace: ns.Name, Name: "frozen"}
+	trackedKey := client.ObjectKey{Namespace: ns.Name, Name: "tracked"}
+
+	frozen := &corev1.ConfigMap{}
+	err = testClient.Get(ctx, frozenKey, frozen)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(frozen.Data).To(HaveKeyWithValue("key", "from-template"))
+
+	tracked := &corev1.ConfigMap{}
+	err = testClient.Get(ctx, trackedKey, tracked)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(tracked.Data).To(HaveKeyWithValue("key", "from-template"))
+
+	// Change both resources outside of the ResourceSet and mark
+	// only one of them with the reconcile disabled annotation.
+	frozenP := frozen.DeepCopy()
+	frozenP.SetAnnotations(map[string]string{
+		fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue,
+	})
+	frozenP.Data["key"] = "manual-edit"
+	err = testClient.Patch(ctx, frozenP, client.MergeFrom(frozen), client.FieldOwner("kubectl-edit"))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	trackedP := tracked.DeepCopy()
+	trackedP.Data["key"] = "manual-edit"
+	err = testClient.Patch(ctx, trackedP, client.MergeFrom(tracked), client.FieldOwner("kubectl-edit"))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Check that the annotated resource was skipped from apply,
+	// with both the manual change and the annotation left in place.
+	err = testClient.Get(ctx, frozenKey, frozen)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(frozen.Data).To(HaveKeyWithValue("key", "manual-edit"))
+	g.Expect(frozen.Annotations).To(HaveKeyWithValue(fluxcdv1.ReconcileAnnotation, fluxcdv1.DisabledValue))
+
+	// Check that the resources without the annotation are still
+	// reconciled and their drift is corrected.
+	err = testClient.Get(ctx, trackedKey, tracked)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(tracked.Data).To(HaveKeyWithValue("key", "from-template"))
+
+	// Check that the skipped resource is kept in the inventory,
+	// so that it is not subject to garbage collection.
+	result := &fluxcdv1.ResourceSet{}
+	err = testClient.Get(ctx, client.ObjectKeyFromObject(obj), result)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	testutils.LogObjectStatus(t, result)
+	g.Expect(result.Status.Inventory.Entries).To(ContainElement(
+		fluxcdv1.ResourceRef{
+			ID:      fmt.Sprintf("%s_frozen__ConfigMap", ns.Name),
+			Version: "v1",
+		},
+	))
+
+	// Remove the annotation from the live object and check that
+	// the resource is reconciled again.
+	frozenP = frozen.DeepCopy()
+	frozenP.SetAnnotations(map[string]string{})
+	err = testClient.Patch(ctx, frozenP, client.MergeFrom(frozen), client.FieldOwner("kubectl-edit"))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(obj),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = testClient.Get(ctx, frozenKey, frozen)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(frozen.Data).To(HaveKeyWithValue("key", "from-template"))
+}
+
 func getResourceSetReconciler(t *testing.T) *ResourceSetReconciler {
 	tmpDir := t.TempDir()
 	err := os.WriteFile(fmt.Sprintf("%s/kubeconfig", tmpDir), testKubeConfig, 0644)

--- a/test/e2e/instance_test.go
+++ b/test/e2e/instance_test.go
@@ -106,6 +106,52 @@ var _ = Describe("FluxInstance", Ordered, func() {
 				ExpectWithOffset(2, err).ToNot(HaveOccurred())
 				ExpectWithOffset(2, output).To(ContainSubstring("Reconciliation finished"))
 
+				// Freeze a managed resource by annotating the live object,
+				// then change it and verify the operator leaves it alone.
+				cmd = exec.Command("kubectl", "annotate", "ocirepository/podinfo-team1",
+					"fluxcd.controlplane.io/reconcile=disabled", "--overwrite",
+				)
+				_, err = Run(cmd, "/test/e2e")
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "patch", "ocirepository/podinfo-team1",
+					"--type=json", `-p=[{"op": "replace", "path": "/spec/interval", "value":"20m"}]`,
+				)
+				_, err = Run(cmd, "/test/e2e")
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+
+				cmd = exec.Command(cli, "reconcile", "rset", "podinfo")
+				_, err = Run(cmd, "/test/e2e")
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "get", "ocirepository/podinfo-team1", "-o=yaml")
+				output, err = Run(cmd, "/test/e2e")
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+				ExpectWithOffset(2, output).To(ContainSubstring("interval: 20m"))
+				ExpectWithOffset(2, output).To(ContainSubstring("fluxcd.controlplane.io/reconcile: disabled"))
+
+				// The resources without the annotation are still reconciled.
+				cmd = exec.Command("kubectl", "get", "ocirepository/podinfo-team2", "-o=yaml")
+				output, err = Run(cmd, "/test/e2e")
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+				ExpectWithOffset(2, output).To(ContainSubstring("interval: 10m"))
+
+				// Unfreeze the resource and verify the drift is corrected.
+				cmd = exec.Command("kubectl", "annotate", "ocirepository/podinfo-team1",
+					"fluxcd.controlplane.io/reconcile-",
+				)
+				_, err = Run(cmd, "/test/e2e")
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+
+				cmd = exec.Command(cli, "reconcile", "rset", "podinfo")
+				_, err = Run(cmd, "/test/e2e")
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "get", "ocirepository/podinfo-team1", "-o=yaml")
+				output, err = Run(cmd, "/test/e2e")
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+				ExpectWithOffset(2, output).To(ContainSubstring("interval: 10m"))
+
 				cmd = exec.Command(cli, "stats")
 				output, err = Run(cmd, "/test/e2e")
 				ExpectWithOffset(2, err).NotTo(HaveOccurred())


### PR DESCRIPTION
Closes #1004

 Sets `ExclusionSelector` on the apply options so in-cluster objects annotated with `fluxcd.controlplane.io/reconcile: disabled` are skipped, the same way kustomize-controller does it. Skipped objects are still recorded in the changeset, so they stay in the inventory and are not garbage collected, and removing the annotation resumes the reconciliation and corrects the drift.

I also skipped failed Jobs annotated with `recreateOnFailure`, since those are deleted before the apply and would come back from the template regardless of the annotation. Happy to pull that out into its own PR if you would rather keep this one to the apply path.

Added envtest coverage for both the frozen and the non frozen resource plus the Job case, and extended the ResourceSet e2e to freeze and unfreeze a live OCIRepository. Let me know if you want more or different coverage @stefanprodan @matheuscscp