### PR TITLE
mcp: add `get_kubernetes_events` tool 

### DIFF
--- a/cmd/mcp/k8s/events.go
+++ b/cmd/mcp/k8s/events.go
@@ -6,12 +6,16 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -57,6 +61,317 @@ func (k *Client) GetEvents(ctx context.Context, kind, name, namespace string, ex
 		})
 	}
 	return events, nil
+}
+
+const (
+	// eventListPageSize is the number of events requested from the API per page.
+	eventListPageSize int64 = 500
+	// eventListHardCap bounds the number of events inspected by a single request.
+	eventListHardCap = 5000
+	// defaultEventLimit is the number of matched events returned when no limit is specified.
+	defaultEventLimit = 100
+)
+
+// ListEventsOptions defines filters and limits for listing Kubernetes events.
+type ListEventsOptions struct {
+	// Namespace restricts events to the namespace of their involved objects.
+	Namespace string
+	// APIVersion filters by the exact involved object API version.
+	APIVersion string
+	// Kind filters by the exact involved object kind.
+	Kind string
+	// Name filters by the exact involved object name.
+	Name string
+	// Type filters by the exact Kubernetes event type.
+	Type string
+	// Since keeps events newer than this duration when set.
+	Since *time.Duration
+	// Grep filters event reasons, messages, and object references.
+	Grep *regexp.Regexp
+	// Limit is the maximum number of matched events to return.
+	Limit int
+}
+
+// ListEventsResult contains filtered Kubernetes events and truncation metadata.
+type ListEventsResult struct {
+	// Namespace is the requested namespace and is omitted for cluster-wide lists.
+	Namespace string `json:"namespace,omitempty"`
+	// Total is the number of matched events before applying Limit.
+	Total int `json:"total"`
+	// Truncated reports whether the hard cap or Limit dropped events.
+	Truncated bool `json:"truncated"`
+	// Events contains one line per matched event in newest-first order.
+	Events string `json:"events"`
+}
+
+// eventWorkloadKinds are the kinds whose events are listed together with the
+// events of the ReplicaSets, Jobs and pods they own.
+var eventWorkloadKinds = map[string]bool{
+	"Deployment":  true,
+	"StatefulSet": true,
+	"DaemonSet":   true,
+	"CronJob":     true,
+	"Job":         true,
+}
+
+// eventTarget identifies one involved object to list events for.
+type eventTarget struct {
+	kind string
+	name string
+}
+
+// ListEvents retrieves Kubernetes events across the cluster, in a namespace,
+// or for a workload together with the objects it owns.
+func (k *Client) ListEvents(ctx context.Context, opts ListEventsOptions) (*ListEventsResult, error) {
+	var clientset kubernetes.Interface
+	if isWorkloadEventQuery(opts) {
+		cs, err := kubernetes.NewForConfig(k.cfg)
+		if err != nil {
+			return nil, err
+		}
+		clientset = cs
+	}
+	return listEvents(ctx, k.Client, clientset, opts)
+}
+
+// isWorkloadEventQuery reports whether the options name a workload whose
+// owned objects must be resolved.
+func isWorkloadEventQuery(opts ListEventsOptions) bool {
+	return eventWorkloadKinds[opts.Kind] && opts.Name != "" && opts.Namespace != ""
+}
+
+// listEvents implements ListEvents with an injectable clientset for unit tests.
+func listEvents(ctx context.Context, c ctrlclient.Client, clientset kubernetes.Interface, opts ListEventsOptions) (*ListEventsResult, error) {
+	var typeSelector []fields.Selector
+	if opts.Type != "" {
+		typeSelector = append(typeSelector, fields.OneTermEqualSelector("type", opts.Type))
+	}
+
+	var allEvents []corev1.Event
+	truncated := false
+	if isWorkloadEventQuery(opts) {
+		targets, podsTruncated, err := resolveEventTargets(ctx, clientset, opts.Kind, opts.Name, opts.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		truncated = podsTruncated
+		for i, target := range targets {
+			selectors := append(slices.Clone(typeSelector),
+				fields.OneTermEqualSelector("involvedObject.kind", target.kind),
+				fields.OneTermEqualSelector("involvedObject.name", target.name))
+			if i == 0 && opts.APIVersion != "" {
+				selectors = append(selectors, fields.OneTermEqualSelector("involvedObject.apiVersion", opts.APIVersion))
+			}
+			events, capped, err := listEventPages(ctx, c, opts.Namespace, selectors, eventListHardCap-len(allEvents))
+			if err != nil {
+				return nil, err
+			}
+			allEvents = append(allEvents, events...)
+			truncated = truncated || capped
+			if len(allEvents) >= eventListHardCap {
+				break
+			}
+		}
+	} else {
+		selectors := slices.Clone(typeSelector)
+		if opts.APIVersion != "" {
+			selectors = append(selectors, fields.OneTermEqualSelector("involvedObject.apiVersion", opts.APIVersion))
+		}
+		if opts.Kind != "" {
+			selectors = append(selectors, fields.OneTermEqualSelector("involvedObject.kind", opts.Kind))
+		}
+		if opts.Name != "" {
+			selectors = append(selectors, fields.OneTermEqualSelector("involvedObject.name", opts.Name))
+		}
+		var err error
+		allEvents, truncated, err = listEventPages(ctx, c, opts.Namespace, selectors, eventListHardCap)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cutoff := time.Time{}
+	if opts.Since != nil {
+		cutoff = time.Now().Add(-*opts.Since)
+	}
+	filtered := make([]corev1.Event, 0, len(allEvents))
+	for _, event := range allEvents {
+		if !cutoff.IsZero() && !eventTime(event).After(cutoff) {
+			continue
+		}
+		object := eventObjectRef(event)
+		if opts.Grep != nil &&
+			!opts.Grep.MatchString(event.Reason) &&
+			!opts.Grep.MatchString(event.Message) &&
+			!opts.Grep.MatchString(object) {
+			continue
+		}
+		filtered = append(filtered, event)
+	}
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return eventTime(filtered[i]).After(eventTime(filtered[j]))
+	})
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultEventLimit
+	}
+	result := &ListEventsResult{
+		Namespace: opts.Namespace,
+		Total:     len(filtered),
+		Truncated: truncated || len(filtered) > limit,
+	}
+	if len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	var events strings.Builder
+	for _, event := range filtered {
+		events.WriteString(renderEventLine(event))
+		events.WriteByte('\n')
+	}
+	result.Events = events.String()
+
+	return result, nil
+}
+
+// listEventPages lists the events matching the selectors, paging with Continue
+// up to maxEvents. It reports whether the cap dropped events.
+func listEventPages(ctx context.Context, c ctrlclient.Client, namespace string, selectors []fields.Selector, maxEvents int) ([]corev1.Event, bool, error) {
+	events := make([]corev1.Event, 0, eventListPageSize)
+	continueToken := ""
+	for len(events) < maxEvents {
+		remaining := maxEvents - len(events)
+		pageLimit := min(eventListPageSize, int64(remaining))
+
+		listOpts := []ctrlclient.ListOption{ctrlclient.Limit(pageLimit)}
+		if namespace != "" {
+			listOpts = append(listOpts, ctrlclient.InNamespace(namespace))
+		}
+		if len(selectors) > 0 {
+			listOpts = append(listOpts, ctrlclient.MatchingFieldsSelector{
+				Selector: fields.AndSelectors(selectors...),
+			})
+		}
+		if continueToken != "" {
+			listOpts = append(listOpts, ctrlclient.Continue(continueToken))
+		}
+
+		page := &corev1.EventList{}
+		if err := c.List(ctx, page, listOpts...); err != nil {
+			return nil, false, err
+		}
+
+		if len(page.Items) > remaining {
+			events = append(events, page.Items[:remaining]...)
+			return events, true, nil
+		}
+		events = append(events, page.Items...)
+		continueToken = page.Continue
+		if continueToken == "" {
+			break
+		}
+	}
+	return events, len(events) == maxEvents && continueToken != "", nil
+}
+
+// resolveEventTargets returns the workload, the ReplicaSets or Jobs it owns,
+// and its newest pods capped at maxLogPods.
+func resolveEventTargets(ctx context.Context, clientset kubernetes.Interface, kind, name, namespace string) ([]eventTarget, bool, error) {
+	targets := []eventTarget{{kind: kind, name: name}}
+	var pods []corev1.Pod
+
+	switch kind {
+	case "Deployment":
+		deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, false, err
+		}
+		selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+		if err != nil {
+			return nil, false, err
+		}
+		replicaSets, err := clientset.AppsV1().ReplicaSets(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+		if err != nil {
+			return nil, false, err
+		}
+		for _, rs := range replicaSets.Items {
+			if hasOwnerUID(rs.OwnerReferences, deployment.UID) {
+				targets = append(targets, eventTarget{kind: "ReplicaSet", name: rs.Name})
+			}
+		}
+		if pods, err = resolveAppsWorkloadPods(ctx, clientset, deployment, namespace, name); err != nil {
+			return nil, false, err
+		}
+	case "CronJob":
+		cronJob, err := clientset.BatchV1().CronJobs(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, false, err
+		}
+		jobs, err := clientset.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, false, err
+		}
+		for _, job := range jobs.Items {
+			if hasOwnerUID(job.OwnerReferences, cronJob.UID) {
+				targets = append(targets, eventTarget{kind: "Job", name: job.Name})
+			}
+		}
+		if pods, err = resolveCronJobPods(ctx, clientset, cronJob); err != nil {
+			return nil, false, err
+		}
+	default:
+		var err error
+		if pods, err = resolveLogPods(ctx, clientset, kind, name, namespace); err != nil {
+			return nil, false, err
+		}
+	}
+
+	sort.SliceStable(pods, func(i, j int) bool {
+		if pods[i].CreationTimestamp.Equal(&pods[j].CreationTimestamp) {
+			return pods[i].Name < pods[j].Name
+		}
+		return pods[i].CreationTimestamp.After(pods[j].CreationTimestamp.Time)
+	})
+	truncated := len(pods) > maxLogPods
+	if truncated {
+		pods = pods[:maxLogPods]
+	}
+	for _, pod := range pods {
+		targets = append(targets, eventTarget{kind: "Pod", name: pod.Name})
+	}
+	return targets, truncated, nil
+}
+
+// eventObjectRef renders the involved object as Kind/namespace/name,
+// or Kind/name for cluster-scoped objects.
+func eventObjectRef(event corev1.Event) string {
+	if event.InvolvedObject.Namespace != "" {
+		return fmt.Sprintf("%s/%s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Namespace, event.InvolvedObject.Name)
+	}
+	return fmt.Sprintf("%s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Name)
+}
+
+// renderEventLine formats an event as a compact, single-line MCP result.
+func renderEventLine(event corev1.Event) string {
+	parts := []string{
+		eventTime(event).UTC().Format(time.RFC3339),
+		event.Type,
+		event.Reason,
+		eventObjectRef(event),
+	}
+	count := event.Count
+	if event.Series != nil {
+		count = event.Series.Count
+	}
+	if count > 1 {
+		parts = append(parts, fmt.Sprintf("x%d", count))
+	}
+
+	if message := strings.Join(strings.Fields(event.Message), " "); message != "" {
+		parts = append(parts, message)
+	}
+	return strings.Join(parts, " ")
 }
 
 // SortableEvents implements sort.Interface for []api.Event by time

--- a/cmd/mcp/k8s/events_test.go
+++ b/cmd/mcp/k8s/events_test.go
@@ -5,13 +5,23 @@ package k8s
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestGetEvents(t *testing.T) {
@@ -145,4 +155,402 @@ func TestGetEvents(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRenderEventLine(t *testing.T) {
+	timestamp := time.Date(2026, time.August, 28, 13, 15, 2, 987654321, time.FixedZone("UTC+3", 3*60*60))
+	tests := []struct {
+		name  string
+		event corev1.Event
+		want  string
+	}{
+		{
+			name: "namespaced warning with repeated count and multiline message",
+			event: corev1.Event{
+				InvolvedObject: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "apps", Name: "backend"},
+				Type:           corev1.EventTypeWarning,
+				Reason:         "BackOff",
+				Message:        "Back-off restarting failed container\nbackend in pod backend_apps   \t",
+				Count:          17,
+				LastTimestamp:  metav1.NewTime(timestamp),
+			},
+			want: "2026-08-28T10:15:02Z Warning BackOff Pod/apps/backend x17 Back-off restarting failed container backend in pod backend_apps",
+		},
+		{
+			name: "cluster-scoped object with single count",
+			event: corev1.Event{
+				InvolvedObject: corev1.ObjectReference{APIVersion: "v1", Kind: "Node", Name: "worker-1"},
+				Type:           corev1.EventTypeNormal,
+				Reason:         "RegisteredNode",
+				Message:        "Node registered",
+				Count:          1,
+				LastTimestamp:  metav1.NewTime(timestamp),
+			},
+			want: "2026-08-28T10:15:02Z Normal RegisteredNode Node/worker-1 Node registered",
+		},
+		{
+			name: "series count and timestamp take precedence",
+			event: corev1.Event{
+				InvolvedObject: corev1.ObjectReference{APIVersion: "apps/v1", Kind: "Deployment", Namespace: "apps", Name: "backend"},
+				Type:           corev1.EventTypeNormal,
+				Reason:         "ScalingReplicaSet",
+				Message:        "Scaled up replica set",
+				Count:          1,
+				Series: &corev1.EventSeries{
+					Count:            3,
+					LastObservedTime: metav1.MicroTime{Time: timestamp},
+				},
+			},
+			want: "2026-08-28T10:15:02Z Normal ScalingReplicaSet Deployment/apps/backend x3 Scaled up replica set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(renderEventLine(tt.event)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestListEvents(t *testing.T) {
+	now := time.Now().UTC()
+	event := func(name, namespace, apiVersion, kind, objectName, eventType, reason, message string, age time.Duration) corev1.Event {
+		return corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			InvolvedObject: corev1.ObjectReference{
+				APIVersion: apiVersion,
+				Kind:       kind,
+				Name:       objectName,
+				Namespace:  namespace,
+			},
+			Type:          eventType,
+			Reason:        reason,
+			Message:       message,
+			Count:         1,
+			LastTimestamp: metav1.NewTime(now.Add(-age)),
+		}
+	}
+
+	backOff := event("backoff", "apps", "v1", "Pod", "backend", corev1.EventTypeWarning,
+		"BackOff", "Back-off restarting failed container", time.Minute)
+	backOff.Count = 17
+	deployment := event("deployment", "apps", "apps/v1", "Deployment", "backend", corev1.EventTypeNormal,
+		"Created", "Created replica set", 2*time.Minute)
+	deployment.LastTimestamp = metav1.Time{}
+	deployment.Series = &corev1.EventSeries{
+		Count:            3,
+		LastObservedTime: metav1.MicroTime{Time: now.Add(-2 * time.Minute)},
+	}
+	failedMount := event("mount", "apps", "v1", "PersistentVolumeClaim", "data", corev1.EventTypeWarning,
+		"FailedMount", "Unable to attach volume", 3*time.Minute)
+	failedMount.LastTimestamp = metav1.Time{}
+	failedMount.EventTime = metav1.MicroTime{Time: now.Add(-3 * time.Minute)}
+	failedScheduling := event("scheduling", "other", "v1", "Pod", "worker", corev1.EventTypeWarning,
+		"FailedScheduling", "No nodes are available", 4*time.Minute)
+	oomKilled := event("oom", "apps", "v1", "Pod", "frontend", corev1.EventTypeWarning,
+		"ContainerRestart", "Container terminated with OOMKilled", 5*time.Minute)
+	old := event("old", "apps", "v1", "Pod", "legacy", corev1.EventTypeWarning,
+		"Unhealthy", "Readiness probe failed", 3*time.Hour)
+
+	mockEventList := &corev1.EventList{Items: []corev1.Event{
+		old, failedScheduling, oomKilled, failedMount, deployment, backOff,
+	}}
+	kubeClient := Client{
+		Client: fake.NewClientBuilder().
+			WithScheme(NewTestScheme()).
+			WithLists(mockEventList).
+			WithIndex(&corev1.Event{}, "involvedObject.apiVersion", func(obj client.Object) []string {
+				return []string{obj.(*corev1.Event).InvolvedObject.APIVersion}
+			}).
+			WithIndex(&corev1.Event{}, "involvedObject.kind", func(obj client.Object) []string {
+				return []string{obj.(*corev1.Event).InvolvedObject.Kind}
+			}).
+			WithIndex(&corev1.Event{}, "involvedObject.name", func(obj client.Object) []string {
+				return []string{obj.(*corev1.Event).InvolvedObject.Name}
+			}).
+			WithIndex(&corev1.Event{}, "type", func(obj client.Object) []string {
+				return []string{obj.(*corev1.Event).Type}
+			}).
+			Build(),
+	}
+
+	sinceWindow := 30 * time.Minute
+	zeroWindow := time.Duration(0)
+	tests := []struct {
+		name          string
+		opts          ListEventsOptions
+		wantTotal     int
+		wantLines     []string
+		wantNamespace string
+		wantTruncated bool
+	}{
+		{
+			name:          "scopes to namespace",
+			opts:          ListEventsOptions{Namespace: "apps", Limit: 100},
+			wantTotal:     5,
+			wantNamespace: "apps",
+		},
+		{
+			name:      "selects apiVersion kind and name",
+			opts:      ListEventsOptions{APIVersion: "apps/v1", Kind: "Deployment", Name: "backend"},
+			wantTotal: 1,
+			wantLines: []string{renderEventLine(deployment)},
+		},
+		{
+			name:          "filters type",
+			opts:          ListEventsOptions{Namespace: "apps", Type: corev1.EventTypeNormal},
+			wantTotal:     1,
+			wantNamespace: "apps",
+		},
+		{
+			name:      "filters since window",
+			opts:      ListEventsOptions{Since: &sinceWindow},
+			wantTotal: 5,
+		},
+		{
+			name:      "applies explicit zero since window",
+			opts:      ListEventsOptions{Since: &zeroWindow},
+			wantTotal: 0,
+		},
+		{
+			name:      "greps reason case insensitively",
+			opts:      ListEventsOptions{Grep: regexp.MustCompile("(?i)backoff")},
+			wantTotal: 1,
+			wantLines: []string{renderEventLine(backOff)},
+		},
+		{
+			name:      "greps message case insensitively",
+			opts:      ListEventsOptions{Grep: regexp.MustCompile("(?i)oomkilled")},
+			wantTotal: 1,
+			wantLines: []string{renderEventLine(oomKilled)},
+		},
+		{
+			name:      "greps object case insensitively",
+			opts:      ListEventsOptions{Grep: regexp.MustCompile("(?i)^persistentvolumeclaim/apps/DATA$")},
+			wantTotal: 1,
+			wantLines: []string{renderEventLine(failedMount)},
+		},
+		{
+			name:          "sorts newest first and applies limit",
+			opts:          ListEventsOptions{Namespace: "apps", Limit: 2},
+			wantTotal:     5,
+			wantLines:     []string{renderEventLine(backOff), renderEventLine(deployment)},
+			wantNamespace: "apps",
+			wantTruncated: true,
+		},
+		{
+			name:      "returns empty result",
+			opts:      ListEventsOptions{Name: "missing"},
+			wantTotal: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := kubeClient.ListEvents(context.Background(), tt.opts)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(result.Total).To(Equal(tt.wantTotal))
+			g.Expect(result.Namespace).To(Equal(tt.wantNamespace))
+			g.Expect(result.Truncated).To(Equal(tt.wantTruncated))
+			if tt.wantLines != nil {
+				lines := strings.Split(strings.TrimSuffix(result.Events, "\n"), "\n")
+				g.Expect(lines).To(Equal(tt.wantLines))
+			}
+			if tt.wantTotal == 0 {
+				g.Expect(result.Events).To(BeEmpty())
+			}
+		})
+	}
+}
+
+// pagedEventLister serves synthetic events in pages through a List interceptor,
+// honoring the requested Limit and Continue token.
+func pagedEventLister(total int, reason string) func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+	return func(_ context.Context, _ client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+		listOpts := &client.ListOptions{}
+		listOpts.ApplyOptions(opts)
+		start := 0
+		if listOpts.Continue != "" {
+			start, _ = strconv.Atoi(listOpts.Continue)
+		}
+		end := min(start+int(listOpts.Limit), total)
+
+		events := list.(*corev1.EventList)
+		events.Items = events.Items[:0]
+		for i := start; i < end; i++ {
+			events.Items = append(events.Items, corev1.Event{
+				ObjectMeta:     metav1.ObjectMeta{Name: fmt.Sprintf("event-%d", i), Namespace: "apps"},
+				InvolvedObject: corev1.ObjectReference{Kind: "Pod", Namespace: "apps", Name: fmt.Sprintf("pod-%d", i)},
+				Type:           corev1.EventTypeWarning,
+				Reason:         reason,
+				LastTimestamp:  metav1.NewTime(time.Unix(int64(i), 0)),
+			})
+		}
+		events.Continue = ""
+		if end < total {
+			events.Continue = strconv.Itoa(end)
+		}
+		return nil
+	}
+}
+
+func TestListEventsPagination(t *testing.T) {
+	newClient := func(total int) *Client {
+		return &Client{Client: fake.NewClientBuilder().
+			WithScheme(NewTestScheme()).
+			WithInterceptorFuncs(interceptor.Funcs{List: pagedEventLister(total, "BackOff")}).
+			Build()}
+	}
+
+	t.Run("collects every page below the cap", func(t *testing.T) {
+		g := NewWithT(t)
+		total := int(eventListPageSize)*2 + 7
+		result, err := newClient(total).ListEvents(context.Background(), ListEventsOptions{Namespace: "apps", Limit: total})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Total).To(Equal(total))
+		g.Expect(result.Truncated).To(BeFalse())
+		g.Expect(result.Events).To(HavePrefix(fmt.Sprintf("1970-01-01T00:%02d:%02dZ Warning BackOff Pod/apps/pod-%d", (total-1)/60, (total-1)%60, total-1)))
+	})
+
+	t.Run("stops at the cap and reports truncation", func(t *testing.T) {
+		g := NewWithT(t)
+		result, err := newClient(eventListHardCap+1).ListEvents(context.Background(), ListEventsOptions{Namespace: "apps", Limit: 1})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Total).To(Equal(eventListHardCap))
+		g.Expect(result.Truncated).To(BeTrue())
+		g.Expect(strings.Count(result.Events, "\n")).To(Equal(1))
+	})
+
+	t.Run("keeps truncation when no inspected event matches", func(t *testing.T) {
+		g := NewWithT(t)
+		result, err := newClient(eventListHardCap+1).ListEvents(context.Background(),
+			ListEventsOptions{Namespace: "apps", Grep: regexp.MustCompile("nomatch")})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Total).To(BeZero())
+		g.Expect(result.Truncated).To(BeTrue())
+		g.Expect(result.Events).To(BeEmpty())
+	})
+}
+
+// newEventsClient builds a fake controller-runtime client with the field
+// indexes used by the event selectors.
+func newEventsClient(events ...corev1.Event) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(NewTestScheme()).
+		WithLists(&corev1.EventList{Items: events}).
+		WithIndex(&corev1.Event{}, "involvedObject.apiVersion", func(obj client.Object) []string {
+			return []string{obj.(*corev1.Event).InvolvedObject.APIVersion}
+		}).
+		WithIndex(&corev1.Event{}, "involvedObject.kind", func(obj client.Object) []string {
+			return []string{obj.(*corev1.Event).InvolvedObject.Kind}
+		}).
+		WithIndex(&corev1.Event{}, "involvedObject.name", func(obj client.Object) []string {
+			return []string{obj.(*corev1.Event).InvolvedObject.Name}
+		}).
+		WithIndex(&corev1.Event{}, "type", func(obj client.Object) []string {
+			return []string{obj.(*corev1.Event).Type}
+		}).
+		Build()
+}
+
+func TestListEventsWorkload(t *testing.T) {
+	now := time.Now().UTC()
+	event := func(name, namespace, apiVersion, kind, objectName, eventType, reason, message string, age time.Duration) corev1.Event {
+		return corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			InvolvedObject: corev1.ObjectReference{
+				APIVersion: apiVersion,
+				Kind:       kind,
+				Name:       objectName,
+				Namespace:  namespace,
+			},
+			Type:          eventType,
+			Reason:        reason,
+			Message:       message,
+			Count:         1,
+			LastTimestamp: metav1.NewTime(now.Add(-age)),
+		}
+	}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "backend", Namespace: "apps", UID: types.UID("deploy-uid")},
+		Spec:       appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "backend"}}},
+	}
+	ownedRS := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
+		Name: "backend-abc", Namespace: "apps", Labels: map[string]string{"app": "backend"},
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "backend", UID: "deploy-uid"}},
+	}}
+	foreignRS := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
+		Name: "other-abc", Namespace: "apps", Labels: map[string]string{"app": "backend"},
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "other", UID: "other-uid"}},
+	}}
+	podNew := testLogPod("backend-abc-new", "apps", now, map[string]string{"app": "backend"},
+		metav1.OwnerReference{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "backend-abc"}, "app")
+	podOld := testLogPod("backend-abc-old", "apps", now.Add(-time.Minute), map[string]string{"app": "backend"},
+		metav1.OwnerReference{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "backend-abc"}, "app")
+	clientset := k8sfake.NewSimpleClientset(deployment, ownedRS, foreignRS, podNew, podOld)
+
+	deployEvent := event("d", "apps", "apps/v1", "Deployment", "backend", corev1.EventTypeNormal,
+		"ScalingReplicaSet", "Scaled up replica set backend-abc to 2", 5*time.Minute)
+	rsEvent := event("rs", "apps", "apps/v1", "ReplicaSet", "backend-abc", corev1.EventTypeWarning,
+		"FailedCreate", "Error creating: pods \"backend-abc-\" is forbidden: exceeded quota", 4*time.Minute)
+	podEvent := event("p", "apps", "v1", "Pod", "backend-abc-new", corev1.EventTypeWarning,
+		"BackOff", "Back-off restarting failed container", time.Minute)
+	oldPodEvent := event("po", "apps", "v1", "Pod", "backend-abc-old", corev1.EventTypeWarning,
+		"Unhealthy", "Readiness probe failed", 2*time.Minute)
+	foreignRSEvent := event("frs", "apps", "apps/v1", "ReplicaSet", "other-abc", corev1.EventTypeWarning,
+		"FailedCreate", "unrelated", time.Minute)
+	foreignPodEvent := event("fp", "apps", "v1", "Pod", "other-abc-xyz", corev1.EventTypeWarning,
+		"BackOff", "unrelated", time.Minute)
+	kubeClient := newEventsClient(deployEvent, rsEvent, podEvent, oldPodEvent, foreignRSEvent, foreignPodEvent)
+
+	t.Run("lists the workload, its replicasets and its pods", func(t *testing.T) {
+		g := NewWithT(t)
+		result, err := listEvents(context.Background(), kubeClient, clientset,
+			ListEventsOptions{Kind: "Deployment", Name: "backend", Namespace: "apps"})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Total).To(Equal(4))
+		g.Expect(result.Truncated).To(BeFalse())
+		g.Expect(strings.Split(strings.TrimSpace(result.Events), "\n")).To(Equal([]string{
+			renderEventLine(podEvent), renderEventLine(oldPodEvent), renderEventLine(rsEvent), renderEventLine(deployEvent),
+		}))
+	})
+
+	t.Run("applies the type selector to every owned object", func(t *testing.T) {
+		g := NewWithT(t)
+		result, err := listEvents(context.Background(), kubeClient, clientset,
+			ListEventsOptions{Kind: "Deployment", Name: "backend", Namespace: "apps", Type: corev1.EventTypeWarning})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Total).To(Equal(3))
+		g.Expect(result.Events).NotTo(ContainSubstring("ScalingReplicaSet"))
+	})
+
+	t.Run("fails when the workload is missing", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := listEvents(context.Background(), kubeClient, clientset,
+			ListEventsOptions{Kind: "Deployment", Name: "missing", Namespace: "apps"})
+		g.Expect(err).To(HaveOccurred())
+	})
+}
+
+func TestResolveEventTargetsCapsPods(t *testing.T) {
+	g := NewWithT(t)
+	now := time.Now()
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "apps"},
+		Spec:       appsv1.StatefulSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "db"}}},
+	}
+	objects := []runtime.Object{statefulSet}
+	for i := 0; i < maxLogPods+2; i++ {
+		objects = append(objects, testLogPod(fmt.Sprintf("db-%d", i), "apps", now.Add(time.Duration(i)*time.Second),
+			map[string]string{"app": "db"}, metav1.OwnerReference{APIVersion: "apps/v1", Kind: "StatefulSet", Name: "db"}, "db"))
+	}
+
+	targets, truncated, err := resolveEventTargets(context.Background(), k8sfake.NewSimpleClientset(objects...), "StatefulSet", "db", "apps")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(truncated).To(BeTrue())
+	g.Expect(targets).To(HaveLen(1 + maxLogPods))
+	g.Expect(targets[0]).To(Equal(eventTarget{kind: "StatefulSet", name: "db"}))
+	g.Expect(targets[1]).To(Equal(eventTarget{kind: "Pod", name: fmt.Sprintf("db-%d", maxLogPods+1)}))
 }

