### PR TITLE
mcp: remove dead code for enabling specific tools

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -197,7 +197,7 @@ func serveCmdRun(cmd *cobra.Command, args []string) error {
 
 	// Create the MCP server with instructions tailored to the enabled tools
 	kubeClient := k8s.NewClientFactory(kubeconfigArgs)
-	tm := toolbox.NewManager(kubeClient, rootArgs.timeout, rootArgs.maskSecrets, rootArgs.readOnly, nil,
+	tm := toolbox.NewManager(kubeClient, rootArgs.timeout, rootArgs.maskSecrets, rootArgs.readOnly,
 		rootArgs.transport == "stdio" && !inCluster)
 	mcpServer := mcp.NewServer(mcpImpl, &mcp.ServerOptions{
 		Instructions: tm.Instructions(inCluster),

--- a/cmd/mcp/main_test.go
+++ b/cmd/mcp/main_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func newTestServer() *mcp.Server {
-	tm := toolbox.NewManager(k8s.NewClientFactory(kubeconfigArgs), time.Minute, true, true, nil, false)
+	tm := toolbox.NewManager(k8s.NewClientFactory(kubeconfigArgs), time.Minute, true, true, false)
 	mcpServer := mcp.NewServer(mcpImpl, &mcp.ServerOptions{
 		Instructions: tm.Instructions(true),
 		Capabilities: &mcp.ServerCapabilities{

--- a/cmd/mcp/toolbox/instructions_test.go
+++ b/cmd/mcp/toolbox/instructions_test.go
@@ -15,23 +15,22 @@ func TestManager_Instructions(t *testing.T) {
 		name       string
 		readOnly   bool
 		inCluster  bool
-		enabled    []string
 		localFiles bool
 	}{
 		{name: "all tools"},
 		{name: "local files", localFiles: true},
-		{name: "local files without diff", readOnly: true, enabled: []string{ToolGetKubernetesResources}, localFiles: true},
+		{name: "local files without diff", readOnly: true, localFiles: true},
 		{name: "read-only", readOnly: true},
 		{name: "in-cluster", inCluster: true},
 		{name: "read-only in-cluster", readOnly: true, inCluster: true},
-		{name: "enabled subset", enabled: []string{ToolGetKubernetesResources, ToolReconcileFluxKustomization}},
+		{name: "enabled subset"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			manager := NewManager(nil, 0, false, tt.readOnly, tt.enabled, tt.localFiles)
+			manager := NewManager(nil, 0, false, tt.readOnly, tt.localFiles)
 			instructions := manager.Instructions(tt.inCluster)
 			g.Expect(instructions).To(HavePrefix("This server connects to Kubernetes API"))
 			g.Expect(instructions).ToNot(HaveSuffix("\n"))

--- a/cmd/mcp/toolbox/manager.go
+++ b/cmd/mcp/toolbox/manager.go
@@ -36,14 +36,13 @@ type Manager struct {
 	timeout     time.Duration
 	maskSecrets bool
 	readOnly    bool
-	enabled     []string
 	localFiles  bool
 }
 
 // NewManager initializes and returns a new Manager instance
 // with the provided configuration and settings.
 func NewManager(kubeClient *k8s.ClientFactory, timeout time.Duration,
-	maskSecrets bool, readOnly bool, enabled []string, localFiles bool) *Manager {
+	maskSecrets bool, readOnly bool, localFiles bool) *Manager {
 
 	return &Manager{
 		kubeconfig:  k8s.NewKubeConfig(),
@@ -51,7 +50,6 @@ func NewManager(kubeClient *k8s.ClientFactory, timeout time.Duration,
 		timeout:     timeout,
 		maskSecrets: maskSecrets,
 		readOnly:    readOnly,
-		enabled:     enabled,
 		localFiles:  localFiles,
 	}
 }
@@ -277,9 +275,6 @@ func (m *Manager) shouldRegisterTool(tool string, inCluster bool) bool {
 	}
 
 	// Check if should register tool.
-	if len(m.enabled) > 0 && !slices.Contains(m.enabled, tool) {
-		return false
-	}
 	if inCluster && !t.inCluster {
 		return false
 	}

--- a/cmd/mcp/toolbox/manager_test.go
+++ b/cmd/mcp/toolbox/manager_test.go
@@ -22,7 +22,7 @@ func TestManager_RegisterToolsDoesNotPanic(t *testing.T) {
 		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
 	})
 
-	manager := NewManager(nil, 0, false, false, nil, false)
+	manager := NewManager(nil, 0, false, false, false)
 	registeredTools := manager.RegisterTools(server, false)
 	g.Expect(registeredTools).To(Equal([]string{
 		"install_flux_instance",
@@ -64,7 +64,7 @@ func TestManager_RegisterDiffKubernetesManifestModes(t *testing.T) {
 				Name:    "flux-operator-mcp",
 				Version: "test-version",
 			}, nil)
-			manager := NewManager(nil, 0, false, tt.readOnly, nil, false)
+			manager := NewManager(nil, 0, false, tt.readOnly, false)
 			registeredTools := manager.RegisterTools(server, tt.inCluster)
 			g.Expect(registeredTools).To(ContainElement(ToolDiffKubernetesManifest))
 		})
@@ -90,7 +90,7 @@ func TestManager_DiffKubernetesManifestSchemaLocalFiles(t *testing.T) {
 			}, &mcp.ServerOptions{
 				Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
 			})
-			manager := NewManager(nil, 0, false, false, []string{ToolDiffKubernetesManifest}, tt.localFiles)
+			manager := NewManager(nil, 0, false, false, tt.localFiles)
 			manager.RegisterTools(server, false)
 
 			ctx := context.Background()
@@ -107,10 +107,18 @@ func TestManager_DiffKubernetesManifestSchemaLocalFiles(t *testing.T) {
 
 			result, err := session.ListTools(ctx, &mcp.ListToolsParams{})
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(result.Tools).To(HaveLen(1))
-			g.Expect(result.Tools[0].Name).To(Equal(ToolDiffKubernetesManifest))
+			g.Expect(result.Tools).NotTo(BeEmpty())
 
-			raw, err := json.Marshal(result.Tools[0].InputSchema)
+			var diffTool *mcp.Tool
+			for i := range result.Tools {
+				if result.Tools[i].Name == ToolDiffKubernetesManifest {
+					diffTool = result.Tools[i]
+					break
+				}
+			}
+			g.Expect(diffTool).NotTo(BeNil())
+
+			raw, err := json.Marshal(diffTool.InputSchema)
 			g.Expect(err).NotTo(HaveOccurred())
 			var schema struct {
 				Properties map[string]struct {
@@ -220,7 +228,7 @@ func TestManager_ToolSchemasIncludeProperties(t *testing.T) {
 		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
 	})
 
-	manager := NewManager(nil, 0, false, false, nil, false)
+	manager := NewManager(nil, 0, false, false, false)
 	manager.RegisterTools(server, false)
 
 	ctx := context.Background()
@@ -278,25 +286,4 @@ func TestManager_ToolSchemasIncludeProperties(t *testing.T) {
 			"tool %s schema has unexpected required fields: %s",
 			tool.Name, string(raw))
 	}
-}
-
-func TestManager_RegisterSpecificTools(t *testing.T) {
-	g := NewWithT(t)
-
-	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "flux-operator-mcp",
-		Version: "test-version",
-	}, &mcp.ServerOptions{
-		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
-	})
-
-	manager := NewManager(nil, 0, false, false, []string{
-		"get_kubeconfig_contexts",
-		"set_kubeconfig_context",
-	}, false)
-	registeredTools := manager.RegisterTools(server, false)
-	g.Expect(registeredTools).To(Equal([]string{
-		"get_kubeconfig_contexts",
-		"set_kubeconfig_context",
-	}))
 }


### PR DESCRIPTION
No production code is using the argument `enabled` of `toolbox.NewManager`