### PR TITLE
mcp: extend `get_kubernetes_logs` tool to workloads 

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,12 +50,9 @@ For a deep understanding of the Flux CRDs, call the `search_flux_docs` tool for 
 
 ## Kubernetes logs analysis
 
-When looking at logs, first you need to determine the pod name:
-
-- Get the Kubernetes deployment that manages the pods using the `get_kubernetes_resources` tool.
-- Look for the `matchLabels` and the container name in the deployment spec.
-- List the pods with the `get_kubernetes_resources` tool using the found `matchLabels` from the deployment spec.
-- Get the logs by calling the `get_kubernetes_logs` tool using the pod name and container name.
+Call `get_kubernetes_logs` directly with the workload `kind`, `name`, and `namespace` found in a
+Flux resource's inventory via `get_kubernetes_resources`. Omit `container` to read all regular
+containers. If the result is truncated, narrow the request with `container` and `limit`.
 
 ## Flux HelmRelease analysis
 

--- a/cmd/mcp/k8s/logs.go
+++ b/cmd/mcp/k8s/logs.go
@@ -4,60 +4,358 @@
 package k8s
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
+	"sort"
+	"strings"
+	"sync"
 
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/podlogs"
 )
 
-// GetLogs retrieves the logs for a specific pod container in the given namespace.
-// If previous is true, the logs from the previous container instance are returned.
-func (k *Client) GetLogs(ctx context.Context, pod, container, namespace string, limit int64, previous bool) (*unstructured.Unstructured, error) {
-	podLogOpts := corev1.PodLogOptions{
-		Container:  container,
-		TailLines:  &limit,
-		LimitBytes: new(int64(256 * 1024)), // 256 KiB cap
-		Previous:   previous,
-	}
+const (
+	// maxLogPods caps the number of workload pods selected for a log request.
+	maxLogPods = 10
 
+	// maxLogStreams caps the total pod and container streams in a log request.
+	maxLogStreams = 20
+
+	// maxLogBytes caps the merged log payload returned by the MCP tool.
+	maxLogBytes = 256 * 1024
+
+	// minPerStreamLogBytes ensures every selected stream gets a useful tail.
+	minPerStreamLogBytes = 64 * 1024
+)
+
+// KubernetesLogs is the YAML response returned by get_kubernetes_logs.
+type KubernetesLogs struct {
+	Kind         string   `json:"kind"`
+	Name         string   `json:"name"`
+	Namespace    string   `json:"namespace"`
+	Pods         []string `json:"pods"`
+	Containers   []string `json:"containers"`
+	PodsTotal    int      `json:"podsTotal"`
+	PodsStreamed int      `json:"podsStreamed"`
+	Tagged       bool     `json:"tagged"`
+	Truncated    bool     `json:"truncated"`
+	Logs         string   `json:"logs"`
+}
+
+// logSelection contains resolved pods and the capped streams to fetch.
+type logSelection struct {
+	kind         string
+	pods         []corev1.Pod
+	targets      []podlogs.LogTarget
+	containers   []string
+	podsTotal    int
+	tagPod       bool
+	tagContainer bool
+	truncated    bool
+}
+
+// GetLogs resolves a pod or workload, fetches its selected container streams,
+// and returns their timestamped logs merged chronologically.
+func (k *Client) GetLogs(ctx context.Context, kind, name, namespace, container string, limit int64, previous bool) (*KubernetesLogs, error) {
 	clientset, err := kubernetes.NewForConfig(k.cfg)
 	if err != nil {
 		return nil, err
 	}
+	return getLogs(ctx, clientset, kind, name, namespace, container, limit, previous)
+}
 
-	req := clientset.CoreV1().Pods(namespace).GetLogs(pod, &podLogOpts)
-	logs, err := req.Stream(ctx)
+// getLogs implements GetLogs with an injectable clientset for unit tests.
+func getLogs(ctx context.Context, clientset kubernetes.Interface, kind, name, namespace, container string, limit int64, previous bool) (*KubernetesLogs, error) {
+	selection, err := resolveLogSelection(ctx, clientset, kind, name, namespace, container)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get logs for pod %s/%s: %w", namespace, pod, err)
-	}
-	defer logs.Close()
-
-	logsBuffer := new(bytes.Buffer)
-	_, err = io.Copy(logsBuffer, logs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read logs for pod %s/%s: %w", namespace, pod, err)
+		return nil, err
 	}
 
-	logsContent := logsBuffer.String()
+	perStreamBytes := max(maxLogBytes/len(selection.targets), minPerStreamLogBytes)
+	logsByTarget := make([]string, len(selection.targets))
+	errsByTarget := make([]error, len(selection.targets))
+	var wg sync.WaitGroup
+	for i, target := range selection.targets {
+		wg.Add(1)
+		go func(i int, target podlogs.LogTarget) {
+			defer wg.Done()
+			opts := &corev1.PodLogOptions{
+				Container:  target.Container,
+				TailLines:  &limit,
+				Previous:   previous,
+				Timestamps: true,
+			}
+			logsByTarget[i], errsByTarget[i] = podlogs.FetchContainerLog(
+				ctx, clientset, namespace, target.Pod, opts, perStreamBytes)
+		}(i, target)
+	}
+	wg.Wait()
 
-	if logsContent == "" {
-		logsContent = fmt.Sprintf("no logs found for container %s", container)
+	streams := make([]podlogs.LogStream, 0, len(selection.targets))
+	streamedPods := make(map[string]struct{})
+	var firstErr error
+	for i, target := range selection.targets {
+		if errsByTarget[i] != nil {
+			if firstErr == nil {
+				firstErr = errsByTarget[i]
+			}
+			continue
+		}
+		streams = append(streams, podlogs.LogStream{
+			Pod:       target.Pod,
+			Container: target.Container,
+			Blob:      logsByTarget[i],
+		})
+		streamedPods[target.Pod] = struct{}{}
+	}
+	if len(streams) == 0 && firstErr != nil {
+		return nil, firstErr
 	}
 
-	return &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "v1",
-			"kind":       "Pod",
-			"metadata": map[string]any{
-				"name":      pod,
-				"namespace": namespace,
-			},
-			"container": container,
-			"logs":      logsContent,
-		},
+	logs := podlogs.MergeLogStreams(streams, int(limit), selection.tagPod, selection.tagContainer, maxLogBytes)
+	if len(selection.targets) == 1 && logs == "" {
+		logs = fmt.Sprintf("no logs found for container %s", selection.targets[0].Container)
+	}
+
+	podNames := make([]string, 0, len(selection.pods))
+	for _, pod := range selection.pods {
+		podNames = append(podNames, pod.Name)
+	}
+
+	return &KubernetesLogs{
+		Kind:         selection.kind,
+		Name:         name,
+		Namespace:    namespace,
+		Pods:         podNames,
+		Containers:   selection.containers,
+		PodsTotal:    selection.podsTotal,
+		PodsStreamed: len(streamedPods),
+		Tagged:       selection.tagPod || selection.tagContainer,
+		Truncated:    selection.truncated,
+		Logs:         logs,
 	}, nil
+}
+
+// resolveLogSelection resolves the named resource to newest-first pods and
+// builds the capped set of regular-container log streams.
+func resolveLogSelection(ctx context.Context, clientset kubernetes.Interface, kind, name, namespace, container string) (*logSelection, error) {
+	canonicalKind, err := canonicalLogKind(kind)
+	if err != nil {
+		return nil, err
+	}
+
+	pods, err := resolveLogPods(ctx, clientset, canonicalKind, name, namespace)
+	if err != nil {
+		return nil, err
+	}
+	if len(pods) == 0 {
+		return nil, fmt.Errorf("no pods found for %s %s/%s", canonicalKind, namespace, name)
+	}
+
+	sort.SliceStable(pods, func(i, j int) bool {
+		if pods[i].CreationTimestamp.Equal(&pods[j].CreationTimestamp) {
+			return pods[i].Name < pods[j].Name
+		}
+		return pods[i].CreationTimestamp.After(pods[j].CreationTimestamp.Time)
+	})
+
+	selection := &logSelection{
+		kind:      canonicalKind,
+		podsTotal: len(pods),
+	}
+	if len(pods) > maxLogPods {
+		pods = pods[:maxLogPods]
+		selection.truncated = true
+	}
+	selection.pods = pods
+	selection.tagPod = len(pods) > 1
+
+	allTargets := make([]podlogs.LogTarget, 0)
+	for _, pod := range pods {
+		if container != "" {
+			allTargets = append(allTargets, podlogs.LogTarget{Pod: pod.Name, Container: container})
+			continue
+		}
+		for _, podContainer := range pod.Spec.Containers {
+			allTargets = append(allTargets, podlogs.LogTarget{Pod: pod.Name, Container: podContainer.Name})
+		}
+	}
+	if len(allTargets) == 0 {
+		return nil, fmt.Errorf("no containers found for %s %s/%s", canonicalKind, namespace, name)
+	}
+	if len(allTargets) > maxLogStreams {
+		allTargets = allTargets[:maxLogStreams]
+		selection.truncated = true
+	}
+	selection.targets = allTargets
+
+	containerNames := make([]string, 0, len(allTargets))
+	for _, target := range allTargets {
+		containerNames = append(containerNames, target.Container)
+	}
+	selection.containers, _ = podlogs.DedupeNames(containerNames, len(containerNames))
+	selection.tagContainer = len(selection.containers) > 1
+
+	return selection, nil
+}
+
+// canonicalLogKind validates a case-insensitive kind and returns its canonical
+// Kubernetes spelling. An empty kind defaults to Pod.
+func canonicalLogKind(kind string) (string, error) {
+	switch strings.ToLower(kind) {
+	case "", "pod":
+		return "Pod", nil
+	case "deployment":
+		return "Deployment", nil
+	case "statefulset":
+		return "StatefulSet", nil
+	case "daemonset":
+		return "DaemonSet", nil
+	case "cronjob":
+		return "CronJob", nil
+	case "job":
+		return "Job", nil
+	default:
+		return "", fmt.Errorf("unsupported kind %q; supported kinds are Pod, Deployment, StatefulSet, DaemonSet, CronJob and Job", kind)
+	}
+}
+
+// resolveLogPods returns all pods owned by the named canonical resource kind.
+func resolveLogPods(ctx context.Context, clientset kubernetes.Interface, kind, name, namespace string) ([]corev1.Pod, error) {
+	switch kind {
+	case "Pod":
+		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return []corev1.Pod{*pod}, nil
+	case "Deployment":
+		obj, err := clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return resolveAppsWorkloadPods(ctx, clientset, obj, namespace, name)
+	case "StatefulSet":
+		obj, err := clientset.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return resolveAppsWorkloadPods(ctx, clientset, obj, namespace, name)
+	case "DaemonSet":
+		obj, err := clientset.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return resolveAppsWorkloadPods(ctx, clientset, obj, namespace, name)
+	case "CronJob":
+		cronJob, err := clientset.BatchV1().CronJobs(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return resolveCronJobPods(ctx, clientset, cronJob)
+	case "Job":
+		job, err := clientset.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return resolveJobPods(ctx, clientset, job)
+	default:
+		return nil, fmt.Errorf("unsupported canonical kind %q", kind)
+	}
+}
+
+// resolveAppsWorkloadPods selects pods by the full workload selector and then
+// verifies the apps/v1 owner name prefix used by workload controllers.
+func resolveAppsWorkloadPods(ctx context.Context, clientset kubernetes.Interface, obj runtime.Object, namespace, name string) ([]corev1.Pod, error) {
+	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	selector := podlogs.WorkloadPodSelector(&unstructured.Unstructured{Object: content})
+	if selector == nil || selector.Empty() {
+		return nil, nil
+	}
+	podList, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+
+	pods := make([]corev1.Pod, 0, len(podList.Items))
+	for _, pod := range podList.Items {
+		for _, owner := range pod.OwnerReferences {
+			if owner.APIVersion == appsv1.SchemeGroupVersion.String() && strings.HasPrefix(owner.Name, name) {
+				pods = append(pods, pod)
+				break
+			}
+		}
+	}
+	return pods, nil
+}
+
+// resolveCronJobPods traverses the CronJob to Job to Pod ownership chain.
+func resolveCronJobPods(ctx context.Context, clientset kubernetes.Interface, cronJob *batchv1.CronJob) ([]corev1.Pod, error) {
+	jobList, err := clientset.BatchV1().Jobs(cronJob.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	ownedJobs := make(map[types.UID]string)
+	for _, job := range jobList.Items {
+		if hasOwnerUID(job.OwnerReferences, cronJob.UID) {
+			ownedJobs[job.UID] = job.Name
+		}
+	}
+	if len(ownedJobs) == 0 {
+		return nil, nil
+	}
+
+	podList, err := clientset.CoreV1().Pods(cronJob.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	pods := make([]corev1.Pod, 0)
+	for _, pod := range podList.Items {
+		jobName := pod.Labels[batchv1.JobNameLabel]
+		for jobUID, ownedJobName := range ownedJobs {
+			if jobName == ownedJobName && hasOwnerUID(pod.OwnerReferences, jobUID) {
+				pods = append(pods, pod)
+				break
+			}
+		}
+	}
+	return pods, nil
+}
+
+// resolveJobPods returns pods carrying the job-name label and owned by the Job.
+func resolveJobPods(ctx context.Context, clientset kubernetes.Interface, job *batchv1.Job) ([]corev1.Pod, error) {
+	selector := labels.Set{batchv1.JobNameLabel: job.Name}.String()
+	podList, err := clientset.CoreV1().Pods(job.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	pods := make([]corev1.Pod, 0, len(podList.Items))
+	for _, pod := range podList.Items {
+		if hasOwnerUID(pod.OwnerReferences, job.UID) {
+			pods = append(pods, pod)
+		}
+	}
+	return pods, nil
+}
+
+// hasOwnerUID reports whether owner references include the given UID.
+func hasOwnerUID(refs []metav1.OwnerReference, uid types.UID) bool {
+	for _, ref := range refs {
+		if ref.UID == uid {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/mcp/k8s/logs_test.go
+++ b/cmd/mcp/k8s/logs_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/podlogs"
+)
+
+func TestResolveLogSelectionDeployment(t *testing.T) {
+	g := NewWithT(t)
+	now := time.Now()
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "backend", Namespace: "apps"},
+		Spec: appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"app": "backend"},
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key: "track", Operator: metav1.LabelSelectorOpIn, Values: []string{"stable"},
+			}},
+		}},
+	}
+	ownedOld := testLogPod("backend-old", "apps", now.Add(-time.Minute), map[string]string{"app": "backend", "track": "stable"},
+		metav1.OwnerReference{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "backend-abc"}, "app")
+	ownedNew := testLogPod("backend-new", "apps", now, map[string]string{"app": "backend", "track": "stable"},
+		metav1.OwnerReference{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "backend-def"}, "app")
+	unowned := testLogPod("shared-labels", "apps", now.Add(time.Minute), map[string]string{"app": "backend", "track": "stable"},
+		metav1.OwnerReference{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "other-abc"}, "app")
+	wrongExpression := testLogPod("wrong-track", "apps", now, map[string]string{"app": "backend", "track": "canary"},
+		metav1.OwnerReference{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "backend-ghi"}, "app")
+
+	selection, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(
+		deployment, ownedOld, ownedNew, unowned, wrongExpression), "deployment", "backend", "apps", "")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(selection.kind).To(Equal("Deployment"))
+	g.Expect(selection.podsTotal).To(Equal(2))
+	g.Expect(logPodNames(selection.pods)).To(Equal([]string{"backend-new", "backend-old"}))
+	g.Expect(selection.targets).To(Equal([]podlogs.LogTarget{
+		{Pod: "backend-new", Container: "app"},
+		{Pod: "backend-old", Container: "app"},
+	}))
+	g.Expect(selection.tagPod).To(BeTrue())
+	g.Expect(selection.truncated).To(BeFalse())
+}
+
+func TestResolveLogSelectionAppsWorkloads(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		kind      string
+		workload  runtime.Object
+		ownerKind string
+		ownerName string
+		wantKind  string
+	}{
+		{
+			name: "StatefulSet", kind: "STATEFULSET", wantKind: "StatefulSet",
+			workload: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "database", Namespace: "apps"},
+				Spec:       appsv1.StatefulSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "database"}}},
+			},
+			ownerKind: "StatefulSet", ownerName: "database",
+		},
+		{
+			name: "DaemonSet", kind: "daemonset", wantKind: "DaemonSet",
+			workload: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "apps"},
+				Spec:       appsv1.DaemonSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "agent"}}},
+			},
+			ownerKind: "DaemonSet", ownerName: "agent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			pod := testLogPod(tt.ownerName+"-0", "apps", now, map[string]string{"app": tt.ownerName},
+				metav1.OwnerReference{APIVersion: "apps/v1", Kind: tt.ownerKind, Name: tt.ownerName}, "main")
+			selection, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(tt.workload, pod),
+				tt.kind, tt.ownerName, "apps", "")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(selection.kind).To(Equal(tt.wantKind))
+			g.Expect(logPodNames(selection.pods)).To(Equal([]string{pod.Name}))
+		})
+	}
+}
+
+func TestResolveLogSelectionCronJob(t *testing.T) {
+	g := NewWithT(t)
+	cronUID := types.UID("cron-uid")
+	jobUID := types.UID("job-uid")
+	cronJob := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "cleanup", Namespace: "apps", UID: cronUID}}
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: "cleanup-123", Namespace: "apps", UID: jobUID,
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "batch/v1", Kind: "CronJob", Name: "cleanup", UID: cronUID}},
+	}}
+	otherJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "other-123", Namespace: "apps", UID: "other-job"}}
+	ownedPod := testLogPod("cleanup-pod", "apps", time.Now(), map[string]string{batchv1.JobNameLabel: job.Name},
+		metav1.OwnerReference{APIVersion: "batch/v1", Kind: "Job", Name: job.Name, UID: jobUID}, "worker")
+	wrongOwner := testLogPod("wrong-owner", "apps", time.Now(), map[string]string{batchv1.JobNameLabel: job.Name},
+		metav1.OwnerReference{APIVersion: "batch/v1", Kind: "Job", Name: job.Name, UID: "wrong"}, "worker")
+	otherPod := testLogPod("other-pod", "apps", time.Now(), map[string]string{batchv1.JobNameLabel: otherJob.Name},
+		metav1.OwnerReference{APIVersion: "batch/v1", Kind: "Job", Name: otherJob.Name, UID: otherJob.UID}, "worker")
+
+	selection, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(
+		cronJob, job, otherJob, ownedPod, wrongOwner, otherPod), "CronJob", "cleanup", "apps", "")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(logPodNames(selection.pods)).To(Equal([]string{"cleanup-pod"}))
+	g.Expect(selection.targets).To(Equal([]podlogs.LogTarget{{Pod: "cleanup-pod", Container: "worker"}}))
+}
+
+func TestResolveLogSelectionJob(t *testing.T) {
+	g := NewWithT(t)
+	jobUID := types.UID("job-uid")
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "migrate", Namespace: "apps", UID: jobUID}}
+	ownedPod := testLogPod("migrate-pod", "apps", time.Now(), map[string]string{batchv1.JobNameLabel: job.Name},
+		metav1.OwnerReference{APIVersion: "batch/v1", Kind: "Job", Name: job.Name, UID: jobUID}, "worker")
+	unownedPod := testLogPod("migrate-other", "apps", time.Now(), map[string]string{batchv1.JobNameLabel: job.Name},
+		metav1.OwnerReference{APIVersion: "batch/v1", Kind: "Job", Name: job.Name, UID: "other"}, "worker")
+
+	selection, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(job, ownedPod, unownedPod),
+		"job", "migrate", "apps", "")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(selection.kind).To(Equal("Job"))
+	g.Expect(logPodNames(selection.pods)).To(Equal([]string{"migrate-pod"}))
+}
+
+func TestResolveLogSelectionValidation(t *testing.T) {
+	t.Run("unknown kind", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(), "ReplicaSet", "app", "apps", "")
+		g.Expect(err).To(MatchError(ContainSubstring("supported kinds are Pod, Deployment, StatefulSet, DaemonSet, CronJob and Job")))
+	})
+
+	t.Run("workload with zero pods", func(t *testing.T) {
+		g := NewWithT(t)
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "backend", Namespace: "apps"},
+			Spec:       appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "backend"}}},
+		}
+		_, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(deployment), "Deployment", "backend", "apps", "")
+		g.Expect(err).To(MatchError("no pods found for Deployment apps/backend"))
+	})
+
+	t.Run("missing named pod", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(), "", "missing", "apps", "")
+		g.Expect(err).To(HaveOccurred())
+	})
+}
+
+func TestResolveLogSelectionCapsPodsAndStreams(t *testing.T) {
+	g := NewWithT(t)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "backend", Namespace: "apps"},
+		Spec:       appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "backend"}}},
+	}
+	objects := []runtime.Object{deployment}
+	base := time.Now()
+	for i := 0; i < maxLogPods+1; i++ {
+		objects = append(objects, testLogPod(fmt.Sprintf("backend-%02d", i), "apps", base.Add(time.Duration(i)*time.Second),
+			map[string]string{"app": "backend"},
+			metav1.OwnerReference{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "backend-rs"}, "app", "sidecar", "metrics"))
+	}
+
+	selection, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(objects...),
+		"Deployment", "backend", "apps", "")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(selection.podsTotal).To(Equal(maxLogPods + 1))
+	g.Expect(selection.pods).To(HaveLen(maxLogPods))
+	g.Expect(selection.pods[0].Name).To(Equal("backend-10"))
+	g.Expect(selection.targets).To(HaveLen(maxLogStreams))
+	g.Expect(selection.truncated).To(BeTrue())
+}
+
+func TestResolveLogSelectionContainers(t *testing.T) {
+	pod := testLogPod("backend", "default", time.Now(), nil, metav1.OwnerReference{}, "app", "sidecar")
+	pod.OwnerReferences = nil
+	pod.Spec.InitContainers = []corev1.Container{{Name: "init"}}
+
+	t.Run("omitted container selects regular containers only", func(t *testing.T) {
+		g := NewWithT(t)
+		selection, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(pod), "Pod", pod.Name, pod.Namespace, "")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(selection.targets).To(Equal([]podlogs.LogTarget{
+			{Pod: pod.Name, Container: "app"},
+			{Pod: pod.Name, Container: "sidecar"},
+		}))
+		g.Expect(selection.containers).To(Equal([]string{"app", "sidecar"}))
+		g.Expect(selection.tagContainer).To(BeTrue())
+	})
+
+	t.Run("container filter selects only the requested name", func(t *testing.T) {
+		g := NewWithT(t)
+		selection, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(pod), "pod", pod.Name, pod.Namespace, "sidecar")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(selection.targets).To(Equal([]podlogs.LogTarget{{Pod: pod.Name, Container: "sidecar"}}))
+		g.Expect(selection.containers).To(Equal([]string{"sidecar"}))
+		g.Expect(selection.tagContainer).To(BeFalse())
+	})
+}
+
+func TestGetLogsWithFakeClient(t *testing.T) {
+	g := NewWithT(t)
+	pod := testLogPod("backend", "default", time.Now(), nil, metav1.OwnerReference{}, "app")
+
+	result, err := getLogs(context.Background(), fake.NewSimpleClientset(pod), "", pod.Name, pod.Namespace, "", 100, false)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Kind).To(Equal("Pod"))
+	g.Expect(result.Name).To(Equal("backend"))
+	g.Expect(result.Namespace).To(Equal("default"))
+	g.Expect(result.Pods).To(Equal([]string{"backend"}))
+	g.Expect(result.Containers).To(Equal([]string{"app"}))
+	g.Expect(result.PodsTotal).To(Equal(1))
+	g.Expect(result.PodsStreamed).To(Equal(1))
+	g.Expect(result.Tagged).To(BeFalse())
+	g.Expect(result.Truncated).To(BeFalse())
+	g.Expect(result.Logs).To(Equal("fake logs\n"))
+}
+func testLogPod(name, namespace string, created time.Time, podLabels map[string]string, owner metav1.OwnerReference, containers ...string) *corev1.Pod {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: namespace, Labels: podLabels, CreationTimestamp: metav1.NewTime(created),
+	}}
+	if owner.Name != "" {
+		pod.OwnerReferences = []metav1.OwnerReference{owner}
+	}
+	for _, container := range containers {
+		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: container})
+	}
+	return pod
+}
+
+func logPodNames(pods []corev1.Pod) []string {
+	names := make([]string, 0, len(pods))
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+	return names
+}

