### PR TITLE
mcp: Add `trace_kubernetes_resource` tool 

### DIFF
--- a/cmd/mcp/k8s/testdata/crds/ag.yaml
+++ b/cmd/mcp/k8s/testdata/crds/ag.yaml
@@ -1,14 +1,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ocirepositories.source.toolkit.fluxcd.io
+  name: artifactgenerators.source.extensions.fluxcd.io
 spec:
-  group: source.toolkit.fluxcd.io
+  group: source.extensions.fluxcd.io
   names:
-    kind: OCIRepository
-    listKind: OCIRepositoryList
-    plural: ocirepositories
-    singular: ocirepository
+    kind: ArtifactGenerator
+    listKind: ArtifactGeneratorList
+    plural: artifactgenerators
+    singular: artifactgenerator
   scope: Namespaced
   versions:
     - name: v1

--- a/cmd/mcp/k8s/testdata/crds/ea.yaml
+++ b/cmd/mcp/k8s/testdata/crds/ea.yaml
@@ -1,14 +1,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ocirepositories.source.toolkit.fluxcd.io
+  name: externalartifacts.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
   names:
-    kind: OCIRepository
-    listKind: OCIRepositoryList
-    plural: ocirepositories
-    singular: ocirepository
+    kind: ExternalArtifact
+    listKind: ExternalArtifactList
+    plural: externalartifacts
+    singular: externalartifact
   scope: Namespaced
   versions:
     - name: v1

--- a/cmd/mcp/k8s/testdata/crds/hc.yaml
+++ b/cmd/mcp/k8s/testdata/crds/hc.yaml
@@ -1,14 +1,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ocirepositories.source.toolkit.fluxcd.io
+  name: helmcharts.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
   names:
-    kind: OCIRepository
-    listKind: OCIRepositoryList
-    plural: ocirepositories
-    singular: ocirepository
+    kind: HelmChart
+    listKind: HelmChartList
+    plural: helmcharts
+    singular: helmchart
   scope: Namespaced
   versions:
     - name: v1

--- a/cmd/mcp/k8s/testdata/crds/helmrepo.yaml
+++ b/cmd/mcp/k8s/testdata/crds/helmrepo.yaml
@@ -1,14 +1,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ocirepositories.source.toolkit.fluxcd.io
+  name: helmrepositories.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
   names:
-    kind: OCIRepository
-    listKind: OCIRepositoryList
-    plural: ocirepositories
-    singular: ocirepository
+    kind: HelmRepository
+    listKind: HelmRepositoryList
+    plural: helmrepositories
+    singular: helmrepository
   scope: Namespaced
   versions:
     - name: v1

