### PR TITLE
web: prevent panic on unsupported resource actions

### DIFF
--- a/internal/web/resource_action.go
+++ b/internal/web/resource_action.go
@@ -39,7 +39,21 @@ type ActionResponse struct {
 	Message string `json:"message"`
 }
 
+// isSupportedResourceAction reports whether action is handled by
+// POST /api/v1/resource/action.
+func isSupportedResourceAction(action string) bool {
+	switch action {
+	case fluxcdv1.UserActionReconcile,
+		fluxcdv1.UserActionSuspend,
+		fluxcdv1.UserActionResume:
+		return true
+	default:
+		return false
+	}
+}
+
 // ActionHandler handles POST /api/v1/resource/action requests to perform actions on Flux resources.
+// It accepts the reconcile, suspend, and resume actions.
 func (h *Handler) ActionHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -65,8 +79,8 @@ func (h *Handler) ActionHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Validate action type
-	if !fluxcdv1.IsUserAction(actionReq.Action) {
+	// Validate that the action is supported by this endpoint.
+	if !isSupportedResourceAction(actionReq.Action) {
 		http.Error(w, "Invalid action. Must be one of: reconcile, suspend, resume", http.StatusBadRequest)
 		return
 	}
@@ -132,6 +146,10 @@ func (h *Handler) ActionHandler(w http.ResponseWriter, req *http.Request) {
 	case fluxcdv1.UserActionResume:
 		obj, actionErr = h.setSuspension(ctx, *gvk, actionReq.Name, actionReq.Namespace, now, false)
 		message = fmt.Sprintf("Resumed %s/%s", actionReq.Namespace, actionReq.Name)
+
+	default:
+		http.Error(w, fmt.Sprintf("Unknown action: %s", actionReq.Action), http.StatusBadRequest)
+		return
 	}
 
 	if actionErr != nil {

--- a/internal/web/resource_action_test.go
+++ b/internal/web/resource_action_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fluxcdv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
@@ -119,30 +120,49 @@ func TestActionHandler_MissingFields(t *testing.T) {
 }
 
 func TestActionHandler_InvalidAction(t *testing.T) {
-	g := NewWithT(t)
-
+	conf := oauthConfig()
+	conf.UserActions.Audit = []string{"*"}
+	recorder := record.NewFakeRecorder(1)
 	handler := &Handler{
-		conf:          oauthConfig(),
-		kubeClient:    kubeClient,
+		conf:          conf,
+		kubeClient:    nil,
+		eventRecorder: recorder,
 		version:       "v1.0.0",
 		statusManager: "test-status-manager",
 		namespace:     "flux-system",
 	}
 
-	actionReq := ActionRequest{
-		Kind:      "ResourceSet",
-		Namespace: "default",
-		Name:      "test",
-		Action:    "invalid-action",
+	for _, action := range []string{
+		"invalid-action",
+		fluxcdv1.UserActionDownload,
+		fluxcdv1.UserActionRestart,
+		fluxcdv1.UserActionDelete,
+	} {
+		t.Run(action, func(t *testing.T) {
+			g := NewWithT(t)
+			actionReq := ActionRequest{
+				Kind:      "ResourceSet",
+				Namespace: "default",
+				Name:      "test",
+				Action:    action,
+			}
+			body, _ := json.Marshal(actionReq)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/resource/action", bytes.NewBuffer(body))
+			rec := httptest.NewRecorder()
+
+			g.Expect(func() {
+				handler.ActionHandler(rec, req)
+			}).NotTo(Panic())
+			g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
+			g.Expect(rec.Body.String()).To(ContainSubstring("Invalid action"))
+
+			select {
+			case event := <-recorder.Events:
+				t.Fatalf("unexpected audit event for unsupported action: %s", event)
+			default:
+			}
+		})
 	}
-	body, _ := json.Marshal(actionReq)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/resource/action", bytes.NewBuffer(body))
-	rec := httptest.NewRecorder()
-
-	handler.ActionHandler(rec, req)
-
-	g.Expect(rec.Code).To(Equal(http.StatusBadRequest))
-	g.Expect(rec.Body.String()).To(ContainSubstring("Invalid action"))
 }
 
 func TestActionHandler_UnknownKind(t *testing.T) {


### PR DESCRIPTION
A request with a user action that is globally valid but unsupported by the `POST /api/v1/resource/action` endpoint may cause `ActionHandler` to invoke `h.sendAuditEvent` with a nil `obj` argument, leading to nil pointer dereference and panic If audit is enabled. This PR makes `ActionHandler` return status 400 Bad Request for actions that are not among the supported reconcile, suspend, or resume. 