--- a/cmd/mcp/toolbox/get_logs.go
+++ b/cmd/mcp/toolbox/get_logs.go
@@ -22,13 +22,14 @@ func init() {
 	}
 }
 
-// getKubernetesLogsInput defines the input parameters for retrieving pod logs.
+// getKubernetesLogsInput defines the input parameters for retrieving pod or workload logs.
 type getKubernetesLogsInput struct {
-	PodName       string  `json:"pod_name" jsonschema:"Pod name."`
-	ContainerName string  `json:"container_name" jsonschema:"Container name."`
-	PodNamespace  string  `json:"pod_namespace" jsonschema:"Namespace of the pod."`
-	Limit         float64 `json:"limit,omitempty" jsonschema:"Max log lines. Defaults to 100."`
-	Previous      bool    `json:"previous,omitempty" jsonschema:"Logs from the previously terminated container."`
+	Kind      string  `json:"kind,omitempty"      jsonschema:"Kind of the resource: Pod (default), Deployment, StatefulSet, DaemonSet, CronJob or Job."`
+	Name      string  `json:"name"                jsonschema:"Name of the pod or workload."`
+	Namespace string  `json:"namespace"           jsonschema:"Namespace of the pod or workload."`
+	Container string  `json:"container,omitempty" jsonschema:"Container name; omit to read all containers."`
+	Limit     float64 `json:"limit,omitempty"     jsonschema:"Max log lines. Defaults to 100."`
+	Previous  bool    `json:"previous,omitempty"  jsonschema:"Logs from the previously terminated containers."`
 }
 
 // HandleGetKubernetesLogs is the handler function for the get_kubernetes_logs tool.