--- a/cmd/mcp/k8s/testdata/crds/hr.yaml
+++ b/cmd/mcp/k8s/testdata/crds/hr.yaml
@@ -1,5 +1,3 @@
-# Copyright 2026 Stefan Prodan.
-# SPDX-License-Identifier: AGPL-3.0
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/cmd/mcp/k8s/testdata/crds/ks.yaml
+++ b/cmd/mcp/k8s/testdata/crds/ks.yaml
@@ -1,5 +1,3 @@
-# Copyright 2026 Stefan Prodan.
-# SPDX-License-Identifier: AGPL-3.0
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/cmd/mcp/k8s/trace.go
+++ b/cmd/mcp/k8s/trace.go
@@ -1,0 +1,424 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fluxcd/cli-utils/pkg/kstatus/status"
+	"github.com/fluxcd/pkg/apis/meta"
+	ssautil "github.com/fluxcd/pkg/ssa/utils"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+const (
+	// traceMaxOwnerDepth bounds the ownerReferences walk from the traced object.
+	traceMaxOwnerDepth = 8
+	// traceMaxChartDepth bounds the HelmChart to repository indirection walk.
+	traceMaxChartDepth = 3
+)
+
+// TraceOptions identifies the Kubernetes object to trace
+// through the GitOps delivery pipeline.
+type TraceOptions struct {
+	// APIVersion of the object.
+	APIVersion string
+	// Kind of the object.
+	Kind string
+	// Name of the object.
+	Name string
+	// Namespace of the object, empty for cluster-scoped objects.
+	Namespace string
+}
+
+// TraceLink describes one object related to the traced Kubernetes resource.
+// The fields are declared in the order they are rendered in YAML.
+type TraceLink struct {
+	// Object identifies the object as Kind/namespace/name,
+	// or Kind/name for cluster-scoped objects.
+	Object string `json:"object" yaml:"object"`
+	// Status is the Ready condition reason for Flux objects,
+	// or the kstatus computed status for other kinds.
+	Status string `json:"status" yaml:"status"`
+	// Suspended is true when the reconciliation of a Flux object is paused.
+	Suspended bool `json:"suspended,omitempty" yaml:"suspended,omitempty"`
+	// Message is set only when the object is not ready.
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	// LastAppliedRevision is the revision applied by a Flux applier.
+	LastAppliedRevision string `json:"lastAppliedRevision,omitempty" yaml:"lastAppliedRevision,omitempty"`
+	// URL is the address a Flux source pulls from.
+	URL string `json:"url,omitempty" yaml:"url,omitempty"`
+	// Revision is the revision of the artifact fetched by a Flux source.
+	Revision string `json:"revision,omitempty" yaml:"revision,omitempty"`
+}
+
+// TraceManager is one object in the upward management path.
+type TraceManager struct {
+	TraceLink `json:",inline" yaml:",inline"`
+	// ManagedBy is the next Flux object up the path, omitted at the top.
+	ManagedBy *TraceManager `json:"managedBy,omitempty" yaml:"managedBy,omitempty"`
+}
+
+// TraceProducer is the producer of an ExternalArtifact.
+type TraceProducer struct {
+	TraceLink `json:",inline" yaml:",inline"`
+	// BuiltFrom contains the upstream Flux sources combined by the producer.
+	BuiltFrom []TraceLink `json:"builtFrom,omitempty" yaml:"builtFrom,omitempty"`
+}
+
+// TraceSource describes the source resolved for the nearest Flux applier.
+type TraceSource struct {
+	// ResolvedFor identifies the applier the source was resolved for.
+	ResolvedFor string `json:"resolvedFor" yaml:"resolvedFor"`
+	TraceLink   `json:",inline" yaml:",inline"`
+	// ProducedBy is the producer of an ExternalArtifact.
+	ProducedBy *TraceProducer `json:"producedBy,omitempty" yaml:"producedBy,omitempty"`
+	// BuiltFrom contains the upstream Flux sources combined by the resolved source.
+	BuiltFrom []TraceLink `json:"builtFrom,omitempty" yaml:"builtFrom,omitempty"`
+}
+
+// TraceResult describes the upward management path from a Kubernetes object
+// and the source of its delivery pipeline.
+type TraceResult struct {
+	// Object identifies the traced object.
+	Object string `json:"object" yaml:"object"`
+	// Unmanaged is true when no Flux ownership labels were found
+	// on the object or its owners.
+	Unmanaged bool `json:"unmanaged,omitempty" yaml:"unmanaged,omitempty"`
+	// ManagedBy is the nearest manager, with each subsequent manager nested recursively.
+	ManagedBy *TraceManager `json:"managedBy,omitempty" yaml:"managedBy,omitempty"`
+	// Source is the source resolved for the applier nearest to the traced object,
+	// omitted when no applier in the path has a source.
+	Source *TraceSource `json:"source,omitempty" yaml:"source,omitempty"`
+}
+
+// Trace walks from a Kubernetes object up its GitOps delivery pipeline:
+// through the ownerReferences to the object carrying Flux ownership labels,
+// then through the labels to the chain of managing Flux objects, and
+// resolves the source pulled by the applier nearest to the traced object.
+func (k *Client) Trace(ctx context.Context, opts TraceOptions) (*TraceResult, error) {
+	gvk, err := k.ParseGroupVersionKind(opts.APIVersion, opts.Kind)
+	if err != nil {
+		return nil, err
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	objKey := types.NamespacedName{Namespace: opts.Namespace, Name: opts.Name}
+	if err := k.Client.Get(ctx, objKey, obj); err != nil {
+		return nil, fmt.Errorf("unable to get %s %s: %w", opts.Kind, objKey, err)
+	}
+
+	result := &TraceResult{Object: objectID(obj)}
+	visited := map[string]bool{result.Object: true}
+	// candidates holds the traced object and its managers, nearest first,
+	// for source resolution.
+	candidates := []*unstructured.Unstructured{obj}
+	managerSlot := &result.ManagedBy
+
+	labeled, owner, err := k.findFluxOwner(ctx, obj, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to trace %s: %w", result.Object, err)
+	}
+	if owner == nil {
+		// The source of an unmanaged Flux applier is still resolved below.
+		result.Unmanaged = true
+	} else if id := objectID(labeled); !visited[id] {
+		visited[id] = true
+		manager := &TraceManager{TraceLink: newTraceLink(labeled)}
+		*managerSlot = manager
+		managerSlot = &manager.ManagedBy
+		candidates = append(candidates, labeled)
+	}
+
+	for owner != nil {
+		ownerObj, err := k.getFluxObject(ctx, "", owner)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get %s/%s/%s managing %s: %w",
+				owner.Kind, owner.Namespace, owner.Name, result.Object, err)
+		}
+		id := objectID(ownerObj)
+		if visited[id] {
+			break
+		}
+		visited[id] = true
+		manager := &TraceManager{TraceLink: newTraceLink(ownerObj)}
+		*managerSlot = manager
+		managerSlot = &manager.ManagedBy
+		candidates = append(candidates, ownerObj)
+		owner, _ = fluxOwnerFromLabels(ownerObj.GetLabels())
+	}
+
+	// Resolve the source of the nearest applier, as the walk may top out at
+	// a ResourceSet or FluxInstance which have no source of their own.
+	for _, candidate := range candidates {
+		srcRef, srcAPIVersion := sourceRefOf(candidate)
+		if srcRef == nil {
+			continue
+		}
+		srcObj, err := k.getSourceObject(ctx, srcAPIVersion, srcRef)
+		if err != nil || visited[objectID(srcObj)] {
+			break
+		}
+		result.Source = k.newTraceSource(ctx, objectID(candidate), srcObj, visited)
+		break
+	}
+
+	return result, nil
+}
+
+// newTraceSource builds the relationships of a resolved Flux source, following
+// an ExternalArtifact to its producer and listing the spec.sources upstreams.
+func (k *Client) newTraceSource(ctx context.Context, resolvedFor string, srcObj *unstructured.Unstructured, visited map[string]bool) *TraceSource {
+	visited[objectID(srcObj)] = true
+	link := newTraceLink(srcObj)
+	link.URL = sourceURL(srcObj)
+	source := &TraceSource{
+		ResolvedFor: resolvedFor,
+		TraceLink:   link,
+	}
+
+	// An ExternalArtifact names its producer, e.g. an ArtifactGenerator, in spec.sourceRef.
+	if srcObj.GetKind() == fluxcdv1.FluxExternalArtifactKind {
+		genRef, genAPIVersion := namedRefAt(srcObj, "spec", "sourceRef")
+		if genRef == nil {
+			return source
+		}
+		genObj, err := k.getFluxObject(ctx, genAPIVersion, genRef)
+		if err != nil || visited[objectID(genObj)] {
+			return source
+		}
+		visited[objectID(genObj)] = true
+		source.ProducedBy = &TraceProducer{
+			TraceLink: newTraceLink(genObj),
+			BuiltFrom: k.traceBuiltFrom(ctx, genObj, visited),
+		}
+		return source
+	}
+
+	source.BuiltFrom = k.traceBuiltFrom(ctx, srcObj, visited)
+	return source
+}
+
+// traceBuiltFrom resolves the spec.sources upstreams of a generated source,
+// omitting objects already present in the trace.
+func (k *Client) traceBuiltFrom(ctx context.Context, producer *unstructured.Unstructured, visited map[string]bool) []TraceLink {
+	var builtFrom []TraceLink
+	sources, found, err := unstructured.NestedSlice(producer.Object, "spec", "sources")
+	if !found || err != nil {
+		return builtFrom
+	}
+	for _, item := range sources {
+		src, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		kind, _ := src["kind"].(string)
+		name, _ := src["name"].(string)
+		if kind == "" || name == "" {
+			continue
+		}
+		namespace, _ := src["namespace"].(string)
+		if namespace == "" {
+			namespace = producer.GetNamespace()
+		}
+		upstream, err := k.getSourceObject(ctx, "", &DiffOwnerRef{Kind: kind, Name: name, Namespace: namespace})
+		if err != nil || visited[objectID(upstream)] {
+			continue
+		}
+		visited[objectID(upstream)] = true
+		upstreamLink := newTraceLink(upstream)
+		upstreamLink.URL = sourceURL(upstream)
+		builtFrom = append(builtFrom, upstreamLink)
+	}
+	return builtFrom
+}
+
+// findFluxOwner returns the object carrying Flux ownership labels, found on
+// the object itself or up its ownerReferences, together with the reference to
+// the Flux object managing it. A nil reference means unmanaged.
+func (k *Client) findFluxOwner(ctx context.Context, obj *unstructured.Unstructured, depth int) (*unstructured.Unstructured, *DiffOwnerRef, error) {
+	if ref, found := fluxOwnerFromLabels(obj.GetLabels()); found {
+		return obj, ref, nil
+	}
+	if depth >= traceMaxOwnerDepth {
+		return nil, nil, nil
+	}
+
+	for _, ownerRef := range obj.GetOwnerReferences() {
+		gv, err := schema.ParseGroupVersion(ownerRef.APIVersion)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ownerObj := &unstructured.Unstructured{}
+		ownerObj.SetGroupVersionKind(gv.WithKind(ownerRef.Kind))
+		ownerKey := types.NamespacedName{Namespace: obj.GetNamespace(), Name: ownerRef.Name}
+		if err := k.Client.Get(ctx, ownerKey, ownerObj); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, nil, err
+		}
+
+		labeled, ref, err := k.findFluxOwner(ctx, ownerObj, depth+1)
+		if err != nil || ref != nil {
+			return labeled, ref, err
+		}
+	}
+	return nil, nil, nil
+}
+
+// getFluxObject fetches a referenced object, resolving its version from the
+// API server discovery when the reference carries no apiVersion.
+func (k *Client) getFluxObject(ctx context.Context, apiVersion string, ref *DiffOwnerRef) (*unstructured.Unstructured, error) {
+	gvk, err := k.ResolveGroupVersionKind(apiVersion, ref.Kind)
+	if err != nil {
+		return nil, err
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	key := types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}
+	if err := k.Client.Get(ctx, key, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// getSourceObject fetches a source object, following a HelmChart to the
+// repository it references.
+func (k *Client) getSourceObject(ctx context.Context, apiVersion string, ref *DiffOwnerRef) (*unstructured.Unstructured, error) {
+	obj, err := k.getFluxObject(ctx, apiVersion, ref)
+	if err != nil {
+		return nil, err
+	}
+	for depth := 0; depth < traceMaxChartDepth && obj.GetKind() == fluxcdv1.FluxHelmChartKind; depth++ {
+		chartSrcRef, chartSrcAPIVersion := namedRefAt(obj, "spec", "sourceRef")
+		if chartSrcRef == nil {
+			break
+		}
+		next, err := k.getFluxObject(ctx, chartSrcAPIVersion, chartSrcRef)
+		if err != nil {
+			break
+		}
+		obj = next
+	}
+	return obj, nil
+}
+
+// sourceRefOf returns the source reference a Flux object pulls from,
+// or nil for kinds without a source.
+func sourceRefOf(obj *unstructured.Unstructured) (*DiffOwnerRef, string) {
+	var paths [][]string
+	switch obj.GetKind() {
+	case fluxcdv1.FluxKustomizationKind, fluxcdv1.FluxHelmChartKind, fluxcdv1.FluxExternalArtifactKind:
+		paths = [][]string{{"spec", "sourceRef"}}
+	case fluxcdv1.FluxHelmReleaseKind:
+		paths = [][]string{{"spec", "chartRef"}, {"spec", "chart", "spec", "sourceRef"}}
+	default:
+		return nil, ""
+	}
+
+	for _, path := range paths {
+		if ref, apiVersion := namedRefAt(obj, path...); ref != nil {
+			return ref, apiVersion
+		}
+	}
+	return nil, ""
+}
+
+// namedRefAt reads an object reference at the given field path, defaulting the
+// namespace to the parent's. The second return value is the reference's
+// apiVersion, empty when the field does not carry one.
+func namedRefAt(obj *unstructured.Unstructured, path ...string) (*DiffOwnerRef, string) {
+	ref, found, err := unstructured.NestedStringMap(obj.Object, path...)
+	if !found || err != nil || ref["kind"] == "" || ref["name"] == "" {
+		return nil, ""
+	}
+
+	namespace := ref["namespace"]
+	if namespace == "" {
+		namespace = obj.GetNamespace()
+	}
+	return &DiffOwnerRef{Kind: ref["kind"], Name: ref["name"], Namespace: namespace}, ref["apiVersion"]
+}
+
+// sourceURL extracts the address a Flux source object points at.
+func sourceURL(obj *unstructured.Unstructured) string {
+	switch obj.GetKind() {
+	case fluxcdv1.FluxBucketKind:
+		url, _, _ := unstructured.NestedString(obj.Object, "spec", "endpoint")
+		return url
+	case fluxcdv1.FluxExternalArtifactKind:
+		url, _, _ := unstructured.NestedString(obj.Object, "status", "artifact", "url")
+		return url
+	default:
+		url, _, _ := unstructured.NestedString(obj.Object, "spec", "url")
+		return url
+	}
+}
+
+// newTraceLink builds a relationship entry from a live object: Flux objects
+// report their Ready condition reason, other kinds the kstatus computed status.
+func newTraceLink(obj *unstructured.Unstructured) TraceLink {
+	link := TraceLink{Object: objectID(obj)}
+
+	if !fluxcdv1.IsFluxAPI(obj.GetAPIVersion()) {
+		res, err := status.Compute(obj)
+		if err != nil {
+			link.Status = string(status.UnknownStatus)
+			link.Message = err.Error()
+			return link
+		}
+		link.Status = string(res.Status)
+		if res.Status != status.CurrentStatus {
+			link.Message = res.Message
+		}
+		return link
+	}
+
+	link.Status = string(status.UnknownStatus)
+	if conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions"); found && err == nil {
+		for _, c := range conditions {
+			cond, ok := c.(map[string]any)
+			if !ok || cond["type"] != meta.ReadyCondition {
+				continue
+			}
+			if reason, _ := cond["reason"].(string); reason != "" {
+				link.Status = reason
+			}
+			if condStatus, _ := cond["status"].(string); condStatus != "True" {
+				link.Message, _ = cond["message"].(string)
+			}
+			break
+		}
+	}
+
+	if suspend, found, err := unstructured.NestedBool(obj.Object, "spec", "suspend"); found && err == nil && suspend {
+		link.Suspended = true
+	}
+	if ssautil.AnyInMetadata(obj, map[string]string{fluxcdv1.ReconcileAnnotation: fluxcdv1.DisabledValue}) {
+		link.Suspended = true
+	}
+
+	link.LastAppliedRevision, _, _ = unstructured.NestedString(obj.Object, "status", "lastAppliedRevision")
+	link.Revision, _, _ = unstructured.NestedString(obj.Object, "status", "artifact", "revision")
+	return link
+}
+
+// objectID renders an object as Kind/namespace/name,
+// or Kind/name for cluster-scoped objects.
+func objectID(obj *unstructured.Unstructured) string {
+	if obj.GetNamespace() != "" {
+		return fmt.Sprintf("%s/%s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+	}
+	return fmt.Sprintf("%s/%s", obj.GetKind(), obj.GetName())
+}

--- a/cmd/mcp/k8s/trace_test.go
+++ b/cmd/mcp/k8s/trace_test.go
@@ -1,0 +1,452 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestTrace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	appsNS := createTraceNamespace(t)
+	fluxNS := createTraceNamespace(t)
+
+	createTraceObject(t, map[string]any{
+		"apiVersion": "source.toolkit.fluxcd.io/v1",
+		"kind":       "OCIRepository",
+		"metadata":   map[string]any{"name": "apps-repo", "namespace": fluxNS},
+		"spec":       map[string]any{"interval": "1m", "url": "oci://ghcr.io/org/apps"},
+	}, map[string]any{
+		"conditions": traceReadyCondition("True", "Succeeded", "stored artifact"),
+		"artifact":   map[string]any{"revision": "latest@sha256:abc123"},
+	})
+
+	createTraceObject(t, map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata": map[string]any{
+			"name":      "apps",
+			"namespace": fluxNS,
+			// The self-referencing labels exercise the cycle guard.
+			"labels": map[string]any{
+				"kustomize.toolkit.fluxcd.io/name":      "apps",
+				"kustomize.toolkit.fluxcd.io/namespace": fluxNS,
+			},
+		},
+		"spec": map[string]any{
+			"interval": "1m",
+			"path":     "./",
+			"prune":    true,
+			"sourceRef": map[string]any{
+				"kind": "OCIRepository",
+				"name": "apps-repo",
+			},
+		},
+	}, map[string]any{
+		"conditions":          traceReadyCondition("True", "ReconciliationSucceeded", "Applied revision latest@sha256:abc123"),
+		"lastAppliedRevision": "latest@sha256:abc123",
+	})
+
+	createTraceObject(t, map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata": map[string]any{
+			"name":      "backend",
+			"namespace": appsNS,
+			"labels": map[string]any{
+				"kustomize.toolkit.fluxcd.io/name":      "apps",
+				"kustomize.toolkit.fluxcd.io/namespace": fluxNS,
+			},
+		},
+		"spec": map[string]any{"interval": "1m"},
+	}, map[string]any{
+		"conditions":          traceReadyCondition("False", "UpgradeFailed", "Helm upgrade failed for release backend"),
+		"lastAppliedRevision": "6.9.0",
+	})
+
+	deploy := createTraceObject(t, map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "backend",
+			"namespace": appsNS,
+			"labels": map[string]any{
+				"helm.toolkit.fluxcd.io/name":      "backend",
+				"helm.toolkit.fluxcd.io/namespace": appsNS,
+			},
+		},
+		"spec": map[string]any{
+			"selector": map[string]any{"matchLabels": map[string]any{"app": "backend"}},
+			"template": map[string]any{
+				"metadata": map[string]any{"labels": map[string]any{"app": "backend"}},
+				"spec": map[string]any{"containers": []any{
+					map[string]any{"name": "app", "image": "app"},
+				}},
+			},
+		},
+	}, nil)
+
+	controller := true
+	rs := createTraceObject(t, map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "ReplicaSet",
+		"metadata": map[string]any{
+			"name":      "backend-7f9d4c",
+			"namespace": appsNS,
+			"ownerReferences": []any{map[string]any{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"name":       deploy.GetName(),
+				"uid":        string(deploy.GetUID()),
+				"controller": true,
+			}},
+		},
+		"spec": map[string]any{
+			"selector": map[string]any{"matchLabels": map[string]any{"app": "backend"}},
+			"template": map[string]any{
+				"metadata": map[string]any{"labels": map[string]any{"app": "backend"}},
+				"spec": map[string]any{"containers": []any{
+					map[string]any{"name": "app", "image": "app"},
+				}},
+			},
+		},
+	}, nil)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend-7f9d4c-abcde",
+			Namespace: appsNS,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "ReplicaSet",
+				Name:       rs.GetName(),
+				UID:        rs.GetUID(),
+				Controller: &controller,
+			}},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: "app"}},
+		},
+	}
+	g.Expect(testClient.Client.Create(ctx, pod)).To(Succeed())
+
+	t.Run("traces pod through owners and labels to the source", func(t *testing.T) {
+		g := NewWithT(t)
+		result, err := testClient.Trace(ctx, TraceOptions{
+			APIVersion: "v1", Kind: "Pod", Name: pod.Name, Namespace: appsNS,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Object).To(Equal("Pod/" + appsNS + "/" + pod.Name))
+		g.Expect(result.Unmanaged).To(BeFalse())
+		g.Expect(result.ManagedBy).NotTo(BeNil())
+
+		deployment := result.ManagedBy
+		g.Expect(deployment.Object).To(Equal("Deployment/" + appsNS + "/backend"))
+		g.Expect(deployment.Status).To(Equal("InProgress"))
+
+		helmRelease := deployment.ManagedBy
+		g.Expect(helmRelease).NotTo(BeNil())
+		g.Expect(helmRelease.Object).To(Equal("HelmRelease/" + appsNS + "/backend"))
+		g.Expect(helmRelease.Status).To(Equal("UpgradeFailed"))
+		g.Expect(helmRelease.Message).To(ContainSubstring("Helm upgrade failed"))
+		g.Expect(helmRelease.LastAppliedRevision).To(Equal("6.9.0"))
+
+		kustomization := helmRelease.ManagedBy
+		g.Expect(kustomization).NotTo(BeNil())
+		g.Expect(kustomization.Object).To(Equal("Kustomization/" + fluxNS + "/apps"))
+		g.Expect(kustomization.Status).To(Equal("ReconciliationSucceeded"))
+		g.Expect(kustomization.Message).To(BeEmpty())
+		g.Expect(kustomization.LastAppliedRevision).To(Equal("latest@sha256:abc123"))
+		// The self-referencing ownership labels must not add another manager.
+		g.Expect(kustomization.ManagedBy).To(BeNil())
+
+		g.Expect(result.Source).NotTo(BeNil())
+		g.Expect(result.Source.ResolvedFor).To(Equal("Kustomization/" + fluxNS + "/apps"))
+		g.Expect(result.Source.Object).To(Equal("OCIRepository/" + fluxNS + "/apps-repo"))
+		g.Expect(result.Source.Status).To(Equal("Succeeded"))
+		g.Expect(result.Source.URL).To(Equal("oci://ghcr.io/org/apps"))
+		g.Expect(result.Source.Revision).To(Equal("latest@sha256:abc123"))
+		g.Expect(result.Source.ProducedBy).To(BeNil())
+		g.Expect(result.Source.BuiltFrom).To(BeEmpty())
+	})
+
+	t.Run("traces flux object to its manager and source", func(t *testing.T) {
+		g := NewWithT(t)
+		result, err := testClient.Trace(ctx, TraceOptions{
+			APIVersion: "helm.toolkit.fluxcd.io/v2", Kind: "HelmRelease", Name: "backend", Namespace: appsNS,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Object).To(Equal("HelmRelease/" + appsNS + "/backend"))
+		g.Expect(result.Unmanaged).To(BeFalse())
+		g.Expect(result.ManagedBy).NotTo(BeNil())
+		g.Expect(result.ManagedBy.Object).To(Equal("Kustomization/" + fluxNS + "/apps"))
+		g.Expect(result.ManagedBy.ManagedBy).To(BeNil())
+		g.Expect(result.Source).NotTo(BeNil())
+		g.Expect(result.Source.ResolvedFor).To(Equal("Kustomization/" + fluxNS + "/apps"))
+		g.Expect(result.Source.Object).To(Equal("OCIRepository/" + fluxNS + "/apps-repo"))
+	})
+
+	t.Run("resolves the source of an unmanaged helmrelease through the chart", func(t *testing.T) {
+		g := NewWithT(t)
+		createTraceObject(t, map[string]any{
+			"apiVersion": "source.toolkit.fluxcd.io/v1",
+			"kind":       "HelmRepository",
+			"metadata":   map[string]any{"name": "charts", "namespace": fluxNS},
+			"spec":       map[string]any{"interval": "1m", "url": "https://charts.example.com"},
+		}, map[string]any{
+			"conditions": traceReadyCondition("True", "Succeeded", "stored artifact"),
+			"artifact":   map[string]any{"revision": "sha256:d4e5f6"},
+		})
+		createTraceObject(t, map[string]any{
+			"apiVersion": "source.toolkit.fluxcd.io/v1",
+			"kind":       "HelmChart",
+			"metadata":   map[string]any{"name": "frontend-chart", "namespace": fluxNS},
+			"spec": map[string]any{
+				"chart": "frontend",
+				"sourceRef": map[string]any{
+					"kind": "HelmRepository",
+					"name": "charts",
+				},
+			},
+		}, nil)
+		createTraceObject(t, map[string]any{
+			"apiVersion": "helm.toolkit.fluxcd.io/v2",
+			"kind":       "HelmRelease",
+			"metadata":   map[string]any{"name": "frontend", "namespace": appsNS},
+			"spec": map[string]any{
+				"interval": "1m",
+				"chartRef": map[string]any{
+					"kind":      "HelmChart",
+					"name":      "frontend-chart",
+					"namespace": fluxNS,
+				},
+			},
+		}, nil)
+
+		result, err := testClient.Trace(ctx, TraceOptions{
+			APIVersion: "helm.toolkit.fluxcd.io/v2", Kind: "HelmRelease", Name: "frontend", Namespace: appsNS,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Unmanaged).To(BeTrue())
+		g.Expect(result.ManagedBy).To(BeNil())
+		g.Expect(result.Source).NotTo(BeNil())
+		g.Expect(result.Source.ResolvedFor).To(Equal("HelmRelease/" + appsNS + "/frontend"))
+		g.Expect(result.Source.Object).To(Equal("HelmRepository/" + fluxNS + "/charts"))
+		g.Expect(result.Source.URL).To(Equal("https://charts.example.com"))
+		g.Expect(result.Source.Revision).To(Equal("sha256:d4e5f6"))
+
+		// Tracing the HelmChart itself resolves its repository source.
+		result, err = testClient.Trace(ctx, TraceOptions{
+			APIVersion: "source.toolkit.fluxcd.io/v1", Kind: "HelmChart", Name: "frontend-chart", Namespace: fluxNS,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Unmanaged).To(BeTrue())
+		g.Expect(result.ManagedBy).To(BeNil())
+		g.Expect(result.Source).NotTo(BeNil())
+		g.Expect(result.Source.ResolvedFor).To(Equal("HelmChart/" + fluxNS + "/frontend-chart"))
+		g.Expect(result.Source.Object).To(Equal("HelmRepository/" + fluxNS + "/charts"))
+	})
+
+	t.Run("follows external artifact to its generator", func(t *testing.T) {
+		g := NewWithT(t)
+		createTraceObject(t, map[string]any{
+			"apiVersion": "source.toolkit.fluxcd.io/v1",
+			"kind":       "HelmRepository",
+			"metadata":   map[string]any{"name": "gen-charts", "namespace": fluxNS},
+			"spec":       map[string]any{"interval": "1m", "url": "https://gen-charts.example.com"},
+		}, map[string]any{
+			"conditions": traceReadyCondition("True", "Succeeded", "stored artifact"),
+		})
+		createTraceObject(t, map[string]any{
+			"apiVersion": "source.toolkit.fluxcd.io/v1",
+			"kind":       "HelmChart",
+			"metadata":   map[string]any{"name": "gen-chart", "namespace": fluxNS},
+			"spec": map[string]any{
+				"chart": "gen",
+				"sourceRef": map[string]any{
+					"kind": "HelmRepository",
+					"name": "gen-charts",
+				},
+			},
+		}, nil)
+		createTraceObject(t, map[string]any{
+			"apiVersion": "source.extensions.fluxcd.io/v1",
+			"kind":       "ArtifactGenerator",
+			"metadata":   map[string]any{"name": "gen", "namespace": fluxNS},
+			"spec": map[string]any{
+				"sources": []any{
+					map[string]any{
+						"alias": "repo",
+						"kind":  "OCIRepository",
+						"name":  "apps-repo",
+					},
+					map[string]any{
+						"alias": "chart",
+						"kind":  "HelmChart",
+						"name":  "gen-chart",
+					},
+				},
+			},
+		}, map[string]any{
+			"conditions": traceReadyCondition("True", "ReconciliationSucceeded", "stored artifact"),
+		})
+		createTraceObject(t, map[string]any{
+			"apiVersion": "source.toolkit.fluxcd.io/v1",
+			"kind":       "ExternalArtifact",
+			"metadata":   map[string]any{"name": "gen-artifact", "namespace": fluxNS},
+			"spec": map[string]any{
+				"sourceRef": map[string]any{
+					"apiVersion": "source.extensions.fluxcd.io/v1",
+					"kind":       "ArtifactGenerator",
+					"name":       "gen",
+					"namespace":  fluxNS,
+				},
+			},
+		}, map[string]any{
+			"conditions": traceReadyCondition("True", "Succeeded", "stored artifact"),
+			"artifact": map[string]any{
+				"revision": "sha256:1a2b3c",
+				"url":      "http://source-watcher.flux-system/ea.tar.gz",
+			},
+		})
+		createTraceObject(t, map[string]any{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata":   map[string]any{"name": "gen-apps", "namespace": fluxNS},
+			"spec": map[string]any{
+				"interval": "1m",
+				"path":     "./",
+				"prune":    true,
+				"sourceRef": map[string]any{
+					"kind": "ExternalArtifact",
+					"name": "gen-artifact",
+				},
+			},
+		}, nil)
+
+		result, err := testClient.Trace(ctx, TraceOptions{
+			APIVersion: "kustomize.toolkit.fluxcd.io/v1", Kind: "Kustomization", Name: "gen-apps", Namespace: fluxNS,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Unmanaged).To(BeTrue())
+		g.Expect(result.ManagedBy).To(BeNil())
+		g.Expect(result.Source).NotTo(BeNil())
+		g.Expect(result.Source.ResolvedFor).To(Equal("Kustomization/" + fluxNS + "/gen-apps"))
+		g.Expect(result.Source.Object).To(Equal("ExternalArtifact/" + fluxNS + "/gen-artifact"))
+		g.Expect(result.Source.URL).To(Equal("http://source-watcher.flux-system/ea.tar.gz"))
+		g.Expect(result.Source.Revision).To(Equal("sha256:1a2b3c"))
+		g.Expect(result.Source.BuiltFrom).To(BeEmpty())
+		g.Expect(result.Source.ProducedBy).NotTo(BeNil())
+		g.Expect(result.Source.ProducedBy.Object).To(Equal("ArtifactGenerator/" + fluxNS + "/gen"))
+		g.Expect(result.Source.ProducedBy.Status).To(Equal("ReconciliationSucceeded"))
+		g.Expect(result.Source.ProducedBy.BuiltFrom).To(HaveLen(2))
+		g.Expect(result.Source.ProducedBy.BuiltFrom[0].Object).To(Equal("OCIRepository/" + fluxNS + "/apps-repo"))
+		g.Expect(result.Source.ProducedBy.BuiltFrom[0].URL).To(Equal("oci://ghcr.io/org/apps"))
+		g.Expect(result.Source.ProducedBy.BuiltFrom[0].Revision).To(Equal("latest@sha256:abc123"))
+		// A HelmChart upstream is resolved to its HelmRepository.
+		g.Expect(result.Source.ProducedBy.BuiltFrom[1].Object).To(Equal("HelmRepository/" + fluxNS + "/gen-charts"))
+		g.Expect(result.Source.ProducedBy.BuiltFrom[1].URL).To(Equal("https://gen-charts.example.com"))
+
+		// Tracing the ExternalArtifact itself resolves the generator and its upstreams.
+		result, err = testClient.Trace(ctx, TraceOptions{
+			APIVersion: "source.toolkit.fluxcd.io/v1", Kind: "ExternalArtifact", Name: "gen-artifact", Namespace: fluxNS,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Unmanaged).To(BeTrue())
+		g.Expect(result.ManagedBy).To(BeNil())
+		g.Expect(result.Source).NotTo(BeNil())
+		g.Expect(result.Source.ResolvedFor).To(Equal("ExternalArtifact/" + fluxNS + "/gen-artifact"))
+		g.Expect(result.Source.Object).To(Equal("ArtifactGenerator/" + fluxNS + "/gen"))
+		g.Expect(result.Source.ProducedBy).To(BeNil())
+		g.Expect(result.Source.BuiltFrom).To(HaveLen(2))
+		g.Expect(result.Source.BuiltFrom[0].Object).To(Equal("OCIRepository/" + fluxNS + "/apps-repo"))
+		g.Expect(result.Source.BuiltFrom[1].Object).To(Equal("HelmRepository/" + fluxNS + "/gen-charts"))
+	})
+
+	t.Run("reports unmanaged objects", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "unmanaged", Namespace: appsNS},
+		}
+		g.Expect(testClient.Client.Create(ctx, cm)).To(Succeed())
+
+		result, err := testClient.Trace(ctx, TraceOptions{
+			APIVersion: "v1", Kind: "ConfigMap", Name: cm.Name, Namespace: appsNS,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Object).To(Equal("ConfigMap/" + appsNS + "/unmanaged"))
+		g.Expect(result.Unmanaged).To(BeTrue())
+		g.Expect(result.ManagedBy).To(BeNil())
+		g.Expect(result.Source).To(BeNil())
+	})
+
+	t.Run("errors on not found objects", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := testClient.Trace(ctx, TraceOptions{
+			APIVersion: "v1", Kind: "ConfigMap", Name: "not-found", Namespace: appsNS,
+		})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unable to get ConfigMap"))
+	})
+
+	t.Run("marks suspended links", func(t *testing.T) {
+		g := NewWithT(t)
+		ks := &unstructured.Unstructured{}
+		ks.SetAPIVersion("kustomize.toolkit.fluxcd.io/v1")
+		ks.SetKind("Kustomization")
+		g.Expect(testClient.Client.Get(ctx, testClient.ObjectKeyFromObject(&metav1.PartialObjectMetadata{
+			ObjectMeta: metav1.ObjectMeta{Name: "apps", Namespace: fluxNS},
+		}), ks)).To(Succeed())
+		g.Expect(unstructured.SetNestedField(ks.Object, true, "spec", "suspend")).To(Succeed())
+		g.Expect(testClient.Client.Update(ctx, ks)).To(Succeed())
+
+		result, err := testClient.Trace(ctx, TraceOptions{
+			APIVersion: "helm.toolkit.fluxcd.io/v2", Kind: "HelmRelease", Name: "backend", Namespace: appsNS,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.ManagedBy).NotTo(BeNil())
+		g.Expect(result.ManagedBy.Object).To(Equal("Kustomization/" + fluxNS + "/apps"))
+		g.Expect(result.ManagedBy.Suspended).To(BeTrue())
+	})
+}
+
+// createTraceNamespace creates a namespace with a generated trace- prefixed name.
+func createTraceNamespace(t *testing.T) string {
+	t.Helper()
+	g := NewWithT(t)
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "trace-"}}
+	g.Expect(testClient.Client.Create(context.Background(), namespace)).To(Succeed())
+	return namespace.Name
+}
+
+// createTraceObject creates an unstructured object and optionally sets its status subresource.
+func createTraceObject(t *testing.T, obj map[string]any, statusFields map[string]any) *unstructured.Unstructured {
+	t.Helper()
+	g := NewWithT(t)
+	u := &unstructured.Unstructured{Object: obj}
+	g.Expect(testClient.Client.Create(context.Background(), u)).To(Succeed())
+	if statusFields != nil {
+		u.Object["status"] = statusFields
+		g.Expect(testClient.Client.Status().Update(context.Background(), u)).To(Succeed())
+	}
+	return u
+}
+
+// traceReadyCondition renders a Ready condition slice for status fixtures.
+func traceReadyCondition(status, reason, message string) []any {
+	return []any{map[string]any{
+		"type":               "Ready",
+		"status":             status,
+		"reason":             reason,
+		"message":            message,
+		"lastTransitionTime": "2026-01-01T00:00:00Z",
+	}}
+}

--- a/cmd/mcp/toolbox/instructions.go
+++ b/cmd/mcp/toolbox/instructions.go
@@ -45,6 +45,10 @@ func (m *Manager) Instructions(inCluster bool) string {
 		b.WriteString("- Resources managed by Flux carry labels containing fluxcd that identify " +
 			"the Kustomization, HelmRelease or ResourceSet managing them.\n")
 	}
+	if has(ToolTraceKubernetesResource) {
+		b.WriteString("- To find the GitOps pipeline that delivers an object (pod, workload or Flux resource), call " +
+			ToolTraceKubernetesResource + "; it reports the Flux objects managing the object and their source.\n")
+	}
 	if has(ToolGetKubernetesEvents) {
 		b.WriteString("- When troubleshooting workloads, call " + ToolGetKubernetesEvents +
 			" with the workload kind, name and namespace, and narrow with type Warning, since and grep.\n")

--- a/cmd/mcp/toolbox/manager.go
+++ b/cmd/mcp/toolbox/manager.go
@@ -148,6 +148,15 @@ func (m *Manager) RegisterTools(server *mcp.Server, inCluster bool) []string {
 			m.HandleGetKubernetesResources,
 		)
 	}
+	if m.shouldRegisterTool(ToolTraceKubernetesResource, inCluster) {
+		addTool(server, &recorder,
+			&mcp.Tool{
+				Name:        ToolTraceKubernetesResource,
+				Description: "Traces a Kubernetes resource up the GitOps delivery pipeline to the Flux objects managing it and their source.",
+			},
+			m.HandleTraceKubernetesResource,
+		)
+	}
 	if m.shouldRegisterTool(ToolSearchFluxDocs, inCluster) {
 		addTool(server, &recorder,
 			&mcp.Tool{

--- a/cmd/mcp/toolbox/manager_test.go
+++ b/cmd/mcp/toolbox/manager_test.go
@@ -32,6 +32,7 @@ func TestManager_RegisterToolsDoesNotPanic(t *testing.T) {
 		"get_kubernetes_events",
 		"get_kubernetes_metrics",
 		"get_kubernetes_resources",
+		"trace_kubernetes_resource",
 		"search_flux_docs",
 		"read_flux_doc",
 		"diff_kubernetes_manifest",
@@ -174,6 +175,10 @@ func TestManager_ToolSchemasIncludeProperties(t *testing.T) {
 		ToolGetKubernetesResources: {
 			properties: []string{"apiVersion", "kind", "name", "namespace", "selector", "limit", "fields"},
 			required:   []string{"apiVersion", "kind"},
+		},
+		ToolTraceKubernetesResource: {
+			properties: []string{"apiVersion", "kind", "name", "namespace"},
+			required:   []string{"apiVersion", "kind", "name"},
 		},
 		ToolSearchFluxDocs: {
 			properties: []string{"query", "path", "limit"},

--- a/cmd/mcp/toolbox/scopes.go
+++ b/cmd/mcp/toolbox/scopes.go
@@ -88,6 +88,10 @@ var scopesPerTool = map[string]toolScopes{
 		ownScopeDescription: "Allow getting Kubernetes resources.",
 		extraScopes:         []string{ScopeReadOnly},
 	},
+	ToolTraceKubernetesResource: {
+		ownScopeDescription: "Allow tracing Kubernetes resources to the Flux objects managing them.",
+		extraScopes:         []string{ScopeReadOnly},
+	},
 	ToolDiffKubernetesManifest: {
 		ownScopeDescription: "Allow diffing Kubernetes manifests against the cluster.",
 		extraScopes:         []string{ScopeReadOnly},

--- a/cmd/mcp/toolbox/scopes_test.go
+++ b/cmd/mcp/toolbox/scopes_test.go
@@ -197,6 +197,28 @@ func TestGetToolScopes(t *testing.T) {
 			},
 		},
 		{
+			name:     "read-only tool TraceKubernetesResource",
+			tool:     ToolTraceKubernetesResource,
+			readOnly: false,
+			expected: []Scope{
+				{
+					Name:        "toolbox:" + ToolTraceKubernetesResource,
+					Description: "Allow tracing Kubernetes resources to the Flux objects managing them.",
+					Tools:       []string{ToolTraceKubernetesResource},
+				},
+				{
+					Name:        "toolbox:read_write",
+					Description: "Allow all operations.",
+					Tools:       []string{ToolTraceKubernetesResource},
+				},
+				{
+					Name:        "toolbox:read_only",
+					Description: "Allow all read-only operations.",
+					Tools:       []string{ToolTraceKubernetesResource},
+				},
+			},
+		},
+		{
 			name:     "read-only diff tool",
 			tool:     ToolDiffKubernetesManifest,
 			readOnly: false,

--- a/cmd/mcp/toolbox/trace_resource.go
+++ b/cmd/mcp/toolbox/trace_resource.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	yamlv3 "go.yaml.in/yaml/v3"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
+)
+
+const (
+	// ToolTraceKubernetesResource is the name of the trace_kubernetes_resource tool.
+	ToolTraceKubernetesResource = "trace_kubernetes_resource"
+)
+
+func init() {
+	systemTools[ToolTraceKubernetesResource] = systemTool{
+		readOnly:  true,
+		inCluster: true,
+	}
+}
+
+// traceKubernetesResourceInput defines the input parameters for tracing a Kubernetes resource.
+type traceKubernetesResourceInput struct {
+	APIVersion string `json:"apiVersion" jsonschema:"apiVersion of the resource. Use get_kubernetes_api_versions when unknown."`
+	Kind       string `json:"kind" jsonschema:"Kind of the resource."`
+	Name       string `json:"name" jsonschema:"Name of the resource."`
+	Namespace  string `json:"namespace,omitempty" jsonschema:"Namespace of the resource; omit for cluster-scoped resources."`
+}
+
+// HandleTraceKubernetesResource is the handler function for the trace_kubernetes_resource tool.
+func (m *Manager) HandleTraceKubernetesResource(ctx context.Context, request *mcp.CallToolRequest, input traceKubernetesResourceInput) (*mcp.CallToolResult, any, error) {
+	if err := CheckScopes(ctx, ToolTraceKubernetesResource, m.readOnly); err != nil {
+		return NewToolResultError(err.Error())
+	}
+
+	if input.APIVersion == "" {
+		return NewToolResultError("apiVersion is required")
+	}
+	if input.Kind == "" {
+		return NewToolResultError("kind is required")
+	}
+	if input.Name == "" {
+		return NewToolResultError("name is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
+	kubeClient, err := m.kubeClient.GetClient(ctx)
+	if err != nil {
+		return NewToolResultErrorFromErr("Failed to get Kubernetes client", err)
+	}
+
+	result, err := kubeClient.Trace(ctx, k8s.TraceOptions{
+		APIVersion: input.APIVersion,
+		Kind:       input.Kind,
+		Name:       input.Name,
+		Namespace:  input.Namespace,
+	})
+	if err != nil {
+		return NewToolResultError(err.Error())
+	}
+
+	data, err := marshalTraceResult(result)
+	if err != nil {
+		return NewToolResultErrorFromErr("Failed marshalling data", err)
+	}
+
+	return NewToolResultText(data)
+}
+
+// marshalTraceResult renders the trace result as YAML,
+// preserving the field order the structs declare.
+func marshalTraceResult(result *k8s.TraceResult) (string, error) {
+	var buf bytes.Buffer
+	encoder := yamlv3.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(result); err != nil {
+		return "", err
+	}
+	if err := encoder.Close(); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/cmd/mcp/toolbox/trace_resource_test.go
+++ b/cmd/mcp/toolbox/trace_resource_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Stefan Prodan.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	. "github.com/onsi/gomega"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/controlplaneio-fluxcd/flux-operator/cmd/mcp/k8s"
+)
+
+func TestManager_HandleTraceKubernetesResource(t *testing.T) {
+	configFile := "testdata/kubeconfig.yaml"
+	t.Setenv("KUBECONFIG", configFile)
+
+	m := &Manager{
+		kubeconfig: k8s.NewKubeConfig(),
+		kubeClient: k8s.NewClientFactory(genericclioptions.NewConfigFlags(false)),
+		timeout:    time.Second,
+	}
+
+	request := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name: ToolTraceKubernetesResource,
+		},
+	}
+
+	tests := []struct {
+		testName  string
+		arguments map[string]any
+		matchErr  string
+	}{
+		{
+			testName:  "rejects missing apiVersion before loading client",
+			arguments: map[string]any{"kind": "Pod", "name": "backend"},
+			matchErr:  "apiVersion is required",
+		},
+		{
+			testName:  "rejects missing kind before loading client",
+			arguments: map[string]any{"apiVersion": "v1", "name": "backend"},
+			matchErr:  "kind is required",
+		},
+		{
+			testName:  "rejects missing name before loading client",
+			arguments: map[string]any{"apiVersion": "v1", "kind": "Pod"},
+			matchErr:  "name is required",
+		},
+		{
+			testName:  "accepts valid input before loading client",
+			arguments: map[string]any{"apiVersion": "v1", "kind": "Pod", "name": "backend", "namespace": "apps"},
+			matchErr:  "Failed to get Kubernetes client",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			argsJSON, _ := json.Marshal(test.arguments)
+			request.Params.Arguments = argsJSON
+
+			var input traceKubernetesResourceInput
+			err := json.Unmarshal(request.Params.Arguments, &input)
+			g.Expect(err).ToNot(HaveOccurred())
+			result, content, err := m.HandleTraceKubernetesResource(context.Background(), request, input)
+			g.Expect(err).ToNot(HaveOccurred())
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(result.IsError).To(BeTrue())
+			g.Expect(textContent.Text).To(ContainSubstring(test.matchErr))
+			_ = content
+		})
+	}
+}
+
+func TestTraceKubernetesResourceOutput(t *testing.T) {
+	g := NewWithT(t)
+	result := &k8s.TraceResult{
+		Object: "Pod/apps/backend-7f9d4c-abcde",
+		ManagedBy: &k8s.TraceManager{
+			TraceLink: k8s.TraceLink{Object: "Deployment/apps/backend", Status: "Current"},
+			ManagedBy: &k8s.TraceManager{
+				TraceLink: k8s.TraceLink{
+					Object: "HelmRelease/apps/backend", Status: "UpgradeFailed",
+					Message: "Helm upgrade failed", LastAppliedRevision: "6.9.0",
+				},
+			},
+		},
+		Source: &k8s.TraceSource{
+			ResolvedFor: "HelmRelease/apps/backend",
+			TraceLink: k8s.TraceLink{
+				Object: "OCIRepository/flux-system/apps-repo", Status: "Succeeded",
+				URL: "oci://ghcr.io/org/apps", Revision: "latest@sha256:abc123",
+			},
+		},
+	}
+
+	data, err := marshalTraceResult(result)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(data).To(Equal(`object: Pod/apps/backend-7f9d4c-abcde
+managedBy:
+  object: Deployment/apps/backend
+  status: Current
+  managedBy:
+    object: HelmRelease/apps/backend
+    status: UpgradeFailed
+    message: Helm upgrade failed
+    lastAppliedRevision: 6.9.0
+source:
+  resolvedFor: HelmRelease/apps/backend
+  object: OCIRepository/flux-system/apps-repo
+  status: Succeeded
+  url: oci://ghcr.io/org/apps
+  revision: latest@sha256:abc123
+`))
+}

--- a/docs/mcp/instructions.md
+++ b/docs/mcp/instructions.md
@@ -43,6 +43,8 @@ then call `read_flux_doc` with the returned `Path` and heading anchor to read th
 - When asked about Kubernetes or Flux resources, call the `get_kubernetes_resources` tool.
 - When troubleshooting workloads, call `get_kubernetes_events` with the workload `kind`, `name`
   and `namespace`, and narrow with `type: Warning`, `since` and `grep`.
+- To find the GitOps pipeline that delivers an object (pod, workload or Flux resource), call
+  the `trace_kubernetes_resource` tool; it reports the Flux objects managing the object and their source.
 - When listing many resources or when only specific fields are relevant, set the `fields` parameter of the `get_kubernetes_resources` tool to kubectl JSONPath expressions (e.g. `spec.chart.spec.version`, `status.conditions[?(@.type=="Ready")].message`) to reduce the result size. Include `status.events` and `status.inventory` in `fields` when the events or the inventory are needed.
 - Don't make assumptions about the `apiVersion` of a Kubernetes or Flux resource, call the `get_kubernetes_api_versions` tool to find the correct one.
 - When asked to use a specific cluster, call the `get_kubeconfig_contexts` tool to find the cluster context before switching to it with the `set_kubeconfig_context` tool.
@@ -150,7 +152,7 @@ When troubleshooting a HelmRelease, follow these steps:
 
 - Use the `get_flux_instance` tool to check the helm-controller deployment status and the apiVersion of the HelmRelease kind.
 - Use the `get_kubernetes_resources` tool to get the HelmRelease, then analyze the spec, the status, inventory and events.
-- Determine which Flux object is managing the HelmRelease by looking at the annotations; it can be a Kustomization or a ResourceSet.
+- Determine which Flux object is managing the HelmRelease with the `trace_kubernetes_resource` tool; it can be a Kustomization or a ResourceSet.
 - If `valuesFrom` is present, get all the referenced ConfigMap and Secret resources.
 - Identify the HelmRelease source by looking at the `chartRef` or the `sourceRef` field.
 - Use the `get_kubernetes_resources` tool to get the HelmRelease source then analyze the source status and events.
@@ -167,7 +169,7 @@ When troubleshooting a Kustomization, follow these steps:
 
 - Use the `get_flux_instance` tool to check the kustomize-controller deployment status and the apiVersion of the Kustomization kind.
 - Use the `get_kubernetes_resources` tool to get the Kustomization, then analyze the spec, the status, inventory and events.
-- Determine which Flux object is managing the Kustomization by looking at the annotations; it can be another Kustomization or a ResourceSet.
+- Determine which Flux object is managing the Kustomization with the `trace_kubernetes_resource` tool; it can be another Kustomization or a ResourceSet.
 - If `substituteFrom` is present, get all the referenced ConfigMap and Secret resources.
 - Identify the Kustomization source by looking at the `sourceRef` field.
 - Use the `get_kubernetes_resources` tool to get the Kustomization source then analyze the source status and events.

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -64,6 +64,77 @@ status.conditions[?(@.type=="Ready")].message: Helm upgrade succeeded for releas
 Use `fields` to reduce the size of the result when
 listing many resources or when only a few fields are relevant.
 
+### trace_kubernetes_resource
+
+Traces a Kubernetes resource up the GitOps delivery pipeline to the Flux objects managing it
+and their source. Starting from any object (a Pod, a workload, or a Flux resource), the tool
+walks the owner references and the Flux ownership labels through the managing Kustomization,
+HelmRelease, ResourceSet or FluxInstance chain.
+
+**Parameters:**
+
+- `apiVersion` (required): The API version of the resource
+- `kind` (required): The kind of the resource
+- `name` (required): The name of the resource
+- `namespace` (optional): The namespace of the resource, omitted for cluster-scoped resources
+
+**Output:**
+
+Returns YAML with the traced object, the recursive `managedBy` chain of the Flux objects
+managing it, and the `source` feeding the delivery pipeline. Each object reports:
+
+- `object`: the identity rendered as `Kind/namespace/name`
+- `status`: the Ready condition reason for Flux objects, or the computed status for other kinds
+- `message`: the status description, set only when the object is not ready
+- `suspended`: set when the reconciliation of a Flux object is paused
+- `lastAppliedRevision`: the revision applied by a Flux applier
+- `url` and `revision`: the address and artifact revision of a Flux source
+
+For example, tracing an app pod delivered from a generated artifact returns:
+
+```yaml
+object: Pod/apps-staging/backend-fd698b8c7-ghzxl
+managedBy:
+  object: Deployment/apps-staging/backend
+  status: Current
+  managedBy:
+    object: Kustomization/apps-staging/backend
+    status: ReconciliationSucceeded
+    lastAppliedRevision: latest@sha256:4d91c1ed
+    managedBy:
+      object: ResourceSet/apps-staging/backend
+      status: ReconciliationSucceeded
+      lastAppliedRevision: sha256:349e3479
+      managedBy:
+        object: Kustomization/flux-system/apps-staging-reconcilers
+        status: ReconciliationSucceeded
+        lastAppliedRevision: dev@sha256:61df7bcc
+        managedBy:
+          object: Kustomization/flux-system/flux-system
+          status: ReconciliationSucceeded
+          lastAppliedRevision: dev@sha256:61df7bcc
+          managedBy:
+            object: FluxInstance/flux-system/flux
+            status: ReconciliationSucceeded
+            lastAppliedRevision: v2.9.4@sha256:9b886517
+source:
+  resolvedFor: Kustomization/apps-staging/backend
+  object: ExternalArtifact/flux-system/backend-staging
+  status: Succeeded
+  url: http://source-watcher.flux-system/backend-staging.tar.gz
+  revision: latest@sha256:4d91c1ed
+  producedBy:
+    object: ArtifactGenerator/flux-system/apps
+    status: Succeeded
+    builtFrom:
+      - object: OCIRepository/flux-system/flux-system
+        status: Succeeded
+        url: oci://flux-registry:5000/flux-cluster
+        revision: dev@sha256:61df7bcc
+```
+
+When no Flux ownership labels are found, the result reports `unmanaged: true`.
+
 ### get_kubernetes_logs
 
 Retrieves timestamped logs for workloads, allowing AI Agents to analyze

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/wI2L/jsondiff v0.7.1
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	go.uber.org/mock v0.6.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b
 	golang.org/x/mod v0.40.0
 	golang.org/x/oauth2 v0.36.0
@@ -223,7 +224,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect


### PR DESCRIPTION
The tool walks from any Kubernetes object up the GitOps delivery pipeline. The result is rendered as YAML preserving field order, reporting each object's readiness, suspension and applied revision, and the source URL and artifact revision.

For debugging purposes, this tool makes the agent aware of any reconciliation failures in a single-shot. In the case of a stuck source when an ExternalArtifact is used, it saves 10 tools calls and 50k+ context bloat.

Example output:

```yaml
object: Pod/apps-staging/backend-fd698b8c7-ghzxl
managedBy:
  object: Deployment/apps-staging/backend
  status: Current
  managedBy:
    object: Kustomization/apps-staging/backend
    status: ReconciliationSucceeded
    lastAppliedRevision: latest@sha256:4d91c1ed
    managedBy:
      object: ResourceSet/apps-staging/backend
      status: ReconciliationSucceeded
      lastAppliedRevision: sha256:349e3479
      managedBy:
        object: Kustomization/flux-system/apps-staging-reconcilers
        status: ReconciliationSucceeded
        lastAppliedRevision: dev@sha256:61df7bcc
        managedBy:
          object: Kustomization/flux-system/flux-system
          status: ReconciliationSucceeded
          lastAppliedRevision: dev@sha256:61df7bcc
          managedBy:
            object: FluxInstance/flux-system/flux
            status: ReconciliationSucceeded
            lastAppliedRevision: v2.9.4@sha256:9b886517
source:
  resolvedFor: Kustomization/apps-staging/backend
  object: ExternalArtifact/flux-system/backend-staging
  status: Succeeded
  url: http://source-watcher.flux-system/backend-staging.tar.gz
  revision: latest@sha256:4d91c1ed
  producedBy:
    object: ArtifactGenerator/flux-system/apps
    status: Succeeded
    builtFrom:
      - object: OCIRepository/flux-system/flux-system
        status: Succeeded
        url: oci://flux-registry:5000/flux-cluster
        revision: dev@sha256:61df7bcc
```