--- a/cmd/mcp/k8s/logs.go
+++ b/cmd/mcp/k8s/logs.go
@@ -6,9 +6,12 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"math"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -35,7 +38,30 @@ const (
 
 	// minPerStreamLogBytes ensures every selected stream gets a useful tail.
 	minPerStreamLogBytes = 64 * 1024
+
+	// grepTailLines is the tail requested per stream when grep is set.
+	grepTailLines int64 = 1000
 )
+
+// LogsOptions configures a GetLogs request.
+type LogsOptions struct {
+	// Kind is the resource kind, Pod when empty.
+	Kind string
+	// Name is the pod or workload name.
+	Name string
+	// Namespace is the pod or workload namespace.
+	Namespace string
+	// Container restricts the streams to one container name.
+	Container string
+	// Limit caps the merged entries returned, keeping the newest.
+	Limit int64
+	// Previous reads the previously terminated container instances.
+	Previous bool
+	// Since keeps only the entries newer than this duration when positive.
+	Since time.Duration
+	// Grep keeps only the entries matching this expression when set.
+	Grep *regexp.Regexp
+}
 
 // KubernetesLogs is the YAML response returned by get_kubernetes_logs.
 type KubernetesLogs struct {
@@ -65,53 +91,49 @@ type logSelection struct {
 
 // GetLogs resolves a pod or workload, fetches its selected container streams,
 // and returns their timestamped logs merged chronologically.
-func (k *Client) GetLogs(ctx context.Context, kind, name, namespace, container string, limit int64, previous bool) (*KubernetesLogs, error) {
+func (k *Client) GetLogs(ctx context.Context, opts LogsOptions) (*KubernetesLogs, error) {
 	clientset, err := kubernetes.NewForConfig(k.cfg)
 	if err != nil {
 		return nil, err
 	}
-	return getLogs(ctx, clientset, kind, name, namespace, container, limit, previous)
+	return getLogs(ctx, clientset, opts)
 }
 
 // getLogs implements GetLogs with an injectable clientset for unit tests.
-func getLogs(ctx context.Context, clientset kubernetes.Interface, kind, name, namespace, container string, limit int64, previous bool) (*KubernetesLogs, error) {
-	selection, err := resolveLogSelection(ctx, clientset, kind, name, namespace, container)
+func getLogs(ctx context.Context, clientset kubernetes.Interface, opts LogsOptions) (*KubernetesLogs, error) {
+	selection, err := resolveLogSelection(ctx, clientset, opts.Kind, opts.Name, opts.Namespace, opts.Container)
 	if err != nil {
 		return nil, err
 	}
 	if len(selection.targets) == 0 {
 		return &KubernetesLogs{
 			Kind:       selection.kind,
-			Name:       name,
-			Namespace:  namespace,
+			Name:       opts.Name,
+			Namespace:  opts.Namespace,
 			Pods:       []string{},
 			Containers: []string{},
-			Logs:       fmt.Sprintf("no pods found for %s %s/%s", selection.kind, namespace, name),
+			Logs:       fmt.Sprintf("no pods found for %s %s/%s", selection.kind, opts.Namespace, opts.Name),
 		}, nil
 	}
 
 	perStreamBytes := max(maxLogBytes/len(selection.targets), minPerStreamLogBytes)
 	logsByTarget := make([]string, len(selection.targets))
+	cappedByTarget := make([]bool, len(selection.targets))
 	errsByTarget := make([]error, len(selection.targets))
 	var wg sync.WaitGroup
 	for i, target := range selection.targets {
 		wg.Add(1)
 		go func(i int, target podlogs.LogTarget) {
 			defer wg.Done()
-			opts := &corev1.PodLogOptions{
-				Container:  target.Container,
-				TailLines:  &limit,
-				Previous:   previous,
-				Timestamps: true,
-			}
-			logsByTarget[i], errsByTarget[i] = podlogs.FetchContainerLog(
-				ctx, clientset, namespace, target.Pod, opts, perStreamBytes)
+			logsByTarget[i], cappedByTarget[i], errsByTarget[i] = podlogs.FetchContainerLogWithStats(
+				ctx, clientset, opts.Namespace, target.Pod, podLogOptions(opts, target.Container), perStreamBytes)
 		}(i, target)
 	}
 	wg.Wait()
 
 	streams := make([]podlogs.LogStream, 0, len(selection.targets))
 	streamedPods := make(map[string]struct{})
+	streamCapped := false
 	var firstErr error
 	for i, target := range selection.targets {
 		if errsByTarget[i] != nil {
@@ -120,6 +142,7 @@ func getLogs(ctx context.Context, clientset kubernetes.Interface, kind, name, na
 			}
 			continue
 		}
+		streamCapped = streamCapped || cappedByTarget[i]
 		streams = append(streams, podlogs.LogStream{
 			Pod:       target.Pod,
 			Container: target.Container,
@@ -131,9 +154,21 @@ func getLogs(ctx context.Context, clientset kubernetes.Interface, kind, name, na
 		return nil, firstErr
 	}
 
-	logs := podlogs.MergeLogStreams(streams, int(limit), selection.tagPod, selection.tagContainer, maxLogBytes,
-		podlogs.WithSecondTimestamps())
-	if len(selection.targets) == 1 && logs == "" {
+	mergeOptions := []podlogs.MergeOption{podlogs.WithSecondTimestamps()}
+	if opts.Grep != nil {
+		mergeOptions = append(mergeOptions, podlogs.WithGrep(opts.Grep))
+	}
+	merged := podlogs.MergeLogStreamsWithStats(streams, int(opts.Limit), selection.tagPod, selection.tagContainer,
+		maxLogBytes, mergeOptions...)
+	logs := merged.Logs
+	truncated := selection.truncated
+	if opts.Grep != nil && (merged.Truncated || streamCapped) {
+		truncated = true
+	}
+	switch {
+	case merged.Entries == 0 && (opts.Grep != nil || opts.Since > 0):
+		logs = noLogEntriesMessage(opts)
+	case len(selection.targets) == 1 && logs == "":
 		logs = fmt.Sprintf("no logs found for container %s", selection.targets[0].Container)
 	}
 
@@ -144,16 +179,47 @@ func getLogs(ctx context.Context, clientset kubernetes.Interface, kind, name, na
 
 	return &KubernetesLogs{
 		Kind:         selection.kind,
-		Name:         name,
-		Namespace:    namespace,
+		Name:         opts.Name,
+		Namespace:    opts.Namespace,
 		Pods:         podNames,
 		Containers:   selection.containers,
 		PodsTotal:    selection.podsTotal,
 		PodsStreamed: len(streamedPods),
 		Tagged:       selection.tagPod || selection.tagContainer,
-		Truncated:    selection.truncated,
+		Truncated:    truncated,
 		Logs:         logs,
 	}, nil
+}
+
+// noLogEntriesMessage describes an empty result in terms of the active filters.
+func noLogEntriesMessage(opts LogsOptions) string {
+	message := "no log entries"
+	if opts.Since > 0 {
+		message += fmt.Sprintf(" newer than %s", opts.Since)
+	}
+	if opts.Grep != nil {
+		message += " matching the grep expression"
+	}
+	return message
+}
+
+// podLogOptions builds the kubelet request for one container stream.
+func podLogOptions(opts LogsOptions, container string) *corev1.PodLogOptions {
+	tailLines := opts.Limit
+	if opts.Grep != nil && tailLines < grepTailLines {
+		tailLines = grepTailLines
+	}
+	logOptions := &corev1.PodLogOptions{
+		Container:  container,
+		TailLines:  &tailLines,
+		Previous:   opts.Previous,
+		Timestamps: true,
+	}
+	if opts.Since > 0 {
+		sinceSeconds := int64(math.Ceil(opts.Since.Seconds()))
+		logOptions.SinceSeconds = &sinceSeconds
+	}
+	return logOptions
 }
 
 // resolveLogSelection resolves the named resource to newest-first pods and

--- a/cmd/mcp/k8s/logs.go
+++ b/cmd/mcp/k8s/logs.go
@@ -79,6 +79,16 @@ func getLogs(ctx context.Context, clientset kubernetes.Interface, kind, name, na
 	if err != nil {
 		return nil, err
 	}
+	if len(selection.targets) == 0 {
+		return &KubernetesLogs{
+			Kind:       selection.kind,
+			Name:       name,
+			Namespace:  namespace,
+			Pods:       []string{},
+			Containers: []string{},
+			Logs:       fmt.Sprintf("no pods found for %s %s/%s", selection.kind, namespace, name),
+		}, nil
+	}
 
 	perStreamBytes := max(maxLogBytes/len(selection.targets), minPerStreamLogBytes)
 	logsByTarget := make([]string, len(selection.targets))
@@ -121,7 +131,8 @@ func getLogs(ctx context.Context, clientset kubernetes.Interface, kind, name, na
 		return nil, firstErr
 	}
 
-	logs := podlogs.MergeLogStreams(streams, int(limit), selection.tagPod, selection.tagContainer, maxLogBytes)
+	logs := podlogs.MergeLogStreams(streams, int(limit), selection.tagPod, selection.tagContainer, maxLogBytes,
+		podlogs.WithSecondTimestamps())
 	if len(selection.targets) == 1 && logs == "" {
 		logs = fmt.Sprintf("no logs found for container %s", selection.targets[0].Container)
 	}
@@ -146,7 +157,8 @@ func getLogs(ctx context.Context, clientset kubernetes.Interface, kind, name, na
 }
 
 // resolveLogSelection resolves the named resource to newest-first pods and
-// builds the capped set of regular-container log streams.
+// builds the capped set of regular-container log streams. A workload that
+// exists but owns no pods yields a selection without targets.
 func resolveLogSelection(ctx context.Context, clientset kubernetes.Interface, kind, name, namespace, container string) (*logSelection, error) {
 	canonicalKind, err := canonicalLogKind(kind)
 	if err != nil {
@@ -158,7 +170,7 @@ func resolveLogSelection(ctx context.Context, clientset kubernetes.Interface, ki
 		return nil, err
 	}
 	if len(pods) == 0 {
-		return nil, fmt.Errorf("no pods found for %s %s/%s", canonicalKind, namespace, name)
+		return &logSelection{kind: canonicalKind}, nil
 	}
 
 	sort.SliceStable(pods, func(i, j int) bool {

--- a/cmd/mcp/k8s/logs_test.go
+++ b/cmd/mcp/k8s/logs_test.go
@@ -151,8 +151,11 @@ func TestResolveLogSelectionValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "backend", Namespace: "apps"},
 			Spec:       appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "backend"}}},
 		}
-		_, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(deployment), "Deployment", "backend", "apps", "")
-		g.Expect(err).To(MatchError("no pods found for Deployment apps/backend"))
+		selection, err := resolveLogSelection(context.Background(), fake.NewSimpleClientset(deployment), "Deployment", "backend", "apps", "")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(selection.kind).To(Equal("Deployment"))
+		g.Expect(selection.targets).To(BeEmpty())
+		g.Expect(selection.podsTotal).To(BeZero())
 	})
 
 	t.Run("missing named pod", func(t *testing.T) {
@@ -229,6 +232,27 @@ func TestGetLogsWithFakeClient(t *testing.T) {
 	g.Expect(result.Tagged).To(BeFalse())
 	g.Expect(result.Truncated).To(BeFalse())
 	g.Expect(result.Logs).To(Equal("fake logs\n"))
+}
+
+func TestGetLogsWorkloadWithoutPods(t *testing.T) {
+	g := NewWithT(t)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "backend", Namespace: "apps"},
+		Spec:       appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "backend"}}},
+	}
+
+	result, err := getLogs(context.Background(), fake.NewSimpleClientset(deployment), "deployment", "backend", "apps", "", 100, false)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Kind).To(Equal("Deployment"))
+	g.Expect(result.Name).To(Equal("backend"))
+	g.Expect(result.Namespace).To(Equal("apps"))
+	g.Expect(result.Pods).To(BeEmpty())
+	g.Expect(result.Containers).To(BeEmpty())
+	g.Expect(result.PodsTotal).To(BeZero())
+	g.Expect(result.PodsStreamed).To(BeZero())
+	g.Expect(result.Tagged).To(BeFalse())
+	g.Expect(result.Truncated).To(BeFalse())
+	g.Expect(result.Logs).To(Equal("no pods found for Deployment apps/backend"))
 }
 func testLogPod(name, namespace string, created time.Time, podLabels map[string]string, owner metav1.OwnerReference, containers ...string) *corev1.Pod {
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{

--- a/cmd/mcp/k8s/logs_test.go
+++ b/cmd/mcp/k8s/logs_test.go
@@ -6,6 +6,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -220,7 +221,7 @@ func TestGetLogsWithFakeClient(t *testing.T) {
 	g := NewWithT(t)
 	pod := testLogPod("backend", "default", time.Now(), nil, metav1.OwnerReference{}, "app")
 
-	result, err := getLogs(context.Background(), fake.NewSimpleClientset(pod), "", pod.Name, pod.Namespace, "", 100, false)
+	result, err := getLogs(context.Background(), fake.NewSimpleClientset(pod), LogsOptions{Name: pod.Name, Namespace: pod.Namespace, Limit: 100})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.Kind).To(Equal("Pod"))
 	g.Expect(result.Name).To(Equal("backend"))
@@ -234,6 +235,62 @@ func TestGetLogsWithFakeClient(t *testing.T) {
 	g.Expect(result.Logs).To(Equal("fake logs\n"))
 }
 
+func TestGetLogsGrep(t *testing.T) {
+	pod := testLogPod("backend", "default", time.Now(), nil, metav1.OwnerReference{}, "app")
+
+	t.Run("keeps matching entries", func(t *testing.T) {
+		g := NewWithT(t)
+		result, err := getLogs(context.Background(), fake.NewSimpleClientset(pod),
+			LogsOptions{Name: pod.Name, Namespace: pod.Namespace, Limit: 100, Grep: regexp.MustCompile("(?i)FAKE")})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Logs).To(Equal("fake logs\n"))
+		g.Expect(result.Truncated).To(BeFalse())
+	})
+
+	t.Run("reports no matching entries", func(t *testing.T) {
+		g := NewWithT(t)
+		result, err := getLogs(context.Background(), fake.NewSimpleClientset(pod),
+			LogsOptions{Name: pod.Name, Namespace: pod.Namespace, Limit: 100, Grep: regexp.MustCompile("(?i)nothing")})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Logs).To(Equal("no log entries matching the grep expression"))
+		g.Expect(result.PodsStreamed).To(Equal(1))
+	})
+}
+
+func TestNoLogEntriesMessage(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(noLogEntriesMessage(LogsOptions{Since: 10 * time.Minute})).To(Equal("no log entries newer than 10m0s"))
+	g.Expect(noLogEntriesMessage(LogsOptions{Grep: regexp.MustCompile("x")})).To(Equal("no log entries matching the grep expression"))
+	g.Expect(noLogEntriesMessage(LogsOptions{Since: time.Hour, Grep: regexp.MustCompile("x")})).To(Equal("no log entries newer than 1h0m0s matching the grep expression"))
+}
+
+func TestPodLogOptions(t *testing.T) {
+	t.Run("uses the limit as tail without grep", func(t *testing.T) {
+		g := NewWithT(t)
+		opts := podLogOptions(LogsOptions{Limit: 50, Previous: true}, "app")
+		g.Expect(opts.Container).To(Equal("app"))
+		g.Expect(*opts.TailLines).To(Equal(int64(50)))
+		g.Expect(opts.Previous).To(BeTrue())
+		g.Expect(opts.Timestamps).To(BeTrue())
+		g.Expect(opts.SinceSeconds).To(BeNil())
+	})
+
+	t.Run("widens the tail with grep", func(t *testing.T) {
+		g := NewWithT(t)
+		opts := podLogOptions(LogsOptions{Limit: 50, Grep: regexp.MustCompile("error")}, "app")
+		g.Expect(*opts.TailLines).To(Equal(grepTailLines))
+
+		opts = podLogOptions(LogsOptions{Limit: grepTailLines + 1, Grep: regexp.MustCompile("error")}, "app")
+		g.Expect(*opts.TailLines).To(Equal(grepTailLines + 1))
+	})
+
+	t.Run("rounds since up to whole seconds", func(t *testing.T) {
+		g := NewWithT(t)
+		opts := podLogOptions(LogsOptions{Limit: 50, Since: 1500 * time.Millisecond}, "app")
+		g.Expect(*opts.SinceSeconds).To(Equal(int64(2)))
+	})
+}
+
 func TestGetLogsWorkloadWithoutPods(t *testing.T) {
 	g := NewWithT(t)
 	deployment := &appsv1.Deployment{
@@ -241,7 +298,7 @@ func TestGetLogsWorkloadWithoutPods(t *testing.T) {
 		Spec:       appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "backend"}}},
 	}
 
-	result, err := getLogs(context.Background(), fake.NewSimpleClientset(deployment), "deployment", "backend", "apps", "", 100, false)
+	result, err := getLogs(context.Background(), fake.NewSimpleClientset(deployment), LogsOptions{Kind: "deployment", Name: "backend", Namespace: "apps", Limit: 100})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.Kind).To(Equal("Deployment"))
 	g.Expect(result.Name).To(Equal("backend"))