@@ -37,14 +38,11 @@ func (m *Manager) HandleGetKubernetesLogs(ctx context.Context, request *mcp.Call
 		return NewToolResultError(err.Error())
 	}
 
-	if input.PodName == "" {
-		return NewToolResultError("pod name is required")
+	if input.Name == "" {
+		return NewToolResultError("name is required")
 	}
-	if input.ContainerName == "" {
-		return NewToolResultError("container name is required")
-	}
-	if input.PodNamespace == "" {
-		return NewToolResultError("pod namespace is required")
+	if input.Namespace == "" {
+		return NewToolResultError("namespace is required")
 	}
 	limit := int64(input.Limit)
 	if limit == 0 {
@@ -59,7 +57,7 @@ func (m *Manager) HandleGetKubernetesLogs(ctx context.Context, request *mcp.Call
 		return NewToolResultErrorFromErr("Failed to get Kubernetes client", err)
 	}
 
-	result, err := kubeClient.GetLogs(ctx, input.PodName, input.ContainerName, input.PodNamespace, limit, input.Previous)
+	result, err := kubeClient.GetLogs(ctx, input.Kind, input.Name, input.Namespace, input.Container, limit, input.Previous)
 	if err != nil {
 		return NewToolResultError(err.Error())
 	}

--- a/cmd/mcp/toolbox/get_logs_test.go
+++ b/cmd/mcp/toolbox/get_logs_test.go
@@ -38,33 +38,24 @@ func TestManager_HandleGetKubernetesLogs(t *testing.T) {
 		matchErr  string
 	}{
 		{
-			testName: "fails without pod name",
+			testName: "fails without name",
 			arguments: map[string]any{
 				"kind": "Pod",
 			},
-			matchErr: "pod name is required",
+			matchErr: "name is required",
 		},
 		{
-			testName: "fails without container name",
+			testName: "fails without namespace",
 			arguments: map[string]any{
-				"pod_name": "test",
+				"name": "test",
 			},
-			matchErr: "container name is required",
+			matchErr: "namespace is required",
 		},
 		{
-			testName: "fails without pod namespace",
+			testName: "accepts omitted kind and container before loading client",
 			arguments: map[string]any{
-				"pod_name":       "test",
-				"container_name": "test-container",
-			},
-			matchErr: "pod namespace is required",
-		},
-		{
-			testName: "fails with invalid kubeconfig",
-			arguments: map[string]any{
-				"pod_name":       "test",
-				"pod_namespace":  "default",
-				"container_name": "test-container",
+				"name":      "test",
+				"namespace": "default",
 			},
 			matchErr: "Failed to get Kubernetes client",
 		},

--- a/cmd/mcp/toolbox/instructions.go
+++ b/cmd/mcp/toolbox/instructions.go
@@ -45,9 +45,10 @@ func (m *Manager) Instructions(inCluster bool) string {
 			"the Kustomization, HelmRelease or ResourceSet managing them.\n")
 	}
 	if has(ToolGetKubernetesLogs) {
-		b.WriteString("- To read pod logs, get the workload with " + ToolGetKubernetesResources +
-			", list its pods using the matchLabels from the workload spec, then call " +
-			ToolGetKubernetesLogs + " with the pod, container and namespace.\n")
+		b.WriteString("- To read application logs, call " + ToolGetKubernetesLogs +
+			" directly with the workload kind, name and namespace found in a Flux resource's inventory via " +
+			ToolGetKubernetesResources + ". Omit container to read all regular containers; if the result is truncated, " +
+			"narrow it with container and limit.\n")
 	}
 	if has(ToolGetKubernetesMetrics) {
 		b.WriteString("- To check the CPU and memory usage of pods, call " + ToolGetKubernetesMetrics + ".\n")

--- a/cmd/mcp/toolbox/instructions_test.go
+++ b/cmd/mcp/toolbox/instructions_test.go
@@ -49,6 +49,12 @@ func TestManager_Instructions(t *testing.T) {
 				}
 			}
 
+			if manager.shouldRegisterTool(ToolGetKubernetesLogs, tt.inCluster) {
+				g.Expect(instructions).To(ContainSubstring("directly with the workload kind, name and namespace"))
+				g.Expect(instructions).To(ContainSubstring("Omit container to read all regular containers"))
+				g.Expect(instructions).ToNot(ContainSubstring("list its pods using the matchLabels"))
+			}
+
 			if manager.shouldRegisterTool(ToolDiffKubernetesManifest, tt.inCluster) {
 				g.Expect(instructions).To(ContainSubstring("Before committing GitOps changes"))
 				g.Expect(instructions).To(ContainSubstring("COMPLETE output"))

--- a/cmd/mcp/toolbox/manager_test.go
+++ b/cmd/mcp/toolbox/manager_test.go
@@ -157,8 +157,8 @@ func TestManager_ToolSchemasIncludeProperties(t *testing.T) {
 			required:   []string{},
 		},
 		ToolGetKubernetesLogs: {
-			properties: []string{"pod_name", "container_name", "pod_namespace", "limit", "previous"},
-			required:   []string{"pod_name", "container_name", "pod_namespace"},
+			properties: []string{"kind", "name", "namespace", "container", "limit", "previous"},
+			required:   []string{"name", "namespace"},
 		},
 		ToolGetKubernetesMetrics: {
 			properties: []string{"pod_name", "pod_namespace", "pod_selector", "limit"},

--- a/docs/mcp/instructions.md
+++ b/docs/mcp/instructions.md
@@ -82,12 +82,9 @@ only when the supplied manifest is complete.
 
 ## Kubernetes logs analysis
 
-When looking at logs, first you need to determine the pod name:
-
-- Get the Kubernetes deployment that manages the pods using the `get_kubernetes_resources` tool.
-- Look for the `matchLabels` and the container name in the deployment spec.
-- List the pods with the `get_kubernetes_resources` tool using the found `matchLabels` from the deployment spec.
-- Get the logs by calling the `get_kubernetes_logs` tool using the pod name and container name.
+Call `get_kubernetes_logs` directly with the workload `kind`, `name`, and `namespace` found in a
+Flux resource's inventory via `get_kubernetes_resources`. Omit `container` to read all regular
+containers. If the result is truncated, narrow the request with `container` and `limit`.
 
 ## Flux HelmRelease analysis
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -66,19 +66,29 @@ listing many resources or when only a few fields are relevant.
 
 ### get_kubernetes_logs
 
-Retrieves logs from Kubernetes pods, allowing AI assistants to analyze application behavior and troubleshoot issues.
+Retrieves timestamped logs for workloads, allowing AI Agents to analyze
+application behavior and troubleshoot issues.
 
 **Parameters:**
 
-- `pod_name` (required): The name of the pod
-- `pod_namespace` (required): The namespace of the pod
-- `container_name` (required): The name of the container
-- `limit` (optional): Maximum number of log lines to return (default: 100)
-- `previous` (optional): Return logs from the previous container instance (default: false)
+- `kind` (optional): Resource kind. Supported values are `Pod` (the default), `Deployment`,
+  `StatefulSet`, `DaemonSet`, `CronJob`, and `Job` (case-insensitive).
+- `name` (required): The name of the pod or workload.
+- `namespace` (required): The namespace of the pod or workload.
+- `container` (optional): A regular container name. When omitted, logs are read from all
+  `spec.containers`; init and ephemeral containers are excluded.
+- `limit` (optional): Maximum number of merged log entries to return (default: 100).
+- `previous` (optional): Read logs from previously terminated container instances (default: false).
+
+For workloads, the tool resolves owned pods, orders them newest-first, and concurrently reads every
+selected pod and container stream. When multiple pods and containers are selected, log lines use
+the `<pod> <container> <timestamp> <message>` format.
 
 **Output:**
 
-Returns the specified number of log lines from the requested container, with timestamps and log levels preserved.
+Returns YAML with `kind`, `name`, `namespace`, selected `pods`, de-duplicated `containers`,
+`podsTotal` (matches before the pod cap), `podsStreamed` (pods with a successful stream), `tagged`,
+`truncated` (a pod or stream cap dropped targets), and the merged `logs` payload.
 
 ### get_kubernetes_metrics
 

--- a/internal/podlogs/logs.go
+++ b/internal/podlogs/logs.go
@@ -1,0 +1,267 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Package podlogs provides helpers for resolving pod selectors and processing
+// Kubernetes container log streams.
+package podlogs
+
+import (
+	"context"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+// LogTarget is one pod and container stream to read. An empty Container lets
+// the kubelet select the pod's default container.
+type LogTarget struct {
+	Pod       string
+	Container string
+}
+
+// LogStream is the timestamped payload fetched from one log target.
+type LogStream struct {
+	Pod       string
+	Container string
+	Blob      string
+}
+
+// logEntry is one timestamped record and any attached continuation lines.
+type logEntry struct {
+	ts        time.Time
+	text      string
+	pod       string
+	container string
+}
+
+// trimPartialLogLine drops a trailing partial log line from the payload.
+//
+// Container runtimes newline-terminate every emitted log line, so a payload
+// that does not end with a newline has been truncated mid-line because the
+// container was writing the line when the logs were read. A payload with no
+// newline at all is returned unchanged so a single short line is not lost.
+func trimPartialLogLine(logs string) string {
+	if logs == "" || logs[len(logs)-1] == '\n' {
+		return logs
+	}
+	if i := strings.LastIndexByte(logs, '\n'); i >= 0 {
+		return logs[:i+1]
+	}
+	return logs
+}
+
+// tailLogBytes reads r to EOF but retains only the most recent limit bytes.
+//
+// The returned bool is partialFirst: true when the retained slice begins
+// mid-line, so the caller should drop that leading fragment.
+func tailLogBytes(r io.Reader, limit int) ([]byte, bool, error) {
+	const chunkSize = 32 * 1024
+	buf := make([]byte, 0, limit+chunkSize)
+	chunk := make([]byte, chunkSize)
+	partialFirst := false
+	for {
+		n, err := r.Read(chunk)
+		if n > 0 {
+			buf = append(buf, chunk[:n]...)
+			if len(buf) > limit {
+				partialFirst = buf[len(buf)-limit-1] != '\n'
+				copy(buf, buf[len(buf)-limit:])
+				buf = buf[:limit]
+			}
+		}
+		if err == io.EOF {
+			return buf, partialFirst, nil
+		}
+		if err != nil {
+			return nil, partialFirst, err
+		}
+	}
+}
+
+// trimPartialFirstLine drops a leading partial log line from a byte-capped
+// payload. A payload with no newline is returned unchanged.
+func trimPartialFirstLine(logs string) string {
+	if _, rest, found := strings.Cut(logs, "\n"); found {
+		return rest
+	}
+	return logs
+}
+
+// FetchContainerLog streams one container's logs and keeps only the newest
+// byteLimit bytes, trimming partial first and last lines.
+func FetchContainerLog(ctx context.Context, clientset kubernetes.Interface, namespace, name string, opts *corev1.PodLogOptions, byteLimit int) (string, error) {
+	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(name, opts).Stream(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+
+	data, partialFirst, err := tailLogBytes(stream, byteLimit)
+	if err != nil {
+		return "", err
+	}
+
+	logs := trimPartialLogLine(string(data))
+	if partialFirst {
+		logs = trimPartialFirstLine(logs)
+	}
+	return logs, nil
+}
+
+// parseLogTimestamp parses the leading RFC3339 timestamp token added by the
+// kubelet when PodLogOptions.Timestamps is enabled.
+func parseLogTimestamp(line string) (time.Time, bool) {
+	tsStr, _, found := strings.Cut(line, " ")
+	if !found {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339Nano, tsStr)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// parseLogEntries splits a timestamped payload into entries and attaches
+// continuation lines, such as stack frames, to the preceding entry.
+func parseLogEntries(blob, pod, container string) []logEntry {
+	var entries []logEntry
+	for line := range strings.SplitSeq(blob, "\n") {
+		if line == "" {
+			continue
+		}
+		if ts, ok := parseLogTimestamp(line); ok {
+			entries = append(entries, logEntry{ts: ts, text: line, pod: pod, container: container})
+			continue
+		}
+		if n := len(entries); n > 0 {
+			entries[n-1].text += "\n" + line
+		} else {
+			entries = append(entries, logEntry{text: line, pod: pod, container: container})
+		}
+	}
+	return entries
+}
+
+// MergeLogStreams interleaves streams chronologically, keeps the newest
+// tailLines entries, and caps the result to byteLimit bytes on a line boundary.
+// Timestamped lines are optionally tagged in pod-then-container order;
+// continuation lines remain attached and untagged.
+func MergeLogStreams(streams []LogStream, tailLines int, tagPod, tagContainer bool, byteLimit int) string {
+	var entries []logEntry
+	for _, stream := range streams {
+		entries = append(entries, parseLogEntries(stream.Blob, stream.Pod, stream.Container)...)
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].ts.Before(entries[j].ts)
+	})
+	if tailLines > 0 && len(entries) > tailLines {
+		entries = entries[len(entries)-tailLines:]
+	}
+
+	var sb strings.Builder
+	for _, entry := range entries {
+		if !entry.ts.IsZero() {
+			if tagPod {
+				sb.WriteString(entry.pod)
+				sb.WriteByte(' ')
+			}
+			if tagContainer {
+				sb.WriteString(entry.container)
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteString(entry.text)
+		sb.WriteByte('\n')
+	}
+	return capLogBytes(sb.String(), byteLimit)
+}
+
+// DedupeNames removes duplicate names while preserving order and caps the
+// result to limit. It reports whether the cap dropped a name.
+func DedupeNames(names []string, limit int) ([]string, bool) {
+	if len(names) == 0 {
+		return names, false
+	}
+	seen := make(map[string]struct{}, len(names))
+	out := make([]string, 0, len(names))
+	truncated := false
+	for _, name := range names {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		if len(out) == limit {
+			truncated = true
+			break
+		}
+		out = append(out, name)
+	}
+	return out, truncated
+}
+
+// BuildLogTargets expands pod and container names into their product, capped
+// to limit streams. An empty container list creates one default-container
+// target per pod. It reports whether the cap dropped a target.
+func BuildLogTargets(pods, containers []string, limit int) ([]LogTarget, bool) {
+	var targets []LogTarget
+	for _, pod := range pods {
+		if len(containers) == 0 {
+			if len(targets) == limit {
+				return targets, true
+			}
+			targets = append(targets, LogTarget{Pod: pod})
+			continue
+		}
+		for _, container := range containers {
+			if len(targets) == limit {
+				return targets, true
+			}
+			targets = append(targets, LogTarget{Pod: pod, Container: container})
+		}
+	}
+	return targets, false
+}
+
+// capLogBytes keeps only the newest limit bytes of a newline-terminated log
+// payload, trimming a partial leading line.
+func capLogBytes(logs string, limit int) string {
+	if limit <= 0 || len(logs) <= limit {
+		return logs
+	}
+	cut := len(logs) - limit
+	if logs[cut-1] == '\n' {
+		return logs[cut:]
+	}
+	if i := strings.IndexByte(logs[cut:], '\n'); i >= 0 {
+		return logs[cut+i+1:]
+	}
+	return logs[cut:]
+}
+
+// WorkloadPodSelector extracts a workload's full pod selector, including
+// matchLabels and matchExpressions. It returns nil if the selector is absent
+// or invalid.
+func WorkloadPodSelector(obj *unstructured.Unstructured) labels.Selector {
+	sel, found, _ := unstructured.NestedMap(obj.Object, "spec", "selector")
+	if !found {
+		return nil
+	}
+	labelSelector := &metav1.LabelSelector{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(sel, labelSelector); err != nil {
+		return nil
+	}
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return nil
+	}
+	return selector
+}

--- a/internal/podlogs/logs_test.go
+++ b/internal/podlogs/logs_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package podlogs
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestTrimPartialLogLine(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "newline terminated", in: "line one\nline two\n", want: "line one\nline two\n"},
+		{name: "drops partial trailing line", in: "line one\nline two\npar", want: "line one\nline two\n"},
+		{name: "single partial line kept", in: "partial", want: "partial"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(trimPartialLogLine(tt.in)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestTrimPartialFirstLine(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "drops partial leading fragment", in: "tial\nline two\nline three\n", want: "line two\nline three\n"},
+		{name: "single line with no newline kept", in: "only-line", want: "only-line"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(trimPartialFirstLine(tt.in)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestTailLogBytes(t *testing.T) {
+	tests := []struct {
+		name             string
+		in               string
+		limit            int
+		want             string
+		wantPartialFirst bool
+	}{
+		{name: "under limit returns all", in: "line1\nline2\n", limit: 100, want: "line1\nline2\n"},
+		{name: "exact limit not truncated", in: "abcd", limit: 4, want: "abcd"},
+		{name: "over limit cut on line boundary keeps complete first line", in: "line1\nline2\nline3\n", limit: 12, want: "line2\nline3\n"},
+		{name: "over limit cutting mid-line", in: "line1\nline2\n", limit: 8, want: "1\nline2\n", wantPartialFirst: true},
+		{name: "empty stream", in: "", limit: 16, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, partialFirst, err := tailLogBytes(strings.NewReader(tt.in), tt.limit)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(string(got)).To(Equal(tt.want))
+			g.Expect(partialFirst).To(Equal(tt.wantPartialFirst))
+		})
+	}
+}
+
+func TestParseLogEntries(t *testing.T) {
+	t.Run("groups continuation lines with their timestamped entry", func(t *testing.T) {
+		g := NewWithT(t)
+		blob := "2026-01-01T00:00:00Z panic: boom\ngoroutine 1 [running]:\nmain.main()\n" +
+			"2026-01-01T00:00:01Z next line\n"
+		entries := parseLogEntries(blob, "pod-a", "app")
+		g.Expect(entries).To(HaveLen(2))
+		g.Expect(entries[0].text).To(Equal("2026-01-01T00:00:00Z panic: boom\ngoroutine 1 [running]:\nmain.main()"))
+		g.Expect(entries[0].pod).To(Equal("pod-a"))
+		g.Expect(entries[0].container).To(Equal("app"))
+		g.Expect(entries[1].text).To(Equal("2026-01-01T00:00:01Z next line"))
+	})
+
+	t.Run("leading continuation becomes a zero timestamp entry", func(t *testing.T) {
+		g := NewWithT(t)
+		entries := parseLogEntries("orphan continuation\n2026-01-01T00:00:00Z line\n", "pod-a", "app")
+		g.Expect(entries).To(HaveLen(2))
+		g.Expect(entries[0].ts.IsZero()).To(BeTrue())
+		g.Expect(entries[0].text).To(Equal("orphan continuation"))
+		g.Expect(entries[1].text).To(Equal("2026-01-01T00:00:00Z line"))
+	})
+
+	t.Run("empty payload yields no entries", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(parseLogEntries("", "pod-a", "app")).To(BeEmpty())
+	})
+}
+
+func TestMergeLogStreams(t *testing.T) {
+	const byteLimit = 512 * 1024
+
+	t.Run("interleaves streams in chronological order", func(t *testing.T) {
+		g := NewWithT(t)
+		app := LogStream{Pod: "pod-a", Blob: "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"}
+		sidecar := LogStream{Pod: "pod-a", Blob: "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"}
+		got := MergeLogStreams([]LogStream{app, sidecar}, 0, false, false, byteLimit)
+		g.Expect(got).To(Equal("2026-01-01T00:00:00Z app a\n2026-01-01T00:00:01Z side a\n2026-01-01T00:00:02Z app b\n2026-01-01T00:00:03Z side b\n"))
+	})
+
+	t.Run("orders fractional timestamps numerically", func(t *testing.T) {
+		g := NewWithT(t)
+		a := LogStream{Blob: "2026-01-01T00:00:00.1Z first\n"}
+		b := LogStream{Blob: "2026-01-01T00:00:00.12Z second\n"}
+		g.Expect(MergeLogStreams([]LogStream{b, a}, 0, false, false, byteLimit)).To(Equal("2026-01-01T00:00:00.1Z first\n2026-01-01T00:00:00.12Z second\n"))
+	})
+
+	t.Run("keeps continuation lines attached", func(t *testing.T) {
+		g := NewWithT(t)
+		app := LogStream{Blob: "2026-01-01T00:00:00Z panic\nstack frame\n"}
+		sidecar := LogStream{Blob: "2026-01-01T00:00:01Z side\n"}
+		g.Expect(MergeLogStreams([]LogStream{app, sidecar}, 0, false, false, byteLimit)).To(Equal("2026-01-01T00:00:00Z panic\nstack frame\n2026-01-01T00:00:01Z side\n"))
+	})
+
+	t.Run("keeps newest entries across all streams", func(t *testing.T) {
+		g := NewWithT(t)
+		app := LogStream{Blob: "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"}
+		sidecar := LogStream{Blob: "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"}
+		g.Expect(MergeLogStreams([]LogStream{app, sidecar}, 2, false, false, byteLimit)).To(Equal("2026-01-01T00:00:02Z app b\n2026-01-01T00:00:03Z side b\n"))
+	})
+
+	t.Run("empty streams yield empty output", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(MergeLogStreams(nil, 100, false, false, byteLimit)).To(BeEmpty())
+		g.Expect(MergeLogStreams([]LogStream{{Pod: "pod-a"}}, 100, false, false, byteLimit)).To(BeEmpty())
+	})
+
+	t.Run("tags pod only on timestamped lines", func(t *testing.T) {
+		g := NewWithT(t)
+		a := LogStream{Pod: "p1", Blob: "2026-01-01T00:00:01Z panic\nstack frame\n"}
+		b := LogStream{Pod: "p2", Blob: "orphan line\n"}
+		g.Expect(MergeLogStreams([]LogStream{a, b}, 0, true, false, byteLimit)).To(Equal("orphan line\np1 2026-01-01T00:00:01Z panic\nstack frame\n"))
+	})
+
+	t.Run("tags container for a single pod", func(t *testing.T) {
+		g := NewWithT(t)
+		app := LogStream{Pod: "p1", Container: "app", Blob: "2026-01-01T00:00:00Z a\n"}
+		side := LogStream{Pod: "p1", Container: "side", Blob: "2026-01-01T00:00:01Z s\n"}
+		g.Expect(MergeLogStreams([]LogStream{app, side}, 0, false, true, byteLimit)).To(Equal("app 2026-01-01T00:00:00Z a\nside 2026-01-01T00:00:01Z s\n"))
+	})
+
+	t.Run("tags pod then container", func(t *testing.T) {
+		g := NewWithT(t)
+		a := LogStream{Pod: "p1", Container: "app", Blob: "2026-01-01T00:00:00Z a\nframe\n"}
+		b := LogStream{Pod: "p2", Container: "side", Blob: "2026-01-01T00:00:01Z b\n"}
+		g.Expect(MergeLogStreams([]LogStream{a, b}, 0, true, true, byteLimit)).To(Equal("p1 app 2026-01-01T00:00:00Z a\nframe\np2 side 2026-01-01T00:00:01Z b\n"))
+	})
+}
+
+func TestCapLogBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		limit int
+		want  string
+	}{
+		{name: "under limit returns all", in: "line1\nline2\n", limit: 100, want: "line1\nline2\n"},
+		{name: "trims partial leading line", in: "line1\nline2\nline3\n", limit: 13, want: "line2\nline3\n"},
+		{name: "keeps boundary line", in: "line1\nline2\nline3\n", limit: 12, want: "line2\nline3\n"},
+		{name: "no newline keeps tail bytes", in: "abcdef", limit: 3, want: "def"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(capLogBytes(tt.in, tt.limit)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestDedupeNames(t *testing.T) {
+	tests := []struct {
+		name          string
+		in            []string
+		limit         int
+		want          []string
+		wantTruncated bool
+	}{
+		{name: "nil stays nil", in: nil, limit: 8, want: nil},
+		{name: "preserves order", in: []string{"app", "sidecar"}, limit: 8, want: []string{"app", "sidecar"}},
+		{name: "drops duplicates", in: []string{"app", "app", "sidecar"}, limit: 8, want: []string{"app", "sidecar"}},
+		{name: "dedup within limit", in: []string{"a", "a", "b", "b"}, limit: 2, want: []string{"a", "b"}},
+		{name: "caps names", in: []string{"a", "b", "c"}, limit: 2, want: []string{"a", "b"}, wantTruncated: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, truncated := DedupeNames(tt.in, tt.limit)
+			g.Expect(got).To(Equal(tt.want))
+			g.Expect(truncated).To(Equal(tt.wantTruncated))
+		})
+	}
+}
+
+func TestBuildLogTargets(t *testing.T) {
+	g := NewWithT(t)
+	targets, truncated := BuildLogTargets([]string{"p1", "p2"}, []string{"app", "side"}, 3)
+	g.Expect(truncated).To(BeTrue())
+	g.Expect(targets).To(Equal([]LogTarget{
+		{Pod: "p1", Container: "app"},
+		{Pod: "p1", Container: "side"},
+		{Pod: "p2", Container: "app"},
+	}))
+
+	targets, truncated = BuildLogTargets([]string{"p1", "p2"}, nil, 4)
+	g.Expect(truncated).To(BeFalse())
+	g.Expect(targets).To(Equal([]LogTarget{{Pod: "p1"}, {Pod: "p2"}}))
+}

--- a/internal/web/workload.go
+++ b/internal/web/workload.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/podlogs"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/kubeclient"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
 )
@@ -275,7 +276,7 @@ func (h *Handler) GetWorkloadStatus(ctx context.Context, kind, name, namespace s
 	// CronJobs have no spec.selector, so their selector is nil and the
 	// series stays empty.
 	if !detailed && h.metrics != nil && h.metrics.Available() {
-		workload.Samples = h.metrics.WorkloadSeries(namespace, nil, workloadPodSelector(obj))
+		workload.Samples = h.metrics.WorkloadSeries(namespace, nil, podlogs.WorkloadPodSelector(obj))
 	}
 
 	if detailed {
@@ -453,7 +454,7 @@ func (h *Handler) GetWorkloadPods(ctx context.Context, obj *unstructured.Unstruc
 	}
 
 	// Match pods on the full workload selector (matchLabels and matchExpressions).
-	selector := workloadPodSelector(obj)
+	selector := podlogs.WorkloadPodSelector(obj)
 	if selector == nil || selector.Empty() {
 		return nil, nil
 	}

--- a/internal/web/workload_logs.go
+++ b/internal/web/workload_logs.go
@@ -7,9 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/podlogs"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
 )
 
@@ -100,108 +99,6 @@ type WorkloadLogsResponse struct {
 	Forbidden int `json:"forbidden,omitempty"`
 }
 
-// trimPartialLogLine drops a trailing partial log line from the payload.
-//
-// Container runtimes newline-terminate every emitted log line, so a payload
-// that does not end with a newline has been truncated mid-line because the
-// container was writing the line when the logs were read (common while
-// following). Returning that fragment as the latest entry shows only a few
-// characters, so it is dropped; the complete line reappears on the next fetch.
-// A payload with no newline at all is returned unchanged so a single short line
-// is not lost.
-func trimPartialLogLine(logs string) string {
-	if logs == "" || logs[len(logs)-1] == '\n' {
-		return logs
-	}
-	if i := strings.LastIndexByte(logs, '\n'); i >= 0 {
-		return logs[:i+1]
-	}
-	return logs
-}
-
-// tailLogBytes reads r to EOF but retains only the most recent limit bytes, so
-// the response stays small while returning the newest log lines.
-//
-// The kubelet's PodLogOptions.LimitBytes keeps the *oldest* bytes of the range
-// it reads, which for a tail window drops the most recent lines. Reading the
-// whole window (bounded by TailLines) and keeping the trailing bytes here
-// returns the newest lines instead. Memory use is bounded to ~limit regardless
-// of the stream length.
-//
-// The returned bool is partialFirst: true when the retained slice begins
-// mid-line (the byte dropped just before it was not a newline), so the caller
-// should drop that leading fragment. A cut that lands exactly on a line boundary
-// keeps a complete first line and reports false.
-func tailLogBytes(r io.Reader, limit int) ([]byte, bool, error) {
-	const chunkSize = 32 * 1024
-	buf := make([]byte, 0, limit+chunkSize)
-	chunk := make([]byte, chunkSize)
-	partialFirst := false
-	for {
-		n, err := r.Read(chunk)
-		if n > 0 {
-			buf = append(buf, chunk[:n]...)
-			if len(buf) > limit {
-				// The byte dropped just before the retained window decides
-				// whether the first kept line is complete (preceded by '\n') or
-				// a mid-line fragment.
-				partialFirst = buf[len(buf)-limit-1] != '\n'
-				// Shift the trailing limit bytes (the newest output) to the
-				// front in place so the backing array, and thus memory, stays
-				// bounded.
-				copy(buf, buf[len(buf)-limit:])
-				buf = buf[:limit]
-			}
-		}
-		if err == io.EOF {
-			return buf, partialFirst, nil
-		}
-		if err != nil {
-			return nil, partialFirst, err
-		}
-	}
-}
-
-// trimPartialFirstLine drops a leading partial log line from the payload. It is
-// applied only when the payload was byte-truncated from the front (see
-// tailLogBytes), where the first line is a mid-line fragment. A payload with no
-// newline is returned unchanged so a single short line is not lost.
-func trimPartialFirstLine(logs string) string {
-	if _, rest, found := strings.Cut(logs, "\n"); found {
-		return rest
-	}
-	return logs
-}
-
-// fetchContainerLog streams the logs of a single container with the given
-// options and returns the payload trimmed of any partial first/last line,
-// keeping only the newest byteLimit bytes. It is shared by the single-stream and
-// fan-out paths of the handler; the fan-out passes a smaller per-stream limit so
-// many concurrent streams stay within the overall byte budget.
-func fetchContainerLog(ctx context.Context, clientset kubernetes.Interface, namespace, name string, opts *corev1.PodLogOptions, byteLimit int) (string, error) {
-	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(name, opts).Stream(ctx)
-	if err != nil {
-		return "", err
-	}
-	defer stream.Close()
-
-	// Read the stream, keeping only the newest byteLimit bytes so the payload
-	// stays bounded while returning the most recent lines.
-	data, partialFirst, err := tailLogBytes(stream, byteLimit)
-	if err != nil {
-		return "", err
-	}
-
-	// Drop the partial first line only when the byte cap cut mid-line (a cut on
-	// a line boundary keeps a complete first line), and the partial last line
-	// when the container was mid-write.
-	logs := trimPartialLogLine(string(data))
-	if partialFirst {
-		logs = trimPartialFirstLine(logs)
-	}
-	return logs, nil
-}
-
 // writeLogStreamError maps a GetLogs stream error to an HTTP response: 403 for a
 // forbidden user, 404 for a missing pod, and 500 otherwise (logged). An empty
 // name produces a workload-scoped message for the all-pods fan-out, where the
@@ -248,144 +145,6 @@ func writeWorkloadLogsResponse(w http.ResponseWriter, resp WorkloadLogsResponse)
 	}
 }
 
-// logTarget is one (pod, container) stream to read in the fan-out. An empty
-// container lets the kubelet pick the pod's default container.
-type logTarget struct {
-	pod       string
-	container string
-}
-
-// logStream is one source blob in the fan-out: the raw timestamped log payload
-// of a single (pod, container) target plus the pod and container it came from, so
-// the merge can tag each line with its origin in the all-pods/all-containers view.
-type logStream struct {
-	pod       string
-	container string
-	blob      string
-}
-
-// logEntry is one record used when interleaving multiple streams: a line
-// carrying a leading RFC3339 timestamp plus any immediately following
-// continuation lines that lack their own timestamp (e.g. stack-trace frames).
-// The parsed timestamp is the sort key; text retains the original line(s),
-// including the timestamp prefix, since the frontend strips it for display. pod
-// and container record the origin so the merge can prefix the line in tagged mode.
-type logEntry struct {
-	ts        time.Time
-	text      string
-	pod       string
-	container string
-}
-
-// parseLogTimestamp parses the leading RFC3339 timestamp token kubelet prepends
-// to each line when PodLogOptions.Timestamps is set. It reports false when the
-// line does not start with such a token (e.g. a stack-trace continuation).
-func parseLogTimestamp(line string) (time.Time, bool) {
-	tsStr, _, found := strings.Cut(line, " ")
-	if !found {
-		return time.Time{}, false
-	}
-	t, err := time.Parse(time.RFC3339Nano, tsStr)
-	if err != nil {
-		return time.Time{}, false
-	}
-	return t, true
-}
-
-// parseLogEntries splits a timestamped log payload into entries, stamping each
-// with pod and container. Each entry begins at a line whose first token parses as
-// an RFC3339 timestamp and absorbs subsequent lines without such a prefix, so
-// multi-line records (stack traces) stay intact and ordered. A continuation line
-// with no preceding entry becomes its own zero-timestamped entry, which sorts to
-// the front.
-func parseLogEntries(blob, pod, container string) []logEntry {
-	var entries []logEntry
-	for line := range strings.SplitSeq(blob, "\n") {
-		if line == "" {
-			continue
-		}
-		if ts, ok := parseLogTimestamp(line); ok {
-			entries = append(entries, logEntry{ts: ts, text: line, pod: pod, container: container})
-			continue
-		}
-		if n := len(entries); n > 0 {
-			entries[n-1].text += "\n" + line
-		} else {
-			entries = append(entries, logEntry{text: line, pod: pod, container: container})
-		}
-	}
-	return entries
-}
-
-// mergeLogStreams interleaves the timestamped payloads of multiple streams into
-// a single chronological stream. Entries are stable-sorted by their timestamp
-// (so records logged at the same instant keep a deterministic order), capped to
-// the newest tailLines entries, and finally to the newest maxLogBytes bytes on a
-// line boundary so the payload stays bounded.
-//
-// Each entry that carries a timestamp is prefixed with its origin tags, in
-// pod-then-container order, for whichever dimensions fanned out: tagPod writes the
-// pod, tagContainer the container ("<pod> <container> <timestamp> <message>", or
-// just one token when only one dimension is tagged), so the client can attribute
-// the line and scope multi-line folding. Zero-timestamped orphan entries are left
-// untagged so every tagged line is uniformly "<tags...> <timestamp> ..." and
-// parses unambiguously. With both flags false the output is byte-for-byte the
-// original single-pod merge.
-func mergeLogStreams(streams []logStream, tailLines int, tagPod, tagContainer bool) string {
-	var entries []logEntry
-	for _, s := range streams {
-		entries = append(entries, parseLogEntries(s.blob, s.pod, s.container)...)
-	}
-	sort.SliceStable(entries, func(i, j int) bool {
-		return entries[i].ts.Before(entries[j].ts)
-	})
-	if tailLines > 0 && len(entries) > tailLines {
-		entries = entries[len(entries)-tailLines:]
-	}
-	var sb strings.Builder
-	for _, e := range entries {
-		if !e.ts.IsZero() {
-			if tagPod {
-				sb.WriteString(e.pod)
-				sb.WriteByte(' ')
-			}
-			if tagContainer {
-				sb.WriteString(e.container)
-				sb.WriteByte(' ')
-			}
-		}
-		sb.WriteString(e.text)
-		sb.WriteByte('\n')
-	}
-	return capLogBytes(sb.String(), int(maxLogBytes))
-}
-
-// dedupeNames removes duplicate names (keeping first occurrence) and caps the
-// result to limit, so a request naming the same pod or container twice does not
-// stream it twice and a request naming many cannot fan out without bound. Order
-// is preserved so the merge input stays deterministic. It reports whether any
-// name was dropped by the cap (not by de-duplication).
-func dedupeNames(names []string, limit int) ([]string, bool) {
-	if len(names) == 0 {
-		return names, false
-	}
-	seen := make(map[string]struct{}, len(names))
-	out := make([]string, 0, len(names))
-	truncated := false
-	for _, n := range names {
-		if _, ok := seen[n]; ok {
-			continue
-		}
-		seen[n] = struct{}{}
-		if len(out) == limit {
-			truncated = true
-			break
-		}
-		out = append(out, n)
-	}
-	return out, truncated
-}
-
 // logFanOut is the outcome of a per-target log fan-out: the successful streams
 // (tagged with their pod), the set of distinct pods that produced logs, the
 // number of distinct pods skipped because the user is forbidden to read them, and
@@ -394,7 +153,7 @@ func dedupeNames(names []string, limit int) ([]string, bool) {
 // deleted, or forbidden) is skipped as long as another succeeded, so firstErr is
 // only meaningful when no stream was collected.
 type logFanOut struct {
-	streams     []logStream
+	streams     []podlogs.LogStream
 	streamedSet map[string]struct{}
 	forbidden   int
 	firstErr    error
@@ -405,7 +164,7 @@ type logFanOut struct {
 // pods forbidden, and the first error. targets, logs, and errs are index-aligned.
 // Forbidden is counted per pod (not per target) so a forbidden pod with several
 // containers is reported once, matching the pod-based Total/Streamed fields.
-func collectLogStreams(targets []logTarget, logs []string, errs []error) logFanOut {
+func collectLogStreams(targets []podlogs.LogTarget, logs []string, errs []error) logFanOut {
 	out := logFanOut{streamedSet: make(map[string]struct{})}
 	forbiddenPods := make(map[string]struct{})
 	for i := range targets {
@@ -414,35 +173,15 @@ func collectLogStreams(targets []logTarget, logs []string, errs []error) logFanO
 				out.firstErr = errs[i]
 			}
 			if errors.IsForbidden(errs[i]) {
-				forbiddenPods[targets[i].pod] = struct{}{}
+				forbiddenPods[targets[i].Pod] = struct{}{}
 			}
 			continue
 		}
-		out.streams = append(out.streams, logStream{pod: targets[i].pod, container: targets[i].container, blob: logs[i]})
-		out.streamedSet[targets[i].pod] = struct{}{}
+		out.streams = append(out.streams, podlogs.LogStream{Pod: targets[i].Pod, Container: targets[i].Container, Blob: logs[i]})
+		out.streamedSet[targets[i].Pod] = struct{}{}
 	}
 	out.forbidden = len(forbiddenPods)
 	return out
-}
-
-// capLogBytes keeps only the newest limit bytes of a newline-terminated log
-// payload, trimming any partial leading line so the result starts on a line
-// boundary.
-func capLogBytes(logs string, limit int) string {
-	if len(logs) <= limit {
-		return logs
-	}
-	cut := len(logs) - limit
-	// When the cut lands exactly on a line boundary (the preceding byte is a
-	// newline), the window already starts with a complete line and must not be
-	// trimmed further; otherwise drop the leading partial fragment.
-	if logs[cut-1] == '\n' {
-		return logs[cut:]
-	}
-	if i := strings.IndexByte(logs[cut:], '\n'); i >= 0 {
-		return logs[cut+i+1:]
-	}
-	return logs[cut:]
 }
 
 // WorkloadLogsHandler handles GET /api/v1/workload/logs requests and returns the
@@ -579,9 +318,9 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 	}
 	// total is the number of distinct pods the client asked for, measured before
 	// the cap so a truncated all-pods view can be reported as partial.
-	deduped, _ := dedupeNames(pods, len(pods))
+	deduped, _ := podlogs.DedupeNames(pods, len(pods))
 	total := len(deduped)
-	pods, podsTruncated := dedupeNames(pods, maxLogPods)
+	pods, podsTruncated := podlogs.DedupeNames(pods, maxLogPods)
 
 	// Collect the requested container names. An absent container lets the kubelet
 	// pick the pod's default container.
@@ -591,7 +330,7 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 			containers = append(containers, c)
 		}
 	}
-	containers, containersTruncated := dedupeNames(containers, maxLogContainers)
+	containers, containersTruncated := podlogs.DedupeNames(containers, maxLogContainers)
 
 	// Tagging is decided from the client's request, before the stream cap, so the
 	// client and server agree on the wire format regardless of which streams
@@ -604,7 +343,7 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 	// Build the (pod, container) targets as the product of the two dimensions,
 	// capped to maxLogStreams overall. An empty container list yields one target
 	// per pod (kubelet default container).
-	targets, streamsTruncated := buildLogTargets(pods, containers, maxLogStreams)
+	targets, streamsTruncated := podlogs.BuildLogTargets(pods, containers, maxLogStreams)
 	truncated := podsTruncated || containersTruncated || streamsTruncated
 
 	// TailLines is always set so the kubelet returns the newest lines (and bounds
@@ -626,12 +365,12 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 	// (maxLogStreams is 50). Were a future cap to collapse it to one target, the
 	// response would report ContainerTagged=false, so client and server still agree.
 	if !tagPod && len(targets) <= 1 {
-		t := logTarget{pod: name}
+		t := podlogs.LogTarget{Pod: name}
 		if len(targets) == 1 {
 			t = targets[0]
 		}
 		opts := &corev1.PodLogOptions{
-			Container:  t.container,
+			Container:  t.Container,
 			TailLines:  &tailLines64,
 			Previous:   previous,
 			Timestamps: true,
@@ -639,12 +378,12 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 		if sinceTime != nil {
 			opts.SinceTime = sinceTime
 		}
-		logs, err := fetchContainerLog(ctx, clientset, namespace, t.pod, opts, int(maxLogBytes))
+		logs, err := podlogs.FetchContainerLog(ctx, clientset, namespace, t.Pod, opts, int(maxLogBytes))
 		if err != nil {
-			writeLogStreamError(ctx, w, err, namespace, t.pod, t.container)
+			writeLogStreamError(ctx, w, err, namespace, t.Pod, t.Container)
 			return
 		}
-		writeWorkloadLogs(w, t.pod, t.container, logs)
+		writeWorkloadLogs(w, t.Pod, t.Container, logs)
 		return
 	}
 
@@ -662,24 +401,24 @@ func (h *Handler) WorkloadLogsHandler(w http.ResponseWriter, req *http.Request) 
 	var wg sync.WaitGroup
 	for i, t := range targets {
 		wg.Add(1)
-		go func(i int, t logTarget) {
+		go func(i int, t podlogs.LogTarget) {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
 			opts := &corev1.PodLogOptions{
-				Container:  t.container,
+				Container:  t.Container,
 				TailLines:  &tailLines64,
 				Timestamps: true,
 			}
 			// Follow cursor: a per-pod `since` for the all-pods view, falling back
 			// to the single global sinceTime (used by a single-pod, multi-container
 			// follow, which routes here yet sends one cursor).
-			if st := sinceByPod[t.pod]; st != nil {
+			if st := sinceByPod[t.Pod]; st != nil {
 				opts.SinceTime = st
 			} else if sinceTime != nil {
 				opts.SinceTime = sinceTime
 			}
-			logsByTarget[i], errsByTarget[i] = fetchContainerLog(ctx, clientset, namespace, t.pod, opts, perStreamBytes)
+			logsByTarget[i], errsByTarget[i] = podlogs.FetchContainerLog(ctx, clientset, namespace, t.Pod, opts, perStreamBytes)
 		}(i, t)
 	}
 	wg.Wait()
@@ -711,7 +450,7 @@ func buildWorkloadLogsResponse(pods, containers []string, fanOut logFanOut, tota
 	return WorkloadLogsResponse{
 		Pod:             strings.Join(pods, ","),
 		Container:       strings.Join(containers, ","),
-		Logs:            mergeLogStreams(fanOut.streams, tailLines, tagPod, tagContainer),
+		Logs:            podlogs.MergeLogStreams(fanOut.streams, tailLines, tagPod, tagContainer, int(maxLogBytes)),
 		Tagged:          tagPod,
 		ContainerTagged: tagContainer,
 		Total:           total,
@@ -719,28 +458,4 @@ func buildWorkloadLogsResponse(pods, containers []string, fanOut logFanOut, tota
 		Partial:         streamed < total || truncated,
 		Forbidden:       fanOut.forbidden,
 	}
-}
-
-// buildLogTargets expands the pod and container dimensions into the (pod,
-// container) product, capped to limit targets overall. An empty container list
-// yields one target per pod (the kubelet default container). It reports whether
-// the cap dropped any target.
-func buildLogTargets(pods, containers []string, limit int) ([]logTarget, bool) {
-	var targets []logTarget
-	for _, p := range pods {
-		if len(containers) == 0 {
-			if len(targets) == limit {
-				return targets, true
-			}
-			targets = append(targets, logTarget{pod: p})
-			continue
-		}
-		for _, c := range containers {
-			if len(targets) == limit {
-				return targets, true
-			}
-			targets = append(targets, logTarget{pod: p, container: c})
-		}
-	}
-	return targets, false
 }

--- a/internal/web/workload_logs_test.go
+++ b/internal/web/workload_logs_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -20,303 +19,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/podlogs"
 	"github.com/controlplaneio-fluxcd/flux-operator/internal/web/user"
 )
-
-func TestTrimPartialLogLine(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{name: "empty", in: "", want: ""},
-		{name: "newline terminated", in: "line one\nline two\n", want: "line one\nline two\n"},
-		{name: "drops partial trailing line", in: "line one\nline two\npar", want: "line one\nline two\n"},
-		{name: "single partial line kept", in: "partial", want: "partial"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			g.Expect(trimPartialLogLine(tt.in)).To(Equal(tt.want))
-		})
-	}
-}
-
-func TestTrimPartialFirstLine(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{name: "empty", in: "", want: ""},
-		{name: "drops partial leading fragment", in: "tial\nline two\nline three\n", want: "line two\nline three\n"},
-		{name: "single line with no newline kept", in: "only-line", want: "only-line"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			g.Expect(trimPartialFirstLine(tt.in)).To(Equal(tt.want))
-		})
-	}
-}
-
-func TestTailLogBytes(t *testing.T) {
-	tests := []struct {
-		name             string
-		in               string
-		limit            int
-		want             string
-		wantPartialFirst bool
-	}{
-		{name: "under limit returns all", in: "line1\nline2\n", limit: 100, want: "line1\nline2\n", wantPartialFirst: false},
-		{name: "exact limit not truncated", in: "abcd", limit: 4, want: "abcd", wantPartialFirst: false},
-		// The cut lands exactly after "line1\n", so the first retained line is
-		// complete and must NOT be reported as partial (or the caller drops it).
-		{name: "over limit cut on line boundary keeps complete first line", in: "line1\nline2\nline3\n", limit: 12, want: "line2\nline3\n", wantPartialFirst: false},
-		{name: "over limit cutting mid-line", in: "line1\nline2\n", limit: 8, want: "1\nline2\n", wantPartialFirst: true},
-		{name: "empty stream", in: "", limit: 16, want: "", wantPartialFirst: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			// strings.Reader hands out small reads, exercising the chunked loop.
-			got, partialFirst, err := tailLogBytes(strings.NewReader(tt.in), tt.limit)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(string(got)).To(Equal(tt.want))
-			g.Expect(partialFirst).To(Equal(tt.wantPartialFirst))
-		})
-	}
-}
-
-func TestParseLogEntries(t *testing.T) {
-	t.Run("groups continuation lines with their timestamped entry and stamps the pod and container", func(t *testing.T) {
-		g := NewWithT(t)
-
-		blob := "2026-01-01T00:00:00Z panic: boom\ngoroutine 1 [running]:\nmain.main()\n" +
-			"2026-01-01T00:00:01Z next line\n"
-		entries := parseLogEntries(blob, "pod-a", "app")
-
-		g.Expect(entries).To(HaveLen(2))
-		// The two non-timestamped lines stay attached to the first entry.
-		g.Expect(entries[0].text).To(Equal("2026-01-01T00:00:00Z panic: boom\ngoroutine 1 [running]:\nmain.main()"))
-		g.Expect(entries[0].pod).To(Equal("pod-a"))
-		g.Expect(entries[0].container).To(Equal("app"))
-		g.Expect(entries[1].text).To(Equal("2026-01-01T00:00:01Z next line"))
-		g.Expect(entries[1].pod).To(Equal("pod-a"))
-		g.Expect(entries[1].container).To(Equal("app"))
-	})
-
-	t.Run("a leading continuation with no preceding entry becomes its own entry, stamped", func(t *testing.T) {
-		g := NewWithT(t)
-
-		entries := parseLogEntries("orphan continuation\n2026-01-01T00:00:00Z line\n", "pod-a", "app")
-		g.Expect(entries).To(HaveLen(2))
-		g.Expect(entries[0].ts.IsZero()).To(BeTrue())
-		g.Expect(entries[0].text).To(Equal("orphan continuation"))
-		g.Expect(entries[0].container).To(Equal("app"))
-		g.Expect(entries[1].text).To(Equal("2026-01-01T00:00:00Z line"))
-		g.Expect(entries[1].container).To(Equal("app"))
-	})
-
-	t.Run("empty payload yields no entries", func(t *testing.T) {
-		g := NewWithT(t)
-		g.Expect(parseLogEntries("", "pod-a", "app")).To(BeEmpty())
-	})
-}
-
-func TestMergeLogStreams(t *testing.T) {
-	t.Run("interleaves two streams in chronological order untagged", func(t *testing.T) {
-		g := NewWithT(t)
-
-		app := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"}
-		sidecar := logStream{pod: "pod-a", blob: "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"}
-
-		got := mergeLogStreams([]logStream{app, sidecar}, 0, false, false)
-		g.Expect(got).To(Equal(
-			"2026-01-01T00:00:00Z app a\n" +
-				"2026-01-01T00:00:01Z side a\n" +
-				"2026-01-01T00:00:02Z app b\n" +
-				"2026-01-01T00:00:03Z side b\n"))
-	})
-
-	t.Run("orders fractional timestamps numerically, not lexically", func(t *testing.T) {
-		g := NewWithT(t)
-
-		// "0.12" is numerically after "0.1" but sorts before it lexically; the
-		// merge must parse the timestamps to get this right.
-		a := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00.1Z first\n"}
-		b := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00.12Z second\n"}
-
-		got := mergeLogStreams([]logStream{b, a}, 0, false, false)
-		g.Expect(got).To(Equal("2026-01-01T00:00:00.1Z first\n2026-01-01T00:00:00.12Z second\n"))
-	})
-
-	t.Run("keeps a multi-line entry attached after sorting", func(t *testing.T) {
-		g := NewWithT(t)
-
-		app := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00Z panic\nstack frame\n"}
-		sidecar := logStream{pod: "pod-a", blob: "2026-01-01T00:00:01Z side\n"}
-
-		got := mergeLogStreams([]logStream{app, sidecar}, 0, false, false)
-		g.Expect(got).To(Equal("2026-01-01T00:00:00Z panic\nstack frame\n2026-01-01T00:00:01Z side\n"))
-	})
-
-	t.Run("caps to the newest tailLines entries across all streams", func(t *testing.T) {
-		g := NewWithT(t)
-
-		app := logStream{pod: "pod-a", blob: "2026-01-01T00:00:00Z app a\n2026-01-01T00:00:02Z app b\n"}
-		sidecar := logStream{pod: "pod-a", blob: "2026-01-01T00:00:01Z side a\n2026-01-01T00:00:03Z side b\n"}
-
-		got := mergeLogStreams([]logStream{app, sidecar}, 2, false, false)
-		g.Expect(got).To(Equal("2026-01-01T00:00:02Z app b\n2026-01-01T00:00:03Z side b\n"))
-	})
-
-	t.Run("empty streams yield an empty payload", func(t *testing.T) {
-		g := NewWithT(t)
-		g.Expect(mergeLogStreams(nil, 100, false, false)).To(BeEmpty())
-		g.Expect(mergeLogStreams([]logStream{{pod: "pod-a"}, {pod: "pod-b"}}, 100, false, false)).To(BeEmpty())
-	})
-
-	t.Run("tagged mode prefixes each timestamped line with its pod, interleaved", func(t *testing.T) {
-		g := NewWithT(t)
-
-		a := logStream{pod: "frontend-abc-gqh2x", blob: "2026-01-01T00:00:00Z a one\n2026-01-01T00:00:02Z a two\n"}
-		b := logStream{pod: "frontend-abc-p8x2k", blob: "2026-01-01T00:00:01Z b one\n"}
-
-		got := mergeLogStreams([]logStream{a, b}, 0, true, false)
-		g.Expect(got).To(Equal(
-			"frontend-abc-gqh2x 2026-01-01T00:00:00Z a one\n" +
-				"frontend-abc-p8x2k 2026-01-01T00:00:01Z b one\n" +
-				"frontend-abc-gqh2x 2026-01-01T00:00:02Z a two\n"))
-	})
-
-	t.Run("tagged mode tags only timestamped lines, not continuation or orphan lines", func(t *testing.T) {
-		g := NewWithT(t)
-
-		// A multi-line entry: only its timestamped first line is tagged; the
-		// stack-trace continuation stays untagged so every tagged line is
-		// uniformly "<pod> <timestamp> ...".
-		a := logStream{pod: "pod-a", blob: "2026-01-01T00:00:01Z panic\nstack frame\n"}
-		// A leading orphan continuation (zero ts) is left untagged too.
-		b := logStream{pod: "pod-b", blob: "orphan line\n"}
-
-		got := mergeLogStreams([]logStream{a, b}, 0, true, false)
-		g.Expect(got).To(Equal(
-			"orphan line\n" +
-				"pod-a 2026-01-01T00:00:01Z panic\nstack frame\n"))
-	})
-
-	t.Run("container-tagged mode prefixes each timestamped line with its container", func(t *testing.T) {
-		g := NewWithT(t)
-
-		// Single-pod all-containers view: tag the container, not the pod, so the
-		// client can scope folding per container.
-		app := logStream{pod: "pod-a", container: "app", blob: "2026-01-01T00:00:00Z a one\n2026-01-01T00:00:02Z a two\n"}
-		side := logStream{pod: "pod-a", container: "envoy", blob: "2026-01-01T00:00:01Z s one\n"}
-
-		got := mergeLogStreams([]logStream{app, side}, 0, false, true)
-		g.Expect(got).To(Equal(
-			"app 2026-01-01T00:00:00Z a one\n" +
-				"envoy 2026-01-01T00:00:01Z s one\n" +
-				"app 2026-01-01T00:00:02Z a two\n"))
-	})
-
-	t.Run("combined mode prefixes pod then container, in order", func(t *testing.T) {
-		g := NewWithT(t)
-
-		// All-pods and all-containers: both dimensions fan out, so each timestamped
-		// line carries "<pod> <container> <ts> <msg>"; orphans stay untagged.
-		a := logStream{pod: "p1", container: "app", blob: "2026-01-01T00:00:00Z a\nframe\n"}
-		b := logStream{pod: "p2", container: "side", blob: "2026-01-01T00:00:01Z b\n"}
-
-		got := mergeLogStreams([]logStream{a, b}, 0, true, true)
-		g.Expect(got).To(Equal(
-			"p1 app 2026-01-01T00:00:00Z a\nframe\n" +
-				"p2 side 2026-01-01T00:00:01Z b\n"))
-	})
-}
-
-func TestCapLogBytes(t *testing.T) {
-	tests := []struct {
-		name  string
-		in    string
-		limit int
-		want  string
-	}{
-		{name: "under limit returns all", in: "line1\nline2\n", limit: 100, want: "line1\nline2\n"},
-		{name: "trims partial leading line on a mid-line cut", in: "line1\nline2\nline3\n", limit: 13, want: "line2\nline3\n"},
-		// The cut lands exactly after "line1\n", so the window already starts with
-		// a complete line and the leading line must NOT be dropped.
-		{name: "keeps complete first line when cut lands on a boundary", in: "line1\nline2\nline3\n", limit: 12, want: "line2\nline3\n"},
-		{name: "no newline in window keeps tail bytes", in: "abcdef", limit: 3, want: "def"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			g.Expect(capLogBytes(tt.in, tt.limit)).To(Equal(tt.want))
-		})
-	}
-}
-
-func TestDedupeNames(t *testing.T) {
-	tests := []struct {
-		name          string
-		in            []string
-		limit         int
-		want          []string
-		wantTruncated bool
-	}{
-		{name: "nil stays nil", in: nil, limit: 8, want: nil},
-		{name: "preserves order without duplicates", in: []string{"app", "sidecar"}, limit: 8, want: []string{"app", "sidecar"}},
-		{name: "drops duplicates keeping first occurrence", in: []string{"app", "app", "sidecar", "app"}, limit: 8, want: []string{"app", "sidecar"}},
-		// De-duplication that leaves the result within the limit is not truncation.
-		{name: "dedup within limit is not truncation", in: []string{"a", "a", "b", "b"}, limit: 2, want: []string{"a", "b"}},
-		{name: "caps to the limit and reports truncation", in: []string{"a", "b", "c", "d"}, limit: 2, want: []string{"a", "b"}, wantTruncated: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			got, truncated := dedupeNames(tt.in, tt.limit)
-			g.Expect(got).To(Equal(tt.want))
-			g.Expect(truncated).To(Equal(tt.wantTruncated))
-		})
-	}
-}
-
-func TestBuildLogTargets(t *testing.T) {
-	t.Run("product of pods and containers", func(t *testing.T) {
-		g := NewWithT(t)
-		targets, truncated := buildLogTargets([]string{"p1", "p2"}, []string{"app", "side"}, 64)
-		g.Expect(truncated).To(BeFalse())
-		g.Expect(targets).To(Equal([]logTarget{
-			{pod: "p1", container: "app"}, {pod: "p1", container: "side"},
-			{pod: "p2", container: "app"}, {pod: "p2", container: "side"},
-		}))
-	})
-
-	t.Run("empty containers yield one default-container target per pod", func(t *testing.T) {
-		g := NewWithT(t)
-		targets, truncated := buildLogTargets([]string{"p1", "p2"}, nil, 64)
-		g.Expect(truncated).To(BeFalse())
-		g.Expect(targets).To(Equal([]logTarget{{pod: "p1"}, {pod: "p2"}}))
-	})
-
-	t.Run("caps to the stream limit and reports truncation", func(t *testing.T) {
-		g := NewWithT(t)
-		targets, truncated := buildLogTargets([]string{"p1", "p2", "p3"}, []string{"app", "side"}, 3)
-		g.Expect(truncated).To(BeTrue())
-		g.Expect(targets).To(HaveLen(3))
-		g.Expect(targets).To(Equal([]logTarget{
-			{pod: "p1", container: "app"}, {pod: "p1", container: "side"},
-			{pod: "p2", container: "app"},
-		}))
-	})
-}
 
 func TestCollectLogStreams(t *testing.T) {
 	errWaiting := errors.New("waiting to start")
@@ -324,9 +29,9 @@ func TestCollectLogStreams(t *testing.T) {
 
 	t.Run("all succeed across two pods", func(t *testing.T) {
 		g := NewWithT(t)
-		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
+		targets := []podlogs.LogTarget{{Pod: "p1", Container: "app"}, {Pod: "p2", Container: "app"}}
 		out := collectLogStreams(targets, []string{"x", "y"}, []error{nil, nil})
-		g.Expect(out.streams).To(Equal([]logStream{{pod: "p1", container: "app", blob: "x"}, {pod: "p2", container: "app", blob: "y"}}))
+		g.Expect(out.streams).To(Equal([]podlogs.LogStream{{Pod: "p1", Container: "app", Blob: "x"}, {Pod: "p2", Container: "app", Blob: "y"}}))
 		g.Expect(out.streamedSet).To(HaveLen(2))
 		g.Expect(out.forbidden).To(Equal(0))
 		g.Expect(out.firstErr).NotTo(HaveOccurred())
@@ -334,9 +39,9 @@ func TestCollectLogStreams(t *testing.T) {
 
 	t.Run("partial failure skips the failed target and counts forbidden", func(t *testing.T) {
 		g := NewWithT(t)
-		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
+		targets := []podlogs.LogTarget{{Pod: "p1", Container: "app"}, {Pod: "p2", Container: "app"}}
 		out := collectLogStreams(targets, []string{"x", ""}, []error{nil, forbidden})
-		g.Expect(out.streams).To(Equal([]logStream{{pod: "p1", container: "app", blob: "x"}}))
+		g.Expect(out.streams).To(Equal([]podlogs.LogStream{{Pod: "p1", Container: "app", Blob: "x"}}))
 		g.Expect(out.streamedSet).To(HaveLen(1))
 		g.Expect(out.forbidden).To(Equal(1))
 		g.Expect(out.firstErr).To(MatchError(forbidden))
@@ -344,7 +49,7 @@ func TestCollectLogStreams(t *testing.T) {
 
 	t.Run("all fail returns no streams and the first error", func(t *testing.T) {
 		g := NewWithT(t)
-		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
+		targets := []podlogs.LogTarget{{Pod: "p1", Container: "app"}, {Pod: "p2", Container: "app"}}
 		out := collectLogStreams(targets, []string{"", ""}, []error{errWaiting, forbidden})
 		g.Expect(out.streams).To(BeEmpty())
 		g.Expect(out.streamedSet).To(BeEmpty())
@@ -355,7 +60,7 @@ func TestCollectLogStreams(t *testing.T) {
 	t.Run("forbidden is counted per pod, not per container target", func(t *testing.T) {
 		g := NewWithT(t)
 		// One forbidden pod with two containers must count once, not twice.
-		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p1", container: "side"}}
+		targets := []podlogs.LogTarget{{Pod: "p1", Container: "app"}, {Pod: "p1", Container: "side"}}
 		out := collectLogStreams(targets, []string{"", ""}, []error{forbidden, forbidden})
 		g.Expect(out.forbidden).To(Equal(1))
 	})
@@ -368,7 +73,7 @@ func TestBuildWorkloadLogsResponse(t *testing.T) {
 		g := NewWithT(t)
 		// Two pods requested, only p1 streams; p2 is forbidden. The response must
 		// report 200-style partial coverage with the per-pod counts the UI shows.
-		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
+		targets := []podlogs.LogTarget{{Pod: "p1", Container: "app"}, {Pod: "p2", Container: "app"}}
 		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z hi\n", ""}, []error{nil, forbidden})
 		resp := buildWorkloadLogsResponse([]string{"p1", "p2"}, []string{"app"}, fanOut, 2, 1000, true, false, false)
 
@@ -384,7 +89,7 @@ func TestBuildWorkloadLogsResponse(t *testing.T) {
 
 	t.Run("full coverage is not partial", func(t *testing.T) {
 		g := NewWithT(t)
-		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p2", container: "app"}}
+		targets := []podlogs.LogTarget{{Pod: "p1", Container: "app"}, {Pod: "p2", Container: "app"}}
 		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z a\n", "2026-01-01T00:00:01Z b\n"}, []error{nil, nil})
 		resp := buildWorkloadLogsResponse([]string{"p1", "p2"}, []string{"app"}, fanOut, 2, 1000, true, false, false)
 
@@ -397,7 +102,7 @@ func TestBuildWorkloadLogsResponse(t *testing.T) {
 		g := NewWithT(t)
 		// total counts requested pods (1) and that pod streamed, but the fan-out
 		// was capped, so the response must still flag the result as partial.
-		targets := []logTarget{{pod: "p1", container: "app"}}
+		targets := []podlogs.LogTarget{{Pod: "p1", Container: "app"}}
 		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z x\n"}, []error{nil})
 		resp := buildWorkloadLogsResponse([]string{"p1"}, []string{"app"}, fanOut, 1, 1000, true, false, true)
 
@@ -410,7 +115,7 @@ func TestBuildWorkloadLogsResponse(t *testing.T) {
 		g := NewWithT(t)
 		// One pod, two containers: ContainerTagged is set and each line is prefixed
 		// with its container so the client scopes folding per container.
-		targets := []logTarget{{pod: "p1", container: "app"}, {pod: "p1", container: "envoy"}}
+		targets := []podlogs.LogTarget{{Pod: "p1", Container: "app"}, {Pod: "p1", Container: "envoy"}}
 		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z a\n", "2026-01-01T00:00:01Z e\n"}, []error{nil, nil})
 		resp := buildWorkloadLogsResponse([]string{"p1"}, []string{"app", "envoy"}, fanOut, 1, 1000, false, true, false)
 

--- a/internal/web/workload_metrics.go
+++ b/internal/web/workload_metrics.go
@@ -20,6 +20,8 @@ import (
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/internal/podlogs"
 )
 
 const (
@@ -422,25 +424,6 @@ func podKey(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
-// workloadPodSelector extracts the pod label selector (matchLabels and
-// matchExpressions) from a workload spec. Returns nil when the workload
-// has no selector or it cannot be parsed.
-func workloadPodSelector(obj *unstructured.Unstructured) labels.Selector {
-	sel, found, _ := unstructured.NestedMap(obj.Object, "spec", "selector")
-	if !found {
-		return nil
-	}
-	labelSelector := &metav1.LabelSelector{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(sel, labelSelector); err != nil {
-		return nil
-	}
-	s, err := metav1.LabelSelectorAsSelector(labelSelector)
-	if err != nil {
-		return nil
-	}
-	return s
-}
-
 // currentPodMetrics returns the latest usage sample of a pod when it is
 // recent enough to describe the pod's present state.
 func (h *Handler) currentPodMetrics(namespace, name string) *MetricsSample {
@@ -494,7 +477,7 @@ func (h *Handler) buildWorkloadMetrics(obj *unstructured.Unstructured, pods []Wo
 		return nil
 	}
 
-	selector := workloadPodSelector(obj)
+	selector := podlogs.WorkloadPodSelector(obj)
 
 	names := make([]string, 0, len(pods))
 	wm := &WorkloadMetrics{}


### PR DESCRIPTION
Accept a workload kind (Deployment, StatefulSet, DaemonSet, CronJob or Job) in addition to Pod, so agents can read application logs directly from the workload name found in a Flux resource inventory, without first resolving selectors, pods and containers.

Tested with Qwen3.6 and Ornith-1.5 run locally. This change makes a huge difference when using agents to debug broken clusters, 3x less tool calls, 50K+ tokens saved per sub-agent.