### PR TITLE
web: make cache keys unambiguous

### DIFF
--- a/internal/web/user/user.go
+++ b/internal/web/user/user.go
@@ -5,6 +5,8 @@ package user
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"slices"
@@ -83,11 +85,11 @@ func (u *session) KubeClient() any {
 // Key generates a unique key for the user based on username and groups.
 func Key(imp Impersonation) string {
 	var key strings.Builder
-	fmt.Fprintf(&key, "username=%s", imp.Username)
+	fmt.Fprintf(&key, "username=%s", base64.StdEncoding.EncodeToString([]byte(imp.Username)))
 	for _, group := range imp.Groups {
-		fmt.Fprintf(&key, "\ngroup=%s", group)
+		fmt.Fprintf(&key, "\ngroup=%s", base64.StdEncoding.EncodeToString([]byte(group)))
 	}
-	return key.String()
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(key.String())))
 }
 
 // sessionContextKey is the context key for storing session values.

--- a/internal/web/user/user_test.go
+++ b/internal/web/user/user_test.go
@@ -186,7 +186,7 @@ func TestSessionKey(t *testing.T) {
 		g.Expect(s.Key()).To(Equal("privileged-user"))
 	})
 
-	t.Run("returns formatted key with username only", func(t *testing.T) {
+	t.Run("returns derived key with username only", func(t *testing.T) {
 		g := NewWithT(t)
 
 		s := &session{
@@ -197,10 +197,10 @@ func TestSessionKey(t *testing.T) {
 				},
 			},
 		}
-		g.Expect(s.Key()).To(Equal("username=test-user"))
+		g.Expect(s.Key()).To(Equal(Key(s.Impersonation)))
 	})
 
-	t.Run("returns formatted key with username and groups", func(t *testing.T) {
+	t.Run("returns derived key with username and groups", func(t *testing.T) {
 		g := NewWithT(t)
 
 		s := &session{
@@ -211,8 +211,7 @@ func TestSessionKey(t *testing.T) {
 				},
 			},
 		}
-		expected := "username=test-user\ngroup=group1\ngroup=group2"
-		g.Expect(s.Key()).To(Equal(expected))
+		g.Expect(s.Key()).To(Equal(Key(s.Impersonation)))
 	})
 }
 
@@ -236,10 +235,10 @@ func TestSessionKubeClient(t *testing.T) {
 }
 
 func TestKey(t *testing.T) {
+	seen := make(map[string]string)
 	for _, tt := range []struct {
-		name     string
-		imp      Impersonation
-		expected string
+		name string
+		imp  Impersonation
 	}{
 		{
 			name: "username only",
@@ -247,7 +246,6 @@ func TestKey(t *testing.T) {
 				Username: "user@example.com",
 				Groups:   []string{},
 			},
-			expected: "username=user@example.com",
 		},
 		{
 			name: "username with single group",
@@ -255,7 +253,6 @@ func TestKey(t *testing.T) {
 				Username: "user@example.com",
 				Groups:   []string{"admins"},
 			},
-			expected: "username=user@example.com\ngroup=admins",
 		},
 		{
 			name: "username with multiple groups",
@@ -263,7 +260,6 @@ func TestKey(t *testing.T) {
 				Username: "user@example.com",
 				Groups:   []string{"admins", "developers", "viewers"},
 			},
-			expected: "username=user@example.com\ngroup=admins\ngroup=developers\ngroup=viewers",
 		},
 		{
 			name: "empty username",
@@ -271,14 +267,30 @@ func TestKey(t *testing.T) {
 				Username: "",
 				Groups:   []string{"group1"},
 			},
-			expected: "username=\ngroup=group1",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(Key(tt.imp)).To(Equal(tt.expected))
+			key := Key(tt.imp)
+			g.Expect(key).NotTo(BeEmpty())
+			g.Expect(seen).NotTo(HaveKey(key))
+			if tt.imp.Username != "" {
+				g.Expect(key).NotTo(ContainSubstring(tt.imp.Username))
+			}
+			for _, group := range tt.imp.Groups {
+				g.Expect(key).NotTo(ContainSubstring(group))
+			}
+			seen[key] = tt.name
 		})
 	}
+
+	t.Run("keys are unambiguous", func(t *testing.T) {
+		g := NewWithT(t)
+		usernameWithDelimiter := Impersonation{Username: "alice\ngroup=platform-admin"}
+		usernameAndGroup := Impersonation{Username: "alice", Groups: []string{"platform-admin"}}
+
+		g.Expect(Key(usernameWithDelimiter)).NotTo(Equal(Key(usernameAndGroup)))
+	})
 }
 
 func TestStoreAndLoadSession(t *testing.T) {


### PR DESCRIPTION
This PR changes the impersonation cache key format by base64-encoding the username and groups before concatenation and sha256-hashing the key, in order to avoid potential key ambiguity if the username or groups contain the `\n` delimiter .