--- a/cmd/mcp/toolbox/get_events.go
+++ b/cmd/mcp/toolbox/get_events.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
+)
+
+const (
+	// ToolGetKubernetesEvents is the name of the get_kubernetes_events tool.
+	ToolGetKubernetesEvents = "get_kubernetes_events"
+)
+
+func init() {
+	systemTools[ToolGetKubernetesEvents] = systemTool{
+		readOnly:  true,
+		inCluster: true,
+	}
+}
+
+// getKubernetesEventsInput defines the input parameters for retrieving Kubernetes events.
+type getKubernetesEventsInput struct {
+	APIVersion string  `json:"apiVersion,omitempty" jsonschema:"Exact apiVersion of the involved object."`
+	Kind       string  `json:"kind,omitempty"       jsonschema:"Exact kind of the involved object."`
+	Name       string  `json:"name,omitempty"       jsonschema:"Exact name of the involved object."`
+	Namespace  string  `json:"namespace,omitempty"  jsonschema:"Namespace of the involved objects; omit to list across all namespaces."`
+	Type       string  `json:"type,omitempty"       jsonschema:"Event type: Normal or Warning."`
+	Since      string  `json:"since,omitempty"      jsonschema:"Only events newer than this Go duration, for example 10m or 1h."`
+	Grep       string  `json:"grep,omitempty"       jsonschema:"Case-insensitive RE2 expression matched against reason, message and the object rendered as Kind/namespace/name."`
+	Limit      float64 `json:"limit,omitempty"      jsonschema:"Maximum number of events to return. Defaults to 100."`
+}
+
+// HandleGetKubernetesEvents is the handler function for the get_kubernetes_events tool.
+func (m *Manager) HandleGetKubernetesEvents(ctx context.Context, request *mcp.CallToolRequest, input getKubernetesEventsInput) (*mcp.CallToolResult, any, error) {
+	if err := CheckScopes(ctx, ToolGetKubernetesEvents, m.readOnly); err != nil {
+		return NewToolResultError(err.Error())
+	}
+
+	if input.Type != "" && input.Type != corev1.EventTypeNormal && input.Type != corev1.EventTypeWarning {
+		return NewToolResultError("type must be Normal or Warning")
+	}
+
+	var since *time.Duration
+	if input.Since != "" {
+		parsed, err := time.ParseDuration(input.Since)
+		if err != nil {
+			return NewToolResultError(fmt.Sprintf("Invalid since: %v", err))
+		}
+		if parsed <= 0 {
+			return NewToolResultError("Invalid since: must be a positive duration")
+		}
+		since = &parsed
+	}
+
+	var grep *regexp.Regexp
+	if input.Grep != "" {
+		var err error
+		grep, err = regexp.Compile("(?i)" + input.Grep)
+		if err != nil {
+			return NewToolResultError(fmt.Sprintf("Invalid grep: %v", err))
+		}
+	}
+
+	limit := int(input.Limit)
+	if limit <= 0 {
+		limit = 100
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
+	kubeClient, err := m.kubeClient.GetClient(ctx)
+	if err != nil {
+		return NewToolResultErrorFromErr("Failed to get Kubernetes client", err)
+	}
+
+	result, err := kubeClient.ListEvents(ctx, k8s.ListEventsOptions{
+		Namespace:  input.Namespace,
+		APIVersion: input.APIVersion,
+		Kind:       input.Kind,
+		Name:       input.Name,
+		Type:       input.Type,
+		Since:      since,
+		Grep:       grep,
+		Limit:      limit,
+	})
+	if err != nil {
+		return NewToolResultError(err.Error())
+	}
+	if result.Total == 0 && !result.Truncated {
+		return NewToolResultText("No events found")
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		return NewToolResultErrorFromErr("Failed marshalling data", err)
+	}
+
+	return NewToolResultText(string(data))
+}

--- a/cmd/mcp/toolbox/get_events_test.go
+++ b/cmd/mcp/toolbox/get_events_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	. "github.com/onsi/gomega"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/yaml"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
+)
+
+func TestManager_HandleGetKubernetesEvents(t *testing.T) {
+	configFile := "testdata/kubeconfig.yaml"
+	t.Setenv("KUBECONFIG", configFile)
+
+	m := &Manager{
+		kubeconfig: k8s.NewKubeConfig(),
+		kubeClient: k8s.NewClientFactory(genericclioptions.NewConfigFlags(false)),
+		timeout:    time.Second,
+	}
+
+	request := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name: ToolGetKubernetesEvents,
+		},
+	}
+
+	tests := []struct {
+		testName  string
+		arguments map[string]any
+		matchErr  string
+	}{
+		{
+			testName:  "rejects invalid type before loading client",
+			arguments: map[string]any{"type": "Error"},
+			matchErr:  "type must be Normal or Warning",
+		},
+		{
+			testName:  "rejects invalid since before loading client",
+			arguments: map[string]any{"since": "recently"},
+			matchErr:  "Invalid since:",
+		},
+		{
+			testName:  "rejects non-positive since before loading client",
+			arguments: map[string]any{"since": "-5m"},
+			matchErr:  "Invalid since: must be a positive duration",
+		},
+		{
+			testName:  "rejects invalid grep before loading client",
+			arguments: map[string]any{"grep": "["},
+			matchErr:  "Invalid grep:",
+		},
+		{
+			testName:  "accepts optional filters before loading client",
+			arguments: map[string]any{"type": "Warning", "since": "10m", "grep": "BackOff"},
+			matchErr:  "Failed to get Kubernetes client",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			argsJSON, _ := json.Marshal(test.arguments)
+			request.Params.Arguments = argsJSON
+
+			var input getKubernetesEventsInput
+			err := json.Unmarshal(request.Params.Arguments, &input)
+			g.Expect(err).ToNot(HaveOccurred())
+			result, content, err := m.HandleGetKubernetesEvents(context.Background(), request, input)
+			g.Expect(err).ToNot(HaveOccurred())
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(result.IsError).To(BeTrue())
+			g.Expect(textContent.Text).To(ContainSubstring(test.matchErr))
+			_ = content
+		})
+	}
+}
+
+func TestGetKubernetesEventsOutput(t *testing.T) {
+	g := NewWithT(t)
+	result := &k8s.ListEventsResult{
+		Events: "2026-08-28T10:15:02Z Warning BackOff Pod/apps/backend-7f9d4c-abcde x17 Back-off restarting failed container\n" +
+			"2026-08-28T10:14:31Z Warning Unhealthy Pod/apps/backend-7f9d4c-abcde Readiness probe failed: HTTP status 503\n",
+		Namespace: "apps",
+		Total:     12,
+		Truncated: false,
+	}
+
+	data, err := yaml.Marshal(result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(string(data)).To(Equal(`events: |
+  2026-08-28T10:15:02Z Warning BackOff Pod/apps/backend-7f9d4c-abcde x17 Back-off restarting failed container
+  2026-08-28T10:14:31Z Warning Unhealthy Pod/apps/backend-7f9d4c-abcde Readiness probe failed: HTTP status 503
+namespace: apps
+total: 12
+truncated: false
+`))
+}

--- a/cmd/mcp/toolbox/get_logs.go
+++ b/cmd/mcp/toolbox/get_logs.go
@@ -5,9 +5,14 @@ package toolbox
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"sigs.k8s.io/yaml"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
 )
 
 const (
@@ -28,6 +33,8 @@ type getKubernetesLogsInput struct {
 	Name      string  `json:"name"                jsonschema:"Name of the pod or workload."`
 	Namespace string  `json:"namespace"           jsonschema:"Namespace of the pod or workload."`
 	Container string  `json:"container,omitempty" jsonschema:"Container name; omit to read all containers."`
+	Since     string  `json:"since,omitempty"     jsonschema:"Only log entries newer than this Go duration, for example 10m or 1h."`
+	Grep      string  `json:"grep,omitempty"      jsonschema:"Case-insensitive RE2 expression; keeps the log entries whose line matches, including attached continuation lines."`
 	Limit     float64 `json:"limit,omitempty"     jsonschema:"Max log lines. Defaults to 100."`
 	Previous  bool    `json:"previous,omitempty"  jsonschema:"Logs from the previously terminated containers."`
 }
@@ -45,8 +52,29 @@ func (m *Manager) HandleGetKubernetesLogs(ctx context.Context, request *mcp.Call
 		return NewToolResultError("namespace is required")
 	}
 	limit := int64(input.Limit)
-	if limit == 0 {
+	if limit <= 0 {
 		limit = 100
+	}
+
+	var since time.Duration
+	if input.Since != "" {
+		parsed, err := time.ParseDuration(input.Since)
+		if err != nil {
+			return NewToolResultError(fmt.Sprintf("Invalid since: %v", err))
+		}
+		if parsed <= 0 {
+			return NewToolResultError("Invalid since: must be a positive duration")
+		}
+		since = parsed
+	}
+
+	var grep *regexp.Regexp
+	if input.Grep != "" {
+		var err error
+		grep, err = regexp.Compile("(?i)" + input.Grep)
+		if err != nil {
+			return NewToolResultError(fmt.Sprintf("Invalid grep: %v", err))
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
@@ -57,7 +85,16 @@ func (m *Manager) HandleGetKubernetesLogs(ctx context.Context, request *mcp.Call
 		return NewToolResultErrorFromErr("Failed to get Kubernetes client", err)
 	}
 
-	result, err := kubeClient.GetLogs(ctx, input.Kind, input.Name, input.Namespace, input.Container, limit, input.Previous)
+	result, err := kubeClient.GetLogs(ctx, k8s.LogsOptions{
+		Kind:      input.Kind,
+		Name:      input.Name,
+		Namespace: input.Namespace,
+		Container: input.Container,
+		Limit:     limit,
+		Previous:  input.Previous,
+		Since:     since,
+		Grep:      grep,
+	})
 	if err != nil {
 		return NewToolResultError(err.Error())
 	}

--- a/cmd/mcp/toolbox/get_logs_test.go
+++ b/cmd/mcp/toolbox/get_logs_test.go
@@ -52,6 +52,43 @@ func TestManager_HandleGetKubernetesLogs(t *testing.T) {
 			matchErr: "namespace is required",
 		},
 		{
+			testName: "fails with invalid since",
+			arguments: map[string]any{
+				"name":      "test",
+				"namespace": "default",
+				"since":     "soon",
+			},
+			matchErr: "Invalid since",
+		},
+		{
+			testName: "fails with non-positive since",
+			arguments: map[string]any{
+				"name":      "test",
+				"namespace": "default",
+				"since":     "-5m",
+			},
+			matchErr: "Invalid since: must be a positive duration",
+		},
+		{
+			testName: "fails with invalid grep",
+			arguments: map[string]any{
+				"name":      "test",
+				"namespace": "default",
+				"grep":      "(",
+			},
+			matchErr: "Invalid grep",
+		},
+		{
+			testName: "accepts since and grep before loading client",
+			arguments: map[string]any{
+				"name":      "test",
+				"namespace": "default",
+				"since":     "10m",
+				"grep":      "error|panic",
+			},
+			matchErr: "Failed to get Kubernetes client",
+		},
+		{
 			testName: "accepts omitted kind and container before loading client",
 			arguments: map[string]any{
 				"name":      "test",

--- a/cmd/mcp/toolbox/instructions.go
+++ b/cmd/mcp/toolbox/instructions.go
@@ -51,8 +51,9 @@ func (m *Manager) Instructions(inCluster bool) string {
 	if has(ToolGetKubernetesLogs) {
 		b.WriteString("- To read application logs, call " + ToolGetKubernetesLogs +
 			" directly with the workload kind, name and namespace found in a Flux resource's inventory via " +
-			ToolGetKubernetesResources + ". Omit container to read all regular containers; if the result is truncated, " +
-			"narrow it with container and limit.\n")
+			ToolGetKubernetesResources + ". Omit container to read all regular containers. Use since to focus on the incident " +
+			"window and grep to keep only the relevant entries, such as error|panic|fatal|exception; if the result is truncated, " +
+			"narrow it with container, since, grep and limit.\n")
 	}
 	if has(ToolGetKubernetesMetrics) {
 		b.WriteString("- To check the CPU and memory usage of pods, call " + ToolGetKubernetesMetrics + ".\n")

--- a/cmd/mcp/toolbox/instructions.go
+++ b/cmd/mcp/toolbox/instructions.go
@@ -44,6 +44,10 @@ func (m *Manager) Instructions(inCluster bool) string {
 		b.WriteString("- Resources managed by Flux carry labels containing fluxcd that identify " +
 			"the Kustomization, HelmRelease or ResourceSet managing them.\n")
 	}
+	if has(ToolGetKubernetesEvents) {
+		b.WriteString("- When troubleshooting workloads, call " + ToolGetKubernetesEvents +
+			" with the workload kind, name and namespace, and narrow with type Warning, since and grep.\n")
+	}
 	if has(ToolGetKubernetesLogs) {
 		b.WriteString("- To read application logs, call " + ToolGetKubernetesLogs +
 			" directly with the workload kind, name and namespace found in a Flux resource's inventory via " +

--- a/cmd/mcp/toolbox/manager.go
+++ b/cmd/mcp/toolbox/manager.go
@@ -121,6 +121,15 @@ func (m *Manager) RegisterTools(server *mcp.Server, inCluster bool) []string {
 			m.HandleGetKubernetesLogs,
 		)
 	}
+	if m.shouldRegisterTool(ToolGetKubernetesEvents, inCluster) {
+		addTool(server, &recorder,
+			&mcp.Tool{
+				Name:        ToolGetKubernetesEvents,
+				Description: "Retrieves Kubernetes events, optionally filtered by namespace, involved object, type, time window and regex.",
+			},
+			m.HandleGetKubernetesEvents,
+		)
+	}
 	if m.shouldRegisterTool(ToolGetKubernetesMetrics, inCluster) {
 		addTool(server, &recorder,
 			&mcp.Tool{

--- a/cmd/mcp/toolbox/manager_test.go
+++ b/cmd/mcp/toolbox/manager_test.go
@@ -158,7 +158,7 @@ func TestManager_ToolSchemasIncludeProperties(t *testing.T) {
 			required:   []string{},
 		},
 		ToolGetKubernetesLogs: {
-			properties: []string{"kind", "name", "namespace", "container", "limit", "previous"},
+			properties: []string{"kind", "name", "namespace", "container", "since", "grep", "limit", "previous"},
 			required:   []string{"name", "namespace"},
 		},
 		ToolGetKubernetesEvents: {

--- a/cmd/mcp/toolbox/manager_test.go
+++ b/cmd/mcp/toolbox/manager_test.go
@@ -29,6 +29,7 @@ func TestManager_RegisterToolsDoesNotPanic(t *testing.T) {
 		"get_flux_instance",
 		"get_kubernetes_api_versions",
 		"get_kubernetes_logs",
+		"get_kubernetes_events",
 		"get_kubernetes_metrics",
 		"get_kubernetes_resources",
 		"search_flux_docs",
@@ -159,6 +160,10 @@ func TestManager_ToolSchemasIncludeProperties(t *testing.T) {
 		ToolGetKubernetesLogs: {
 			properties: []string{"kind", "name", "namespace", "container", "limit", "previous"},
 			required:   []string{"name", "namespace"},
+		},
+		ToolGetKubernetesEvents: {
+			properties: []string{"namespace", "apiVersion", "kind", "name", "type", "since", "grep", "limit"},
+			required:   []string{},
 		},
 		ToolGetKubernetesMetrics: {
 			properties: []string{"pod_name", "pod_namespace", "pod_selector", "limit"},

--- a/cmd/mcp/toolbox/scopes.go
+++ b/cmd/mcp/toolbox/scopes.go
@@ -72,6 +72,10 @@ var scopesPerTool = map[string]toolScopes{
 		ownScopeDescription: "Allow getting logs from pods.",
 		extraScopes:         []string{ScopeReadOnly},
 	},
+	ToolGetKubernetesEvents: {
+		ownScopeDescription: "Allow getting Kubernetes events.",
+		extraScopes:         []string{ScopeReadOnly},
+	},
 	ToolGetKubernetesMetrics: {
 		ownScopeDescription: "Allow getting metrics from the Kubernetes API.",
 		extraScopes:         []string{ScopeReadOnly},

--- a/cmd/mcp/toolbox/scopes_test.go
+++ b/cmd/mcp/toolbox/scopes_test.go
@@ -104,6 +104,28 @@ func TestGetToolScopes(t *testing.T) {
 			},
 		},
 		{
+			name:     "read-only tool GetKubernetesEvents",
+			tool:     ToolGetKubernetesEvents,
+			readOnly: false,
+			expected: []Scope{
+				{
+					Name:        "toolbox:" + ToolGetKubernetesEvents,
+					Description: "Allow getting Kubernetes events.",
+					Tools:       []string{ToolGetKubernetesEvents},
+				},
+				{
+					Name:        "toolbox:read_write",
+					Description: "Allow all operations.",
+					Tools:       []string{ToolGetKubernetesEvents},
+				},
+				{
+					Name:        "toolbox:read_only",
+					Description: "Allow all read-only operations.",
+					Tools:       []string{ToolGetKubernetesEvents},
+				},
+			},
+		},
+		{
 			name:     "read-only tool GetKubernetesMetrics",
 			tool:     ToolGetKubernetesMetrics,
 			readOnly: false,

--- a/docs/mcp/instructions.md
+++ b/docs/mcp/instructions.md
@@ -93,7 +93,9 @@ to narrow the result.
 
 Call `get_kubernetes_logs` directly with the workload `kind`, `name`, and `namespace` found in a
 Flux resource's inventory via `get_kubernetes_resources`. Omit `container` to read all regular
-containers. If the result is truncated, narrow the request with `container` and `limit`.
+containers. Use `since` to focus on the incident window and `grep` to keep only the relevant
+entries, such as `error|panic|fatal|exception`. If the result is truncated, narrow the request
+with `container`, `since`, `grep` and `limit`.
 
 ## Flux HelmRelease analysis
 

--- a/docs/mcp/instructions.md
+++ b/docs/mcp/instructions.md
@@ -39,6 +39,8 @@ For Flux API guidance, call the `search_flux_docs` tool with targeted questions.
 
 - When asked about the Flux installation status, call the `get_flux_instance` tool.
 - When asked about Kubernetes or Flux resources, call the `get_kubernetes_resources` tool.
+- When troubleshooting workloads, call `get_kubernetes_events` with the workload `kind`, `name`
+  and `namespace`, and narrow with `type: Warning`, `since` and `grep`.
 - When listing many resources or when only specific fields are relevant, set the `fields` parameter of the `get_kubernetes_resources` tool to kubectl JSONPath expressions (e.g. `spec.chart.spec.version`, `status.conditions[?(@.type=="Ready")].message`) to reduce the result size. Include `status.events` and `status.inventory` in `fields` when the events or the inventory are needed.
 - Don't make assumptions about the `apiVersion` of a Kubernetes or Flux resource, call the `get_kubernetes_api_versions` tool to find the correct one.
 - When asked to use a specific cluster, call the `get_kubeconfig_contexts` tool to find the cluster context before switching to it with the `set_kubeconfig_context` tool.
@@ -80,6 +82,13 @@ these directories, run `kustomize create --autodetect` in a copy before building
 the YAML files. Read all header warnings. Treat `delete` entries as objects that would be pruned
 only when the supplied manifest is complete.
 
+## Kubernetes events analysis
+
+Call `get_kubernetes_events` with the workload `kind`, `name` and `namespace` found in a Flux
+resource's inventory before reading logs; the result covers the workload, its ReplicaSets or Jobs
+and its pods. Use `type: Warning`, `since` and `grep` (e.g. `BackOff|OOMKilled|FailedScheduling`)
+to narrow the result.
+
 ## Kubernetes logs analysis
 
 Call `get_kubernetes_logs` directly with the workload `kind`, `name`, and `namespace` found in a
@@ -98,6 +107,7 @@ When troubleshooting a HelmRelease, follow these steps:
 - Use the `get_kubernetes_resources` tool to get the HelmRelease source then analyze the source status and events.
 - If the HelmRelease is in a failed state or in progress, it may be due to failures in one of the managed resources found in the inventory.
 - Use the `get_kubernetes_resources` tool to get the managed resources and analyze their status.
+- Fetch Warning events for the managed resources with the `get_kubernetes_events` tool.
 - If the managed resources are in a failed state, analyze their logs using the `get_kubernetes_logs` tool.
 - If any issues were found, create a root cause analysis report for the user.
 - If no issues were found, create a report with the current status of the HelmRelease and its managed resources and container images.
@@ -114,6 +124,7 @@ When troubleshooting a Kustomization, follow these steps:
 - Use the `get_kubernetes_resources` tool to get the Kustomization source then analyze the source status and events.
 - If the Kustomization is in a failed state or in progress, it may be due to failures in one of the managed resources found in the inventory.
 - Use the `get_kubernetes_resources` tool to get the managed resources and analyze their status.
+- Fetch Warning events for the managed resources with the `get_kubernetes_events` tool.
 - If the managed resources are in a failed state, analyze their logs using the `get_kubernetes_logs` tool.
 - If any issues were found, create a root cause analysis report for the user.
 - If no issues were found, create a report with the current status of the Kustomization and its managed resources.

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -117,6 +117,54 @@ When a single container has no output, `logs` contains `no logs found for contai
 When a workload has no pods, `logs` contains `no pods found for <kind> <namespace>/<name>` and
 `podsTotal` is `0`.
 
+### get_kubernetes_events
+
+Retrieves Kubernetes events for workloads and other Kubernetes objects, including Pods,
+Deployments, PersistentVolumeClaims, Nodes, and Flux resources. For a `Deployment`, `StatefulSet`,
+`DaemonSet`, `CronJob` or `Job`, the events of the workload, of the ReplicaSets or Jobs it owns,
+and of its newest 10 pods are returned together.
+
+**Parameters:**
+
+- `apiVersion` (optional): Exact API version of the involved object, such as `v1`, `apps/v1`,
+  or `helm.toolkit.fluxcd.io/v2`.
+- `kind` (optional): Exact, case-sensitive kind of the involved object. Workload kinds are
+  resolved to their owned objects when `name` and `namespace` are set.
+- `name` (optional): Exact name of the involved object.
+- `namespace` (optional): Namespace of the involved objects. When omitted, events are listed
+  across all namespaces.
+- `type` (optional): Event type, either `Normal` or `Warning`.
+- `since` (optional): Only return events newer than this Go duration, such as `10m` or `1h`.
+- `grep` (optional): Case-insensitive RE2 expression matched against the event reason, message,
+  and involved object rendered as `Kind/namespace/name` (`Kind/name` when cluster-scoped).
+- `limit` (optional): Maximum number of events to return after filtering and sorting
+  (default: 100).
+
+**Output:**
+
+Returns events newest-first in YAML, with the matched total before the requested limit and a
+`truncated` indicator when the limit drops entries, when the pod cap drops workload pods, or when
+more than 5,000 events matched the selectors; the cap inspects the first 5,000 in API order, so
+narrow the request with `namespace`, `kind` or `type` when `truncated` is set. The `events`
+value contains one event per line with space-separated `<time> <type> <reason> <object> [x<count>]
+<message>` columns. The object is rendered as `Kind/namespace/name`, or `Kind/name` for a
+cluster-scoped object, and the count is omitted when it is one.
+
+For example, `namespace: kube-system`, `kind: Pod`, `type: Warning`, `since: 1h` and `limit: 3` return:
+
+```yaml
+namespace: kube-system
+total: 6
+truncated: true
+events: |
+  2026-08-28T15:32:21Z Warning Unhealthy Pod/kube-system/coredns-589f44dc88-244lp Readiness probe failed: Get "http://10.244.0.4:8181/ready": dial tcp 10.244.0.4:8181: connect: connection refused
+  2026-08-28T15:32:21Z Warning Unhealthy Pod/kube-system/coredns-589f44dc88-km8w5 Readiness probe failed: Get "http://10.244.0.2:8181/ready": dial tcp 10.244.0.2:8181: connect: connection refused
+  2026-08-28T15:32:09Z Warning FailedScheduling Pod/kube-system/coredns-589f44dc88-244lp 0/1 nodes are available: 1 node(s) had untolerated taint(s). no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.
+```
+
+When no events match, the tool returns `No events found` as a normal text result, unless the
+cap was reached, in which case the YAML result is returned with `truncated: true`.
+
 ### get_kubernetes_metrics
 
 Retrieves CPU and Memory usage for Kubernetes pods, allowing AI assistants to monitor resource consumption and performance.

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -82,13 +82,40 @@ application behavior and troubleshoot issues.
 
 For workloads, the tool resolves owned pods, orders them newest-first, and concurrently reads every
 selected pod and container stream. When multiple pods and containers are selected, log lines use
-the `<pod> <container> <timestamp> <message>` format.
+the `<pod> <container> <timestamp> <message>` format, where the timestamp is RFC 3339 at seconds precision.
 
 **Output:**
 
 Returns YAML with `kind`, `name`, `namespace`, selected `pods`, de-duplicated `containers`,
 `podsTotal` (matches before the pod cap), `podsStreamed` (pods with a successful stream), `tagged`,
 `truncated` (a pod or stream cap dropped targets), and the merged `logs` payload.
+
+For example, `kind: Deployment`, `name: backend`, `namespace: apps-staging` and `limit: 4` return:
+
+```yaml
+kind: Deployment
+name: backend
+namespace: apps-staging
+pods:
+- backend-567b7494c-ddddm
+- backend-567b7494c-2vxhm
+containers:
+- podinfod
+podsTotal: 2
+podsStreamed: 2
+tagged: true
+truncated: false
+logs: |
+  backend-567b7494c-2vxhm 2026-08-28T15:35:51Z {"level":"info","ts":"2026-08-28T15:35:51.199Z","caller":"podinfo/main.go:170","msg":"Starting podinfo","version":"6.14.0","revision":"a30fa3224289a3f3e413157104dee8844e329926","port":"9898"}
+  backend-567b7494c-2vxhm 2026-08-28T15:35:51Z {"level":"info","ts":"2026-08-28T15:35:51.199Z","caller":"http/server.go:273","msg":"Starting HTTP Server.","addr":":9898"}
+  backend-567b7494c-ddddm 2026-08-28T15:36:05Z {"level":"info","ts":"2026-08-28T15:36:05.911Z","caller":"podinfo/main.go:170","msg":"Starting podinfo","version":"6.14.0","revision":"a30fa3224289a3f3e413157104dee8844e329926","port":"9898"}
+  backend-567b7494c-ddddm 2026-08-28T15:36:05Z {"level":"info","ts":"2026-08-28T15:36:05.911Z","caller":"http/server.go:273","msg":"Starting HTTP Server.","addr":":9898"}
+```
+
+When a single container has no output, `logs` contains `no logs found for container <name>`.
+
+When a workload has no pods, `logs` contains `no pods found for <kind> <namespace>/<name>` and
+`podsTotal` is `0`.
 
 ### get_kubernetes_metrics
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -77,18 +77,22 @@ application behavior and troubleshoot issues.
 - `namespace` (required): The namespace of the pod or workload.
 - `container` (optional): A regular container name. When omitted, logs are read from all
   `spec.containers`; init and ephemeral containers are excluded.
+- `since` (optional): Only return log entries newer than this Go duration, such as `10m` or `1h`.
+- `grep` (optional): Case-insensitive RE2 expression that keeps the log entries whose line matches.
 - `limit` (optional): Maximum number of merged log entries to return (default: 100).
 - `previous` (optional): Read logs from previously terminated container instances (default: false).
 
-For workloads, the tool resolves owned pods, orders them newest-first, and concurrently reads every
-selected pod and container stream. When multiple pods and containers are selected, log lines use
-the `<pod> <container> <timestamp> <message>` format, where the timestamp is RFC 3339 at seconds precision.
+For workloads, the tool resolves owned pods and orders them newest-first.
+When multiple pods and containers are selected, log lines use
+the `<pod> <container> <timestamp> <message>` format.
 
 **Output:**
 
 Returns YAML with `kind`, `name`, `namespace`, selected `pods`, de-duplicated `containers`,
 `podsTotal` (matches before the pod cap), `podsStreamed` (pods with a successful stream), `tagged`,
-`truncated` (a pod or stream cap dropped targets), and the merged `logs` payload.
+`truncated`, and the merged `logs` payload. `truncated` is set when the pod or stream cap dropped
+targets and, with `grep`, when more entries matched than `limit` or when the byte cap dropped
+older lines before the filter ran, so earlier matches may exist.
 
 For example, `kind: Deployment`, `name: backend`, `namespace: apps-staging` and `limit: 4` return:
 
@@ -116,6 +120,9 @@ When a single container has no output, `logs` contains `no logs found for contai
 
 When a workload has no pods, `logs` contains `no pods found for <kind> <namespace>/<name>` and
 `podsTotal` is `0`.
+
+When `since` or `grep` leave no entries, `logs` describes the filters, for example
+`no log entries newer than 10m0s matching the grep expression`.
 
 ### get_kubernetes_events
 

--- a/internal/podlogs/logs.go
+++ b/internal/podlogs/logs.go
@@ -42,6 +42,21 @@ type logEntry struct {
 	container string
 }
 
+// MergeOption configures MergeLogStreams output rendering.
+type MergeOption func(*mergeOptions)
+
+// mergeOptions contains optional MergeLogStreams rendering behavior.
+type mergeOptions struct {
+	secondTimestamps bool
+}
+
+// WithSecondTimestamps formats timestamped entries at RFC 3339 seconds precision.
+func WithSecondTimestamps() MergeOption {
+	return func(opts *mergeOptions) {
+		opts.secondTimestamps = true
+	}
+}
+
 // trimPartialLogLine drops a trailing partial log line from the payload.
 //
 // Container runtimes newline-terminate every emitted log line, so a payload
@@ -154,8 +169,14 @@ func parseLogEntries(blob, pod, container string) []logEntry {
 // MergeLogStreams interleaves streams chronologically, keeps the newest
 // tailLines entries, and caps the result to byteLimit bytes on a line boundary.
 // Timestamped lines are optionally tagged in pod-then-container order;
-// continuation lines remain attached and untagged.
-func MergeLogStreams(streams []LogStream, tailLines int, tagPod, tagContainer bool, byteLimit int) string {
+// continuation lines remain attached and untagged. Merge options only affect
+// output rendering and do not change chronological ordering.
+func MergeLogStreams(streams []LogStream, tailLines int, tagPod, tagContainer bool, byteLimit int, options ...MergeOption) string {
+	opts := mergeOptions{}
+	for _, option := range options {
+		option(&opts)
+	}
+
 	var entries []logEntry
 	for _, stream := range streams {
 		entries = append(entries, parseLogEntries(stream.Blob, stream.Pod, stream.Container)...)
@@ -179,7 +200,13 @@ func MergeLogStreams(streams []LogStream, tailLines int, tagPod, tagContainer bo
 				sb.WriteByte(' ')
 			}
 		}
-		sb.WriteString(entry.text)
+		text := entry.text
+		if opts.secondTimestamps && !entry.ts.IsZero() {
+			if _, rest, found := strings.Cut(text, " "); found {
+				text = entry.ts.UTC().Format(time.RFC3339) + " " + rest
+			}
+		}
+		sb.WriteString(text)
 		sb.WriteByte('\n')
 	}
 	return capLogBytes(sb.String(), byteLimit)

--- a/internal/podlogs/logs.go
+++ b/internal/podlogs/logs.go
@@ -8,6 +8,7 @@ package podlogs
 import (
 	"context"
 	"io"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -42,12 +43,13 @@ type logEntry struct {
 	container string
 }
 
-// MergeOption configures MergeLogStreams output rendering.
+// MergeOption configures MergeLogStreams filtering and output rendering.
 type MergeOption func(*mergeOptions)
 
-// mergeOptions contains optional MergeLogStreams rendering behavior.
+// mergeOptions contains optional MergeLogStreams behavior.
 type mergeOptions struct {
 	secondTimestamps bool
+	grep             *regexp.Regexp
 }
 
 // WithSecondTimestamps formats timestamped entries at RFC 3339 seconds precision.
@@ -55,6 +57,24 @@ func WithSecondTimestamps() MergeOption {
 	return func(opts *mergeOptions) {
 		opts.secondTimestamps = true
 	}
+}
+
+// WithGrep keeps only the entries whose rendered text, including
+// continuation lines, matches the expression.
+func WithGrep(expression *regexp.Regexp) MergeOption {
+	return func(opts *mergeOptions) {
+		opts.grep = expression
+	}
+}
+
+// MergeResult is the merged log payload and its entry statistics.
+type MergeResult struct {
+	// Logs is the merged payload.
+	Logs string
+	// Entries is the number of entries kept after filtering and before tailing.
+	Entries int
+	// Truncated reports whether the tail or the byte limit dropped entries.
+	Truncated bool
 }
 
 // trimPartialLogLine drops a trailing partial log line from the payload.
@@ -75,28 +95,29 @@ func trimPartialLogLine(logs string) string {
 
 // tailLogBytes reads r to EOF but retains only the most recent limit bytes.
 //
-// The returned bool is partialFirst: true when the retained slice begins
-// mid-line, so the caller should drop that leading fragment.
-func tailLogBytes(r io.Reader, limit int) ([]byte, bool, error) {
+// partialFirst is true when the retained slice begins mid-line, so the caller
+// should drop that leading fragment; dropped is true when older bytes were
+// discarded to honor the limit.
+func tailLogBytes(r io.Reader, limit int) (data []byte, partialFirst, dropped bool, err error) {
 	const chunkSize = 32 * 1024
 	buf := make([]byte, 0, limit+chunkSize)
 	chunk := make([]byte, chunkSize)
-	partialFirst := false
 	for {
 		n, err := r.Read(chunk)
 		if n > 0 {
 			buf = append(buf, chunk[:n]...)
 			if len(buf) > limit {
 				partialFirst = buf[len(buf)-limit-1] != '\n'
+				dropped = true
 				copy(buf, buf[len(buf)-limit:])
 				buf = buf[:limit]
 			}
 		}
 		if err == io.EOF {
-			return buf, partialFirst, nil
+			return buf, partialFirst, dropped, nil
 		}
 		if err != nil {
-			return nil, partialFirst, err
+			return nil, partialFirst, dropped, err
 		}
 	}
 }
@@ -113,22 +134,29 @@ func trimPartialFirstLine(logs string) string {
 // FetchContainerLog streams one container's logs and keeps only the newest
 // byteLimit bytes, trimming partial first and last lines.
 func FetchContainerLog(ctx context.Context, clientset kubernetes.Interface, namespace, name string, opts *corev1.PodLogOptions, byteLimit int) (string, error) {
+	logs, _, err := FetchContainerLogWithStats(ctx, clientset, namespace, name, opts, byteLimit)
+	return logs, err
+}
+
+// FetchContainerLogWithStats is FetchContainerLog that also reports whether
+// the byte limit dropped older log lines.
+func FetchContainerLogWithStats(ctx context.Context, clientset kubernetes.Interface, namespace, name string, opts *corev1.PodLogOptions, byteLimit int) (string, bool, error) {
 	stream, err := clientset.CoreV1().Pods(namespace).GetLogs(name, opts).Stream(ctx)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	defer stream.Close()
 
-	data, partialFirst, err := tailLogBytes(stream, byteLimit)
+	data, partialFirst, dropped, err := tailLogBytes(stream, byteLimit)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	logs := trimPartialLogLine(string(data))
 	if partialFirst {
 		logs = trimPartialFirstLine(logs)
 	}
-	return logs, nil
+	return logs, dropped, nil
 }
 
 // parseLogTimestamp parses the leading RFC3339 timestamp token added by the
@@ -169,9 +197,14 @@ func parseLogEntries(blob, pod, container string) []logEntry {
 // MergeLogStreams interleaves streams chronologically, keeps the newest
 // tailLines entries, and caps the result to byteLimit bytes on a line boundary.
 // Timestamped lines are optionally tagged in pod-then-container order;
-// continuation lines remain attached and untagged. Merge options only affect
-// output rendering and do not change chronological ordering.
+// continuation lines remain attached and untagged. Merge options filter the
+// entries and shape the rendered lines without changing chronological ordering.
 func MergeLogStreams(streams []LogStream, tailLines int, tagPod, tagContainer bool, byteLimit int, options ...MergeOption) string {
+	return MergeLogStreamsWithStats(streams, tailLines, tagPod, tagContainer, byteLimit, options...).Logs
+}
+
+// MergeLogStreamsWithStats is MergeLogStreams with entry statistics.
+func MergeLogStreamsWithStats(streams []LogStream, tailLines int, tagPod, tagContainer bool, byteLimit int, options ...MergeOption) MergeResult {
 	opts := mergeOptions{}
 	for _, option := range options {
 		option(&opts)
@@ -179,37 +212,65 @@ func MergeLogStreams(streams []LogStream, tailLines int, tagPod, tagContainer bo
 
 	var entries []logEntry
 	for _, stream := range streams {
-		entries = append(entries, parseLogEntries(stream.Blob, stream.Pod, stream.Container)...)
+		for _, entry := range parseLogEntries(stream.Blob, stream.Pod, stream.Container) {
+			if opts.grep != nil {
+				entry.text = renderLogEntry(entry, opts, tagPod, tagContainer)
+				if !opts.grep.MatchString(entry.text) {
+					continue
+				}
+			}
+			entries = append(entries, entry)
+		}
 	}
 	sort.SliceStable(entries, func(i, j int) bool {
 		return entries[i].ts.Before(entries[j].ts)
 	})
+
+	result := MergeResult{Entries: len(entries)}
 	if tailLines > 0 && len(entries) > tailLines {
 		entries = entries[len(entries)-tailLines:]
+		result.Truncated = true
 	}
 
 	var sb strings.Builder
 	for _, entry := range entries {
-		if !entry.ts.IsZero() {
-			if tagPod {
-				sb.WriteString(entry.pod)
-				sb.WriteByte(' ')
-			}
-			if tagContainer {
-				sb.WriteString(entry.container)
-				sb.WriteByte(' ')
-			}
-		}
 		text := entry.text
-		if opts.secondTimestamps && !entry.ts.IsZero() {
-			if _, rest, found := strings.Cut(text, " "); found {
-				text = entry.ts.UTC().Format(time.RFC3339) + " " + rest
-			}
+		if opts.grep == nil {
+			text = renderLogEntry(entry, opts, tagPod, tagContainer)
 		}
 		sb.WriteString(text)
 		sb.WriteByte('\n')
 	}
-	return capLogBytes(sb.String(), byteLimit)
+	result.Logs = capLogBytes(sb.String(), byteLimit)
+	if len(result.Logs) < sb.Len() {
+		result.Truncated = true
+	}
+	return result
+}
+
+// renderLogEntry returns the entry text as emitted in the merged payload.
+func renderLogEntry(entry logEntry, opts mergeOptions, tagPod, tagContainer bool) string {
+	if entry.ts.IsZero() {
+		return entry.text
+	}
+
+	var sb strings.Builder
+	if tagPod {
+		sb.WriteString(entry.pod)
+		sb.WriteByte(' ')
+	}
+	if tagContainer {
+		sb.WriteString(entry.container)
+		sb.WriteByte(' ')
+	}
+	text := entry.text
+	if opts.secondTimestamps {
+		if _, rest, found := strings.Cut(text, " "); found {
+			text = entry.ts.UTC().Format(time.RFC3339) + " " + rest
+		}
+	}
+	sb.WriteString(text)
+	return sb.String()
 }
 
 // DedupeNames removes duplicate names while preserving order and caps the

--- a/internal/podlogs/logs_test.go
+++ b/internal/podlogs/logs_test.go
@@ -4,6 +4,7 @@
 package podlogs
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -56,21 +57,23 @@ func TestTailLogBytes(t *testing.T) {
 		limit            int
 		want             string
 		wantPartialFirst bool
+		wantDropped      bool
 	}{
 		{name: "under limit returns all", in: "line1\nline2\n", limit: 100, want: "line1\nline2\n"},
 		{name: "exact limit not truncated", in: "abcd", limit: 4, want: "abcd"},
-		{name: "over limit cut on line boundary keeps complete first line", in: "line1\nline2\nline3\n", limit: 12, want: "line2\nline3\n"},
-		{name: "over limit cutting mid-line", in: "line1\nline2\n", limit: 8, want: "1\nline2\n", wantPartialFirst: true},
+		{name: "over limit cut on line boundary keeps complete first line", in: "line1\nline2\nline3\n", limit: 12, want: "line2\nline3\n", wantDropped: true},
+		{name: "over limit cutting mid-line", in: "line1\nline2\n", limit: 8, want: "1\nline2\n", wantPartialFirst: true, wantDropped: true},
 		{name: "empty stream", in: "", limit: 16, want: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			got, partialFirst, err := tailLogBytes(strings.NewReader(tt.in), tt.limit)
+			got, partialFirst, dropped, err := tailLogBytes(strings.NewReader(tt.in), tt.limit)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(string(got)).To(Equal(tt.want))
 			g.Expect(partialFirst).To(Equal(tt.wantPartialFirst))
+			g.Expect(dropped).To(Equal(tt.wantDropped))
 		})
 	}
 }
@@ -168,6 +171,65 @@ func TestMergeLogStreams(t *testing.T) {
 		a := LogStream{Pod: "p1", Container: "app", Blob: "2026-01-01T00:00:00Z a\nframe\n"}
 		b := LogStream{Pod: "p2", Container: "side", Blob: "2026-01-01T00:00:01Z b\n"}
 		g.Expect(MergeLogStreams([]LogStream{a, b}, 0, true, true, byteLimit)).To(Equal("p1 app 2026-01-01T00:00:00Z a\nframe\np2 side 2026-01-01T00:00:01Z b\n"))
+	})
+}
+
+func TestMergeLogStreamsWithStats(t *testing.T) {
+	const byteLimit = 512 * 1024
+	app := LogStream{Pod: "p1", Container: "app", Blob: "2026-01-01T00:00:00Z ready\n2026-01-01T00:00:01Z ERROR boom\nstack frame one\n2026-01-01T00:00:03Z ready again\n"}
+	side := LogStream{Pod: "p2", Container: "side", Blob: "2026-01-01T00:00:02Z error: side failed\n2026-01-01T00:00:04Z ok\n"}
+
+	t.Run("reports entries and no truncation without options", func(t *testing.T) {
+		g := NewWithT(t)
+		got := MergeLogStreamsWithStats([]LogStream{app, side}, 0, false, false, byteLimit)
+		g.Expect(got.Entries).To(Equal(5))
+		g.Expect(got.Truncated).To(BeFalse())
+		g.Expect(got.Logs).To(HavePrefix("2026-01-01T00:00:00Z ready\n"))
+	})
+
+	t.Run("grep keeps matching entries with their continuation lines", func(t *testing.T) {
+		g := NewWithT(t)
+		got := MergeLogStreamsWithStats([]LogStream{app, side}, 0, false, false, byteLimit, WithGrep(regexp.MustCompile("(?i)error")))
+		g.Expect(got.Entries).To(Equal(2))
+		g.Expect(got.Truncated).To(BeFalse())
+		g.Expect(got.Logs).To(Equal("2026-01-01T00:00:01Z ERROR boom\nstack frame one\n2026-01-01T00:00:02Z error: side failed\n"))
+	})
+
+	t.Run("grep matches inside continuation lines", func(t *testing.T) {
+		g := NewWithT(t)
+		got := MergeLogStreamsWithStats([]LogStream{app, side}, 0, false, false, byteLimit, WithGrep(regexp.MustCompile("frame one")))
+		g.Expect(got.Logs).To(Equal("2026-01-01T00:00:01Z ERROR boom\nstack frame one\n"))
+	})
+
+	t.Run("grep matches the rendered tags and seconds timestamps", func(t *testing.T) {
+		g := NewWithT(t)
+		got := MergeLogStreamsWithStats([]LogStream{app, side}, 0, true, true, byteLimit,
+			WithSecondTimestamps(), WithGrep(regexp.MustCompile("^p2 side 2026-01-01T00:00:04Z")))
+		g.Expect(got.Entries).To(Equal(1))
+		g.Expect(got.Logs).To(Equal("p2 side 2026-01-01T00:00:04Z ok\n"))
+	})
+
+	t.Run("tail applies after grep and reports truncation", func(t *testing.T) {
+		g := NewWithT(t)
+		got := MergeLogStreamsWithStats([]LogStream{app, side}, 1, false, false, byteLimit, WithGrep(regexp.MustCompile("(?i)error")))
+		g.Expect(got.Entries).To(Equal(2))
+		g.Expect(got.Truncated).To(BeTrue())
+		g.Expect(got.Logs).To(Equal("2026-01-01T00:00:02Z error: side failed\n"))
+	})
+
+	t.Run("byte cap reports truncation", func(t *testing.T) {
+		g := NewWithT(t)
+		got := MergeLogStreamsWithStats([]LogStream{app, side}, 0, false, false, 40)
+		g.Expect(got.Truncated).To(BeTrue())
+		g.Expect(len(got.Logs)).To(BeNumerically("<=", 40))
+	})
+
+	t.Run("grep with no matches yields no entries", func(t *testing.T) {
+		g := NewWithT(t)
+		got := MergeLogStreamsWithStats([]LogStream{app, side}, 0, false, false, byteLimit, WithGrep(regexp.MustCompile("nothing")))
+		g.Expect(got.Entries).To(BeZero())
+		g.Expect(got.Truncated).To(BeFalse())
+		g.Expect(got.Logs).To(BeEmpty())
 	})
 }
 

--- a/internal/podlogs/logs_test.go
+++ b/internal/podlogs/logs_test.go
@@ -114,11 +114,19 @@ func TestMergeLogStreams(t *testing.T) {
 		g.Expect(got).To(Equal("2026-01-01T00:00:00Z app a\n2026-01-01T00:00:01Z side a\n2026-01-01T00:00:02Z app b\n2026-01-01T00:00:03Z side b\n"))
 	})
 
-	t.Run("orders fractional timestamps numerically", func(t *testing.T) {
+	t.Run("keeps fractional timestamps by default", func(t *testing.T) {
 		g := NewWithT(t)
 		a := LogStream{Blob: "2026-01-01T00:00:00.1Z first\n"}
 		b := LogStream{Blob: "2026-01-01T00:00:00.12Z second\n"}
 		g.Expect(MergeLogStreams([]LogStream{b, a}, 0, false, false, byteLimit)).To(Equal("2026-01-01T00:00:00.1Z first\n2026-01-01T00:00:00.12Z second\n"))
+	})
+
+	t.Run("formats seconds while preserving fractional ordering", func(t *testing.T) {
+		g := NewWithT(t)
+		a := LogStream{Blob: "2026-01-01T00:00:00.100000001Z first\nstack frame\n"}
+		b := LogStream{Blob: "2026-01-01T00:00:00.100000002Z second\n"}
+		got := MergeLogStreams([]LogStream{b, a}, 0, false, false, byteLimit, WithSecondTimestamps())
+		g.Expect(got).To(Equal("2026-01-01T00:00:00Z first\nstack frame\n2026-01-01T00:00:00Z second\n"))
 	})
 
 	t.Run("keeps continuation lines attached", func(t *testing.T) {

--- a/internal/web/workload_logs_test.go
+++ b/internal/web/workload_logs_test.go
@@ -116,12 +116,12 @@ func TestBuildWorkloadLogsResponse(t *testing.T) {
 		// One pod, two containers: ContainerTagged is set and each line is prefixed
 		// with its container so the client scopes folding per container.
 		targets := []podlogs.LogTarget{{Pod: "p1", Container: "app"}, {Pod: "p1", Container: "envoy"}}
-		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00Z a\n", "2026-01-01T00:00:01Z e\n"}, []error{nil, nil})
+		fanOut := collectLogStreams(targets, []string{"2026-01-01T00:00:00.123456789Z a\n", "2026-01-01T00:00:01.987654321Z e\n"}, []error{nil, nil})
 		resp := buildWorkloadLogsResponse([]string{"p1"}, []string{"app", "envoy"}, fanOut, 1, 1000, false, true, false)
 
 		g.Expect(resp.Tagged).To(BeFalse())
 		g.Expect(resp.ContainerTagged).To(BeTrue())
-		g.Expect(resp.Logs).To(Equal("app 2026-01-01T00:00:00Z a\nenvoy 2026-01-01T00:00:01Z e\n"))
+		g.Expect(resp.Logs).To(Equal("app 2026-01-01T00:00:00.123456789Z a\nenvoy 2026-01-01T00:00:01.987654321Z e\n"))
 	})
 }
 


### PR DESCRIPTION
Kubernetes events were only attached to Flux resources, leaving agents without ImagePullBackOff, FailedMount, etc or probe failures for workloads.

The new read-only tool lists core events with field selectors and a regex expression, so agents can grep server-side to avoid filling the context with unwanted events.

In addition, the `get_kubernetes_logs` tool gains `since` and `grep` filters.